### PR TITLE
v2 Adds refModule

### DIFF
--- a/modules/openapi-json-schema-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-json-schema-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -173,6 +173,7 @@ public class CodegenModel implements JsonSchema {
     private boolean isUuid;
     private Map<String, CodegenProperty> requiredVarsMap;
     private String ref;
+    private String refModule;
 
     public String getAdditionalPropertiesType() {
         return additionalPropertiesType;
@@ -241,6 +242,10 @@ public class CodegenModel implements JsonSchema {
     public void setRef(String ref) {
         this.ref = ref;
     }
+
+    public String getRefModule() { return refModule; }
+
+    public void setRefModule(String refModule) { this.refModule=refModule; }
 
     @Override
     public boolean getSchemaIsFromAdditionalProperties() {
@@ -1023,6 +1028,7 @@ public class CodegenModel implements JsonSchema {
                 Objects.equals(format, that.getFormat()) &&
                 Objects.equals(uniqueItemsBoolean, that.getUniqueItemsBoolean()) &&
                 Objects.equals(ref, that.getRef()) &&
+                Objects.equals(refModule, that.getRefModule()) &&
                 Objects.equals(requiredVarsMap, that.getRequiredVarsMap()) &&
                 Objects.equals(composedSchemas, that.composedSchemas) &&
                 Objects.equals(parent, that.parent) &&
@@ -1098,7 +1104,7 @@ public class CodegenModel implements JsonSchema {
                 getAdditionalPropertiesIsAnyType(), hasDiscriminatorWithNonEmptyMapping,
                 isAnyType, getComposedSchemas(), hasMultipleTypes, isDecimal, isUuid, requiredVarsMap, ref,
                 uniqueItemsBoolean, schemaIsFromAdditionalProperties, isBooleanSchemaTrue, isBooleanSchemaFalse,
-                format, dependentRequired, contains);
+                format, dependentRequired, contains, refModule);
     }
 
     @Override
@@ -1198,6 +1204,7 @@ public class CodegenModel implements JsonSchema {
         sb.append(", isUUID=").append(isUuid);
         sb.append(", requiredVarsMap=").append(requiredVarsMap);
         sb.append(", ref=").append(ref);
+        sb.append(", refModule=").append(refModule);
         sb.append(", schemaIsFromAdditionalProperties=").append(schemaIsFromAdditionalProperties);
         sb.append(", isBooleanSchemaTrue=").append(isBooleanSchemaTrue);
         sb.append(", isBooleanSchemaFalse=").append(isBooleanSchemaFalse);

--- a/modules/openapi-json-schema-generator/src/main/java/org/openapitools/codegen/CodegenParameter.java
+++ b/modules/openapi-json-schema-generator/src/main/java/org/openapitools/codegen/CodegenParameter.java
@@ -46,6 +46,7 @@ public class CodegenParameter {
     private boolean hasMultipleTypes = false;
     private LinkedHashMap<String, CodegenMediaType> content;
     private String ref;
+    private String refModule;
 
     public CodegenParameter copy() {
         CodegenParameter output = new CodegenParameter();
@@ -75,6 +76,9 @@ public class CodegenParameter {
         if (this.ref != null) {
             output.setRef(this.ref);
         }
+        if (this.refModule != null) {
+            output.setRefModule(this.refModule);
+        }
         output.isDeprecated = this.isDeprecated;
         output.isExplode = this.isExplode;
         output.style = this.style;
@@ -86,7 +90,7 @@ public class CodegenParameter {
 
     @Override
     public int hashCode() {
-        return Objects.hash(isFormParam, isQueryParam, isPathParam, isHeaderParam, isCookieParam, isBodyParam, isExplode, baseName, paramName, description, unescapedDescription, style, isDeepObject, isAllowEmptyValue, example, jsonSchema, vendorExtensions, isDeprecated, required, hasMultipleTypes, schema, content, ref);
+        return Objects.hash(isFormParam, isQueryParam, isPathParam, isHeaderParam, isCookieParam, isBodyParam, isExplode, baseName, paramName, description, unescapedDescription, style, isDeepObject, isAllowEmptyValue, example, jsonSchema, vendorExtensions, isDeprecated, required, hasMultipleTypes, schema, content, ref, refModule);
     }
 
     @Override
@@ -104,6 +108,7 @@ public class CodegenParameter {
                 isDeprecated == that.isDeprecated &&
                 required == that.required &&
                 Objects.equals(ref, that.getRef()) &&
+                Objects.equals(refModule, that.getRefModule()) &&
                 Objects.equals(content, that.getContent()) &&
                 Objects.equals(schema, that.getSchema()) &&
                 Objects.equals(baseName, that.baseName) &&
@@ -144,6 +149,7 @@ public class CodegenParameter {
         sb.append(", schema=").append(schema);
         sb.append(", content=").append(content);
         sb.append(", ref=").append(ref);
+        sb.append(", refModule=").append(refModule);
         sb.append('}');
         return sb.toString();
     }
@@ -169,5 +175,8 @@ public class CodegenParameter {
 
     public void setRef(String ref) { this.ref=ref; }
 
+    public String getRefModule() { return refModule; }
+
+    public void setRefModule(String refModule) { this.refModule=refModule; }
 }
 

--- a/modules/openapi-json-schema-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
+++ b/modules/openapi-json-schema-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
@@ -197,6 +197,7 @@ public class CodegenProperty implements Cloneable, JsonSchema {
     private boolean hasMultipleTypes = false;
     private Map<String, CodegenProperty> requiredVarsMap;
     private String ref;
+    private String refModule;
     private boolean schemaIsFromAdditionalProperties;
     private boolean isBooleanSchemaTrue;
     private boolean isBooleanSchemaFalse;
@@ -780,6 +781,9 @@ public class CodegenProperty implements Cloneable, JsonSchema {
             if (this.contains != null) {
                 cp.setContains(this.contains);
             }
+            if (this.getRefModule() != null) {
+                cp.setRefClass(this.refModule);
+            }
 
             return cp;
         } catch (CloneNotSupportedException e) {
@@ -973,6 +977,10 @@ public class CodegenProperty implements Cloneable, JsonSchema {
     @Override
     public void setRequiredVarsMap(Map<String, CodegenProperty> requiredVarsMap) { this.requiredVarsMap=requiredVarsMap; }
 
+    public String getRefModule() { return refModule; }
+
+    public void setRefModule(String refModule) { this.refModule=refModule; }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("CodegenProperty{");
@@ -1075,6 +1083,7 @@ public class CodegenProperty implements Cloneable, JsonSchema {
         sb.append(", hasMultipleTypes=").append(hasMultipleTypes);
         sb.append(", requiredVarsMap=").append(requiredVarsMap);
         sb.append(", ref=").append(ref);
+        sb.append(", refModule=").append(refModule);
         sb.append(", schemaIsFromAdditionalProperties=").append(schemaIsFromAdditionalProperties);
         sb.append(", isBooleanSchemaTrue=").append(isBooleanSchemaTrue);
         sb.append(", isBooleanSchemaFalse=").append(isBooleanSchemaFalse);
@@ -1147,6 +1156,7 @@ public class CodegenProperty implements Cloneable, JsonSchema {
                 Objects.equals(format, that.getFormat()) &&
                 Objects.equals(uniqueItemsBoolean, that.getUniqueItemsBoolean()) &&
                 Objects.equals(ref, that.getRef()) &&
+                Objects.equals(refModule, that.getRefModule()) &&
                 Objects.equals(requiredVarsMap, that.getRequiredVarsMap()) &&
                 Objects.equals(composedSchemas, that.composedSchemas) &&
                 Objects.equals(openApiType, that.openApiType) &&
@@ -1213,6 +1223,6 @@ public class CodegenProperty implements Cloneable, JsonSchema {
                 xmlNamespace, isXmlWrapped, isNull, additionalPropertiesIsAnyType, hasVars, hasRequired,
                 hasDiscriminatorWithNonEmptyMapping, composedSchemas, hasMultipleTypes, requiredVarsMap,
                 ref, uniqueItemsBoolean, schemaIsFromAdditionalProperties, isBooleanSchemaTrue, isBooleanSchemaFalse,
-                format, dependentRequired, contains);
+                format, dependentRequired, contains, refModule);
     }
 }

--- a/modules/openapi-json-schema-generator/src/main/java/org/openapitools/codegen/CodegenResponse.java
+++ b/modules/openapi-json-schema-generator/src/main/java/org/openapitools/codegen/CodegenResponse.java
@@ -37,6 +37,7 @@ public class CodegenResponse {
     private LinkedHashMap<String, CodegenMediaType> content;
     private String ref;
     public Set<String> imports = new TreeSet<>();
+    private String refModule;
 
     @Override
     public int hashCode() {
@@ -44,7 +45,7 @@ public class CodegenResponse {
                 jsonSchema, vendorExtensions,
                 is1xx, is2xx, is3xx, is4xx, is5xx, isDefault,
                 responseHeaders, content,
-                ref, imports);
+                ref, imports, refModule);
     }
 
     @Override
@@ -68,7 +69,8 @@ public class CodegenResponse {
                 Objects.equals(message, that.message) &&
                 Objects.equals(examples, that.examples) &&
                 Objects.equals(jsonSchema, that.jsonSchema) &&
-                Objects.equals(vendorExtensions, that.vendorExtensions);
+                Objects.equals(vendorExtensions, that.vendorExtensions) &&
+                Objects.equals(refModule, that.getRefModule());
 
     }
 
@@ -107,6 +109,7 @@ public class CodegenResponse {
         sb.append(", responseHeaders=").append(responseHeaders);
         sb.append(", content=").append(content);
         sb.append(", ref=").append(ref);
+        sb.append(", refModule=").append(refModule);
         sb.append(", imports=").append(imports);
         sb.append('}');
         return sb.toString();
@@ -132,4 +135,9 @@ public class CodegenResponse {
     public String getRef() { return ref; }
 
     public void setRef(String ref) { this.ref=ref; }
+
+    public String getRefModule() { return refModule; }
+
+    public void setRefModule(String refModule) { this.refModule=refModule; }
+
 }


### PR DESCRIPTION
Adds refModule to classes that can be imported, especially those in components
Note: CodegenProperty probably doesn't need it but it doesn't hurt to add it

refModule added to:
- CodegenParameter (request parameter, response headers, request body)
- CodegenResponse
- CodegenModel

This info will allow components to be generated in component modules and then import those into endpoints and codegenresponses

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-json-schema-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
