### PR TITLE
Fixes documentation, adds validate invocation in schema examples

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,8 @@ jobs:
     steps:
       - command_build_and_test:
           jobId: "ensureSamplesAndGeneratorDocsUpToDate"
+      - run:
+          command: zip -r /tmp/circleci-artifacts/samples.zip samples
   mvnCleanInstall:
     machine:
       image: ubuntu-2004:202201-02

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,8 +111,6 @@ jobs:
     steps:
       - command_build_and_test:
           jobId: "ensureSamplesAndGeneratorDocsUpToDate"
-      - run:
-          command: zip -r /tmp/circleci-artifacts/samples.zip samples
   mvnCleanInstall:
     machine:
       image: ubuntu-2004:202201-02

--- a/bin/utils/ensure-up-to-date
+++ b/bin/utils/ensure-up-to-date
@@ -57,6 +57,7 @@ if [ -n "$(git status --porcelain)" ]; then
     echo "When you see unexpected files here, it likely means that there are newer commits in master that you need to "
     echo -e "rebase or merge into your branch.\n"
     echo "Please run 'bin/utils/ensure-up-to-date' locally and commit changes (UNCOMMITTED CHANGES ERROR)"
+    zip -r /tmp/circleci-artifacts/samples.zip samples
     exit 1
 else
     echo "Git working tree is clean"

