### PR TITLE
CircleCi cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ commands: # a reusable command with parameters
   command_build_and_test:
     parameters:
       jobId:
-        default: "0"
+        default: "unset"
         type: string
     steps:
       # Restore the dependency cache
@@ -47,7 +47,6 @@ commands: # a reusable command with parameters
       - run: sleep 30
       - run: cat /etc/hosts
       # Test
-      - run: mvn --no-snapshot-updates --quiet clean install -Dorg.slf4j.simpleLogger.defaultLogLevel=error
       - run:
           name: "Setup custom environment variables"
           command: echo 'export CIRCLE_JOB_ID="<<parameters.jobId>>"' >> $BASH_ENV
@@ -106,7 +105,7 @@ commands: # a reusable command with parameters
   command_docker_build_and_test:
     parameters:
       jobId:
-        default: "0"
+        default: "unset"
         type: string
     steps:
       # Machine Setup
@@ -138,17 +137,6 @@ commands: # a reusable command with parameters
       - store_artifacts:
           path: /tmp/circleci-test-results
 jobs:
-  job0:
-    machine:
-      image: ubuntu-2004:202201-02
-    working_directory: ~/OpenAPITools/openapi-json-schema-generator
-    shell: /bin/bash --login
-    environment:
-      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
-      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
-    steps:
-      - command_build_and_test:
-          jobId: "0"
   ensureSamplesAndGeneratorDocsUpToDate:
     machine:
       image: ubuntu-2004:202201-02
@@ -160,7 +148,7 @@ jobs:
     steps:
       - command_build_and_test:
           jobId: "ensureSamplesAndGeneratorDocsUpToDate"
-  job2:
+  mvnCleanInstall:
     machine:
       image: ubuntu-2004:202201-02
     working_directory: ~/OpenAPITools/openapi-json-schema-generator
@@ -170,7 +158,7 @@ jobs:
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     steps:
       - command_build_and_test:
-          jobId: "2"
+          jobId: "mvnCleanInstall"
   testPythonClientSamples:
     docker:
       - image: python:3.8
@@ -187,7 +175,6 @@ workflows:
   version: 2
   build:
     jobs:
-      - job0
       - ensureSamplesAndGeneratorDocsUpToDate
-      - job2
+      - mvnCleanInstall
       - testPythonClientSamples

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 commands: # a reusable command with parameters
   command_build_and_test:
     parameters:
-      nodeId:
+      jobId:
         default: "0"
         type: string
     steps:
@@ -50,7 +50,7 @@ commands: # a reusable command with parameters
       - run: mvn --no-snapshot-updates --quiet clean install -Dorg.slf4j.simpleLogger.defaultLogLevel=error
       - run:
           name: "Setup custom environment variables"
-          command: echo 'export CIRCLE_NODE_ID="<<parameters.nodeId>>"' >> $BASH_ENV
+          command: echo 'export CIRCLE_JOB_ID="<<parameters.jobId>>"' >> $BASH_ENV
       - run: ./.circleci/parallel.sh
       # Save dependency cache
       - save_cache:
@@ -105,7 +105,7 @@ commands: # a reusable command with parameters
           path: /tmp/circleci-test-results
   command_docker_build_and_test:
     parameters:
-      nodeId:
+      jobId:
         default: "0"
         type: string
     steps:
@@ -125,7 +125,7 @@ commands: # a reusable command with parameters
       #      - run: mvn --no-snapshot-updates --quiet clean install -Dorg.slf4j.simpleLogger.defaultLogLevel=error
       - run:
           name: "Setup custom environment variables"
-          command: echo 'export CIRCLE_NODE_ID="<<parameters.nodeId>>"' >> $BASH_ENV
+          command: echo 'export CIRCLE_JOB_ID="<<parameters.jobId>>"' >> $BASH_ENV
       - run: ./.circleci/parallel.sh
       # Teardown
       #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
@@ -138,7 +138,7 @@ commands: # a reusable command with parameters
       - store_artifacts:
           path: /tmp/circleci-test-results
 jobs:
-  node0:
+  job0:
     machine:
       image: ubuntu-2004:202201-02
     working_directory: ~/OpenAPITools/openapi-json-schema-generator
@@ -148,8 +148,8 @@ jobs:
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     steps:
       - command_build_and_test:
