### PR TITLE
v2 fix python warnings when running pytest

### DIFF
--- a/modules/openapi-json-schema-generator/src/main/resources/python/api_client.handlebars
+++ b/modules/openapi-json-schema-generator/src/main/resources/python/api_client.handlebars
@@ -884,7 +884,7 @@ class OpenApiResponse(JSONDetector, TypedDictInputVerifier, typing.Generic[T]):
 
     @classmethod
     def deserialize(cls, response: urllib3.HTTPResponse, configuration: configuration_module.Configuration) -> T:
-        content_type = response.getheader('content-type')
+        content_type = response.headers.get('content-type')
         deserialized_body = schemas.unset
         streamed = response.supports_chunked_reads()
 
@@ -893,7 +893,7 @@ class OpenApiResponse(JSONDetector, TypedDictInputVerifier, typing.Generic[T]):
             cls._verify_typed_dict_inputs(cls.response_cls.headers, response.headers)
             deserialized_headers = {}
             for header_name, header_param in self.headers.items():
-                header_value = response.getheader(header_name)
+                header_value = response.headers.get(header_name)
                 if header_value is None:
                     continue
                 header_value = header_param.deserialize(header_value, header_name)
@@ -1094,7 +1094,7 @@ class ApiClient:
         :param stream: if True, the urllib3.HTTPResponse object will
                                  be returned without reading/decoding response
                                  data. Also when True, if the openapi spec describes a file download,
-                                 the data will be written to a local filesystme file and the schemas.BinarySchema
+                                 the data will be written to a local filesystem file and the schemas.BinarySchema
                                  instance will also inherit from FileSchema and schemas.FileIO
                                  Default is False.
         :type stream: bool, optional

--- a/modules/openapi-json-schema-generator/src/main/resources/python/exceptions.handlebars
+++ b/modules/openapi-json-schema-generator/src/main/resources/python/exceptions.handlebars
@@ -108,9 +108,9 @@ class ApiException(OpenApiException, typing.Generic[T]):
         error_message = "({0})\n"\
                         "Reason: {1}\n".format(self.status, self.reason)
         if self.api_response:
-            if self.api_response.response.getheaders():
+            if self.api_response.response.headers:
                 error_message += "HTTP response headers: {0}\n".format(
-                    self.api_response.response.getheaders())
+                    self.api_response.response.headers)
             if self.api_response.response.data:
                 error_message += "HTTP response body: {0}\n".format(self.api_response.response.data)
 