--- a/samples/client/3_0_3_unit_test/python/README.md
+++ b/samples/client/3_0_3_unit_test/python/README.md
@@ -146,7 +146,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = additionalproperties_allows_a_schema_which_should_validate.AdditionalpropertiesAllowsASchemaWhichShouldValidate({
+    body = additionalproperties_allows_a_schema_which_should_validate.AdditionalpropertiesAllowsASchemaWhichShouldValidate.validate({
         "foo": None,
         "bar": None,
     })

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_additionalproperties_allows_a_schema_which_should_validate_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_additionalproperties_allows_a_schema_which_should_validate_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = additionalproperties_allows_a_schema_which_should_validate.AdditionalpropertiesAllowsASchemaWhichShouldValidate({
+    body = additionalproperties_allows_a_schema_which_should_validate.AdditionalpropertiesAllowsASchemaWhichShouldValidate.validate({
         "foo": None,
         "bar": None,
     })

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_additionalproperties_are_allowed_by_default_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_additionalproperties_are_allowed_by_default_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = additionalproperties_are_allowed_by_default.AdditionalpropertiesAreAllowedByDefault(None)
+    body = additionalproperties_are_allowed_by_default.AdditionalpropertiesAreAllowedByDefault.validate(None)
     try:
         api_response = api_instance.post_additionalproperties_are_allowed_by_default_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_additionalproperties_can_exist_by_itself_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_additionalproperties_can_exist_by_itself_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = additionalproperties_can_exist_by_itself.AdditionalpropertiesCanExistByItself({
+    body = additionalproperties_can_exist_by_itself.AdditionalpropertiesCanExistByItself.validate({
         "key": True,
     })
     try:

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_additionalproperties_should_not_look_in_applicators_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_additionalproperties_should_not_look_in_applicators_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = additionalproperties_should_not_look_in_applicators.AdditionalpropertiesShouldNotLookInApplicators(None)
+    body = additionalproperties_should_not_look_in_applicators.AdditionalpropertiesShouldNotLookInApplicators.validate(None)
     try:
         api_response = api_instance.post_additionalproperties_should_not_look_in_applicators_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_allof_combined_with_anyof_oneof_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_allof_combined_with_anyof_oneof_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = allof_combined_with_anyof_oneof.AllofCombinedWithAnyofOneof(None)
+    body = allof_combined_with_anyof_oneof.AllofCombinedWithAnyofOneof.validate(None)
     try:
         api_response = api_instance.post_allof_combined_with_anyof_oneof_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_allof_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_allof_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = allof.Allof(None)
+    body = allof.Allof.validate(None)
     try:
         api_response = api_instance.post_allof_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_allof_simple_types_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_allof_simple_types_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = allof_simple_types.AllofSimpleTypes(None)
+    body = allof_simple_types.AllofSimpleTypes.validate(None)
     try:
         api_response = api_instance.post_allof_simple_types_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_allof_with_base_schema_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_allof_with_base_schema_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = allof_with_base_schema.AllofWithBaseSchema({})
+    body = allof_with_base_schema.AllofWithBaseSchema.validate({})
     try:
         api_response = api_instance.post_allof_with_base_schema_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_allof_with_one_empty_schema_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_allof_with_one_empty_schema_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = allof_with_one_empty_schema.AllofWithOneEmptySchema(None)
+    body = allof_with_one_empty_schema.AllofWithOneEmptySchema.validate(None)
     try:
         api_response = api_instance.post_allof_with_one_empty_schema_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_allof_with_the_first_empty_schema_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_allof_with_the_first_empty_schema_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = allof_with_the_first_empty_schema.AllofWithTheFirstEmptySchema(None)
+    body = allof_with_the_first_empty_schema.AllofWithTheFirstEmptySchema.validate(None)
     try:
         api_response = api_instance.post_allof_with_the_first_empty_schema_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_allof_with_the_last_empty_schema_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_allof_with_the_last_empty_schema_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = allof_with_the_last_empty_schema.AllofWithTheLastEmptySchema(None)
+    body = allof_with_the_last_empty_schema.AllofWithTheLastEmptySchema.validate(None)
     try:
         api_response = api_instance.post_allof_with_the_last_empty_schema_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_allof_with_two_empty_schemas_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_allof_with_two_empty_schemas_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = allof_with_two_empty_schemas.AllofWithTwoEmptySchemas(None)
+    body = allof_with_two_empty_schemas.AllofWithTwoEmptySchemas.validate(None)
     try:
         api_response = api_instance.post_allof_with_two_empty_schemas_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_anyof_complex_types_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_anyof_complex_types_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = anyof_complex_types.AnyofComplexTypes(None)
+    body = anyof_complex_types.AnyofComplexTypes.validate(None)
     try:
         api_response = api_instance.post_anyof_complex_types_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_anyof_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_anyof_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = anyof.Anyof(None)
+    body = anyof.Anyof.validate(None)
     try:
         api_response = api_instance.post_anyof_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_anyof_with_base_schema_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_anyof_with_base_schema_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = anyof_with_base_schema.AnyofWithBaseSchema("string_example")
+    body = anyof_with_base_schema.AnyofWithBaseSchema.validate("string_example")
     try:
         api_response = api_instance.post_anyof_with_base_schema_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_anyof_with_one_empty_schema_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_anyof_with_one_empty_schema_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = anyof_with_one_empty_schema.AnyofWithOneEmptySchema(None)
+    body = anyof_with_one_empty_schema.AnyofWithOneEmptySchema.validate(None)
     try:
         api_response = api_instance.post_anyof_with_one_empty_schema_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_array_type_matches_arrays_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_array_type_matches_arrays_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = array_type_matches_arrays.ArrayTypeMatchesArrays([
+    body = array_type_matches_arrays.ArrayTypeMatchesArrays.validate([
         None
     ])
     try:

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_boolean_type_matches_booleans_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_boolean_type_matches_booleans_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = boolean_type_matches_booleans.BooleanTypeMatchesBooleans(True)
+    body = boolean_type_matches_booleans.BooleanTypeMatchesBooleans.validate(True)
     try:
         api_response = api_instance.post_boolean_type_matches_booleans_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_by_int_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_by_int_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = multiple_of_api.MultipleOfApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = by_int.ByInt(None)
+    body = by_int.ByInt.validate(None)
     try:
         api_response = api_instance.post_by_int_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_by_number_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_by_number_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = multiple_of_api.MultipleOfApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = by_number.ByNumber(None)
+    body = by_number.ByNumber.validate(None)
     try:
         api_response = api_instance.post_by_number_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_by_small_number_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_by_small_number_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = multiple_of_api.MultipleOfApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = by_small_number.BySmallNumber(None)
+    body = by_small_number.BySmallNumber.validate(None)
     try:
         api_response = api_instance.post_by_small_number_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_date_time_format_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_date_time_format_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = date_time_format.DateTimeFormat(None)
+    body = date_time_format.DateTimeFormat.validate(None)
     try:
         api_response = api_instance.post_date_time_format_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_email_format_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_email_format_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = email_format.EmailFormat(None)
+    body = email_format.EmailFormat.validate(None)
     try:
         api_response = api_instance.post_email_format_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_enum_with0_does_not_match_false_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_enum_with0_does_not_match_false_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = enum_with0_does_not_match_false.EnumWith0DoesNotMatchFalse(0)
+    body = enum_with0_does_not_match_false.EnumWith0DoesNotMatchFalse.validate(0)
     try:
         api_response = api_instance.post_enum_with0_does_not_match_false_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_enum_with1_does_not_match_true_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_enum_with1_does_not_match_true_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = enum_with1_does_not_match_true.EnumWith1DoesNotMatchTrue(1)
+    body = enum_with1_does_not_match_true.EnumWith1DoesNotMatchTrue.validate(1)
     try:
         api_response = api_instance.post_enum_with1_does_not_match_true_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_enum_with_escaped_characters_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_enum_with_escaped_characters_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = enum_with_escaped_characters.EnumWithEscapedCharacters("foo\nbar")
+    body = enum_with_escaped_characters.EnumWithEscapedCharacters.validate("foo\nbar")
     try:
         api_response = api_instance.post_enum_with_escaped_characters_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_enum_with_false_does_not_match0_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_enum_with_false_does_not_match0_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = enum_with_false_does_not_match0.EnumWithFalseDoesNotMatch0(False)
+    body = enum_with_false_does_not_match0.EnumWithFalseDoesNotMatch0.validate(False)
     try:
         api_response = api_instance.post_enum_with_false_does_not_match0_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_enum_with_true_does_not_match1_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_enum_with_true_does_not_match1_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = enum_with_true_does_not_match1.EnumWithTrueDoesNotMatch1(True)
+    body = enum_with_true_does_not_match1.EnumWithTrueDoesNotMatch1.validate(True)
     try:
         api_response = api_instance.post_enum_with_true_does_not_match1_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_enums_in_properties_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_enums_in_properties_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = enums_in_properties.EnumsInProperties({
+    body = enums_in_properties.EnumsInProperties.validate({
         "foo": "foo",
         "bar": "bar",
     })

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_forbidden_property_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_forbidden_property_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = forbidden_property.ForbiddenProperty(None)
+    body = forbidden_property.ForbiddenProperty.validate(None)
     try:
         api_response = api_instance.post_forbidden_property_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_hostname_format_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_hostname_format_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = hostname_format.HostnameFormat(None)
+    body = hostname_format.HostnameFormat.validate(None)
     try:
         api_response = api_instance.post_hostname_format_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_integer_type_matches_integers_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_integer_type_matches_integers_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = integer_type_matches_integers.IntegerTypeMatchesIntegers(1)
+    body = integer_type_matches_integers.IntegerTypeMatchesIntegers.validate(1)
     try:
         api_response = api_instance.post_integer_type_matches_integers_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_invalid_instance_should_not_raise_error_when_float_division_inf_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_invalid_instance_should_not_raise_error_when_float_division_inf_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = multiple_of_api.MultipleOfApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = invalid_instance_should_not_raise_error_when_float_division_inf.InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf(1)
+    body = invalid_instance_should_not_raise_error_when_float_division_inf.InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf.validate(1)
     try:
         api_response = api_instance.post_invalid_instance_should_not_raise_error_when_float_division_inf_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_invalid_string_value_for_default_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_invalid_string_value_for_default_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = invalid_string_value_for_default.InvalidStringValueForDefault(None)
+    body = invalid_string_value_for_default.InvalidStringValueForDefault.validate(None)
     try:
         api_response = api_instance.post_invalid_string_value_for_default_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_ipv4_format_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_ipv4_format_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = ipv4_format.Ipv4Format(None)
+    body = ipv4_format.Ipv4Format.validate(None)
     try:
         api_response = api_instance.post_ipv4_format_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_ipv6_format_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_ipv6_format_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = ipv6_format.Ipv6Format(None)
+    body = ipv6_format.Ipv6Format.validate(None)
     try:
         api_response = api_instance.post_ipv6_format_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_json_pointer_format_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_json_pointer_format_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = json_pointer_format.JsonPointerFormat(None)
+    body = json_pointer_format.JsonPointerFormat.validate(None)
     try:
         api_response = api_instance.post_json_pointer_format_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_maximum_validation_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_maximum_validation_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = maximum_validation.MaximumValidation(None)
+    body = maximum_validation.MaximumValidation.validate(None)
     try:
         api_response = api_instance.post_maximum_validation_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_maximum_validation_with_unsigned_integer_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_maximum_validation_with_unsigned_integer_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = maximum_validation_with_unsigned_integer.MaximumValidationWithUnsignedInteger(None)
+    body = maximum_validation_with_unsigned_integer.MaximumValidationWithUnsignedInteger.validate(None)
     try:
         api_response = api_instance.post_maximum_validation_with_unsigned_integer_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_maxitems_validation_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_maxitems_validation_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = maxitems_validation.MaxitemsValidation(None)
+    body = maxitems_validation.MaxitemsValidation.validate(None)
     try:
         api_response = api_instance.post_maxitems_validation_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_maxlength_validation_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_maxlength_validation_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = maxlength_validation.MaxlengthValidation(None)
+    body = maxlength_validation.MaxlengthValidation.validate(None)
     try:
         api_response = api_instance.post_maxlength_validation_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_maxproperties0_means_the_object_is_empty_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_maxproperties0_means_the_object_is_empty_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = maxproperties0_means_the_object_is_empty.Maxproperties0MeansTheObjectIsEmpty(None)
+    body = maxproperties0_means_the_object_is_empty.Maxproperties0MeansTheObjectIsEmpty.validate(None)
     try:
         api_response = api_instance.post_maxproperties0_means_the_object_is_empty_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_maxproperties_validation_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_maxproperties_validation_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = maxproperties_validation.MaxpropertiesValidation(None)
+    body = maxproperties_validation.MaxpropertiesValidation.validate(None)
     try:
         api_response = api_instance.post_maxproperties_validation_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_minimum_validation_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_minimum_validation_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = minimum_validation.MinimumValidation(None)
+    body = minimum_validation.MinimumValidation.validate(None)
     try:
         api_response = api_instance.post_minimum_validation_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_minimum_validation_with_signed_integer_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_minimum_validation_with_signed_integer_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = minimum_validation_with_signed_integer.MinimumValidationWithSignedInteger(None)
+    body = minimum_validation_with_signed_integer.MinimumValidationWithSignedInteger.validate(None)
     try:
         api_response = api_instance.post_minimum_validation_with_signed_integer_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_minitems_validation_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_minitems_validation_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = min_items_api.MinItemsApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = minitems_validation.MinitemsValidation(None)
+    body = minitems_validation.MinitemsValidation.validate(None)
     try:
         api_response = api_instance.post_minitems_validation_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_minlength_validation_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_minlength_validation_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = minlength_validation.MinlengthValidation(None)
+    body = minlength_validation.MinlengthValidation.validate(None)
     try:
         api_response = api_instance.post_minlength_validation_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_minproperties_validation_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_minproperties_validation_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = minproperties_validation.MinpropertiesValidation(None)
+    body = minproperties_validation.MinpropertiesValidation.validate(None)
     try:
         api_response = api_instance.post_minproperties_validation_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_nested_allof_to_check_validation_semantics_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_nested_allof_to_check_validation_semantics_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = nested_allof_to_check_validation_semantics.NestedAllofToCheckValidationSemantics(None)
+    body = nested_allof_to_check_validation_semantics.NestedAllofToCheckValidationSemantics.validate(None)
     try:
         api_response = api_instance.post_nested_allof_to_check_validation_semantics_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_nested_anyof_to_check_validation_semantics_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_nested_anyof_to_check_validation_semantics_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = nested_anyof_to_check_validation_semantics.NestedAnyofToCheckValidationSemantics(None)
+    body = nested_anyof_to_check_validation_semantics.NestedAnyofToCheckValidationSemantics.validate(None)
     try:
         api_response = api_instance.post_nested_anyof_to_check_validation_semantics_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_nested_items_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_nested_items_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = nested_items.NestedItems([
+    body = nested_items.NestedItems.validate([
         [
             [
                 [

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_nested_oneof_to_check_validation_semantics_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_nested_oneof_to_check_validation_semantics_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = nested_oneof_to_check_validation_semantics.NestedOneofToCheckValidationSemantics(None)
+    body = nested_oneof_to_check_validation_semantics.NestedOneofToCheckValidationSemantics.validate(None)
     try:
         api_response = api_instance.post_nested_oneof_to_check_validation_semantics_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_not_more_complex_schema_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_not_more_complex_schema_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = not_more_complex_schema.NotMoreComplexSchema(None)
+    body = not_more_complex_schema.NotMoreComplexSchema.validate(None)
     try:
         api_response = api_instance.post_not_more_complex_schema_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_not_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_not_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = _not._Not(None)
+    body = _not._Not.validate(None)
     try:
         api_response = api_instance.post_not_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_nul_characters_in_strings_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_nul_characters_in_strings_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = nul_characters_in_strings.NulCharactersInStrings("hello\x00there")
+    body = nul_characters_in_strings.NulCharactersInStrings.validate("hello\x00there")
     try:
         api_response = api_instance.post_nul_characters_in_strings_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_null_type_matches_only_the_null_object_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_null_type_matches_only_the_null_object_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = null_type_matches_only_the_null_object.NullTypeMatchesOnlyTheNullObject(None)
+    body = null_type_matches_only_the_null_object.NullTypeMatchesOnlyTheNullObject.validate(None)
     try:
         api_response = api_instance.post_null_type_matches_only_the_null_object_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_number_type_matches_numbers_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_number_type_matches_numbers_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = number_type_matches_numbers.NumberTypeMatchesNumbers(3.14)
+    body = number_type_matches_numbers.NumberTypeMatchesNumbers.validate(3.14)
     try:
         api_response = api_instance.post_number_type_matches_numbers_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_object_properties_validation_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_object_properties_validation_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = object_properties_validation.ObjectPropertiesValidation(None)
+    body = object_properties_validation.ObjectPropertiesValidation.validate(None)
     try:
         api_response = api_instance.post_object_properties_validation_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_object_type_matches_objects_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_object_type_matches_objects_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = object_type_matches_objects.ObjectTypeMatchesObjects({})
+    body = object_type_matches_objects.ObjectTypeMatchesObjects.validate({})
     try:
         api_response = api_instance.post_object_type_matches_objects_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_oneof_complex_types_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_oneof_complex_types_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = oneof_complex_types.OneofComplexTypes(None)
+    body = oneof_complex_types.OneofComplexTypes.validate(None)
     try:
         api_response = api_instance.post_oneof_complex_types_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_oneof_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_oneof_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = oneof.Oneof(None)
+    body = oneof.Oneof.validate(None)
     try:
         api_response = api_instance.post_oneof_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_oneof_with_base_schema_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_oneof_with_base_schema_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = oneof_with_base_schema.OneofWithBaseSchema("string_example")
+    body = oneof_with_base_schema.OneofWithBaseSchema.validate("string_example")
     try:
         api_response = api_instance.post_oneof_with_base_schema_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_oneof_with_empty_schema_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_oneof_with_empty_schema_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = oneof_with_empty_schema.OneofWithEmptySchema(None)
+    body = oneof_with_empty_schema.OneofWithEmptySchema.validate(None)
     try:
         api_response = api_instance.post_oneof_with_empty_schema_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_oneof_with_required_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_oneof_with_required_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = oneof_with_required.OneofWithRequired({})
+    body = oneof_with_required.OneofWithRequired.validate({})
     try:
         api_response = api_instance.post_oneof_with_required_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_pattern_is_not_anchored_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_pattern_is_not_anchored_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = pattern_is_not_anchored.PatternIsNotAnchored(None)
+    body = pattern_is_not_anchored.PatternIsNotAnchored.validate(None)
     try:
         api_response = api_instance.post_pattern_is_not_anchored_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_pattern_validation_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_pattern_validation_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = pattern_validation.PatternValidation(None)
+    body = pattern_validation.PatternValidation.validate(None)
     try:
         api_response = api_instance.post_pattern_validation_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_properties_with_escaped_characters_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_properties_with_escaped_characters_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = properties_with_escaped_characters.PropertiesWithEscapedCharacters(None)
+    body = properties_with_escaped_characters.PropertiesWithEscapedCharacters.validate(None)
     try:
         api_response = api_instance.post_properties_with_escaped_characters_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_property_named_ref_that_is_not_a_reference_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_property_named_ref_that_is_not_a_reference_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = property_named_ref_that_is_not_a_reference.PropertyNamedRefThatIsNotAReference(None)
+    body = property_named_ref_that_is_not_a_reference.PropertyNamedRefThatIsNotAReference.validate(None)
     try:
         api_response = api_instance.post_property_named_ref_that_is_not_a_reference_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_ref_in_additionalproperties_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_ref_in_additionalproperties_request_body/post.md
@@ -98,8 +98,8 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = ref_in_additionalproperties.RefInAdditionalproperties({
-        "key": property_named_ref_that_is_not_a_reference.PropertyNamedRefThatIsNotAReference(None),
+    body = ref_in_additionalproperties.RefInAdditionalproperties.validate({
+        "key": property_named_ref_that_is_not_a_reference.PropertyNamedRefThatIsNotAReference.validate(None),
     })
     try:
         api_response = api_instance.post_ref_in_additionalproperties_request_body(

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_ref_in_allof_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_ref_in_allof_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = ref_in_allof.RefInAllof(None)
+    body = ref_in_allof.RefInAllof.validate(None)
     try:
         api_response = api_instance.post_ref_in_allof_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_ref_in_anyof_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_ref_in_anyof_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = ref_in_anyof.RefInAnyof(None)
+    body = ref_in_anyof.RefInAnyof.validate(None)
     try:
         api_response = api_instance.post_ref_in_anyof_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_ref_in_items_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_ref_in_items_request_body/post.md
@@ -98,8 +98,8 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = ref_in_items.RefInItems([
-        property_named_ref_that_is_not_a_reference.PropertyNamedRefThatIsNotAReference(None)
+    body = ref_in_items.RefInItems.validate([
+        property_named_ref_that_is_not_a_reference.PropertyNamedRefThatIsNotAReference.validate(None)
     ])
     try:
         api_response = api_instance.post_ref_in_items_request_body(

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_ref_in_not_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_ref_in_not_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = ref_in_not.RefInNot(None)
+    body = ref_in_not.RefInNot.validate(None)
     try:
         api_response = api_instance.post_ref_in_not_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_ref_in_oneof_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_ref_in_oneof_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = ref_in_oneof.RefInOneof(None)
+    body = ref_in_oneof.RefInOneof.validate(None)
     try:
         api_response = api_instance.post_ref_in_oneof_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_ref_in_property_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_ref_in_property_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = ref_in_property.RefInProperty(None)
+    body = ref_in_property.RefInProperty.validate(None)
     try:
         api_response = api_instance.post_ref_in_property_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_required_default_validation_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_required_default_validation_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = required_default_validation.RequiredDefaultValidation(None)
+    body = required_default_validation.RequiredDefaultValidation.validate(None)
     try:
         api_response = api_instance.post_required_default_validation_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_required_validation_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_required_validation_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = required_validation.RequiredValidation(None)
+    body = required_validation.RequiredValidation.validate(None)
     try:
         api_response = api_instance.post_required_validation_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_required_with_empty_array_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_required_with_empty_array_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = required_with_empty_array.RequiredWithEmptyArray(None)
+    body = required_with_empty_array.RequiredWithEmptyArray.validate(None)
     try:
         api_response = api_instance.post_required_with_empty_array_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_required_with_escaped_characters_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_required_with_escaped_characters_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = required_with_escaped_characters.RequiredWithEscapedCharacters(None)
+    body = required_with_escaped_characters.RequiredWithEscapedCharacters.validate(None)
     try:
         api_response = api_instance.post_required_with_escaped_characters_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_simple_enum_validation_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_simple_enum_validation_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = simple_enum_validation.SimpleEnumValidation(1)
+    body = simple_enum_validation.SimpleEnumValidation.validate(1)
     try:
         api_response = api_instance.post_simple_enum_validation_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_string_type_matches_strings_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_string_type_matches_strings_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = string_type_matches_strings.StringTypeMatchesStrings("string_example")
+    body = string_type_matches_strings.StringTypeMatchesStrings.validate("string_example")
     try:
         api_response = api_instance.post_string_type_matches_strings_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_the_default_keyword_does_not_do_anything_if_the_property_is_missing_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_the_default_keyword_does_not_do_anything_if_the_property_is_missing_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = the_default_keyword_does_not_do_anything_if_the_property_is_missing.TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing({
+    body = the_default_keyword_does_not_do_anything_if_the_property_is_missing.TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.validate({
         "alpha": 5,
     })
     try:

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_uniqueitems_false_validation_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_uniqueitems_false_validation_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = uniqueitems_false_validation.UniqueitemsFalseValidation(None)
+    body = uniqueitems_false_validation.UniqueitemsFalseValidation.validate(None)
     try:
         api_response = api_instance.post_uniqueitems_false_validation_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_uniqueitems_validation_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_uniqueitems_validation_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = uniqueitems_validation.UniqueitemsValidation(None)
+    body = uniqueitems_validation.UniqueitemsValidation.validate(None)
     try:
         api_response = api_instance.post_uniqueitems_validation_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_uri_format_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_uri_format_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = uri_format.UriFormat(None)
+    body = uri_format.UriFormat.validate(None)
     try:
         api_response = api_instance.post_uri_format_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_uri_reference_format_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_uri_reference_format_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = uri_reference_format.UriReferenceFormat(None)
+    body = uri_reference_format.UriReferenceFormat.validate(None)
     try:
         api_response = api_instance.post_uri_reference_format_request_body(
             body=body,

--- a/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_uri_template_format_request_body/post.md
+++ b/samples/client/3_0_3_unit_test/python/docs/paths/request_body_post_uri_template_format_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = uri_template_format.UriTemplateFormat(None)
+    body = uri_template_format.UriTemplateFormat.validate(None)
     try:
         api_response = api_instance.post_uri_template_format_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/README.md
+++ b/samples/client/3_1_0_unit_test/python/README.md
@@ -146,7 +146,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = additionalproperties_are_allowed_by_default.AdditionalpropertiesAreAllowedByDefault(None)
+    body = additionalproperties_are_allowed_by_default.AdditionalpropertiesAreAllowedByDefault.validate(None)
     try:
         api_response = api_instance.post_additionalproperties_are_allowed_by_default_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_additionalproperties_are_allowed_by_default_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_additionalproperties_are_allowed_by_default_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = additionalproperties_are_allowed_by_default.AdditionalpropertiesAreAllowedByDefault(None)
+    body = additionalproperties_are_allowed_by_default.AdditionalpropertiesAreAllowedByDefault.validate(None)
     try:
         api_response = api_instance.post_additionalproperties_are_allowed_by_default_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_additionalproperties_can_exist_by_itself_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_additionalproperties_can_exist_by_itself_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = additionalproperties_can_exist_by_itself.AdditionalpropertiesCanExistByItself({
+    body = additionalproperties_can_exist_by_itself.AdditionalpropertiesCanExistByItself.validate({
         "key": None,
     })
     try:

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_additionalproperties_does_not_look_in_applicators_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_additionalproperties_does_not_look_in_applicators_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = additionalproperties_does_not_look_in_applicators.AdditionalpropertiesDoesNotLookInApplicators(None)
+    body = additionalproperties_does_not_look_in_applicators.AdditionalpropertiesDoesNotLookInApplicators.validate(None)
     try:
         api_response = api_instance.post_additionalproperties_does_not_look_in_applicators_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_additionalproperties_with_null_valued_instance_properties_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_additionalproperties_with_null_valued_instance_properties_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = additionalproperties_with_null_valued_instance_properties.AdditionalpropertiesWithNullValuedInstanceProperties({
+    body = additionalproperties_with_null_valued_instance_properties.AdditionalpropertiesWithNullValuedInstanceProperties.validate({
         "key": None,
     })
     try:

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_additionalproperties_with_schema_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_additionalproperties_with_schema_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = additionalproperties_with_schema.AdditionalpropertiesWithSchema({
+    body = additionalproperties_with_schema.AdditionalpropertiesWithSchema.validate({
         "foo": None,
         "bar": None,
     })

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_allof_combined_with_anyof_oneof_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_allof_combined_with_anyof_oneof_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = allof_combined_with_anyof_oneof.AllofCombinedWithAnyofOneof(None)
+    body = allof_combined_with_anyof_oneof.AllofCombinedWithAnyofOneof.validate(None)
     try:
         api_response = api_instance.post_allof_combined_with_anyof_oneof_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_allof_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_allof_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = allof.Allof(None)
+    body = allof.Allof.validate(None)
     try:
         api_response = api_instance.post_allof_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_allof_simple_types_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_allof_simple_types_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = allof_simple_types.AllofSimpleTypes(None)
+    body = allof_simple_types.AllofSimpleTypes.validate(None)
     try:
         api_response = api_instance.post_allof_simple_types_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_allof_with_base_schema_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_allof_with_base_schema_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = allof_with_base_schema.AllofWithBaseSchema(None)
+    body = allof_with_base_schema.AllofWithBaseSchema.validate(None)
     try:
         api_response = api_instance.post_allof_with_base_schema_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_allof_with_one_empty_schema_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_allof_with_one_empty_schema_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = allof_with_one_empty_schema.AllofWithOneEmptySchema(None)
+    body = allof_with_one_empty_schema.AllofWithOneEmptySchema.validate(None)
     try:
         api_response = api_instance.post_allof_with_one_empty_schema_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_allof_with_the_first_empty_schema_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_allof_with_the_first_empty_schema_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = allof_with_the_first_empty_schema.AllofWithTheFirstEmptySchema(None)
+    body = allof_with_the_first_empty_schema.AllofWithTheFirstEmptySchema.validate(None)
     try:
         api_response = api_instance.post_allof_with_the_first_empty_schema_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_allof_with_the_last_empty_schema_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_allof_with_the_last_empty_schema_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = allof_with_the_last_empty_schema.AllofWithTheLastEmptySchema(None)
+    body = allof_with_the_last_empty_schema.AllofWithTheLastEmptySchema.validate(None)
     try:
         api_response = api_instance.post_allof_with_the_last_empty_schema_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_allof_with_two_empty_schemas_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_allof_with_two_empty_schemas_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = allof_with_two_empty_schemas.AllofWithTwoEmptySchemas(None)
+    body = allof_with_two_empty_schemas.AllofWithTwoEmptySchemas.validate(None)
     try:
         api_response = api_instance.post_allof_with_two_empty_schemas_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_anyof_complex_types_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_anyof_complex_types_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = anyof_complex_types.AnyofComplexTypes(None)
+    body = anyof_complex_types.AnyofComplexTypes.validate(None)
     try:
         api_response = api_instance.post_anyof_complex_types_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_anyof_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_anyof_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = anyof.Anyof(None)
+    body = anyof.Anyof.validate(None)
     try:
         api_response = api_instance.post_anyof_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_anyof_with_base_schema_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_anyof_with_base_schema_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = anyof_with_base_schema.AnyofWithBaseSchema(None)
+    body = anyof_with_base_schema.AnyofWithBaseSchema.validate(None)
     try:
         api_response = api_instance.post_anyof_with_base_schema_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_anyof_with_one_empty_schema_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_anyof_with_one_empty_schema_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = anyof_with_one_empty_schema.AnyofWithOneEmptySchema(None)
+    body = anyof_with_one_empty_schema.AnyofWithOneEmptySchema.validate(None)
     try:
         api_response = api_instance.post_anyof_with_one_empty_schema_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_array_type_matches_arrays_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_array_type_matches_arrays_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = array_type_matches_arrays.ArrayTypeMatchesArrays(None)
+    body = array_type_matches_arrays.ArrayTypeMatchesArrays.validate(None)
     try:
         api_response = api_instance.post_array_type_matches_arrays_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_boolean_type_matches_booleans_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_boolean_type_matches_booleans_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = boolean_type_matches_booleans.BooleanTypeMatchesBooleans(None)
+    body = boolean_type_matches_booleans.BooleanTypeMatchesBooleans.validate(None)
     try:
         api_response = api_instance.post_boolean_type_matches_booleans_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_by_int_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_by_int_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = multiple_of_api.MultipleOfApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = by_int.ByInt(None)
+    body = by_int.ByInt.validate(None)
     try:
         api_response = api_instance.post_by_int_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_by_number_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_by_number_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = multiple_of_api.MultipleOfApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = by_number.ByNumber(None)
+    body = by_number.ByNumber.validate(None)
     try:
         api_response = api_instance.post_by_number_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_by_small_number_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_by_small_number_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = multiple_of_api.MultipleOfApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = by_small_number.BySmallNumber(None)
+    body = by_small_number.BySmallNumber.validate(None)
     try:
         api_response = api_instance.post_by_small_number_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_date_format_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_date_format_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = date_format.DateFormat(None)
+    body = date_format.DateFormat.validate(None)
     try:
         api_response = api_instance.post_date_format_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_date_time_format_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_date_time_format_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = date_time_format.DateTimeFormat(None)
+    body = date_time_format.DateTimeFormat.validate(None)
     try:
         api_response = api_instance.post_date_time_format_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_duration_format_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_duration_format_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = duration_format.DurationFormat(None)
+    body = duration_format.DurationFormat.validate(None)
     try:
         api_response = api_instance.post_duration_format_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_email_format_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_email_format_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = email_format.EmailFormat(None)
+    body = email_format.EmailFormat.validate(None)
     try:
         api_response = api_instance.post_email_format_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_enum_with0_does_not_match_false_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_enum_with0_does_not_match_false_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = enum_with0_does_not_match_false.EnumWith0DoesNotMatchFalse(None)
+    body = enum_with0_does_not_match_false.EnumWith0DoesNotMatchFalse.validate(None)
     try:
         api_response = api_instance.post_enum_with0_does_not_match_false_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_enum_with1_does_not_match_true_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_enum_with1_does_not_match_true_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = enum_with1_does_not_match_true.EnumWith1DoesNotMatchTrue(None)
+    body = enum_with1_does_not_match_true.EnumWith1DoesNotMatchTrue.validate(None)
     try:
         api_response = api_instance.post_enum_with1_does_not_match_true_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_enum_with_escaped_characters_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_enum_with_escaped_characters_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = enum_with_escaped_characters.EnumWithEscapedCharacters(None)
+    body = enum_with_escaped_characters.EnumWithEscapedCharacters.validate(None)
     try:
         api_response = api_instance.post_enum_with_escaped_characters_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_enum_with_false_does_not_match0_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_enum_with_false_does_not_match0_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = enum_with_false_does_not_match0.EnumWithFalseDoesNotMatch0(None)
+    body = enum_with_false_does_not_match0.EnumWithFalseDoesNotMatch0.validate(None)
     try:
         api_response = api_instance.post_enum_with_false_does_not_match0_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_enum_with_true_does_not_match1_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_enum_with_true_does_not_match1_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = enum_with_true_does_not_match1.EnumWithTrueDoesNotMatch1(None)
+    body = enum_with_true_does_not_match1.EnumWithTrueDoesNotMatch1.validate(None)
     try:
         api_response = api_instance.post_enum_with_true_does_not_match1_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_enums_in_properties_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_enums_in_properties_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = enums_in_properties.EnumsInProperties(None)
+    body = enums_in_properties.EnumsInProperties.validate(None)
     try:
         api_response = api_instance.post_enums_in_properties_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_float_division_inf_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_float_division_inf_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = multiple_of_api.MultipleOfApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = float_division_inf.FloatDivisionInf(None)
+    body = float_division_inf.FloatDivisionInf.validate(None)
     try:
         api_response = api_instance.post_float_division_inf_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_forbidden_property_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_forbidden_property_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = forbidden_property.ForbiddenProperty(None)
+    body = forbidden_property.ForbiddenProperty.validate(None)
     try:
         api_response = api_instance.post_forbidden_property_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_hostname_format_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_hostname_format_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = hostname_format.HostnameFormat(None)
+    body = hostname_format.HostnameFormat.validate(None)
     try:
         api_response = api_instance.post_hostname_format_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_idn_email_format_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_idn_email_format_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = idn_email_format.IdnEmailFormat(None)
+    body = idn_email_format.IdnEmailFormat.validate(None)
     try:
         api_response = api_instance.post_idn_email_format_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_idn_hostname_format_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_idn_hostname_format_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = idn_hostname_format.IdnHostnameFormat(None)
+    body = idn_hostname_format.IdnHostnameFormat.validate(None)
     try:
         api_response = api_instance.post_idn_hostname_format_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_integer_type_matches_integers_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_integer_type_matches_integers_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = integer_type_matches_integers.IntegerTypeMatchesIntegers(None)
+    body = integer_type_matches_integers.IntegerTypeMatchesIntegers.validate(None)
     try:
         api_response = api_instance.post_integer_type_matches_integers_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_ipv4_format_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_ipv4_format_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = ipv4_format.Ipv4Format(None)
+    body = ipv4_format.Ipv4Format.validate(None)
     try:
         api_response = api_instance.post_ipv4_format_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_ipv6_format_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_ipv6_format_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = ipv6_format.Ipv6Format(None)
+    body = ipv6_format.Ipv6Format.validate(None)
     try:
         api_response = api_instance.post_ipv6_format_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_iri_format_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_iri_format_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = iri_format.IriFormat(None)
+    body = iri_format.IriFormat.validate(None)
     try:
         api_response = api_instance.post_iri_format_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_iri_reference_format_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_iri_reference_format_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = iri_reference_format.IriReferenceFormat(None)
+    body = iri_reference_format.IriReferenceFormat.validate(None)
     try:
         api_response = api_instance.post_iri_reference_format_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_items_does_not_look_in_applicators_valid_case_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_items_does_not_look_in_applicators_valid_case_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = items_does_not_look_in_applicators_valid_case.ItemsDoesNotLookInApplicatorsValidCase([
+    body = items_does_not_look_in_applicators_valid_case.ItemsDoesNotLookInApplicatorsValidCase.validate([
         None
     ])
     try:

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_items_with_null_instance_elements_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_items_with_null_instance_elements_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = items_with_null_instance_elements.ItemsWithNullInstanceElements([
+    body = items_with_null_instance_elements.ItemsWithNullInstanceElements.validate([
         None
     ])
     try:

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_json_pointer_format_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_json_pointer_format_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = json_pointer_format.JsonPointerFormat(None)
+    body = json_pointer_format.JsonPointerFormat.validate(None)
     try:
         api_response = api_instance.post_json_pointer_format_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_maximum_validation_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_maximum_validation_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = maximum_validation.MaximumValidation(None)
+    body = maximum_validation.MaximumValidation.validate(None)
     try:
         api_response = api_instance.post_maximum_validation_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_maximum_validation_with_unsigned_integer_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_maximum_validation_with_unsigned_integer_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = maximum_validation_with_unsigned_integer.MaximumValidationWithUnsignedInteger(None)
+    body = maximum_validation_with_unsigned_integer.MaximumValidationWithUnsignedInteger.validate(None)
     try:
         api_response = api_instance.post_maximum_validation_with_unsigned_integer_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_maxitems_validation_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_maxitems_validation_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = maxitems_validation.MaxitemsValidation(None)
+    body = maxitems_validation.MaxitemsValidation.validate(None)
     try:
         api_response = api_instance.post_maxitems_validation_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_maxlength_validation_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_maxlength_validation_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = maxlength_validation.MaxlengthValidation(None)
+    body = maxlength_validation.MaxlengthValidation.validate(None)
     try:
         api_response = api_instance.post_maxlength_validation_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_maxproperties0_means_the_object_is_empty_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_maxproperties0_means_the_object_is_empty_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = maxproperties0_means_the_object_is_empty.Maxproperties0MeansTheObjectIsEmpty(None)
+    body = maxproperties0_means_the_object_is_empty.Maxproperties0MeansTheObjectIsEmpty.validate(None)
     try:
         api_response = api_instance.post_maxproperties0_means_the_object_is_empty_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_maxproperties_validation_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_maxproperties_validation_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = maxproperties_validation.MaxpropertiesValidation(None)
+    body = maxproperties_validation.MaxpropertiesValidation.validate(None)
     try:
         api_response = api_instance.post_maxproperties_validation_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_minimum_validation_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_minimum_validation_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = minimum_validation.MinimumValidation(None)
+    body = minimum_validation.MinimumValidation.validate(None)
     try:
         api_response = api_instance.post_minimum_validation_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_minimum_validation_with_signed_integer_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_minimum_validation_with_signed_integer_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = minimum_validation_with_signed_integer.MinimumValidationWithSignedInteger(None)
+    body = minimum_validation_with_signed_integer.MinimumValidationWithSignedInteger.validate(None)
     try:
         api_response = api_instance.post_minimum_validation_with_signed_integer_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_minitems_validation_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_minitems_validation_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = min_items_api.MinItemsApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = minitems_validation.MinitemsValidation(None)
+    body = minitems_validation.MinitemsValidation.validate(None)
     try:
         api_response = api_instance.post_minitems_validation_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_minlength_validation_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_minlength_validation_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = minlength_validation.MinlengthValidation(None)
+    body = minlength_validation.MinlengthValidation.validate(None)
     try:
         api_response = api_instance.post_minlength_validation_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_minproperties_validation_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_minproperties_validation_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = minproperties_validation.MinpropertiesValidation(None)
+    body = minproperties_validation.MinpropertiesValidation.validate(None)
     try:
         api_response = api_instance.post_minproperties_validation_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_multiple_types_can_be_specified_in_an_array_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_multiple_types_can_be_specified_in_an_array_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = multiple_types_can_be_specified_in_an_array.MultipleTypesCanBeSpecifiedInAnArray(None)
+    body = multiple_types_can_be_specified_in_an_array.MultipleTypesCanBeSpecifiedInAnArray.validate(None)
     try:
         api_response = api_instance.post_multiple_types_can_be_specified_in_an_array_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_nested_allof_to_check_validation_semantics_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_nested_allof_to_check_validation_semantics_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = nested_allof_to_check_validation_semantics.NestedAllofToCheckValidationSemantics(None)
+    body = nested_allof_to_check_validation_semantics.NestedAllofToCheckValidationSemantics.validate(None)
     try:
         api_response = api_instance.post_nested_allof_to_check_validation_semantics_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_nested_anyof_to_check_validation_semantics_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_nested_anyof_to_check_validation_semantics_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = nested_anyof_to_check_validation_semantics.NestedAnyofToCheckValidationSemantics(None)
+    body = nested_anyof_to_check_validation_semantics.NestedAnyofToCheckValidationSemantics.validate(None)
     try:
         api_response = api_instance.post_nested_anyof_to_check_validation_semantics_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_nested_items_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_nested_items_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = nested_items.NestedItems([
+    body = nested_items.NestedItems.validate([
         [
             [
                 [

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_nested_oneof_to_check_validation_semantics_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_nested_oneof_to_check_validation_semantics_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = nested_oneof_to_check_validation_semantics.NestedOneofToCheckValidationSemantics(None)
+    body = nested_oneof_to_check_validation_semantics.NestedOneofToCheckValidationSemantics.validate(None)
     try:
         api_response = api_instance.post_nested_oneof_to_check_validation_semantics_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_not_more_complex_schema_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_not_more_complex_schema_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = not_more_complex_schema.NotMoreComplexSchema(None)
+    body = not_more_complex_schema.NotMoreComplexSchema.validate(None)
     try:
         api_response = api_instance.post_not_more_complex_schema_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_not_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_not_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = _not._Not(None)
+    body = _not._Not.validate(None)
     try:
         api_response = api_instance.post_not_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_nul_characters_in_strings_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_nul_characters_in_strings_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = nul_characters_in_strings.NulCharactersInStrings(None)
+    body = nul_characters_in_strings.NulCharactersInStrings.validate(None)
     try:
         api_response = api_instance.post_nul_characters_in_strings_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_null_type_matches_only_the_null_object_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_null_type_matches_only_the_null_object_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = null_type_matches_only_the_null_object.NullTypeMatchesOnlyTheNullObject(None)
+    body = null_type_matches_only_the_null_object.NullTypeMatchesOnlyTheNullObject.validate(None)
     try:
         api_response = api_instance.post_null_type_matches_only_the_null_object_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_number_type_matches_numbers_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_number_type_matches_numbers_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = number_type_matches_numbers.NumberTypeMatchesNumbers(None)
+    body = number_type_matches_numbers.NumberTypeMatchesNumbers.validate(None)
     try:
         api_response = api_instance.post_number_type_matches_numbers_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_object_properties_validation_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_object_properties_validation_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = object_properties_validation.ObjectPropertiesValidation(None)
+    body = object_properties_validation.ObjectPropertiesValidation.validate(None)
     try:
         api_response = api_instance.post_object_properties_validation_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_object_type_matches_objects_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_object_type_matches_objects_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = object_type_matches_objects.ObjectTypeMatchesObjects(None)
+    body = object_type_matches_objects.ObjectTypeMatchesObjects.validate(None)
     try:
         api_response = api_instance.post_object_type_matches_objects_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_oneof_complex_types_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_oneof_complex_types_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = oneof_complex_types.OneofComplexTypes(None)
+    body = oneof_complex_types.OneofComplexTypes.validate(None)
     try:
         api_response = api_instance.post_oneof_complex_types_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_oneof_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_oneof_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = oneof.Oneof(None)
+    body = oneof.Oneof.validate(None)
     try:
         api_response = api_instance.post_oneof_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_oneof_with_base_schema_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_oneof_with_base_schema_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = oneof_with_base_schema.OneofWithBaseSchema(None)
+    body = oneof_with_base_schema.OneofWithBaseSchema.validate(None)
     try:
         api_response = api_instance.post_oneof_with_base_schema_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_oneof_with_empty_schema_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_oneof_with_empty_schema_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = oneof_with_empty_schema.OneofWithEmptySchema(None)
+    body = oneof_with_empty_schema.OneofWithEmptySchema.validate(None)
     try:
         api_response = api_instance.post_oneof_with_empty_schema_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_oneof_with_required_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_oneof_with_required_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = oneof_with_required.OneofWithRequired(None)
+    body = oneof_with_required.OneofWithRequired.validate(None)
     try:
         api_response = api_instance.post_oneof_with_required_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_pattern_is_not_anchored_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_pattern_is_not_anchored_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = pattern_is_not_anchored.PatternIsNotAnchored(None)
+    body = pattern_is_not_anchored.PatternIsNotAnchored.validate(None)
     try:
         api_response = api_instance.post_pattern_is_not_anchored_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_pattern_validation_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_pattern_validation_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = pattern_validation.PatternValidation(None)
+    body = pattern_validation.PatternValidation.validate(None)
     try:
         api_response = api_instance.post_pattern_validation_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_prefixitems_validation_adjusts_the_starting_index_for_items_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_prefixitems_validation_adjusts_the_starting_index_for_items_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = prefixitems_validation_adjusts_the_starting_index_for_items.PrefixitemsValidationAdjustsTheStartingIndexForItems([
+    body = prefixitems_validation_adjusts_the_starting_index_for_items.PrefixitemsValidationAdjustsTheStartingIndexForItems.validate([
         None
     ])
     try:

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_properties_whose_names_are_javascript_object_property_names_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_properties_whose_names_are_javascript_object_property_names_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = properties_whose_names_are_javascript_object_property_names.PropertiesWhoseNamesAreJavascriptObjectPropertyNames(None)
+    body = properties_whose_names_are_javascript_object_property_names.PropertiesWhoseNamesAreJavascriptObjectPropertyNames.validate(None)
     try:
         api_response = api_instance.post_properties_whose_names_are_javascript_object_property_names_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_properties_with_escaped_characters_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_properties_with_escaped_characters_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = properties_with_escaped_characters.PropertiesWithEscapedCharacters(None)
+    body = properties_with_escaped_characters.PropertiesWithEscapedCharacters.validate(None)
     try:
         api_response = api_instance.post_properties_with_escaped_characters_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_properties_with_null_valued_instance_properties_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_properties_with_null_valued_instance_properties_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = properties_with_null_valued_instance_properties.PropertiesWithNullValuedInstanceProperties(None)
+    body = properties_with_null_valued_instance_properties.PropertiesWithNullValuedInstanceProperties.validate(None)
     try:
         api_response = api_instance.post_properties_with_null_valued_instance_properties_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_property_named_ref_that_is_not_a_reference_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_property_named_ref_that_is_not_a_reference_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = property_named_ref_that_is_not_a_reference.PropertyNamedRefThatIsNotAReference(None)
+    body = property_named_ref_that_is_not_a_reference.PropertyNamedRefThatIsNotAReference.validate(None)
     try:
         api_response = api_instance.post_property_named_ref_that_is_not_a_reference_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_regex_format_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_regex_format_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = regex_format.RegexFormat(None)
+    body = regex_format.RegexFormat.validate(None)
     try:
         api_response = api_instance.post_regex_format_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_relative_json_pointer_format_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_relative_json_pointer_format_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = relative_json_pointer_format.RelativeJsonPointerFormat(None)
+    body = relative_json_pointer_format.RelativeJsonPointerFormat.validate(None)
     try:
         api_response = api_instance.post_relative_json_pointer_format_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_required_default_validation_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_required_default_validation_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = required_default_validation.RequiredDefaultValidation(None)
+    body = required_default_validation.RequiredDefaultValidation.validate(None)
     try:
         api_response = api_instance.post_required_default_validation_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_required_properties_whose_names_are_javascript_object_property_names_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_required_properties_whose_names_are_javascript_object_property_names_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = required_properties_whose_names_are_javascript_object_property_names.RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames(None)
+    body = required_properties_whose_names_are_javascript_object_property_names.RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames.validate(None)
     try:
         api_response = api_instance.post_required_properties_whose_names_are_javascript_object_property_names_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_required_validation_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_required_validation_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = required_validation.RequiredValidation(None)
+    body = required_validation.RequiredValidation.validate(None)
     try:
         api_response = api_instance.post_required_validation_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_required_with_empty_array_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_required_with_empty_array_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = required_with_empty_array.RequiredWithEmptyArray(None)
+    body = required_with_empty_array.RequiredWithEmptyArray.validate(None)
     try:
         api_response = api_instance.post_required_with_empty_array_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_required_with_escaped_characters_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_required_with_escaped_characters_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = required_with_escaped_characters.RequiredWithEscapedCharacters(None)
+    body = required_with_escaped_characters.RequiredWithEscapedCharacters.validate(None)
     try:
         api_response = api_instance.post_required_with_escaped_characters_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_simple_enum_validation_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_simple_enum_validation_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = simple_enum_validation.SimpleEnumValidation(None)
+    body = simple_enum_validation.SimpleEnumValidation.validate(None)
     try:
         api_response = api_instance.post_simple_enum_validation_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_small_multiple_of_large_integer_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_small_multiple_of_large_integer_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = multiple_of_api.MultipleOfApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = small_multiple_of_large_integer.SmallMultipleOfLargeInteger(None)
+    body = small_multiple_of_large_integer.SmallMultipleOfLargeInteger.validate(None)
     try:
         api_response = api_instance.post_small_multiple_of_large_integer_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_string_type_matches_strings_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_string_type_matches_strings_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = string_type_matches_strings.StringTypeMatchesStrings(None)
+    body = string_type_matches_strings.StringTypeMatchesStrings.validate(None)
     try:
         api_response = api_instance.post_string_type_matches_strings_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_time_format_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_time_format_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = time_format.TimeFormat(None)
+    body = time_format.TimeFormat.validate(None)
     try:
         api_response = api_instance.post_time_format_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_type_array_object_or_null_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_type_array_object_or_null_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = type_array_object_or_null.TypeArrayObjectOrNull(None)
+    body = type_array_object_or_null.TypeArrayObjectOrNull.validate(None)
     try:
         api_response = api_instance.post_type_array_object_or_null_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_type_array_or_object_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_type_array_or_object_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = type_array_or_object.TypeArrayOrObject(None)
+    body = type_array_or_object.TypeArrayOrObject.validate(None)
     try:
         api_response = api_instance.post_type_array_or_object_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_type_as_array_with_one_item_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_type_as_array_with_one_item_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = type_as_array_with_one_item.TypeAsArrayWithOneItem(None)
+    body = type_as_array_with_one_item.TypeAsArrayWithOneItem.validate(None)
     try:
         api_response = api_instance.post_type_as_array_with_one_item_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_uniqueitems_false_validation_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_uniqueitems_false_validation_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = uniqueitems_false_validation.UniqueitemsFalseValidation(None)
+    body = uniqueitems_false_validation.UniqueitemsFalseValidation.validate(None)
     try:
         api_response = api_instance.post_uniqueitems_false_validation_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_uniqueitems_false_with_an_array_of_items_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_uniqueitems_false_with_an_array_of_items_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = uniqueitems_false_with_an_array_of_items.UniqueitemsFalseWithAnArrayOfItems(None)
+    body = uniqueitems_false_with_an_array_of_items.UniqueitemsFalseWithAnArrayOfItems.validate(None)
     try:
         api_response = api_instance.post_uniqueitems_false_with_an_array_of_items_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_uniqueitems_validation_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_uniqueitems_validation_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = uniqueitems_validation.UniqueitemsValidation(None)
+    body = uniqueitems_validation.UniqueitemsValidation.validate(None)
     try:
         api_response = api_instance.post_uniqueitems_validation_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_uniqueitems_with_an_array_of_items_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_uniqueitems_with_an_array_of_items_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = uniqueitems_with_an_array_of_items.UniqueitemsWithAnArrayOfItems(None)
+    body = uniqueitems_with_an_array_of_items.UniqueitemsWithAnArrayOfItems.validate(None)
     try:
         api_response = api_instance.post_uniqueitems_with_an_array_of_items_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_uri_format_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_uri_format_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = uri_format.UriFormat(None)
+    body = uri_format.UriFormat.validate(None)
     try:
         api_response = api_instance.post_uri_format_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_uri_reference_format_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_uri_reference_format_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = uri_reference_format.UriReferenceFormat(None)
+    body = uri_reference_format.UriReferenceFormat.validate(None)
     try:
         api_response = api_instance.post_uri_reference_format_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_uri_template_format_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_uri_template_format_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = uri_template_format.UriTemplateFormat(None)
+    body = uri_template_format.UriTemplateFormat.validate(None)
     try:
         api_response = api_instance.post_uri_template_format_request_body(
             body=body,

--- a/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_uuid_format_request_body/post.md
+++ b/samples/client/3_1_0_unit_test/python/docs/paths/request_body_post_uuid_format_request_body/post.md
@@ -98,7 +98,7 @@ with unit_test_api.ApiClient(used_configuration) as api_client:
     api_instance = operation_request_body_api.OperationRequestBodyApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = uuid_format.UuidFormat(None)
+    body = uuid_format.UuidFormat.validate(None)
     try:
         api_response = api_instance.post_uuid_format_request_body(
             body=body,

--- a/samples/client/openapi_features/nonCompliantUseDiscriminatorIfCompositionFails/python/README.md
+++ b/samples/client/openapi_features/nonCompliantUseDiscriminatorIfCompositionFails/python/README.md
@@ -146,7 +146,7 @@ with this_package.ApiClient(used_configuration) as api_client:
     api_instance = default_api.DefaultApi(api_client)
 
     # example passing only optional values
-    body = operator.Operator(
+    body = operator.Operator.validate(
         "a": 3.14,
         "b": 3.14,
         "operator_id": "ADD",

--- a/samples/client/openapi_features/nonCompliantUseDiscriminatorIfCompositionFails/python/docs/paths/operators/post.md
+++ b/samples/client/openapi_features/nonCompliantUseDiscriminatorIfCompositionFails/python/docs/paths/operators/post.md
@@ -95,7 +95,7 @@ with this_package.ApiClient(used_configuration) as api_client:
     api_instance = default_api.DefaultApi(api_client)
 
     # example passing only optional values
-    body = operator.Operator(
+    body = operator.Operator.validate(
         "a": 3.14,
         "b": 3.14,
         "operator_id": "ADD",

--- a/samples/client/petstore/python/docs/paths/another_fake_dummy/patch.md
+++ b/samples/client/petstore/python/docs/paths/another_fake_dummy/patch.md
@@ -99,7 +99,7 @@ with petstore_api.ApiClient(used_configuration) as api_client:
     api_instance = another_fake_api.AnotherFakeApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = client.Client({
+    body = client.Client.validate({
         "client": "client_example",
     })
     try:

--- a/samples/client/petstore/python/docs/paths/fake/patch.md
+++ b/samples/client/petstore/python/docs/paths/fake/patch.md
@@ -99,7 +99,7 @@ with petstore_api.ApiClient(used_configuration) as api_client:
     api_instance = fake_api.FakeApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = client.Client({
+    body = client.Client.validate({
         "client": "client_example",
     })
     try:

--- a/samples/client/petstore/python/docs/paths/fake_additional_properties_with_array_of_enums/get.md
+++ b/samples/client/petstore/python/docs/paths/fake_additional_properties_with_array_of_enums/get.md
@@ -119,9 +119,9 @@ with petstore_api.ApiClient(used_configuration) as api_client:
     api_instance = fake_api.FakeApi(api_client)
 
     # example passing only optional values
-    body = additional_properties_with_array_of_enums.AdditionalPropertiesWithArrayOfEnums({
+    body = additional_properties_with_array_of_enums.AdditionalPropertiesWithArrayOfEnums.validate({
         "key": [
-            enum_class.EnumClass("-efg")
+            enum_class.EnumClass.validate("-efg")
         ],
     })
     try:

--- a/samples/client/petstore/python/docs/paths/fake_body_with_file_schema/put.md
+++ b/samples/client/petstore/python/docs/paths/fake_body_with_file_schema/put.md
@@ -86,12 +86,12 @@ with petstore_api.ApiClient(used_configuration) as api_client:
     api_instance = fake_api.FakeApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = file_schema_test_class.FileSchemaTestClass({
-        "file": file.File({
+    body = file_schema_test_class.FileSchemaTestClass.validate({
+        "file": file.File.validate({
             "source_uri": "source_uri_example",
         }),
         "files": [
-            file.File({})
+            file.File.validate({})
         ],
     })
     try:

--- a/samples/client/petstore/python/docs/paths/fake_body_with_query_params/put.md
+++ b/samples/client/petstore/python/docs/paths/fake_body_with_query_params/put.md
@@ -128,7 +128,7 @@ with petstore_api.ApiClient(used_configuration) as api_client:
     query_params: operation.QueryParametersDictInput = {
         'query': "query_example",
     }
-    body = user.User({
+    body = user.User.validate({
         "id": 1,
         "username": "username_example",
         "first_name": "first_name_example",

--- a/samples/client/petstore/python/docs/paths/fake_classname_test/patch.md
+++ b/samples/client/petstore/python/docs/paths/fake_classname_test/patch.md
@@ -126,7 +126,7 @@ with petstore_api.ApiClient(used_configuration) as api_client:
     api_instance = fake_classname_tags123_api.FakeClassnameTags123Api(api_client)
 
     # example passing only required values which don't have defaults set
-    body = client.Client({
+    body = client.Client.validate({
         "client": "client_example",
     })
     try:

--- a/samples/client/petstore/python/docs/paths/fake_json_patch/patch.md
+++ b/samples/client/petstore/python/docs/paths/fake_json_patch/patch.md
@@ -87,7 +87,7 @@ with petstore_api.ApiClient(used_configuration) as api_client:
     api_instance = fake_api.FakeApi(api_client)
 
     # example passing only optional values
-    body = json_patch_request.JSONPatchRequest([
+    body = json_patch_request.JSONPatchRequest.validate([
         None
     ])
     try:

--- a/samples/client/petstore/python/docs/paths/fake_ref_obj_in_query/get.md
+++ b/samples/client/petstore/python/docs/paths/fake_ref_obj_in_query/get.md
@@ -107,8 +107,8 @@ with petstore_api.ApiClient(used_configuration) as api_client:
 
     # example passing only optional values
     query_params: operation.QueryParametersDictInput = {
-        'mapBean': foo.Foo({
-        "bar": bar.Bar("bar"),
+        'mapBean': foo.Foo.validate({
+        "bar": bar.Bar.validate("bar"),
     }),
     }
     try:

--- a/samples/client/petstore/python/docs/paths/fake_refs_array_of_enums/post.md
+++ b/samples/client/petstore/python/docs/paths/fake_refs_array_of_enums/post.md
@@ -119,8 +119,8 @@ with petstore_api.ApiClient(used_configuration) as api_client:
     api_instance = fake_api.FakeApi(api_client)
 
     # example passing only optional values
-    body = array_of_enums.ArrayOfEnums([
-        string_enum.StringEnum("string_example")
+    body = array_of_enums.ArrayOfEnums.validate([
+        string_enum.StringEnum.validate("string_example")
     ])
     try:
         # Array of Enums

--- a/samples/client/petstore/python/docs/paths/fake_refs_arraymodel/post.md
+++ b/samples/client/petstore/python/docs/paths/fake_refs_arraymodel/post.md
@@ -119,8 +119,8 @@ with petstore_api.ApiClient(used_configuration) as api_client:
     api_instance = fake_api.FakeApi(api_client)
 
     # example passing only optional values
-    body = animal_farm.AnimalFarm([
-        animal.Animal({})
+    body = animal_farm.AnimalFarm.validate([
+        animal.Animal.validate({})
     ])
     try:
         api_response = api_instance.array_model(

--- a/samples/client/petstore/python/docs/paths/fake_refs_boolean/post.md
+++ b/samples/client/petstore/python/docs/paths/fake_refs_boolean/post.md
@@ -119,7 +119,7 @@ with petstore_api.ApiClient(used_configuration) as api_client:
     api_instance = fake_api.FakeApi(api_client)
 
     # example passing only optional values
-    body = boolean.Boolean(True)
+    body = boolean.Boolean.validate(True)
     try:
         api_response = api_instance.boolean(
             body=body,

--- a/samples/client/petstore/python/docs/paths/fake_refs_composed_one_of_number_with_validations/post.md
+++ b/samples/client/petstore/python/docs/paths/fake_refs_composed_one_of_number_with_validations/post.md
@@ -119,7 +119,7 @@ with petstore_api.ApiClient(used_configuration) as api_client:
     api_instance = fake_api.FakeApi(api_client)
 
     # example passing only optional values
-    body = composed_one_of_different_types.ComposedOneOfDifferentTypes(None)
+    body = composed_one_of_different_types.ComposedOneOfDifferentTypes.validate(None)
     try:
         api_response = api_instance.composed_one_of_different_types(
             body=body,

--- a/samples/client/petstore/python/docs/paths/fake_refs_enum/post.md
+++ b/samples/client/petstore/python/docs/paths/fake_refs_enum/post.md
@@ -119,7 +119,7 @@ with petstore_api.ApiClient(used_configuration) as api_client:
     api_instance = fake_api.FakeApi(api_client)
 
     # example passing only optional values
-    body = string_enum.StringEnum("placed")
+    body = string_enum.StringEnum.validate("placed")
     try:
         api_response = api_instance.string_enum(
             body=body,

--- a/samples/client/petstore/python/docs/paths/fake_refs_mammal/post.md
+++ b/samples/client/petstore/python/docs/paths/fake_refs_mammal/post.md
@@ -119,7 +119,7 @@ with petstore_api.ApiClient(used_configuration) as api_client:
     api_instance = fake_api.FakeApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = mammal.Mammal(
+    body = mammal.Mammal.validate(
         "has_baleen": True,
         "has_teeth": True,
         "class_name": "whale",

--- a/samples/client/petstore/python/docs/paths/fake_refs_number/post.md
+++ b/samples/client/petstore/python/docs/paths/fake_refs_number/post.md
@@ -119,7 +119,7 @@ with petstore_api.ApiClient(used_configuration) as api_client:
     api_instance = fake_api.FakeApi(api_client)
 
     # example passing only optional values
-    body = number_with_validations.NumberWithValidations(10)
+    body = number_with_validations.NumberWithValidations.validate(10)
     try:
         api_response = api_instance.number_with_validations(
             body=body,

--- a/samples/client/petstore/python/docs/paths/fake_refs_object_model_with_ref_props/post.md
+++ b/samples/client/petstore/python/docs/paths/fake_refs_object_model_with_ref_props/post.md
@@ -119,10 +119,10 @@ with petstore_api.ApiClient(used_configuration) as api_client:
     api_instance = fake_api.FakeApi(api_client)
 
     # example passing only optional values
-    body = object_model_with_ref_props.ObjectModelWithRefProps({
-        "my_number": number_with_validations.NumberWithValidations(10),
-        "my_string": string.String("my_string_example"),
-        "my_boolean": boolean.Boolean(True),
+    body = object_model_with_ref_props.ObjectModelWithRefProps.validate({
+        "my_number": number_with_validations.NumberWithValidations.validate(10),
+        "my_string": string.String.validate("my_string_example"),
+        "my_boolean": boolean.Boolean.validate(True),
     })
     try:
         api_response = api_instance.object_model_with_ref_props(

--- a/samples/client/petstore/python/docs/paths/fake_refs_string/post.md
+++ b/samples/client/petstore/python/docs/paths/fake_refs_string/post.md
@@ -119,7 +119,7 @@ with petstore_api.ApiClient(used_configuration) as api_client:
     api_instance = fake_api.FakeApi(api_client)
 
     # example passing only optional values
-    body = string.String("string_example")
+    body = string.String.validate("string_example")
     try:
         api_response = api_instance.string(
             body=body,

--- a/samples/client/petstore/python/docs/paths/fake_test_query_paramters/put.md
+++ b/samples/client/petstore/python/docs/paths/fake_test_query_paramters/put.md
@@ -136,7 +136,7 @@ with petstore_api.ApiClient(used_configuration) as api_client:
         'context': [
         "context_example"
     ],
-        'refParam': string_with_validation.StringWithValidation("refParam_example"),
+        'refParam': string_with_validation.StringWithValidation.validate("refParam_example"),
     }
     try:
         api_response = api_instance.query_parameter_collection_format(

--- a/samples/client/petstore/python/docs/paths/pet/post.md
+++ b/samples/client/petstore/python/docs/paths/pet/post.md
@@ -154,9 +154,9 @@ with petstore_api.ApiClient(used_configuration) as api_client:
     api_instance = pet_api.PetApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = pet.Pet({
+    body = pet.Pet.validate({
         "id": 1,
-        "category": category.Category({
+        "category": category.Category.validate({
             "id": 1,
             "name": "default-name",
         }),
@@ -165,7 +165,7 @@ with petstore_api.ApiClient(used_configuration) as api_client:
             "photo_urls_example"
         ],
         "tags": [
-            tag.Tag({
+            tag.Tag.validate({
                 "id": 1,
                 "name": "name_example",
             })

--- a/samples/client/petstore/python/docs/paths/pet/put.md
+++ b/samples/client/petstore/python/docs/paths/pet/put.md
@@ -166,9 +166,9 @@ with petstore_api.ApiClient(used_configuration) as api_client:
     api_instance = pet_api.PetApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = pet.Pet({
+    body = pet.Pet.validate({
         "id": 1,
-        "category": category.Category({
+        "category": category.Category.validate({
             "id": 1,
             "name": "default-name",
         }),
@@ -177,7 +177,7 @@ with petstore_api.ApiClient(used_configuration) as api_client:
             "photo_urls_example"
         ],
         "tags": [
-            tag.Tag({
+            tag.Tag.validate({
                 "id": 1,
                 "name": "name_example",
             })

--- a/samples/client/petstore/python/docs/paths/store_order/post.md
+++ b/samples/client/petstore/python/docs/paths/store_order/post.md
@@ -143,7 +143,7 @@ with petstore_api.ApiClient(used_configuration) as api_client:
     api_instance = store_api.StoreApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = order.Order({
+    body = order.Order.validate({
         "id": 1,
         "pet_id": 1,
         "quantity": 1,

--- a/samples/client/petstore/python/docs/paths/user/post.md
+++ b/samples/client/petstore/python/docs/paths/user/post.md
@@ -102,7 +102,7 @@ with petstore_api.ApiClient(used_configuration) as api_client:
     api_instance = user_api.UserApi(api_client)
 
     # example passing only required values which don't have defaults set
-    body = user.User({
+    body = user.User.validate({
         "id": 1,
         "username": "username_example",
         "first_name": "first_name_example",

--- a/samples/client/petstore/python/docs/paths/user_create_with_array/post.md
+++ b/samples/client/petstore/python/docs/paths/user_create_with_array/post.md
@@ -81,7 +81,7 @@ with petstore_api.ApiClient(used_configuration) as api_client:
 
     # example passing only required values which don't have defaults set
     body = [
-        user.User({
+        user.User.validate({
             "id": 1,
             "username": "username_example",
             "first_name": "first_name_example",

--- a/samples/client/petstore/python/docs/paths/user_create_with_list/post.md
+++ b/samples/client/petstore/python/docs/paths/user_create_with_list/post.md
@@ -81,7 +81,7 @@ with petstore_api.ApiClient(used_configuration) as api_client:
 
     # example passing only required values which don't have defaults set
     body = [
-        user.User({
+        user.User.validate({
             "id": 1,
             "username": "username_example",
             "first_name": "first_name_example",

--- a/samples/client/petstore/python/docs/paths/user_username/put.md
+++ b/samples/client/petstore/python/docs/paths/user_username/put.md
@@ -158,7 +158,7 @@ with petstore_api.ApiClient(used_configuration) as api_client:
     path_params: operation.PathParametersDictInput = {
         'username': "username_example",
     }
-    body = user.User({
+    body = user.User.validate({
         "id": 1,
         "username": "username_example",
         "first_name": "first_name_example",

--- a/src/main/java/org/openapijsonschematools/codegen/generators/PythonClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/PythonClientGenerator.java
@@ -1280,7 +1280,7 @@ public class PythonClientGenerator extends AbstractPythonGenerator {
         String openChars = "";
         String closeChars = "";
         if (modelName != null) {
-            openChars = modelName + "(";
+            openChars = modelName + ".validate(";
             closeChars = ")";
             if (ModelUtils.isTypeObjectSchema(schema)) {
                 openChars = openChars + "{";

--- a/src/test/resources/3_0/issue_13043_geometry_collection_expected_value.txt
+++ b/src/test/resources/3_0/issue_13043_geometry_collection_expected_value.txt
@@ -1,4 +1,4 @@
-geometry_collection.GeometryCollection({
+geometry_collection.GeometryCollection.validate({
         "type": "GeometryCollection",
         "geometries": [],
     })

--- a/src/test/resources/3_0/issue_13043_recursive_model_expected_value.txt
+++ b/src/test/resources/3_0/issue_13043_recursive_model_expected_value.txt
@@ -1,4 +1,4 @@
-geo_json_geometry.GeoJsonGeometry({
+geo_json_geometry.GeoJsonGeometry.validate({
         "type": "GeometryCollection",
         "geometries": [],
     })

--- a/src/test/resources/3_0/issue_7532_tree_example_value_expected.txt
+++ b/src/test/resources/3_0/issue_7532_tree_example_value_expected.txt
@@ -1,15 +1,15 @@
 {
-        "trees": tree.Tree({
+        "trees": tree.Tree.validate({
             "id": 1,
             "name": "name_example",
             "description": "description_example",
             "children": [
                 tree.Tree({})
             ],
-            "parent": tree.Tree({}),
-            "forest": forest.Forest({}),
+            "parent": tree.Tree.validate({}),
+            "forest": forest.Forest.validate({}),
             "additional": {
-                "key": tree.Tree({}),
+                "key": tree.Tree.validate({}),
             },
         }),
     }

--- a/src/test/resources/3_0/issue_7532_tree_example_value_expected.txt
+++ b/src/test/resources/3_0/issue_7532_tree_example_value_expected.txt
@@ -4,7 +4,7 @@
             "name": "name_example",
             "description": "description_example",
             "children": [
-                tree.Tree({})
+                tree.Tree.validate({})
             ],
             "parent": tree.Tree.validate({}),
             "forest": forest.Forest.validate({}),


### PR DESCRIPTION
Fixes documentation, adds validate invocation in schema examples
Merging this will close the documentation bug that created the issue linked to this PR

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
