### PR TITLE
Fixes model import when packageName has periods

### DIFF
--- a/modules/openapi-json-schema-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/modules/openapi-json-schema-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -889,7 +889,7 @@ public class PythonClientCodegen extends AbstractPythonCodegen {
     @Override
     public String toModelImport(String name) {
         // name looks like Cat
-        return "from " + packagePath() + "." +  modelPackage() + "." + toModelFilename(name) + " import " + toModelName(name);
+        return "from " + packageName + "." +  modelPackage() + "." + toModelFilename(name) + " import " + toModelName(name);
     }
 
     @Override

--- a/modules/openapi-json-schema-generator/src/test/java/org/openapitools/codegen/python/PythonClientTest.java
+++ b/modules/openapi-json-schema-generator/src/test/java/org/openapitools/codegen/python/PythonClientTest.java
@@ -224,4 +224,13 @@ public class PythonClientTest {
         Assert.assertEquals(enumVars.get(0).get("name"), "DIGIT_THREE_67B9C");
         Assert.assertEquals(enumVars.get(1).get("name"), "FFA5A4");
     }
+
+    @Test(description = "format imports of models using a package containing dots")
+    public void testImportWithQualifiedPackageName() throws Exception {
+        final PythonClientCodegen codegen = new PythonClientCodegen();
+        codegen.setPackageName("openapi.client");
+
+        String importValue = codegen.toModelImport("model_name");
+        Assert.assertEquals(importValue, "from openapi.client.model.model_name import ModelName");
+    }
 }


### PR DESCRIPTION
Fixes model import when packageName has periods
Synonym PR for https://github.com/OpenAPITools/openapi-generator/pull/14015
Thank you @loleary

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-json-schema-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