--- a/modules/openapi-json-schema-generator/src/main/resources/python/required_libraries.handlebars
+++ b/modules/openapi-json-schema-generator/src/main/resources/python/required_libraries.handlebars
@@ -13,4 +13,4 @@
 {{#if quoted}}"{{/if}}tornado >= 4.2{{#if quoted}}",{{/if}}
 {{/if}}
 {{#if quoted}}"{{/if}}typing_extensions ~= 4.3.0{{#if quoted}}",{{/if}}
-{{#if quoted}}"{{/if}}urllib3 ~= 1.26.7{{#if quoted}}",{{/if}}
+{{#if quoted}}"{{/if}}urllib3 ~= 2.0.a3{{#if quoted}}",{{/if}}

--- a/samples/openapi3/client/3_0_3_unit_test/python/pyproject.toml
+++ b/samples/openapi3/client/3_0_3_unit_test/python/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
     "python-dateutil ~= 2.7.0",
     "setuptools >= 61.0",
     "typing_extensions ~= 4.3.0",
-    "urllib3 ~= 1.26.7",
+    "urllib3 ~= 2.0.a3",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/samples/openapi3/client/3_0_3_unit_test/python/requirements.txt
+++ b/samples/openapi3/client/3_0_3_unit_test/python/requirements.txt
@@ -3,4 +3,4 @@ frozendict ~= 2.3.4
 python-dateutil ~= 2.7.0
 setuptools >= 61.0
 typing_extensions ~= 4.3.0
-urllib3 ~= 1.26.7
+urllib3 ~= 2.0.a3

--- a/samples/openapi3/client/3_0_3_unit_test/python/src/unit_test_api/api_client.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/src/unit_test_api/api_client.py
@@ -888,7 +888,7 @@ class OpenApiResponse(JSONDetector, TypedDictInputVerifier, typing.Generic[T]):
 
     @classmethod
     def deserialize(cls, response: urllib3.HTTPResponse, configuration: configuration_module.Configuration) -> T:
-        content_type = response.getheader('content-type')
+        content_type = response.headers.get('content-type')
         deserialized_body = schemas.unset
         streamed = response.supports_chunked_reads()
 
@@ -897,7 +897,7 @@ class OpenApiResponse(JSONDetector, TypedDictInputVerifier, typing.Generic[T]):
             cls._verify_typed_dict_inputs(cls.response_cls.headers, response.headers)
             deserialized_headers = {}
             for header_name, header_param in self.headers.items():
-                header_value = response.getheader(header_name)
+                header_value = response.headers.get(header_name)
                 if header_value is None:
                     continue
                 header_value = header_param.deserialize(header_value, header_name)
@@ -1095,7 +1095,7 @@ class ApiClient:
         :param stream: if True, the urllib3.HTTPResponse object will
                                  be returned without reading/decoding response
                                  data. Also when True, if the openapi spec describes a file download,
-                                 the data will be written to a local filesystme file and the schemas.BinarySchema
+                                 the data will be written to a local filesystem file and the schemas.BinarySchema
                                  instance will also inherit from FileSchema and schemas.FileIO
                                  Default is False.
         :type stream: bool, optional

--- a/samples/openapi3/client/3_0_3_unit_test/python/src/unit_test_api/exceptions.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/src/unit_test_api/exceptions.py
@@ -115,9 +115,9 @@ class ApiException(OpenApiException, typing.Generic[T]):
         error_message = "({0})\n"\
                         "Reason: {1}\n".format(self.status, self.reason)
         if self.api_response:
-            if self.api_response.response.getheaders():
+            if self.api_response.response.headers:
                 error_message += "HTTP response headers: {0}\n".format(
-                    self.api_response.response.getheaders())
+                    self.api_response.response.headers)
             if self.api_response.response.data:
                 error_message += "HTTP response body: {0}\n".format(self.api_response.response.data)
 

--- a/samples/openapi3/client/features/nonCompliantUseDiscriminatorIfCompositionFails/python/pyproject.toml
+++ b/samples/openapi3/client/features/nonCompliantUseDiscriminatorIfCompositionFails/python/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
     "python-dateutil ~= 2.7.0",
     "setuptools >= 61.0",
     "typing_extensions ~= 4.3.0",
-    "urllib3 ~= 1.26.7",
+    "urllib3 ~= 2.0.a3",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/samples/openapi3/client/features/nonCompliantUseDiscriminatorIfCompositionFails/python/requirements.txt
+++ b/samples/openapi3/client/features/nonCompliantUseDiscriminatorIfCompositionFails/python/requirements.txt
@@ -3,4 +3,4 @@ frozendict ~= 2.3.4
 python-dateutil ~= 2.7.0
 setuptools >= 61.0
 typing_extensions ~= 4.3.0
-urllib3 ~= 1.26.7
+urllib3 ~= 2.0.a3

--- a/samples/openapi3/client/features/nonCompliantUseDiscriminatorIfCompositionFails/python/src/this_package/api_client.py
+++ b/samples/openapi3/client/features/nonCompliantUseDiscriminatorIfCompositionFails/python/src/this_package/api_client.py
@@ -888,7 +888,7 @@ class OpenApiResponse(JSONDetector, TypedDictInputVerifier, typing.Generic[T]):
 
     @classmethod
     def deserialize(cls, response: urllib3.HTTPResponse, configuration: configuration_module.Configuration) -> T:
-        content_type = response.getheader('content-type')
+        content_type = response.headers.get('content-type')
         deserialized_body = schemas.unset
         streamed = response.supports_chunked_reads()
 
@@ -897,7 +897,7 @@ class OpenApiResponse(JSONDetector, TypedDictInputVerifier, typing.Generic[T]):
             cls._verify_typed_dict_inputs(cls.response_cls.headers, response.headers)
             deserialized_headers = {}
             for header_name, header_param in self.headers.items():
-                header_value = response.getheader(header_name)
+                header_value = response.headers.get(header_name)
                 if header_value is None:
                     continue
                 header_value = header_param.deserialize(header_value, header_name)
@@ -1095,7 +1095,7 @@ class ApiClient:
         :param stream: if True, the urllib3.HTTPResponse object will
                                  be returned without reading/decoding response
                                  data. Also when True, if the openapi spec describes a file download,
-                                 the data will be written to a local filesystme file and the schemas.BinarySchema
+                                 the data will be written to a local filesystem file and the schemas.BinarySchema
                                  instance will also inherit from FileSchema and schemas.FileIO
                                  Default is False.
         :type stream: bool, optional

--- a/samples/openapi3/client/features/nonCompliantUseDiscriminatorIfCompositionFails/python/src/this_package/exceptions.py
+++ b/samples/openapi3/client/features/nonCompliantUseDiscriminatorIfCompositionFails/python/src/this_package/exceptions.py
@@ -115,9 +115,9 @@ class ApiException(OpenApiException, typing.Generic[T]):
         error_message = "({0})\n"\
                         "Reason: {1}\n".format(self.status, self.reason)
         if self.api_response:
-            if self.api_response.response.getheaders():
+            if self.api_response.response.headers:
                 error_message += "HTTP response headers: {0}\n".format(
-                    self.api_response.response.getheaders())
+                    self.api_response.response.headers)
             if self.api_response.response.data:
                 error_message += "HTTP response body: {0}\n".format(self.api_response.response.data)
 

--- a/samples/openapi3/client/petstore/python/pyproject.toml
+++ b/samples/openapi3/client/petstore/python/pyproject.toml
@@ -9,7 +9,7 @@ requires = [
     "python-dateutil ~= 2.7.0",
     "setuptools >= 61.0",
     "typing_extensions ~= 4.3.0",
-    "urllib3 ~= 1.26.7",
+    "urllib3 ~= 2.0.a3",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/samples/openapi3/client/petstore/python/requirements.txt
+++ b/samples/openapi3/client/petstore/python/requirements.txt
@@ -5,4 +5,4 @@ pycryptodome >= 3.9.0
 python-dateutil ~= 2.7.0
 setuptools >= 61.0
 typing_extensions ~= 4.3.0
-urllib3 ~= 1.26.7
+urllib3 ~= 2.0.a3

--- a/samples/openapi3/client/petstore/python/src/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/src/petstore_api/api_client.py
@@ -888,7 +888,7 @@ class OpenApiResponse(JSONDetector, TypedDictInputVerifier, typing.Generic[T]):
 
     @classmethod
     def deserialize(cls, response: urllib3.HTTPResponse, configuration: configuration_module.Configuration) -> T:
-        content_type = response.getheader('content-type')
+        content_type = response.headers.get('content-type')
         deserialized_body = schemas.unset
         streamed = response.supports_chunked_reads()
 
@@ -897,7 +897,7 @@ class OpenApiResponse(JSONDetector, TypedDictInputVerifier, typing.Generic[T]):
             cls._verify_typed_dict_inputs(cls.response_cls.headers, response.headers)
             deserialized_headers = {}
             for header_name, header_param in self.headers.items():
-                header_value = response.getheader(header_name)
+                header_value = response.headers.get(header_name)
                 if header_value is None:
                     continue
                 header_value = header_param.deserialize(header_value, header_name)
@@ -1095,7 +1095,7 @@ class ApiClient:
         :param stream: if True, the urllib3.HTTPResponse object will
                                  be returned without reading/decoding response
                                  data. Also when True, if the openapi spec describes a file download,
-                                 the data will be written to a local filesystme file and the schemas.BinarySchema
+                                 the data will be written to a local filesystem file and the schemas.BinarySchema
                                  instance will also inherit from FileSchema and schemas.FileIO
                                  Default is False.
         :type stream: bool, optional

--- a/samples/openapi3/client/petstore/python/src/petstore_api/exceptions.py
+++ b/samples/openapi3/client/petstore/python/src/petstore_api/exceptions.py
@@ -115,9 +115,9 @@ class ApiException(OpenApiException, typing.Generic[T]):
         error_message = "({0})\n"\
                         "Reason: {1}\n".format(self.status, self.reason)
         if self.api_response:
-            if self.api_response.response.getheaders():
+            if self.api_response.response.headers:
                 error_message += "HTTP response headers: {0}\n".format(
-                    self.api_response.response.getheaders())
+                    self.api_response.response.headers)
             if self.api_response.response.data:
                 error_message += "HTTP response body: {0}\n".format(self.api_response.response.data)
 

--- a/samples/openapi3/client/petstore/python/tests_manual/__init__.py
+++ b/samples/openapi3/client/petstore/python/tests_manual/__init__.py
@@ -1,4 +1,5 @@
 import collections
+import http
 import json
 import typing
 import unittest
@@ -87,7 +88,7 @@ class ApiTestMixin(unittest.TestCase):
     @classmethod
     def response(
         cls,
-        body: typing.Union[str, bytes],
+        body: typing.Union[str, bytes, http.client.HTTPResponse],
         status: int = 200,
         content_type: str = json_content_type,
         headers: typing.Optional[typing.Dict[str, str]] = None,
@@ -102,7 +103,8 @@ class ApiTestMixin(unittest.TestCase):
             headers=headers,
             status=status,
             preload_content=preload_content,
-            reason=reason
+            reason=reason,
+            auto_close = True
         )
 
     @staticmethod

--- a/samples/openapi3/client/petstore/python/tests_manual/test_fake_api.py
+++ b/samples/openapi3/client/petstore/python/tests_manual/test_fake_api.py
@@ -349,7 +349,6 @@ class TestFakeApi(ApiTestMixin):
             content_type='application/octet-stream',
             preload_content=False
         )
-        print('streamable_body.length ', streamable_body.length)
         with patch.object(RESTClientObject, 'request') as mock_request:
             mock_request.return_value = mock_response
             api_response = self.api.upload_download_file(body=file_bytes, stream=True)


### PR DESCRIPTION
v2 fix python warnings when running pytest
- these were from urllib3's update letting users know not to use deprecated methods that will be removed in the future
- urllib3 version now pegged to ~= 2.0.0a3
- stopped using deprecated urllib3 methods
- fixed tests

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-json-schema-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