-          nodeId: "0"
-  node1:
+          jobId: "0"
+  job1:
     machine:
       image: ubuntu-2004:202201-02
     working_directory: ~/OpenAPITools/openapi-json-schema-generator
@@ -159,8 +159,8 @@ jobs:
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     steps:
       - command_build_and_test:
-          nodeId: "1"
-  node2:
+          jobId: "1"
+  job2:
     machine:
       image: ubuntu-2004:202201-02
     working_directory: ~/OpenAPITools/openapi-json-schema-generator
@@ -170,8 +170,8 @@ jobs:
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     steps:
       - command_build_and_test:
-          nodeId: "2"
-  node3:
+          jobId: "2"
+  job3:
     docker:
       - image: python:3.8
     working_directory: ~/OpenAPITools/openapi-json-schema-generator
@@ -182,12 +182,12 @@ jobs:
     steps:
       - checkout
       - command_docker_build_and_test:
-          nodeId: "3"
+          jobId: "3"
 workflows:
   version: 2
   build:
     jobs:
-      - node0
-      - node1
-      - node2
-      - node3
+      - job0
+      - job1
+      - job2
+      - job3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 commands: # a reusable command with parameters
   command_build_and_test:
     parameters:
-      nodeNo:
+      nodeId:
         default: "0"
         type: string
     steps:
@@ -50,7 +50,7 @@ commands: # a reusable command with parameters
       - run: mvn --no-snapshot-updates --quiet clean install -Dorg.slf4j.simpleLogger.defaultLogLevel=error
       - run:
           name: "Setup custom environment variables"
-          command: echo 'export CIRCLE_NODE_INDEX="<<parameters.nodeNo>>"' >> $BASH_ENV
+          command: echo 'export CIRCLE_NODE_ID="<<parameters.nodeId>>"' >> $BASH_ENV
       - run: ./.circleci/parallel.sh
       # Save dependency cache
       - save_cache:
@@ -105,7 +105,7 @@ commands: # a reusable command with parameters
           path: /tmp/circleci-test-results
   command_docker_build_and_test:
     parameters:
-      nodeNo:
+      nodeId:
         default: "0"
         type: string
     steps:
@@ -125,7 +125,7 @@ commands: # a reusable command with parameters
       #      - run: mvn --no-snapshot-updates --quiet clean install -Dorg.slf4j.simpleLogger.defaultLogLevel=error
       - run:
           name: "Setup custom environment variables"
-          command: echo 'export CIRCLE_NODE_INDEX="<<parameters.nodeNo>>"' >> $BASH_ENV
+          command: echo 'export CIRCLE_NODE_ID="<<parameters.nodeId>>"' >> $BASH_ENV
       - run: ./.circleci/parallel.sh
       # Teardown
       #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
@@ -148,7 +148,7 @@ jobs:
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     steps:
       - command_build_and_test:
-          nodeNo: "0"
+          nodeId: "0"
   node1:
     machine:
       image: ubuntu-2004:202201-02
@@ -159,7 +159,7 @@ jobs:
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     steps:
       - command_build_and_test:
-          nodeNo: "1"
+          nodeId: "1"
   node2:
     machine:
       image: ubuntu-2004:202201-02
@@ -170,7 +170,7 @@ jobs:
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     steps:
       - command_build_and_test:
-          nodeNo: "2"
+          nodeId: "2"
   node3:
     machine:
       image: ubuntu-2004:202201-02
@@ -182,7 +182,7 @@ jobs:
     steps:
       - checkout
       - command_build_and_test:
-          nodeNo: "3"
+          nodeId: "3"
   node4:
     docker:
       - image: python:3.8
@@ -194,7 +194,7 @@ jobs:
     steps:
       - checkout
       - command_docker_build_and_test:
-          nodeNo: "4"
+          nodeId: "4"
 workflows:
   version: 2
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,7 @@ jobs:
     steps:
       - command_build_and_test:
           jobId: "2"
-  job3:
+  testPythonClientSamples:
     docker:
       - image: python:3.8
     working_directory: ~/OpenAPITools/openapi-json-schema-generator
@@ -182,7 +182,7 @@ jobs:
     steps:
       - checkout
       - command_docker_build_and_test:
-          jobId: "3"
+          jobId: "testPythonClientSamples"
 workflows:
   version: 2
   build:
