### PR TITLE
Adds python 3.9 CI testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,9 +122,21 @@ jobs:
     steps:
       - command_build_and_test:
           jobId: "mvnCleanInstall"
-  testPythonClientSamples:
+  testPython38ClientSamples:
     docker:
       - image: python:3.8
+    working_directory: ~/OpenAPITools/openapi-json-schema-generator
+    shell: /bin/bash --login
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+    steps:
+      - checkout
+      - command_docker_build_and_test:
+          jobId: "testPythonClientSamples"
+  testPython39ClientSamples:
+    docker:
+      - image: python:3.9
     working_directory: ~/OpenAPITools/openapi-json-schema-generator
     shell: /bin/bash --login
     environment:
@@ -140,4 +152,5 @@ workflows:
     jobs:
       - ensureSamplesAndGeneratorDocsUpToDate
       - mvnCleanInstall
-      - testPythonClientSamples
+      - testPython38ClientSamples
+      - testPython39ClientSamples


### PR DESCRIPTION
Adds python 3.9 CI testing

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
