### PR TITLE
Fixes issues 90, allow access to deserialized body for non 2XX statuses

### DIFF
--- a/modules/openapi-json-schema-generator/src/main/resources/python/endpoint.handlebars
+++ b/modules/openapi-json-schema-generator/src/main/resources/python/endpoint.handlebars
@@ -393,7 +393,11 @@ class BaseApi(api_client.Api):
                 {{/if}}
 
         if not 200 <= response.status <= 299:
-            raise exceptions.ApiException(api_response=api_response)
+            raise exceptions.ApiException(
+                status=response.status,
+                reason=response.reason,
+                api_response=api_response
+            )
 
         return api_response
 

--- a/modules/openapi-json-schema-generator/src/main/resources/python/exceptions.handlebars
+++ b/modules/openapi-json-schema-generator/src/main/resources/python/exceptions.handlebars
@@ -1,6 +1,10 @@
 # coding: utf-8
 
 {{>partial_header}}
+import dataclasses
+import typing
+
+from urllib3._collections import HTTPHeaderDict
 
 
 class OpenApiException(Exception):
@@ -90,19 +94,27 @@ class ApiKeyError(OpenApiException, KeyError):
         super(ApiKeyError, self).__init__(full_msg)
 
 
-class ApiException(OpenApiException):
+T = typing.TypeVar("T")
 
-    def __init__(self, status=None, reason=None, api_response: '{{packageName}}.api_client.ApiResponse' = None):
-        if api_response:
-            self.status = api_response.response.status
-            self.reason = api_response.response.reason
-            self.body = api_response.response.data
-            self.headers = api_response.response.getheaders()
-        else:
-            self.status = status
-            self.reason = reason
-            self.body = None
-            self.headers = None
+
+@dataclasses.dataclass
+class ApiException(OpenApiException, typing.Generic[T]):
+    status: int
+    reason: str
+    api_response: typing.Optional[T] = None
+    headers: typing.Optional[HTTPHeaderDict]
+
+    @property
+    def body(self) -> typing.Union[str, bytes, None]:
+        if not self.api_response:
+            return None
+        return self.api_response.response.data
+
+    @property
+    def headers(self) -> typing.Optional[HTTPHeaderDict]:
+        if not self.api_response:
+            return None
+        return self.api_response.response.getheaders()
 
     def __str__(self):
         """Custom error messages for exception"""


### PR DESCRIPTION
Fixes issues 90, allow access to deserialized body for non 2XX statuses

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-json-schema-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