@@ -190,4 +190,4 @@ workflows:
       - job0
       - job1
       - job2
-      - job3
+      - testPythonClientSamples

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,7 @@ jobs:
     steps:
       - command_build_and_test:
           jobId: "0"
-  job1:
+  ensureSamplesAndGeneratorDocsUpToDate:
     machine:
       image: ubuntu-2004:202201-02
     working_directory: ~/OpenAPITools/openapi-json-schema-generator
@@ -159,7 +159,7 @@ jobs:
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     steps:
       - command_build_and_test:
-          jobId: "1"
+          jobId: "ensureSamplesAndGeneratorDocsUpToDate"
   job2:
     machine:
       image: ubuntu-2004:202201-02
@@ -188,6 +188,6 @@ workflows:
   build:
     jobs:
       - job0
-      - job1
+      - ensureSamplesAndGeneratorDocsUpToDate
       - job2
       - testPythonClientSamples

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,17 +13,6 @@ commands: # a reusable command with parameters
             - source-v2-{{ .Branch }}-{{ .Revision }}
             - source-v2-{{ .Branch }}-
             - source-v2-
-      # Machine Setup
-      #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
-      - run:
-          name: Install Headless Chrome dependencies
-          command: |
-            sudo apt-get update && sudo apt-get install -yq \
-            gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
-            libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
-            libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 \
-            libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates \
-            fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget libgbm1
       # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
       - checkout
       # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
@@ -33,19 +22,6 @@ commands: # a reusable command with parameters
       # This is based on your 1.0 configuration file or project settings
       - run:
           command: java -version
-      - run:
-          command: 'sudo docker info >/dev/null 2>&1 || sudo service docker start; '
-      - run:
-          command: |-
-            printf '127.0.0.1       petstore.swagger.io
-            ' | sudo tee -a /etc/hosts
-      #    - run: docker pull openapijsonschematools/openapi-petstore
-      #    - run: docker run -d -e OPENAPI_BASE_PATH=/v3 -e DISABLE_API_KEY=1 -e DISABLE_OAUTH=1 -p 80:8080 openapijsonschematools/openapi-petstore
-      - run: docker pull swaggerapi/petstore
-      - run: docker run --name petstore.swagger -d -e SWAGGER_HOST=http://petstore.swagger.io -e SWAGGER_BASE_PATH=/v2 -p 80:8080 swaggerapi/petstore
-      - run: docker ps -a
-      - run: sleep 30
-      - run: cat /etc/hosts
       # Test
       - run:
           name: "Setup custom environment variables"
@@ -58,19 +34,16 @@ commands: # a reusable command with parameters
             # This is a broad list of cache paths to include many possible development environments
             # You can probably delete some of these entries
             - vendor/bundle
-            - ~/.nvm
             - ~/.pyenv
             - ~/virtualenvs
             - ~/.m2
             - ~/.ivy2
             - ~/.sbt
             - ~/.bundle
-            - ~/.go_workspace
             - ~/.gradle
             - ~/.cache/bower
             - ".git"
             - ~/.stack
-            - ~/R
       # save "default" cache using the key "source-v2-"
       - save_cache:
           key: source-v2-
@@ -78,20 +51,16 @@ commands: # a reusable command with parameters
             # This is a broad list of cache paths to include many possible development environments
             # You can probably delete some of these entries
             - vendor/bundle
-            - ~/.nvm
             - ~/.pyenv
             - ~/virtualenvs
             - ~/.m2
             - ~/.ivy2
             - ~/.sbt
             - ~/.bundle
-            - ~/.go_workspace
             - ~/.gradle
             - ~/.cache/bower
             - ".git"
             - ~/.stack
-            - /home/circleci/OpenAPITools/openapi-json-schema-generator/samples/client/petstore/haskell-http-client/.stack-work
-            - ~/R
       # Teardown
       #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
       # Save test results
@@ -116,12 +85,6 @@ commands: # a reusable command with parameters
       # In many cases you can simplify this from what is generated here.
       # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
       - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
