### PR TITLE
Fixes low spec version bug

### DIFF
--- a/modules/openapi-json-schema-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/modules/openapi-json-schema-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -2759,14 +2759,14 @@ public class PythonClientCodegen extends AbstractPythonCodegen {
     public void preprocessOpenAPI(OpenAPI openAPI) {
         String originalSpecVersion;
         String xOriginalSwaggerVersion = "x-original-swagger-version";
-        if (openAPI.getExtensions() != null && !openAPI.getExtensions().isEmpty() && openAPI.getExtensions().containsValue(xOriginalSwaggerVersion)) {
+        if (openAPI.getExtensions() != null && !openAPI.getExtensions().isEmpty() && openAPI.getExtensions().containsKey(xOriginalSwaggerVersion)) {
             originalSpecVersion = (String) openAPI.getExtensions().get(xOriginalSwaggerVersion);
         } else {
             originalSpecVersion = openAPI.getOpenapi();
         }
         Integer specMajorVersion = Integer.parseInt(originalSpecVersion.substring(0, 1));
         if (specMajorVersion < 3) {
-            throw new RuntimeException("Your spec version of "+originalSpecVersion+" is too low. python-experimental only works with specs with version >= 3.X.X. Please use a tool like Swagger Editor or Swagger Converter to convert your spec to v3");
+            throw new RuntimeException("Your spec version of "+originalSpecVersion+" is too low. " + getName() + " only works with specs with version >= 3.X.X. Please use a tool like Swagger Editor or Swagger Converter to convert your spec to v3");
         }
     }
 

--- a/modules/openapi-json-schema-generator/src/test/java/org/openapitools/codegen/python/PythonClientTest.java
+++ b/modules/openapi-json-schema-generator/src/test/java/org/openapitools/codegen/python/PythonClientTest.java
@@ -59,8 +59,8 @@ public class PythonClientTest {
         Assert.assertEquals(exampleValue.trim(), expectedValue.trim());
     }
 
-    @Test
-    public void testSpecWithTooLowVersionThrowsException() throws RuntimeException {
+    @Test(expectedExceptions = RuntimeException.class)
+    public void testSpecWithTooLowVersionThrowsException() {
         final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/petstore.yaml");
         final PythonClientCodegen codegen = new PythonClientCodegen();
         codegen.preprocessOpenAPI(openAPI);


### PR DESCRIPTION
The generate command was succeeding with specs < v3.0.0 which is not supported.
This fixes that bug.
v2.0.0 specs are not supported because they are very old and because I have seen parsing bugs in them that do not exist in v3.0.0 specs.

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-json-schema-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
