### PR TITLE
Fixes fromModel arrayModel items assignment

### DIFF
--- a/modules/openapi-json-schema-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-json-schema-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2934,8 +2934,7 @@ public class DefaultCodegen implements CodegenConfig {
         m.setFormat(schema.getFormat());
         m.setComposedSchemas(getComposedSchemas(schema));
         if (ModelUtils.isArraySchema(schema)) {
-            String itemName = getItemsName(null, name);
-            CodegenProperty arrayProperty = fromProperty(itemName, schema, false);
+            CodegenProperty arrayProperty = fromProperty(name, schema, false);
             m.setItems(arrayProperty.items);
             m.arrayModelType = arrayProperty.complexType;
             addParentContainer(m, name, schema);
@@ -7910,16 +7909,10 @@ public class DefaultCodegen implements CodegenConfig {
     protected String handleSpecialCharacters(String name) { return name; }
 
     public String getItemsName(Schema containingSchema, String containingSchemaName) {
-        String itemName = null;
-        if (containingSchema != null) {
-            // fromProperty use case
-            if (containingSchema.getExtensions() != null && containingSchema.getExtensions().get("x-item-name") != null) {
-                return containingSchema.getExtensions().get("x-item-name").toString();
-            }
-            return toVarName(containingSchemaName);
+        if (containingSchema.getExtensions() != null && containingSchema.getExtensions().get("x-item-name") != null) {
+            return containingSchema.getExtensions().get("x-item-name").toString();
         }
-        // fromModel use case
-        return containingSchemaName;
+        return toVarName(containingSchemaName);
     }
 
     public String getAdditionalPropertiesName() {


### PR DESCRIPTION
Fixes fromModel arrayModel items assignment
The last PR made an incorrect change to how model arrayModel items are assigned

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-json-schema-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