-      # This is based on your 1.0 configuration file or project settings
-      #      - run:
-      #          command: sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java; sudo update-alternatives --set javac /usr/lib/jvm/java-8-openjdk-amd64/bin/javac; echo -e "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64" >> $BASH_ENV
-      #      - run:
-      # Test
-      #      - run: mvn --no-snapshot-updates --quiet clean install -Dorg.slf4j.simpleLogger.defaultLogLevel=error
       - run:
           name: "Setup custom environment variables"
           command: echo 'export CIRCLE_JOB_ID="<<parameters.jobId>>"' >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,18 +172,6 @@ jobs:
       - command_build_and_test:
           nodeId: "2"
   node3:
-    machine:
-      image: ubuntu-2004:202201-02
-    working_directory: ~/OpenAPITools/openapi-json-schema-generator
-    shell: /bin/bash --login
-    environment:
-      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
-      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
-    steps:
-      - checkout
-      - command_build_and_test:
-          nodeId: "3"
-  node4:
     docker:
       - image: python:3.8
     working_directory: ~/OpenAPITools/openapi-json-schema-generator
@@ -194,7 +182,7 @@ jobs:
     steps:
       - checkout
       - command_docker_build_and_test:
-          nodeId: "4"
+          nodeId: "3"
 workflows:
   version: 2
   build:
@@ -203,4 +191,3 @@ workflows:
       - node1
       - node2
       - node3
-      - node4

--- a/.circleci/parallel.sh
+++ b/.circleci/parallel.sh
@@ -3,7 +3,7 @@
 # A bash script to run CircleCI node/test in parallel
 #
 
-NODE_INDEX=${CIRCLE_NODE_INDEX:-0}
+NODE_ID=${CIRCLE_NODE_ID:-0}
 
 set -e
 
@@ -11,28 +11,28 @@ export NODE_ENV=test
 
 function cleanup {
   # Show logs of 'petstore.swagger' container to troubleshoot Unit Test failures, if any.
-  if [ "$NODE_INDEX" != "4" ]; then
+  if [ "$NODE_ID" != "4" ]; then
     docker logs petstore.swagger # container name specified in circle.yml
   fi
 }
 
 trap cleanup EXIT
 
-if [ "$NODE_INDEX" = "1" ]; then
+if [ "$NODE_ID" = "1" ]; then
   # node1
   # ensures samples + docs up to date
-  echo "Running node $NODE_INDEX"
+  echo "Running node $NODE_ID"
 
   ./bin/utils/ensure-up-to-date
 
-elif [ "$NODE_INDEX" = "2" ]; then
+elif [ "$NODE_ID" = "2" ]; then
   # node2
-  echo "Running node $NODE_INDEX"
+  echo "Running node $NODE_ID"
 
-elif [ "$NODE_INDEX" = "3" ]; then
+elif [ "$NODE_ID" = "3" ]; then
   # node3
 
-  echo "Running node $NODE_INDEX to test 'samples.circleci.node3' defined in pom.xml ..."
+  echo "Running node $NODE_ID to test 'samples.circleci.node3' defined in pom.xml ..."
   #wget https://www.python.org/ftp/python/3.8.9/Python-3.8.9.tgz
   #tar -xf Python-3.8.9.tgz
   #cd Python-3.8.9
@@ -61,10 +61,10 @@ elif [ "$NODE_INDEX" = "3" ]; then
   # no longer testing python-prior
   #mvn --no-snapshot-updates --quiet verify -Psamples.circleci.node3 -Dorg.slf4j.simpleLogger.defaultLogLevel=error
 
-elif [ "$NODE_INDEX" = "4" ]; then
+elif [ "$NODE_ID" = "4" ]; then
   # node4
 
-  echo "Running node $NODE_INDEX to test 'samples.circleci.node4' defined in pom.xml ..."
+  echo "Running node $NODE_ID to test 'samples.circleci.node4' defined in pom.xml ..."
 
   #mvn --no-snapshot-updates --quiet verify -Psamples.circleci.node4 -Dorg.slf4j.simpleLogger.defaultLogLevel=error
   (cd samples/client/petstore/python && make test)
@@ -73,7 +73,7 @@ elif [ "$NODE_INDEX" = "4" ]; then
   (cd samples/client/openapi_features/security/python && make test)
 
 else
-  echo "Running node $NODE_INDEX"
+  echo "Running node $NODE_ID"
 
 fi
 

--- a/.circleci/parallel.sh
+++ b/.circleci/parallel.sh
@@ -25,11 +25,11 @@ if [ "$JOB_ID" = "1" ]; then
 
   ./bin/utils/ensure-up-to-date
 
