### PR TITLE
v3 updates java version 11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,7 @@ commands: # a reusable command with parameters
 jobs:
   node0:
     machine:
-      image: ubuntu-2004:2023.07.1
+      image: ubuntu-2004:202201-02
     working_directory: ~/OpenAPITools/openapi-json-schema-generator
     shell: /bin/bash --login
     environment:
@@ -151,7 +151,7 @@ jobs:
           nodeNo: "0"
   node1:
     machine:
-      image: ubuntu-2004:2023.07.1
+      image: ubuntu-2004:202201-02
     working_directory: ~/OpenAPITools/openapi-json-schema-generator
     shell: /bin/bash --login
     environment:
@@ -162,7 +162,7 @@ jobs:
           nodeNo: "1"
   node2:
     machine:
-      image: ubuntu-2004:2023.07.1
+      image: ubuntu-2004:202201-02
     working_directory: ~/OpenAPITools/openapi-json-schema-generator
     shell: /bin/bash --login
     environment:
@@ -173,7 +173,7 @@ jobs:
           nodeNo: "2"
   node3:
     machine:
-      image: ubuntu-2004:2023.07.1
+      image: ubuntu-2004:202201-02
     working_directory: ~/OpenAPITools/openapi-json-schema-generator
     shell: /bin/bash --login
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,7 @@ commands: # a reusable command with parameters
 jobs:
   node0:
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2004:2023.07.1
     working_directory: ~/OpenAPITools/openapi-json-schema-generator
     shell: /bin/bash --login
     environment:
@@ -151,7 +151,7 @@ jobs:
           nodeNo: "0"
   node1:
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2004:2023.07.1
     working_directory: ~/OpenAPITools/openapi-json-schema-generator
     shell: /bin/bash --login
     environment:
@@ -162,7 +162,7 @@ jobs:
           nodeNo: "1"
   node2:
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2004:2023.07.1
     working_directory: ~/OpenAPITools/openapi-json-schema-generator
     shell: /bin/bash --login
     environment:
@@ -173,7 +173,7 @@ jobs:
           nodeNo: "2"
   node3:
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2004:2023.07.1
     working_directory: ~/OpenAPITools/openapi-json-schema-generator
     shell: /bin/bash --login
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ commands: # a reusable command with parameters
       - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
       # This is based on your 1.0 configuration file or project settings
       - run:
-          command: sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java; sudo update-alternatives --set javac /usr/lib/jvm/java-8-openjdk-amd64/bin/javac; echo -e "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64" >> $BASH_ENV
+          command: java -version
       - run:
           command: 'sudo docker info >/dev/null 2>&1 || sudo service docker start; '
       - run:

--- a/.github/workflows/check-supported-versions.yaml
+++ b/.github/workflows/check-supported-versions.yaml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [8, 11]
+        java: [11, 17]
         os: [ubuntu-latest]
         include:
-          - java: 8
+          - java: 11
             os: windows-latest
           - java: 17
             os: ubuntu-latest
@@ -51,7 +51,7 @@ jobs:
 
       - name: Upload Maven build artifact
         uses: actions/upload-artifact@v3
-        if: matrix.java == '8' && matrix.os == 'ubuntu-latest'
+        if: matrix.java == '11' && matrix.os == 'ubuntu-latest'
         with:
           name: artifact
           path: modules/openapi-generator-cli/target/openapi-generator-cli.jar
@@ -61,7 +61,7 @@ jobs:
         run: gradle -b modules/openapi-generator-gradle-plugin/samples/local-spec/build.gradle buildGoSdk --stacktrace
 
       - name: Test Maven plugin integration
-        if: matrix.java == '8'
+        if: matrix.java == '11'
         shell: bash
         run: |
           cd modules/openapi-generator-maven-plugin

--- a/.github/workflows/openapi-generator.yaml
+++ b/.github/workflows/openapi-generator.yaml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          java-version: 8
+          java-version: 11
           distribution: 'temurin'
       - name: Cache maven dependencies
         uses: actions/cache@v3
@@ -52,10 +52,10 @@ jobs:
       - build
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          java-version: 8
+          java-version: 11
           distribution: 'temurin'
       - name: Cache maven dependencies
         uses: actions/cache@v3
