### PR TITLE
Fixes issue 39 skip deserialization true overload

### DIFF
--- a/modules/openapi-json-schema-generator/src/main/resources/python/endpoint_args.handlebars
+++ b/modules/openapi-json-schema-generator/src/main/resources/python/endpoint_args.handlebars
@@ -73,6 +73,12 @@
         {{/eq}}
         {{/with}}
     {{/if}}
+{{else}}
+    {{#if isOverload}}
+        {{#eq skipDeserialization "True"}}
+    skip_deserialization: typing_extensions.Literal[True],
+        {{/eq}}
+    {{/if}}
 {{/if}}
 {{#if queryParams}}
     query_params: RequestQueryParams = frozendict.frozendict(),

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_additionalproperties_allows_a_schema_which_should_validate_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_additionalproperties_allows_a_schema_which_should_validate_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_additionalproperties_allows_a_schema_which_should_validate_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostAdditionalpropertiesAllowsASchemaWhichShouldValidateResponseBodyForCon
     @typing.overload
     def post_additionalproperties_allows_a_schema_which_should_validate_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_additionalproperties_allows_a_schema_which_should_validate_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_additionalproperties_allows_a_schema_which_should_validate_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_additionalproperties_allows_a_schema_which_should_validate_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostAdditionalpropertiesAllowsASchemaWhichShouldValidateResponseBodyForCon
     @typing.overload
     def post_additionalproperties_allows_a_schema_which_should_validate_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_additionalproperties_are_allowed_by_default_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_additionalproperties_are_allowed_by_default_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_additionalproperties_are_allowed_by_default_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostAdditionalpropertiesAreAllowedByDefaultResponseBodyForContentTypes(Bas
     @typing.overload
     def post_additionalproperties_are_allowed_by_default_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_additionalproperties_are_allowed_by_default_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_additionalproperties_are_allowed_by_default_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_additionalproperties_are_allowed_by_default_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostAdditionalpropertiesAreAllowedByDefaultResponseBodyForContentTypes(Bas
     @typing.overload
     def post_additionalproperties_are_allowed_by_default_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_additionalproperties_can_exist_by_itself_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_additionalproperties_can_exist_by_itself_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_additionalproperties_can_exist_by_itself_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostAdditionalpropertiesCanExistByItselfResponseBodyForContentTypes(BaseAp
     @typing.overload
     def post_additionalproperties_can_exist_by_itself_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_additionalproperties_can_exist_by_itself_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_additionalproperties_can_exist_by_itself_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_additionalproperties_can_exist_by_itself_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostAdditionalpropertiesCanExistByItselfResponseBodyForContentTypes(BaseAp
     @typing.overload
     def post_additionalproperties_can_exist_by_itself_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_additionalproperties_should_not_look_in_applicators_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_additionalproperties_should_not_look_in_applicators_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_additionalproperties_should_not_look_in_applicators_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostAdditionalpropertiesShouldNotLookInApplicatorsResponseBodyForContentTy
     @typing.overload
     def post_additionalproperties_should_not_look_in_applicators_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_additionalproperties_should_not_look_in_applicators_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_additionalproperties_should_not_look_in_applicators_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_additionalproperties_should_not_look_in_applicators_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostAdditionalpropertiesShouldNotLookInApplicatorsResponseBodyForContentTy
     @typing.overload
     def post_additionalproperties_should_not_look_in_applicators_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_allof_combined_with_anyof_oneof_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_allof_combined_with_anyof_oneof_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_allof_combined_with_anyof_oneof_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostAllofCombinedWithAnyofOneofResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_allof_combined_with_anyof_oneof_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_allof_combined_with_anyof_oneof_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_allof_combined_with_anyof_oneof_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_allof_combined_with_anyof_oneof_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostAllofCombinedWithAnyofOneofResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_allof_combined_with_anyof_oneof_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_allof_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_allof_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_allof_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostAllofResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_allof_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_allof_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_allof_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_allof_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostAllofResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_allof_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_allof_simple_types_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_allof_simple_types_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_allof_simple_types_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostAllofSimpleTypesResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_allof_simple_types_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_allof_simple_types_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_allof_simple_types_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_allof_simple_types_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostAllofSimpleTypesResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_allof_simple_types_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_allof_with_base_schema_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_allof_with_base_schema_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_allof_with_base_schema_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostAllofWithBaseSchemaResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_allof_with_base_schema_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_allof_with_base_schema_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_allof_with_base_schema_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_allof_with_base_schema_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostAllofWithBaseSchemaResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_allof_with_base_schema_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_allof_with_one_empty_schema_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_allof_with_one_empty_schema_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_allof_with_one_empty_schema_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostAllofWithOneEmptySchemaResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_allof_with_one_empty_schema_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_allof_with_one_empty_schema_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_allof_with_one_empty_schema_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_allof_with_one_empty_schema_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostAllofWithOneEmptySchemaResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_allof_with_one_empty_schema_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_allof_with_the_first_empty_schema_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_allof_with_the_first_empty_schema_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_allof_with_the_first_empty_schema_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostAllofWithTheFirstEmptySchemaResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_allof_with_the_first_empty_schema_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_allof_with_the_first_empty_schema_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_allof_with_the_first_empty_schema_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_allof_with_the_first_empty_schema_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostAllofWithTheFirstEmptySchemaResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_allof_with_the_first_empty_schema_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_allof_with_the_last_empty_schema_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_allof_with_the_last_empty_schema_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_allof_with_the_last_empty_schema_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostAllofWithTheLastEmptySchemaResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_allof_with_the_last_empty_schema_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_allof_with_the_last_empty_schema_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_allof_with_the_last_empty_schema_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_allof_with_the_last_empty_schema_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostAllofWithTheLastEmptySchemaResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_allof_with_the_last_empty_schema_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_allof_with_two_empty_schemas_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_allof_with_two_empty_schemas_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_allof_with_two_empty_schemas_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostAllofWithTwoEmptySchemasResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_allof_with_two_empty_schemas_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_allof_with_two_empty_schemas_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_allof_with_two_empty_schemas_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_allof_with_two_empty_schemas_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostAllofWithTwoEmptySchemasResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_allof_with_two_empty_schemas_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_anyof_complex_types_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_anyof_complex_types_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_anyof_complex_types_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostAnyofComplexTypesResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_anyof_complex_types_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_anyof_complex_types_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_anyof_complex_types_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_anyof_complex_types_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostAnyofComplexTypesResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_anyof_complex_types_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_anyof_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_anyof_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_anyof_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostAnyofResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_anyof_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_anyof_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_anyof_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_anyof_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostAnyofResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_anyof_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_anyof_with_base_schema_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_anyof_with_base_schema_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_anyof_with_base_schema_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostAnyofWithBaseSchemaResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_anyof_with_base_schema_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_anyof_with_base_schema_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_anyof_with_base_schema_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_anyof_with_base_schema_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostAnyofWithBaseSchemaResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_anyof_with_base_schema_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_anyof_with_one_empty_schema_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_anyof_with_one_empty_schema_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_anyof_with_one_empty_schema_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostAnyofWithOneEmptySchemaResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_anyof_with_one_empty_schema_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_anyof_with_one_empty_schema_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_anyof_with_one_empty_schema_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_anyof_with_one_empty_schema_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostAnyofWithOneEmptySchemaResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_anyof_with_one_empty_schema_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_array_type_matches_arrays_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_array_type_matches_arrays_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_array_type_matches_arrays_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostArrayTypeMatchesArraysResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_array_type_matches_arrays_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_array_type_matches_arrays_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_array_type_matches_arrays_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_array_type_matches_arrays_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostArrayTypeMatchesArraysResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_array_type_matches_arrays_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_boolean_type_matches_booleans_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_boolean_type_matches_booleans_response_body_for_content_types/post.py
@@ -69,6 +69,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_boolean_type_matches_booleans_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -146,6 +147,7 @@ class PostBooleanTypeMatchesBooleansResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_boolean_type_matches_booleans_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -195,6 +197,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_boolean_type_matches_booleans_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_boolean_type_matches_booleans_response_body_for_content_types/post.pyi
@@ -64,6 +64,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_boolean_type_matches_booleans_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -141,6 +142,7 @@ class PostBooleanTypeMatchesBooleansResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_boolean_type_matches_booleans_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -190,6 +192,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_by_int_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_by_int_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_by_int_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostByIntResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_by_int_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_by_int_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_by_int_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_by_int_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostByIntResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_by_int_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_by_number_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_by_number_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_by_number_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostByNumberResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_by_number_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_by_number_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_by_number_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_by_number_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostByNumberResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_by_number_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_by_small_number_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_by_small_number_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_by_small_number_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostBySmallNumberResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_by_small_number_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_by_small_number_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_by_small_number_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_by_small_number_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostBySmallNumberResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_by_small_number_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_date_time_format_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_date_time_format_response_body_for_content_types/post.py
@@ -92,6 +92,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_date_time_format_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -169,6 +170,7 @@ class PostDateTimeFormatResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_date_time_format_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -218,6 +220,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_date_time_format_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_date_time_format_response_body_for_content_types/post.pyi
@@ -87,6 +87,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_date_time_format_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -164,6 +165,7 @@ class PostDateTimeFormatResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_date_time_format_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -213,6 +215,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_email_format_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_email_format_response_body_for_content_types/post.py
@@ -91,6 +91,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_email_format_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -168,6 +169,7 @@ class PostEmailFormatResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_email_format_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -217,6 +219,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_email_format_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_email_format_response_body_for_content_types/post.pyi
@@ -86,6 +86,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_email_format_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -163,6 +164,7 @@ class PostEmailFormatResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_email_format_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -212,6 +214,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_enum_with0_does_not_match_false_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_enum_with0_does_not_match_false_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_enum_with0_does_not_match_false_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostEnumWith0DoesNotMatchFalseResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_enum_with0_does_not_match_false_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_enum_with0_does_not_match_false_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_enum_with0_does_not_match_false_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_enum_with0_does_not_match_false_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostEnumWith0DoesNotMatchFalseResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_enum_with0_does_not_match_false_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_enum_with1_does_not_match_true_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_enum_with1_does_not_match_true_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_enum_with1_does_not_match_true_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostEnumWith1DoesNotMatchTrueResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_enum_with1_does_not_match_true_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_enum_with1_does_not_match_true_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_enum_with1_does_not_match_true_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_enum_with1_does_not_match_true_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostEnumWith1DoesNotMatchTrueResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_enum_with1_does_not_match_true_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_enum_with_escaped_characters_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_enum_with_escaped_characters_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_enum_with_escaped_characters_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostEnumWithEscapedCharactersResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_enum_with_escaped_characters_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_enum_with_escaped_characters_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_enum_with_escaped_characters_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_enum_with_escaped_characters_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostEnumWithEscapedCharactersResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_enum_with_escaped_characters_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_enum_with_false_does_not_match0_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_enum_with_false_does_not_match0_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_enum_with_false_does_not_match0_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostEnumWithFalseDoesNotMatch0ResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_enum_with_false_does_not_match0_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_enum_with_false_does_not_match0_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_enum_with_false_does_not_match0_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_enum_with_false_does_not_match0_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostEnumWithFalseDoesNotMatch0ResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_enum_with_false_does_not_match0_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_enum_with_true_does_not_match1_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_enum_with_true_does_not_match1_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_enum_with_true_does_not_match1_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostEnumWithTrueDoesNotMatch1ResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_enum_with_true_does_not_match1_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_enum_with_true_does_not_match1_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_enum_with_true_does_not_match1_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_enum_with_true_does_not_match1_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostEnumWithTrueDoesNotMatch1ResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_enum_with_true_does_not_match1_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_enums_in_properties_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_enums_in_properties_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_enums_in_properties_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostEnumsInPropertiesResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_enums_in_properties_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_enums_in_properties_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_enums_in_properties_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_enums_in_properties_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostEnumsInPropertiesResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_enums_in_properties_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_forbidden_property_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_forbidden_property_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_forbidden_property_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostForbiddenPropertyResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_forbidden_property_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_forbidden_property_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_forbidden_property_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_forbidden_property_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostForbiddenPropertyResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_forbidden_property_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_hostname_format_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_hostname_format_response_body_for_content_types/post.py
@@ -91,6 +91,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_hostname_format_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -168,6 +169,7 @@ class PostHostnameFormatResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_hostname_format_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -217,6 +219,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_hostname_format_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_hostname_format_response_body_for_content_types/post.pyi
@@ -86,6 +86,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_hostname_format_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -163,6 +164,7 @@ class PostHostnameFormatResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_hostname_format_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -212,6 +214,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_integer_type_matches_integers_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_integer_type_matches_integers_response_body_for_content_types/post.py
@@ -69,6 +69,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_integer_type_matches_integers_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -146,6 +147,7 @@ class PostIntegerTypeMatchesIntegersResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_integer_type_matches_integers_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -195,6 +197,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_integer_type_matches_integers_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_integer_type_matches_integers_response_body_for_content_types/post.pyi
@@ -64,6 +64,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_integer_type_matches_integers_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -141,6 +142,7 @@ class PostIntegerTypeMatchesIntegersResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_integer_type_matches_integers_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -190,6 +192,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_invalid_instance_should_not_raise_error_when_float_division_inf_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_invalid_instance_should_not_raise_error_when_float_division_inf_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_invalid_instance_should_not_raise_error_when_float_division_inf_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostInvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInfResponseBodyForC
     @typing.overload
     def post_invalid_instance_should_not_raise_error_when_float_division_inf_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_invalid_instance_should_not_raise_error_when_float_division_inf_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_invalid_instance_should_not_raise_error_when_float_division_inf_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_invalid_instance_should_not_raise_error_when_float_division_inf_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostInvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInfResponseBodyForC
     @typing.overload
     def post_invalid_instance_should_not_raise_error_when_float_division_inf_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_invalid_string_value_for_default_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_invalid_string_value_for_default_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_invalid_string_value_for_default_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostInvalidStringValueForDefaultResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_invalid_string_value_for_default_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_invalid_string_value_for_default_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_invalid_string_value_for_default_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_invalid_string_value_for_default_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostInvalidStringValueForDefaultResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_invalid_string_value_for_default_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ipv4_format_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ipv4_format_response_body_for_content_types/post.py
@@ -91,6 +91,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_ipv4_format_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -168,6 +169,7 @@ class PostIpv4FormatResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_ipv4_format_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -217,6 +219,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ipv4_format_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ipv4_format_response_body_for_content_types/post.pyi
@@ -86,6 +86,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_ipv4_format_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -163,6 +164,7 @@ class PostIpv4FormatResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_ipv4_format_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -212,6 +214,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ipv6_format_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ipv6_format_response_body_for_content_types/post.py
@@ -91,6 +91,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_ipv6_format_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -168,6 +169,7 @@ class PostIpv6FormatResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_ipv6_format_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -217,6 +219,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ipv6_format_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ipv6_format_response_body_for_content_types/post.pyi
@@ -86,6 +86,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_ipv6_format_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -163,6 +164,7 @@ class PostIpv6FormatResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_ipv6_format_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -212,6 +214,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_json_pointer_format_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_json_pointer_format_response_body_for_content_types/post.py
@@ -91,6 +91,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_json_pointer_format_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -168,6 +169,7 @@ class PostJsonPointerFormatResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_json_pointer_format_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -217,6 +219,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_json_pointer_format_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_json_pointer_format_response_body_for_content_types/post.pyi
@@ -86,6 +86,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_json_pointer_format_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -163,6 +164,7 @@ class PostJsonPointerFormatResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_json_pointer_format_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -212,6 +214,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_maximum_validation_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_maximum_validation_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_maximum_validation_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostMaximumValidationResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_maximum_validation_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_maximum_validation_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_maximum_validation_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_maximum_validation_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostMaximumValidationResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_maximum_validation_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_maximum_validation_with_unsigned_integer_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_maximum_validation_with_unsigned_integer_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_maximum_validation_with_unsigned_integer_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostMaximumValidationWithUnsignedIntegerResponseBodyForContentTypes(BaseAp
     @typing.overload
     def post_maximum_validation_with_unsigned_integer_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_maximum_validation_with_unsigned_integer_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_maximum_validation_with_unsigned_integer_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_maximum_validation_with_unsigned_integer_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostMaximumValidationWithUnsignedIntegerResponseBodyForContentTypes(BaseAp
     @typing.overload
     def post_maximum_validation_with_unsigned_integer_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_maxitems_validation_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_maxitems_validation_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_maxitems_validation_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostMaxitemsValidationResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_maxitems_validation_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_maxitems_validation_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_maxitems_validation_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_maxitems_validation_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostMaxitemsValidationResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_maxitems_validation_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_maxlength_validation_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_maxlength_validation_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_maxlength_validation_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostMaxlengthValidationResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_maxlength_validation_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_maxlength_validation_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_maxlength_validation_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_maxlength_validation_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostMaxlengthValidationResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_maxlength_validation_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_maxproperties0_means_the_object_is_empty_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_maxproperties0_means_the_object_is_empty_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_maxproperties0_means_the_object_is_empty_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostMaxproperties0MeansTheObjectIsEmptyResponseBodyForContentTypes(BaseApi
     @typing.overload
     def post_maxproperties0_means_the_object_is_empty_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_maxproperties0_means_the_object_is_empty_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_maxproperties0_means_the_object_is_empty_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_maxproperties0_means_the_object_is_empty_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostMaxproperties0MeansTheObjectIsEmptyResponseBodyForContentTypes(BaseApi
     @typing.overload
     def post_maxproperties0_means_the_object_is_empty_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_maxproperties_validation_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_maxproperties_validation_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_maxproperties_validation_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostMaxpropertiesValidationResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_maxproperties_validation_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_maxproperties_validation_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_maxproperties_validation_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_maxproperties_validation_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostMaxpropertiesValidationResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_maxproperties_validation_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_minimum_validation_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_minimum_validation_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_minimum_validation_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostMinimumValidationResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_minimum_validation_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_minimum_validation_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_minimum_validation_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_minimum_validation_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostMinimumValidationResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_minimum_validation_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_minimum_validation_with_signed_integer_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_minimum_validation_with_signed_integer_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_minimum_validation_with_signed_integer_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostMinimumValidationWithSignedIntegerResponseBodyForContentTypes(BaseApi)
     @typing.overload
     def post_minimum_validation_with_signed_integer_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_minimum_validation_with_signed_integer_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_minimum_validation_with_signed_integer_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_minimum_validation_with_signed_integer_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostMinimumValidationWithSignedIntegerResponseBodyForContentTypes(BaseApi)
     @typing.overload
     def post_minimum_validation_with_signed_integer_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_minitems_validation_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_minitems_validation_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_minitems_validation_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostMinitemsValidationResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_minitems_validation_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_minitems_validation_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_minitems_validation_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_minitems_validation_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostMinitemsValidationResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_minitems_validation_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_minlength_validation_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_minlength_validation_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_minlength_validation_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostMinlengthValidationResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_minlength_validation_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_minlength_validation_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_minlength_validation_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_minlength_validation_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostMinlengthValidationResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_minlength_validation_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_minproperties_validation_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_minproperties_validation_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_minproperties_validation_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostMinpropertiesValidationResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_minproperties_validation_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_minproperties_validation_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_minproperties_validation_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_minproperties_validation_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostMinpropertiesValidationResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_minproperties_validation_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_nested_allof_to_check_validation_semantics_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_nested_allof_to_check_validation_semantics_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_nested_allof_to_check_validation_semantics_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostNestedAllofToCheckValidationSemanticsResponseBodyForContentTypes(BaseA
     @typing.overload
     def post_nested_allof_to_check_validation_semantics_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_nested_allof_to_check_validation_semantics_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_nested_allof_to_check_validation_semantics_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_nested_allof_to_check_validation_semantics_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostNestedAllofToCheckValidationSemanticsResponseBodyForContentTypes(BaseA
     @typing.overload
     def post_nested_allof_to_check_validation_semantics_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_nested_anyof_to_check_validation_semantics_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_nested_anyof_to_check_validation_semantics_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_nested_anyof_to_check_validation_semantics_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostNestedAnyofToCheckValidationSemanticsResponseBodyForContentTypes(BaseA
     @typing.overload
     def post_nested_anyof_to_check_validation_semantics_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_nested_anyof_to_check_validation_semantics_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_nested_anyof_to_check_validation_semantics_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_nested_anyof_to_check_validation_semantics_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostNestedAnyofToCheckValidationSemanticsResponseBodyForContentTypes(BaseA
     @typing.overload
     def post_nested_anyof_to_check_validation_semantics_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_nested_items_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_nested_items_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_nested_items_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostNestedItemsResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_nested_items_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_nested_items_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_nested_items_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_nested_items_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostNestedItemsResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_nested_items_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_nested_oneof_to_check_validation_semantics_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_nested_oneof_to_check_validation_semantics_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_nested_oneof_to_check_validation_semantics_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostNestedOneofToCheckValidationSemanticsResponseBodyForContentTypes(BaseA
     @typing.overload
     def post_nested_oneof_to_check_validation_semantics_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_nested_oneof_to_check_validation_semantics_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_nested_oneof_to_check_validation_semantics_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_nested_oneof_to_check_validation_semantics_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostNestedOneofToCheckValidationSemanticsResponseBodyForContentTypes(BaseA
     @typing.overload
     def post_nested_oneof_to_check_validation_semantics_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_not_more_complex_schema_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_not_more_complex_schema_response_body_for_content_types/post.py
@@ -140,6 +140,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_not_more_complex_schema_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -217,6 +218,7 @@ class PostNotMoreComplexSchemaResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_not_more_complex_schema_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -266,6 +268,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_not_more_complex_schema_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_not_more_complex_schema_response_body_for_content_types/post.pyi
@@ -135,6 +135,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_not_more_complex_schema_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -212,6 +213,7 @@ class PostNotMoreComplexSchemaResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_not_more_complex_schema_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -261,6 +263,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_not_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_not_response_body_for_content_types/post.py
@@ -91,6 +91,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_not_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -168,6 +169,7 @@ class PostNotResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_not_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -217,6 +219,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_not_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_not_response_body_for_content_types/post.pyi
@@ -86,6 +86,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_not_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -163,6 +164,7 @@ class PostNotResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_not_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -212,6 +214,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_nul_characters_in_strings_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_nul_characters_in_strings_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_nul_characters_in_strings_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostNulCharactersInStringsResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_nul_characters_in_strings_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_nul_characters_in_strings_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_nul_characters_in_strings_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_nul_characters_in_strings_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostNulCharactersInStringsResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_nul_characters_in_strings_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_null_type_matches_only_the_null_object_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_null_type_matches_only_the_null_object_response_body_for_content_types/post.py
@@ -69,6 +69,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_null_type_matches_only_the_null_object_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -146,6 +147,7 @@ class PostNullTypeMatchesOnlyTheNullObjectResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_null_type_matches_only_the_null_object_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -195,6 +197,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_null_type_matches_only_the_null_object_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_null_type_matches_only_the_null_object_response_body_for_content_types/post.pyi
@@ -64,6 +64,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_null_type_matches_only_the_null_object_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -141,6 +142,7 @@ class PostNullTypeMatchesOnlyTheNullObjectResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_null_type_matches_only_the_null_object_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -190,6 +192,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_number_type_matches_numbers_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_number_type_matches_numbers_response_body_for_content_types/post.py
@@ -69,6 +69,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_number_type_matches_numbers_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -146,6 +147,7 @@ class PostNumberTypeMatchesNumbersResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_number_type_matches_numbers_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -195,6 +197,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_number_type_matches_numbers_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_number_type_matches_numbers_response_body_for_content_types/post.pyi
@@ -64,6 +64,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_number_type_matches_numbers_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -141,6 +142,7 @@ class PostNumberTypeMatchesNumbersResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_number_type_matches_numbers_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -190,6 +192,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_object_properties_validation_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_object_properties_validation_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_object_properties_validation_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostObjectPropertiesValidationResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_object_properties_validation_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_object_properties_validation_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_object_properties_validation_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_object_properties_validation_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostObjectPropertiesValidationResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_object_properties_validation_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_object_type_matches_objects_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_object_type_matches_objects_response_body_for_content_types/post.py
@@ -69,6 +69,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_object_type_matches_objects_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -146,6 +147,7 @@ class PostObjectTypeMatchesObjectsResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_object_type_matches_objects_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -195,6 +197,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_object_type_matches_objects_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_object_type_matches_objects_response_body_for_content_types/post.pyi
@@ -64,6 +64,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_object_type_matches_objects_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -141,6 +142,7 @@ class PostObjectTypeMatchesObjectsResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_object_type_matches_objects_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -190,6 +192,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_oneof_complex_types_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_oneof_complex_types_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_oneof_complex_types_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostOneofComplexTypesResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_oneof_complex_types_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_oneof_complex_types_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_oneof_complex_types_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_oneof_complex_types_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostOneofComplexTypesResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_oneof_complex_types_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_oneof_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_oneof_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_oneof_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostOneofResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_oneof_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_oneof_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_oneof_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_oneof_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostOneofResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_oneof_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_oneof_with_base_schema_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_oneof_with_base_schema_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_oneof_with_base_schema_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostOneofWithBaseSchemaResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_oneof_with_base_schema_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_oneof_with_base_schema_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_oneof_with_base_schema_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_oneof_with_base_schema_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostOneofWithBaseSchemaResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_oneof_with_base_schema_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_oneof_with_empty_schema_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_oneof_with_empty_schema_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_oneof_with_empty_schema_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostOneofWithEmptySchemaResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_oneof_with_empty_schema_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_oneof_with_empty_schema_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_oneof_with_empty_schema_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_oneof_with_empty_schema_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostOneofWithEmptySchemaResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_oneof_with_empty_schema_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_oneof_with_required_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_oneof_with_required_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_oneof_with_required_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostOneofWithRequiredResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_oneof_with_required_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_oneof_with_required_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_oneof_with_required_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_oneof_with_required_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostOneofWithRequiredResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_oneof_with_required_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_pattern_is_not_anchored_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_pattern_is_not_anchored_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_pattern_is_not_anchored_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostPatternIsNotAnchoredResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_pattern_is_not_anchored_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_pattern_is_not_anchored_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_pattern_is_not_anchored_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_pattern_is_not_anchored_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostPatternIsNotAnchoredResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_pattern_is_not_anchored_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_pattern_validation_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_pattern_validation_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_pattern_validation_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostPatternValidationResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_pattern_validation_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_pattern_validation_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_pattern_validation_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_pattern_validation_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostPatternValidationResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_pattern_validation_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_properties_with_escaped_characters_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_properties_with_escaped_characters_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_properties_with_escaped_characters_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostPropertiesWithEscapedCharactersResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_properties_with_escaped_characters_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_properties_with_escaped_characters_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_properties_with_escaped_characters_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_properties_with_escaped_characters_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostPropertiesWithEscapedCharactersResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_properties_with_escaped_characters_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_property_named_ref_that_is_not_a_reference_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_property_named_ref_that_is_not_a_reference_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_property_named_ref_that_is_not_a_reference_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostPropertyNamedRefThatIsNotAReferenceResponseBodyForContentTypes(BaseApi
     @typing.overload
     def post_property_named_ref_that_is_not_a_reference_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_property_named_ref_that_is_not_a_reference_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_property_named_ref_that_is_not_a_reference_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_property_named_ref_that_is_not_a_reference_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostPropertyNamedRefThatIsNotAReferenceResponseBodyForContentTypes(BaseApi
     @typing.overload
     def post_property_named_ref_that_is_not_a_reference_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ref_in_additionalproperties_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ref_in_additionalproperties_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_ref_in_additionalproperties_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostRefInAdditionalpropertiesResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_ref_in_additionalproperties_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ref_in_additionalproperties_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ref_in_additionalproperties_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_ref_in_additionalproperties_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostRefInAdditionalpropertiesResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_ref_in_additionalproperties_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ref_in_allof_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ref_in_allof_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_ref_in_allof_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostRefInAllofResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_ref_in_allof_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ref_in_allof_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ref_in_allof_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_ref_in_allof_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostRefInAllofResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_ref_in_allof_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ref_in_anyof_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ref_in_anyof_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_ref_in_anyof_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostRefInAnyofResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_ref_in_anyof_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ref_in_anyof_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ref_in_anyof_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_ref_in_anyof_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostRefInAnyofResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_ref_in_anyof_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ref_in_items_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ref_in_items_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_ref_in_items_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostRefInItemsResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_ref_in_items_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ref_in_items_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ref_in_items_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_ref_in_items_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostRefInItemsResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_ref_in_items_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ref_in_not_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ref_in_not_response_body_for_content_types/post.py
@@ -96,6 +96,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_ref_in_not_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -173,6 +174,7 @@ class PostRefInNotResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_ref_in_not_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -222,6 +224,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ref_in_not_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ref_in_not_response_body_for_content_types/post.pyi
@@ -91,6 +91,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_ref_in_not_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -168,6 +169,7 @@ class PostRefInNotResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_ref_in_not_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -217,6 +219,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ref_in_oneof_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ref_in_oneof_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_ref_in_oneof_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostRefInOneofResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_ref_in_oneof_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ref_in_oneof_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ref_in_oneof_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_ref_in_oneof_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostRefInOneofResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_ref_in_oneof_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ref_in_property_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ref_in_property_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_ref_in_property_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostRefInPropertyResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_ref_in_property_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ref_in_property_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_ref_in_property_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_ref_in_property_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostRefInPropertyResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_ref_in_property_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_required_default_validation_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_required_default_validation_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_required_default_validation_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostRequiredDefaultValidationResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_required_default_validation_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_required_default_validation_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_required_default_validation_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_required_default_validation_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostRequiredDefaultValidationResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_required_default_validation_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_required_validation_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_required_validation_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_required_validation_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostRequiredValidationResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_required_validation_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_required_validation_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_required_validation_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_required_validation_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostRequiredValidationResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_required_validation_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_required_with_empty_array_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_required_with_empty_array_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_required_with_empty_array_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostRequiredWithEmptyArrayResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_required_with_empty_array_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_required_with_empty_array_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_required_with_empty_array_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_required_with_empty_array_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostRequiredWithEmptyArrayResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_required_with_empty_array_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_required_with_escaped_characters_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_required_with_escaped_characters_response_body_for_content_types/post.py
@@ -99,6 +99,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_required_with_escaped_characters_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -176,6 +177,7 @@ class PostRequiredWithEscapedCharactersResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_required_with_escaped_characters_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -225,6 +227,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_required_with_escaped_characters_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_required_with_escaped_characters_response_body_for_content_types/post.pyi
@@ -94,6 +94,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_required_with_escaped_characters_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -171,6 +172,7 @@ class PostRequiredWithEscapedCharactersResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_required_with_escaped_characters_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -220,6 +222,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_simple_enum_validation_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_simple_enum_validation_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_simple_enum_validation_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostSimpleEnumValidationResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_simple_enum_validation_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_simple_enum_validation_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_simple_enum_validation_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_simple_enum_validation_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostSimpleEnumValidationResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_simple_enum_validation_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_string_type_matches_strings_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_string_type_matches_strings_response_body_for_content_types/post.py
@@ -69,6 +69,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_string_type_matches_strings_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -146,6 +147,7 @@ class PostStringTypeMatchesStringsResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_string_type_matches_strings_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -195,6 +197,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_string_type_matches_strings_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_string_type_matches_strings_response_body_for_content_types/post.pyi
@@ -64,6 +64,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_string_type_matches_strings_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -141,6 +142,7 @@ class PostStringTypeMatchesStringsResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_string_type_matches_strings_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -190,6 +192,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_the_default_keyword_does_not_do_anything_if_the_property_is_missing_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_the_default_keyword_does_not_do_anything_if_the_property_is_missing_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_the_default_keyword_does_not_do_anything_if_the_property_is_missing_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostTheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissingResponseBodyFo
     @typing.overload
     def post_the_default_keyword_does_not_do_anything_if_the_property_is_missing_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_the_default_keyword_does_not_do_anything_if_the_property_is_missing_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_the_default_keyword_does_not_do_anything_if_the_property_is_missing_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_the_default_keyword_does_not_do_anything_if_the_property_is_missing_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostTheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissingResponseBodyFo
     @typing.overload
     def post_the_default_keyword_does_not_do_anything_if_the_property_is_missing_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_uniqueitems_false_validation_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_uniqueitems_false_validation_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_uniqueitems_false_validation_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostUniqueitemsFalseValidationResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_uniqueitems_false_validation_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_uniqueitems_false_validation_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_uniqueitems_false_validation_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_uniqueitems_false_validation_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostUniqueitemsFalseValidationResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_uniqueitems_false_validation_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_uniqueitems_validation_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_uniqueitems_validation_response_body_for_content_types/post.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_uniqueitems_validation_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class PostUniqueitemsValidationResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_uniqueitems_validation_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_uniqueitems_validation_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_uniqueitems_validation_response_body_for_content_types/post.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_uniqueitems_validation_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class PostUniqueitemsValidationResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_uniqueitems_validation_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_uri_format_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_uri_format_response_body_for_content_types/post.py
@@ -91,6 +91,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_uri_format_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -168,6 +169,7 @@ class PostUriFormatResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_uri_format_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -217,6 +219,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_uri_format_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_uri_format_response_body_for_content_types/post.pyi
@@ -86,6 +86,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_uri_format_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -163,6 +164,7 @@ class PostUriFormatResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_uri_format_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -212,6 +214,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_uri_reference_format_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_uri_reference_format_response_body_for_content_types/post.py
@@ -91,6 +91,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_uri_reference_format_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -168,6 +169,7 @@ class PostUriReferenceFormatResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_uri_reference_format_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -217,6 +219,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_uri_reference_format_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_uri_reference_format_response_body_for_content_types/post.pyi
@@ -86,6 +86,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_uri_reference_format_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -163,6 +164,7 @@ class PostUriReferenceFormatResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_uri_reference_format_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -212,6 +214,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_uri_template_format_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_uri_template_format_response_body_for_content_types/post.py
@@ -91,6 +91,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_uri_template_format_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -168,6 +169,7 @@ class PostUriTemplateFormatResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_uri_template_format_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -217,6 +219,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_uri_template_format_response_body_for_content_types/post.pyi
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/paths/response_body_post_uri_template_format_response_body_for_content_types/post.pyi
@@ -86,6 +86,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _post_uri_template_format_response_body_for_content_types_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -163,6 +164,7 @@ class PostUriTemplateFormatResponseBodyForContentTypes(BaseApi):
     @typing.overload
     def post_uri_template_format_response_body_for_content_types(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -212,6 +214,7 @@ class ApiForpost(BaseApi):
     @typing.overload
     def post(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/fake/delete.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/fake/delete.py
@@ -148,6 +148,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _group_parameters_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         header_params: RequestHeaderParams = frozendict.frozendict(),
         stream: bool = False,
@@ -255,6 +256,7 @@ class GroupParameters(BaseApi):
     @typing.overload
     def group_parameters(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         header_params: RequestHeaderParams = frozendict.frozendict(),
         stream: bool = False,
@@ -309,6 +311,7 @@ class ApiFordelete(BaseApi):
     @typing.overload
     def delete(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         header_params: RequestHeaderParams = frozendict.frozendict(),
         stream: bool = False,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/fake/delete.pyi
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/fake/delete.pyi
@@ -140,6 +140,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _group_parameters_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         header_params: RequestHeaderParams = frozendict.frozendict(),
         stream: bool = False,
@@ -247,6 +248,7 @@ class GroupParameters(BaseApi):
     @typing.overload
     def group_parameters(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         header_params: RequestHeaderParams = frozendict.frozendict(),
         stream: bool = False,
@@ -301,6 +303,7 @@ class ApiFordelete(BaseApi):
     @typing.overload
     def delete(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         header_params: RequestHeaderParams = frozendict.frozendict(),
         stream: bool = False,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/fake_case_sensitive_params/put.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/fake_case_sensitive_params/put.py
@@ -103,6 +103,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _case_sensitive_params_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -190,6 +191,7 @@ class CaseSensitiveParams(BaseApi):
     @typing.overload
     def case_sensitive_params(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -239,6 +241,7 @@ class ApiForput(BaseApi):
     @typing.overload
     def put(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/fake_case_sensitive_params/put.pyi
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/fake_case_sensitive_params/put.pyi
@@ -98,6 +98,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _case_sensitive_params_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -185,6 +186,7 @@ class CaseSensitiveParams(BaseApi):
     @typing.overload
     def case_sensitive_params(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -234,6 +236,7 @@ class ApiForput(BaseApi):
     @typing.overload
     def put(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/fake_delete_coffee_id/delete.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/fake_delete_coffee_id/delete.py
@@ -98,6 +98,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _delete_coffee_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -190,6 +191,7 @@ class DeleteCoffee(BaseApi):
     @typing.overload
     def delete_coffee(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -241,6 +243,7 @@ class ApiFordelete(BaseApi):
     @typing.overload
     def delete(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/fake_delete_coffee_id/delete.pyi
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/fake_delete_coffee_id/delete.pyi
@@ -92,6 +92,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _delete_coffee_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -184,6 +185,7 @@ class DeleteCoffee(BaseApi):
     @typing.overload
     def delete_coffee(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -235,6 +237,7 @@ class ApiFordelete(BaseApi):
     @typing.overload
     def delete(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/fake_health/get.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/fake_health/get.py
@@ -71,6 +71,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _fake_health_get_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -149,6 +150,7 @@ class FakeHealthGet(BaseApi):
     @typing.overload
     def fake_health_get(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -198,6 +200,7 @@ class ApiForget(BaseApi):
     @typing.overload
     def get(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/fake_health/get.pyi
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/fake_health/get.pyi
@@ -66,6 +66,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _fake_health_get_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -144,6 +145,7 @@ class FakeHealthGet(BaseApi):
     @typing.overload
     def fake_health_get(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -193,6 +195,7 @@ class ApiForget(BaseApi):
     @typing.overload
     def get(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/fake_obj_in_query/get.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/fake_obj_in_query/get.py
@@ -133,6 +133,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _object_in_query_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -219,6 +220,7 @@ class ObjectInQuery(BaseApi):
     @typing.overload
     def object_in_query(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -268,6 +270,7 @@ class ApiForget(BaseApi):
     @typing.overload
     def get(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/fake_obj_in_query/get.pyi
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/fake_obj_in_query/get.pyi
@@ -128,6 +128,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _object_in_query_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -214,6 +215,7 @@ class ObjectInQuery(BaseApi):
     @typing.overload
     def object_in_query(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -263,6 +265,7 @@ class ApiForget(BaseApi):
     @typing.overload
     def get(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/fake_query_param_with_json_content_type/get.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/fake_query_param_with_json_content_type/get.py
@@ -97,6 +97,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _query_param_with_json_content_type_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -193,6 +194,7 @@ class QueryParamWithJsonContentType(BaseApi):
     @typing.overload
     def query_param_with_json_content_type(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -247,6 +249,7 @@ class ApiForget(BaseApi):
     @typing.overload
     def get(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/fake_query_param_with_json_content_type/get.pyi
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/fake_query_param_with_json_content_type/get.pyi
@@ -92,6 +92,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _query_param_with_json_content_type_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -188,6 +189,7 @@ class QueryParamWithJsonContentType(BaseApi):
     @typing.overload
     def query_param_with_json_content_type(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -242,6 +244,7 @@ class ApiForget(BaseApi):
     @typing.overload
     def get(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/fake_ref_obj_in_query/get.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/fake_ref_obj_in_query/get.py
@@ -86,6 +86,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _ref_object_in_query_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -172,6 +173,7 @@ class RefObjectInQuery(BaseApi):
     @typing.overload
     def ref_object_in_query(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -221,6 +223,7 @@ class ApiForget(BaseApi):
     @typing.overload
     def get(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/fake_ref_obj_in_query/get.pyi
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/fake_ref_obj_in_query/get.pyi
@@ -81,6 +81,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _ref_object_in_query_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -167,6 +168,7 @@ class RefObjectInQuery(BaseApi):
     @typing.overload
     def ref_object_in_query(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -216,6 +218,7 @@ class ApiForget(BaseApi):
     @typing.overload
     def get(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/fake_response_without_schema/get.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/fake_response_without_schema/get.py
@@ -70,6 +70,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _response_without_schema_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -148,6 +149,7 @@ class ResponseWithoutSchema(BaseApi):
     @typing.overload
     def response_without_schema(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -197,6 +199,7 @@ class ApiForget(BaseApi):
     @typing.overload
     def get(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/fake_response_without_schema/get.pyi
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/fake_response_without_schema/get.pyi
@@ -65,6 +65,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _response_without_schema_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -143,6 +144,7 @@ class ResponseWithoutSchema(BaseApi):
     @typing.overload
     def response_without_schema(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -192,6 +194,7 @@ class ApiForget(BaseApi):
     @typing.overload
     def get(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/fake_test_query_paramters/put.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/fake_test_query_paramters/put.py
@@ -239,6 +239,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _query_parameter_collection_format_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -329,6 +330,7 @@ class QueryParameterCollectionFormat(BaseApi):
     @typing.overload
     def query_parameter_collection_format(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -378,6 +380,7 @@ class ApiForput(BaseApi):
     @typing.overload
     def put(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/fake_test_query_paramters/put.pyi
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/fake_test_query_paramters/put.pyi
@@ -234,6 +234,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _query_parameter_collection_format_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -324,6 +325,7 @@ class QueryParameterCollectionFormat(BaseApi):
     @typing.overload
     def query_parameter_collection_format(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -373,6 +375,7 @@ class ApiForput(BaseApi):
     @typing.overload
     def put(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/foo/get.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/foo/get.py
@@ -123,6 +123,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _foo_get_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -204,6 +205,7 @@ class FooGet(BaseApi):
     @typing.overload
     def foo_get(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -253,6 +255,7 @@ class ApiForget(BaseApi):
     @typing.overload
     def get(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/foo/get.pyi
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/foo/get.pyi
@@ -118,6 +118,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _foo_get_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -199,6 +200,7 @@ class FooGet(BaseApi):
     @typing.overload
     def foo_get(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -248,6 +250,7 @@ class ApiForget(BaseApi):
     @typing.overload
     def get(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/pet_find_by_status/get.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/pet_find_by_status/get.py
@@ -217,6 +217,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _find_pets_by_status_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -314,6 +315,7 @@ class FindPetsByStatus(BaseApi):
     @typing.overload
     def find_pets_by_status(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -368,6 +370,7 @@ class ApiForget(BaseApi):
     @typing.overload
     def get(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/pet_find_by_status/get.pyi
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/pet_find_by_status/get.pyi
@@ -199,6 +199,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _find_pets_by_status_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -296,6 +297,7 @@ class FindPetsByStatus(BaseApi):
     @typing.overload
     def find_pets_by_status(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -350,6 +352,7 @@ class ApiForget(BaseApi):
     @typing.overload
     def get(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/pet_find_by_tags/get.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/pet_find_by_tags/get.py
@@ -192,6 +192,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _find_pets_by_tags_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -289,6 +290,7 @@ class FindPetsByTags(BaseApi):
     @typing.overload
     def find_pets_by_tags(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -343,6 +345,7 @@ class ApiForget(BaseApi):
     @typing.overload
     def get(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/pet_find_by_tags/get.pyi
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/pet_find_by_tags/get.pyi
@@ -182,6 +182,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _find_pets_by_tags_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -279,6 +280,7 @@ class FindPetsByTags(BaseApi):
     @typing.overload
     def find_pets_by_tags(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -333,6 +335,7 @@ class ApiForget(BaseApi):
     @typing.overload
     def get(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/pet_pet_id/delete.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/pet_pet_id/delete.py
@@ -111,6 +111,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _delete_pet_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         stream: bool = False,
@@ -210,6 +211,7 @@ class DeletePet(BaseApi):
     @typing.overload
     def delete_pet(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         stream: bool = False,
@@ -260,6 +262,7 @@ class ApiFordelete(BaseApi):
     @typing.overload
     def delete(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         stream: bool = False,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/pet_pet_id/delete.pyi
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/pet_pet_id/delete.pyi
@@ -103,6 +103,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _delete_pet_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         stream: bool = False,
@@ -202,6 +203,7 @@ class DeletePet(BaseApi):
     @typing.overload
     def delete_pet(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         stream: bool = False,
@@ -252,6 +254,7 @@ class ApiFordelete(BaseApi):
     @typing.overload
     def delete(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         stream: bool = False,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/pet_pet_id/get.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/pet_pet_id/get.py
@@ -132,6 +132,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _get_pet_by_id_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -229,6 +230,7 @@ class GetPetById(BaseApi):
     @typing.overload
     def get_pet_by_id(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -283,6 +285,7 @@ class ApiForget(BaseApi):
     @typing.overload
     def get(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/pet_pet_id/get.pyi
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/pet_pet_id/get.pyi
@@ -122,6 +122,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _get_pet_by_id_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -219,6 +220,7 @@ class GetPetById(BaseApi):
     @typing.overload
     def get_pet_by_id(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -273,6 +275,7 @@ class ApiForget(BaseApi):
     @typing.overload
     def get(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/store_inventory/get.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/store_inventory/get.py
@@ -100,6 +100,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _get_inventory_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -179,6 +180,7 @@ class GetInventory(BaseApi):
     @typing.overload
     def get_inventory(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -228,6 +230,7 @@ class ApiForget(BaseApi):
     @typing.overload
     def get(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/store_inventory/get.pyi
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/store_inventory/get.pyi
@@ -92,6 +92,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _get_inventory_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -171,6 +172,7 @@ class GetInventory(BaseApi):
     @typing.overload
     def get_inventory(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -220,6 +222,7 @@ class ApiForget(BaseApi):
     @typing.overload
     def get(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/store_order_order_id/delete.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/store_order_order_id/delete.py
@@ -94,6 +94,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _delete_order_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -176,6 +177,7 @@ class DeleteOrder(BaseApi):
     @typing.overload
     def delete_order(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -221,6 +223,7 @@ class ApiFordelete(BaseApi):
     @typing.overload
     def delete(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/store_order_order_id/delete.pyi
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/store_order_order_id/delete.pyi
@@ -88,6 +88,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _delete_order_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -170,6 +171,7 @@ class DeleteOrder(BaseApi):
     @typing.overload
     def delete_order(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -215,6 +217,7 @@ class ApiFordelete(BaseApi):
     @typing.overload
     def delete(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/store_order_order_id/get.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/store_order_order_id/get.py
@@ -139,6 +139,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _get_order_by_id_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -235,6 +236,7 @@ class GetOrderById(BaseApi):
     @typing.overload
     def get_order_by_id(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -289,6 +291,7 @@ class ApiForget(BaseApi):
     @typing.overload
     def get(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/store_order_order_id/get.pyi
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/store_order_order_id/get.pyi
@@ -127,6 +127,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _get_order_by_id_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -223,6 +224,7 @@ class GetOrderById(BaseApi):
     @typing.overload
     def get_order_by_id(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -277,6 +279,7 @@ class ApiForget(BaseApi):
     @typing.overload
     def get(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/user_login/get.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/user_login/get.py
@@ -147,6 +147,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _login_user_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -244,6 +245,7 @@ class LoginUser(BaseApi):
     @typing.overload
     def login_user(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -298,6 +300,7 @@ class ApiForget(BaseApi):
     @typing.overload
     def get(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/user_login/get.pyi
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/user_login/get.pyi
@@ -131,6 +131,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _login_user_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -228,6 +229,7 @@ class LoginUser(BaseApi):
     @typing.overload
     def login_user(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -282,6 +284,7 @@ class ApiForget(BaseApi):
     @typing.overload
     def get(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         query_params: RequestQueryParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/user_logout/get.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/user_logout/get.py
@@ -57,6 +57,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _logout_user_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
     ) -> api_client.ApiResponseWithoutDeserialization: ...
@@ -129,6 +130,7 @@ class LogoutUser(BaseApi):
     @typing.overload
     def logout_user(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
     ) -> api_client.ApiResponseWithoutDeserialization: ...
@@ -173,6 +175,7 @@ class ApiForget(BaseApi):
     @typing.overload
     def get(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
     ) -> api_client.ApiResponseWithoutDeserialization: ...

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/user_logout/get.pyi
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/user_logout/get.pyi
@@ -52,6 +52,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _logout_user_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
     ) -> api_client.ApiResponseWithoutDeserialization: ...
@@ -124,6 +125,7 @@ class LogoutUser(BaseApi):
     @typing.overload
     def logout_user(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
     ) -> api_client.ApiResponseWithoutDeserialization: ...
@@ -168,6 +170,7 @@ class ApiForget(BaseApi):
     @typing.overload
     def get(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
     ) -> api_client.ApiResponseWithoutDeserialization: ...

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/user_username/delete.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/user_username/delete.py
@@ -97,6 +97,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _delete_user_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -183,6 +184,7 @@ class DeleteUser(BaseApi):
     @typing.overload
     def delete_user(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -232,6 +234,7 @@ class ApiFordelete(BaseApi):
     @typing.overload
     def delete(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/user_username/delete.pyi
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/user_username/delete.pyi
@@ -91,6 +91,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _delete_user_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -177,6 +178,7 @@ class DeleteUser(BaseApi):
     @typing.overload
     def delete_user(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
@@ -226,6 +228,7 @@ class ApiFordelete(BaseApi):
     @typing.overload
     def delete(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         stream: bool = False,
         timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/user_username/get.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/user_username/get.py
@@ -129,6 +129,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _get_user_by_name_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -225,6 +226,7 @@ class GetUserByName(BaseApi):
     @typing.overload
     def get_user_by_name(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -279,6 +281,7 @@ class ApiForget(BaseApi):
     @typing.overload
     def get(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,

--- a/samples/openapi3/client/petstore/python/petstore_api/paths/user_username/get.pyi
+++ b/samples/openapi3/client/petstore/python/petstore_api/paths/user_username/get.pyi
@@ -122,6 +122,7 @@ class BaseApi(api_client.Api):
     @typing.overload
     def _get_user_by_name_oapg(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -218,6 +219,7 @@ class GetUserByName(BaseApi):
     @typing.overload
     def get_user_by_name(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -272,6 +274,7 @@ class ApiForget(BaseApi):
     @typing.overload
     def get(
         self,
+        skip_deserialization: typing_extensions.Literal[True],
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,


### PR DESCRIPTION
Fixes issue 39 skip deserialization true overload

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-json-schema-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