-elif [ "$NODE_ID" = "2" ]; then
+elif [ "$JOB_ID" = "2" ]; then
   # node2
   echo "Running job $JOB_ID"
 
-elif [ "$NODE_ID" = "3" ]; then
+elif [ "$JOB_ID" = "3" ]; then
   # node4
 
   echo "Running job $JOB_ID to test python client samples ..."

--- a/.circleci/parallel.sh
+++ b/.circleci/parallel.sh
@@ -18,7 +18,7 @@ function cleanup {
 
 trap cleanup EXIT
 
-if [ "$JOB_ID" = "1" ]; then
+if [ "$JOB_ID" = "ensureSamplesAndGeneratorDocsUpToDate" ]; then
   # node1
   # ensures samples + docs up to date
   echo "Running job $JOB_ID"

--- a/.circleci/parallel.sh
+++ b/.circleci/parallel.sh
@@ -30,43 +30,10 @@ elif [ "$NODE_ID" = "2" ]; then
   echo "Running node $NODE_ID"
 
 elif [ "$NODE_ID" = "3" ]; then
-  # node3
-
-  echo "Running node $NODE_ID to test 'samples.circleci.node3' defined in pom.xml ..."
-  #wget https://www.python.org/ftp/python/3.8.9/Python-3.8.9.tgz
-  #tar -xf Python-3.8.9.tgz
-  #cd Python-3.8.9
-  #./configure --enable-optimizations
-  #sudo make altinstall
-  pyenv install --list 
-  pyenv install 3.6.3
-  pyenv install 2.7.14
-  pyenv global 3.6.3
-
-  # Install node@stable (for angular 6)
-  set +e
-  curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
-  export NVM_DIR="/opt/circleci/.nvm"
-  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-  #nvm install stable
-  # install v16 instead of the latest stable version
-  nvm install 16
-  nvm alias default 16
-  node --version
-
-  # Each step uses the same `$BASH_ENV`, so need to modify it
-  echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
-  echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
-
-  # no longer testing python-prior
-  #mvn --no-snapshot-updates --quiet verify -Psamples.circleci.node3 -Dorg.slf4j.simpleLogger.defaultLogLevel=error
-
-elif [ "$NODE_ID" = "4" ]; then
   # node4
 
-  echo "Running node $NODE_ID to test 'samples.circleci.node4' defined in pom.xml ..."
+  echo "Running node $NODE_ID to test python client samples ..."
 
-  #mvn --no-snapshot-updates --quiet verify -Psamples.circleci.node4 -Dorg.slf4j.simpleLogger.defaultLogLevel=error
   (cd samples/client/petstore/python && make test)
   (cd samples/client/3_0_3_unit_test/python && make test)
   (cd samples/client/openapi_features/nonCompliantUseDiscriminatorIfCompositionFails/python && make test)

--- a/.circleci/parallel.sh
+++ b/.circleci/parallel.sh
@@ -11,7 +11,7 @@ export NODE_ENV=test
 
 function cleanup {
   # Show logs of 'petstore.swagger' container to troubleshoot Unit Test failures, if any.
-  if [ "$JOB_ID" != "3" ]; then
+  if [ "$JOB_ID" != "testPythonClientSamples" ]; then
     docker logs petstore.swagger # container name specified in circle.yml
   fi
 }

--- a/.circleci/parallel.sh
+++ b/.circleci/parallel.sh
@@ -29,10 +29,9 @@ elif [ "$JOB_ID" = "2" ]; then
   # node2
   echo "Running job $JOB_ID"
 
-elif [ "$JOB_ID" = "3" ]; then
-  # node4
+elif [ "$JOB_ID" = "testPythonClientSamples" ]; then
 
-  echo "Running job $JOB_ID to test python client samples ..."
+  echo "Running job $JOB_ID ..."
 
   (cd samples/client/petstore/python && make test)
   (cd samples/client/3_0_3_unit_test/python && make test)

--- a/.circleci/parallel.sh
+++ b/.circleci/parallel.sh
@@ -11,7 +11,7 @@ export NODE_ENV=test
 
 function cleanup {
   # Show logs of 'petstore.swagger' container to troubleshoot Unit Test failures, if any.
-  if [ "$NODE_ID" != "4" ]; then
+  if [ "$NODE_ID" != "3" ]; then
     docker logs petstore.swagger # container name specified in circle.yml
   fi
 }

--- a/.circleci/parallel.sh
+++ b/.circleci/parallel.sh
@@ -9,15 +9,6 @@ set -e
 
 export NODE_ENV=test
 
-function cleanup {
-  # Show logs of 'petstore.swagger' container to troubleshoot Unit Test failures, if any.
-  if [ "$JOB_ID" != "testPythonClientSamples" ]; then
-    docker logs petstore.swagger # container name specified in circle.yml
-  fi
-}
-
-trap cleanup EXIT
-
 if [ "$JOB_ID" = "ensureSamplesAndGeneratorDocsUpToDate" ]; then
   echo "Running job $JOB_ID"
   ./bin/utils/ensure-up-to-date

--- a/.circleci/parallel.sh
+++ b/.circleci/parallel.sh
@@ -3,7 +3,7 @@
 # A bash script to run CircleCI node/test in parallel
 #
 
-JOB_ID=${CIRCLE_JOB_ID:-0}
+JOB_ID=${CIRCLE_JOB_ID:-"unset"}
 
 set -e
 
@@ -19,20 +19,15 @@ function cleanup {
 trap cleanup EXIT
 
 if [ "$JOB_ID" = "ensureSamplesAndGeneratorDocsUpToDate" ]; then
-  # node1
-  # ensures samples + docs up to date
   echo "Running job $JOB_ID"
-
   ./bin/utils/ensure-up-to-date
 
-elif [ "$JOB_ID" = "2" ]; then
-  # node2
+elif [ "$JOB_ID" = "mvnCleanInstall" ]; then
   echo "Running job $JOB_ID"
+  mvn --no-snapshot-updates --quiet clean install -Dorg.slf4j.simpleLogger.defaultLogLevel=error
 
 elif [ "$JOB_ID" = "testPythonClientSamples" ]; then
-
   echo "Running job $JOB_ID ..."
-
   (cd samples/client/petstore/python && make test)
   (cd samples/client/3_0_3_unit_test/python && make test)
   (cd samples/client/openapi_features/nonCompliantUseDiscriminatorIfCompositionFails/python && make test)

--- a/.circleci/parallel.sh
+++ b/.circleci/parallel.sh
@@ -3,7 +3,7 @@
 # A bash script to run CircleCI node/test in parallel
 #
 
-NODE_ID=${CIRCLE_NODE_ID:-0}
+JOB_ID=${CIRCLE_JOB_ID:-0}
 
 set -e
 
@@ -11,28 +11,28 @@ export NODE_ENV=test
 
 function cleanup {
   # Show logs of 'petstore.swagger' container to troubleshoot Unit Test failures, if any.
-  if [ "$NODE_ID" != "3" ]; then
+  if [ "$JOB_ID" != "3" ]; then
     docker logs petstore.swagger # container name specified in circle.yml
   fi
 }
 
 trap cleanup EXIT
 
-if [ "$NODE_ID" = "1" ]; then
+if [ "$JOB_ID" = "1" ]; then
   # node1
   # ensures samples + docs up to date
-  echo "Running node $NODE_ID"
+  echo "Running job $JOB_ID"
 
   ./bin/utils/ensure-up-to-date
 
 elif [ "$NODE_ID" = "2" ]; then
   # node2
-  echo "Running node $NODE_ID"
+  echo "Running job $JOB_ID"
 
 elif [ "$NODE_ID" = "3" ]; then
   # node4
 
-  echo "Running node $NODE_ID to test python client samples ..."
+  echo "Running job $JOB_ID to test python client samples ..."
 
   (cd samples/client/petstore/python && make test)
   (cd samples/client/3_0_3_unit_test/python && make test)
@@ -40,7 +40,7 @@ elif [ "$NODE_ID" = "3" ]; then
   (cd samples/client/openapi_features/security/python && make test)
 
 else
-  echo "Running node $NODE_ID"
+  echo "Running job $JOB_ID"
 
 fi
 


### PR DESCRIPTION
CircleCi cleanup
- job qty reduced from 5 to 3
- removed unused docker petstore server
- changed from numbered to string job identifiers to show what each job does

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