@@ -87,10 +87,10 @@ jobs:
       - build
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          java-version: 8
+          java-version: 11
           distribution: 'temurin'
       - name: Download openapi-generator-cli.jar artifact
         uses: actions/download-artifact@v3
@@ -125,10 +125,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          java-version: 8
+          java-version: 11
           distribution: 'temurin'
       - name: Download openapi-generator-cli.jar artifact
         uses: actions/download-artifact@v3

--- a/.gitignore
+++ b/.gitignore
@@ -46,9 +46,6 @@ test-output/
 nbactions.xml
 test-output/
 
-# jgit is making a local file in ? dir, needs a version upgrade
-?
-
 # scalatra
 samples/server-generator/scalatra/output
 samples/server-generator/scalatra/target

--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ The OpenAPI Specification has undergone 3 revisions since initial creation in 20
 
 To build from source, you need the following installed and available in your `$PATH:`
 
-* [Java 8](https://www.oracle.com/technetwork/java/index.html)
+* [Java 11](https://www.oracle.com/technetwork/java/index.html)
 
-* [Apache Maven 3.3.4 or greater](https://maven.apache.org/)
+* [Apache Maven 3.8.0 or greater](https://maven.apache.org/)
 
 After cloning the project, you can build it from source with this command:
 ```sh

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ To build from source, you need the following installed and available in your `$P
 
 * [Java 11](https://www.oracle.com/technetwork/java/index.html)
 
-* [Apache Maven 3.8.0 or greater](https://maven.apache.org/)
+* [Apache Maven 3.9.3 or greater](https://maven.apache.org/)
 
 After cloning the project, you can build it from source with this command:
 ```sh

--- a/pom.xml
+++ b/pom.xml
@@ -421,8 +421,9 @@
         <revision>3.0.0</revision>
         <!-- /RELEASE_VERSION -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <java.version>11</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
         <archunit.version>0.23.1</archunit.version>
         <checkstyle.plugin.version>3.1.0</checkstyle.plugin.version>
         <commons-cli.version>1.4</commons-cli.version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,27 @@
         <finalName>${project.artifactId}</finalName>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven-javadoc-plugin.version}</version>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <encoding>UTF-8</encoding>
+                    <maxmemory>1g</maxmemory>
+                    <failOnWarnings>false</failOnWarnings>
+                    <doclint>none</doclint>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <version>${spotbugs-plugin.version}</version>
@@ -429,7 +450,7 @@
         <commons-text.version>1.9</commons-text.version>
         <diffutils.version>1.3.0</diffutils.version>
         <generex.version>1.0.2</generex.version>
-        <git-commit-id-plugin.version>5.0.1</git-commit-id-plugin.version><!--5.0.1 needs java11, will fix jgit issue-->
+        <git-commit-id-plugin.version>5.0.1</git-commit-id-plugin.version>
         <groovy.version>3.0.9</groovy.version>
         <guava.version>30.1.1-jre</guava.version>
         <handlebars-java.version>4.3.0</handlebars-java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -76,8 +76,8 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>pl.project13.maven</groupId>
-                <artifactId>git-commit-id-plugin</artifactId>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
                 <version>${git-commit-id-plugin.version}</version>
                 <executions>
                     <execution>
@@ -166,10 +166,7 @@
                         </goals>
                         <configuration>
                             <minimizeJar>false</minimizeJar>
-                            <createDependencyReducedPom>true</createDependencyReducedPom>
-                            <dependencyReducedPomLocation>
-                                ${java.io.tmpdir}/dependency-reduced-pom.xml
-                            </dependencyReducedPomLocation>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <transformers>
                                 <transformer
                                         implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
@@ -432,7 +429,7 @@
         <commons-text.version>1.9</commons-text.version>
         <diffutils.version>1.3.0</diffutils.version>
         <generex.version>1.0.2</generex.version>
-        <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version><!--5.0.1 needs java11, will fix jgit issue-->
+        <git-commit-id-plugin.version>5.0.1</git-commit-id-plugin.version><!--5.0.1 needs java11, will fix jgit issue-->
         <groovy.version>3.0.9</groovy.version>
         <guava.version>30.1.1-jre</guava.version>
         <handlebars-java.version>4.3.0</handlebars-java.version>


### PR DESCRIPTION
- v3 updates java to java 11 because java8 is no longer supported

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
