### PR TITLE
Fixes mypy redundant casts issue

### DIFF
--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/additionalproperties_are_allowed_by_default.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/additionalproperties_are_allowed_by_default.py
@@ -73,20 +73,14 @@ class AdditionalpropertiesAreAllowedByDefaultDict(schemas.immutabledict[str, sch
         val = self.get("foo", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     @property
     def bar(self) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         val = self.get("bar", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/additionalproperties_should_not_look_in_applicators.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/additionalproperties_should_not_look_in_applicators.py
@@ -65,10 +65,7 @@ class _0Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
         val = self.get("foo", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/allof.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/allof.py
@@ -125,10 +125,7 @@ class _1Dict(schemas.immutabledict[str, str]):
     
     @property
     def foo(self) -> str:
-        return typing.cast(
-            str,
-            self.__getitem__("foo")
-        )
+        return self.__getitem__("foo")
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/allof_with_base_schema.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/allof_with_base_schema.py
@@ -53,10 +53,7 @@ class _0Dict(schemas.immutabledict[str, str]):
     
     @property
     def foo(self) -> str:
-        return typing.cast(
-            str,
-            self.__getitem__("foo")
-        )
+        return self.__getitem__("foo")
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)
@@ -125,10 +122,7 @@ class _1Dict(schemas.immutabledict[str, None]):
     
     @property
     def baz(self) -> None:
-        return typing.cast(
-            None,
-            self.__getitem__("baz")
-        )
+        return self.__getitem__("baz")
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/anyof_complex_types.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/anyof_complex_types.py
@@ -125,10 +125,7 @@ class _1Dict(schemas.immutabledict[str, str]):
     
     @property
     def foo(self) -> str:
-        return typing.cast(
-            str,
-            self.__getitem__("foo")
-        )
+        return self.__getitem__("foo")
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/invalid_string_value_for_default.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/invalid_string_value_for_default.py
@@ -73,10 +73,7 @@ class InvalidStringValueForDefaultDict(schemas.immutabledict[str, str]):
         val = self.get("bar", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/not_more_complex_schema.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/not_more_complex_schema.py
@@ -63,10 +63,7 @@ class NotDict(schemas.immutabledict[str, str]):
         val = self.get("foo", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/oneof_complex_types.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/oneof_complex_types.py
@@ -125,10 +125,7 @@ class _1Dict(schemas.immutabledict[str, str]):
     
     @property
     def foo(self) -> str:
-        return typing.cast(
-            str,
-            self.__getitem__("foo")
-        )
+        return self.__getitem__("foo")
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/required_default_validation.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/required_default_validation.py
@@ -64,10 +64,7 @@ class RequiredDefaultValidationDict(schemas.immutabledict[str, schemas.OUTPUT_BA
         val = self.get("foo", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/required_validation.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/required_validation.py
@@ -70,20 +70,14 @@ class RequiredValidationDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPE
     
     @property
     def foo(self) -> schemas.OUTPUT_BASE_TYPES:
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            self.__getitem__("foo")
-        )
+        return self.__getitem__("foo")
     
     @property
     def bar(self) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         val = self.get("bar", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/required_with_empty_array.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/required_with_empty_array.py
@@ -64,10 +64,7 @@ class RequiredWithEmptyArrayDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_
         val = self.get("foo", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/the_default_keyword_does_not_do_anything_if_the_property_is_missing.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/the_default_keyword_does_not_do_anything_if_the_property_is_missing.py
@@ -74,10 +74,7 @@ class TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissingDict(schemas.immut
         val = self.get("alpha", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            typing.Union[int, float],
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_1_0_json_schema/python/src/json_schema_api/components/schema/any_type_unevaluated_properties_false_with_properties.py
+++ b/samples/client/3_1_0_json_schema/python/src/json_schema_api/components/schema/any_type_unevaluated_properties_false_with_properties.py
@@ -63,10 +63,7 @@ class AnyTypeUnevaluatedPropertiesFalseWithPropertiesDict(schemas.immutabledict[
         val = self.get("someProp", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_1_0_json_schema/python/src/json_schema_api/components/schema/object_unevaluated_properties_false_with_properties.py
+++ b/samples/client/3_1_0_json_schema/python/src/json_schema_api/components/schema/object_unevaluated_properties_false_with_properties.py
@@ -63,10 +63,7 @@ class ObjectUnevaluatedPropertiesFalseWithPropertiesDict(schemas.immutabledict[s
         val = self.get("someProp", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/additionalproperties_are_allowed_by_default.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/additionalproperties_are_allowed_by_default.py
@@ -73,20 +73,14 @@ class AdditionalpropertiesAreAllowedByDefaultDict(schemas.immutabledict[str, sch
         val = self.get("foo", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     @property
     def bar(self) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         val = self.get("bar", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/additionalproperties_does_not_look_in_applicators.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/additionalproperties_does_not_look_in_applicators.py
@@ -65,10 +65,7 @@ class _0Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
         val = self.get("foo", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/allof.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/allof.py
@@ -125,10 +125,7 @@ class _1Dict(schemas.immutabledict[str, str]):
     
     @property
     def foo(self) -> str:
-        return typing.cast(
-            str,
-            self.__getitem__("foo")
-        )
+        return self.__getitem__("foo")
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/allof_with_base_schema.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/allof_with_base_schema.py
@@ -53,10 +53,7 @@ class _0Dict(schemas.immutabledict[str, str]):
     
     @property
     def foo(self) -> str:
-        return typing.cast(
-            str,
-            self.__getitem__("foo")
-        )
+        return self.__getitem__("foo")
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)
@@ -125,10 +122,7 @@ class _1Dict(schemas.immutabledict[str, None]):
     
     @property
     def baz(self) -> None:
-        return typing.cast(
-            None,
-            self.__getitem__("baz")
-        )
+        return self.__getitem__("baz")
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/anyof_complex_types.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/anyof_complex_types.py
@@ -125,10 +125,7 @@ class _1Dict(schemas.immutabledict[str, str]):
     
     @property
     def foo(self) -> str:
-        return typing.cast(
-            str,
-            self.__getitem__("foo")
-        )
+        return self.__getitem__("foo")
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/dependent_schemas_dependent_subschema_incompatible_with_root.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/dependent_schemas_dependent_subschema_incompatible_with_root.py
@@ -63,10 +63,7 @@ class FooDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
         val = self.get("bar", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
 FooDictInput = typing.TypedDict(
     'FooDictInput',
     {
@@ -169,10 +166,7 @@ class DependentSchemasDependentSubschemaIncompatibleWithRootDict(schemas.immutab
         val = self.get("foo", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/not_more_complex_schema.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/not_more_complex_schema.py
@@ -63,10 +63,7 @@ class NotDict(schemas.immutabledict[str, str]):
         val = self.get("foo", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/oneof_complex_types.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/oneof_complex_types.py
@@ -125,10 +125,7 @@ class _1Dict(schemas.immutabledict[str, str]):
     
     @property
     def foo(self) -> str:
-        return typing.cast(
-            str,
-            self.__getitem__("foo")
-        )
+        return self.__getitem__("foo")
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/properties_whose_names_are_javascript_object_property_names.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/properties_whose_names_are_javascript_object_property_names.py
@@ -64,10 +64,7 @@ class ToStringDict(schemas.immutabledict[str, str]):
         val = self.get("length", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)
@@ -160,10 +157,7 @@ class PropertiesWhoseNamesAreJavascriptObjectPropertyNamesDict(schemas.immutable
         val = self.get("__proto__", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            typing.Union[int, float],
-            val
-        )
+        return val
     
     @property
     def toString(self) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
@@ -180,10 +174,7 @@ class PropertiesWhoseNamesAreJavascriptObjectPropertyNamesDict(schemas.immutable
         val = self.get("constructor", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            typing.Union[int, float],
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/properties_with_null_valued_instance_properties.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/properties_with_null_valued_instance_properties.py
@@ -63,10 +63,7 @@ class PropertiesWithNullValuedInstancePropertiesDict(schemas.immutabledict[str, 
         val = self.get("foo", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            None,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/required_default_validation.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/required_default_validation.py
@@ -64,10 +64,7 @@ class RequiredDefaultValidationDict(schemas.immutabledict[str, schemas.OUTPUT_BA
         val = self.get("foo", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/required_validation.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/required_validation.py
@@ -70,20 +70,14 @@ class RequiredValidationDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPE
     
     @property
     def foo(self) -> schemas.OUTPUT_BASE_TYPES:
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            self.__getitem__("foo")
-        )
+        return self.__getitem__("foo")
     
     @property
     def bar(self) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         val = self.get("bar", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/required_with_empty_array.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/required_with_empty_array.py
@@ -64,10 +64,7 @@ class RequiredWithEmptyArrayDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_
         val = self.get("foo", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/unevaluatedproperties_with_adjacent_additionalproperties.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/unevaluatedproperties_with_adjacent_additionalproperties.py
@@ -64,10 +64,7 @@ class UnevaluatedpropertiesWithAdjacentAdditionalpropertiesDict(schemas.immutabl
         val = self.get("foo", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/abstract_step_message.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/abstract_step_message.py
@@ -72,10 +72,7 @@ class AbstractStepMessageDict(schemas.immutabledict[str, str]):
     
     @property
     def discriminator(self) -> str:
-        return typing.cast(
-            str,
-            self.__getitem__("discriminator")
-        )
+        return self.__getitem__("discriminator")
     
     @property
     def sequenceNumber(self) -> schemas.OUTPUT_BASE_TYPES:

--- a/samples/client/petstore/python/src/petstore_api/components/schema/additional_properties_class.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/additional_properties_class.py
@@ -536,20 +536,14 @@ class AdditionalPropertiesClassDict(schemas.immutabledict[str, schemas.immutable
         val = self.get("map_property", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            MapPropertyDict,
-            val
-        )
+        return val
     
     @property
     def map_of_map_property(self) -> typing.Union[MapOfMapPropertyDict, schemas.Unset]:
         val = self.get("map_of_map_property", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            MapOfMapPropertyDict,
-            val
-        )
+        return val
     
     @property
     def anytype_1(self) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
@@ -566,50 +560,35 @@ class AdditionalPropertiesClassDict(schemas.immutabledict[str, schemas.immutable
         val = self.get("map_with_undeclared_properties_anytype_1", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES],
-            val
-        )
+        return val
     
     @property
     def map_with_undeclared_properties_anytype_2(self) -> typing.Union[schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES], schemas.Unset]:
         val = self.get("map_with_undeclared_properties_anytype_2", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES],
-            val
-        )
+        return val
     
     @property
     def map_with_undeclared_properties_anytype_3(self) -> typing.Union[MapWithUndeclaredPropertiesAnytype3Dict, schemas.Unset]:
         val = self.get("map_with_undeclared_properties_anytype_3", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            MapWithUndeclaredPropertiesAnytype3Dict,
-            val
-        )
+        return val
     
     @property
     def empty_map(self) -> typing.Union[EmptyMapDict, schemas.Unset]:
         val = self.get("empty_map", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            EmptyMapDict,
-            val
-        )
+        return val
     
     @property
     def map_with_undeclared_properties_string(self) -> typing.Union[MapWithUndeclaredPropertiesStringDict, schemas.Unset]:
         val = self.get("map_with_undeclared_properties_string", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            MapWithUndeclaredPropertiesStringDict,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/additional_properties_class.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/additional_properties_class.py
@@ -536,14 +536,20 @@ class AdditionalPropertiesClassDict(schemas.immutabledict[str, schemas.immutable
         val = self.get("map_property", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            MapPropertyDict,
+            val
+        )
     
     @property
     def map_of_map_property(self) -> typing.Union[MapOfMapPropertyDict, schemas.Unset]:
         val = self.get("map_of_map_property", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            MapOfMapPropertyDict,
+            val
+        )
     
     @property
     def anytype_1(self) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
@@ -574,21 +580,30 @@ class AdditionalPropertiesClassDict(schemas.immutabledict[str, schemas.immutable
         val = self.get("map_with_undeclared_properties_anytype_3", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            MapWithUndeclaredPropertiesAnytype3Dict,
+            val
+        )
     
     @property
     def empty_map(self) -> typing.Union[EmptyMapDict, schemas.Unset]:
         val = self.get("empty_map", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            EmptyMapDict,
+            val
+        )
     
     @property
     def map_with_undeclared_properties_string(self) -> typing.Union[MapWithUndeclaredPropertiesStringDict, schemas.Unset]:
         val = self.get("map_with_undeclared_properties_string", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            MapWithUndeclaredPropertiesStringDict,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/animal.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/animal.py
@@ -75,20 +75,14 @@ class AnimalDict(schemas.immutabledict[str, str]):
     
     @property
     def className(self) -> str:
-        return typing.cast(
-            str,
-            self.__getitem__("className")
-        )
+        return self.__getitem__("className")
     
     @property
     def color(self) -> typing.Union[str, schemas.Unset]:
         val = self.get("color", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/apple.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/apple.py
@@ -89,20 +89,14 @@ class AppleDict(schemas.immutabledict[str, str]):
     
     @property
     def cultivar(self) -> str:
-        return typing.cast(
-            str,
-            self.__getitem__("cultivar")
-        )
+        return self.__getitem__("cultivar")
     
     @property
     def origin(self) -> typing.Union[str, schemas.Unset]:
         val = self.get("origin", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/array_of_array_of_number_only.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/array_of_array_of_number_only.py
@@ -176,10 +176,7 @@ class ArrayOfArrayOfNumberOnlyDict(schemas.immutabledict[str, typing.Tuple[schem
         val = self.get("ArrayArrayNumber", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            ArrayArrayNumberTuple,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/array_of_array_of_number_only.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/array_of_array_of_number_only.py
@@ -176,7 +176,10 @@ class ArrayOfArrayOfNumberOnlyDict(schemas.immutabledict[str, typing.Tuple[schem
         val = self.get("ArrayArrayNumber", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            ArrayArrayNumberTuple,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/array_of_number_only.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/array_of_number_only.py
@@ -120,7 +120,10 @@ class ArrayOfNumberOnlyDict(schemas.immutabledict[str, typing.Tuple[schemas.OUTP
         val = self.get("ArrayNumber", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            ArrayNumberTuple,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/array_of_number_only.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/array_of_number_only.py
@@ -120,10 +120,7 @@ class ArrayOfNumberOnlyDict(schemas.immutabledict[str, typing.Tuple[schemas.OUTP
         val = self.get("ArrayNumber", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            ArrayNumberTuple,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/array_test.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/array_test.py
@@ -351,30 +351,21 @@ class ArrayTestDict(schemas.immutabledict[str, typing.Tuple[schemas.OUTPUT_BASE_
         val = self.get("array_of_string", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            ArrayOfStringTuple,
-            val
-        )
+        return val
     
     @property
     def array_array_of_integer(self) -> typing.Union[ArrayArrayOfIntegerTuple, schemas.Unset]:
         val = self.get("array_array_of_integer", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            ArrayArrayOfIntegerTuple,
-            val
-        )
+        return val
     
     @property
     def array_array_of_model(self) -> typing.Union[ArrayArrayOfModelTuple, schemas.Unset]:
         val = self.get("array_array_of_model", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            ArrayArrayOfModelTuple,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/array_test.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/array_test.py
@@ -351,21 +351,30 @@ class ArrayTestDict(schemas.immutabledict[str, typing.Tuple[schemas.OUTPUT_BASE_
         val = self.get("array_of_string", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            ArrayOfStringTuple,
+            val
+        )
     
     @property
     def array_array_of_integer(self) -> typing.Union[ArrayArrayOfIntegerTuple, schemas.Unset]:
         val = self.get("array_array_of_integer", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            ArrayArrayOfIntegerTuple,
+            val
+        )
     
     @property
     def array_array_of_model(self) -> typing.Union[ArrayArrayOfModelTuple, schemas.Unset]:
         val = self.get("array_array_of_model", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            ArrayArrayOfModelTuple,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/banana.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/banana.py
@@ -56,10 +56,7 @@ class BananaDict(schemas.immutabledict[str, typing.Union[int, float]]):
     
     @property
     def lengthCm(self) -> typing.Union[int, float]:
-        return typing.cast(
-            typing.Union[int, float],
-            self.__getitem__("lengthCm")
-        )
+        return self.__getitem__("lengthCm")
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/capitalization.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/capitalization.py
@@ -103,60 +103,42 @@ class CapitalizationDict(schemas.immutabledict[str, str]):
         val = self.get("smallCamel", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     @property
     def CapitalCamel(self) -> typing.Union[str, schemas.Unset]:
         val = self.get("CapitalCamel", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     @property
     def small_Snake(self) -> typing.Union[str, schemas.Unset]:
         val = self.get("small_Snake", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     @property
     def Capital_Snake(self) -> typing.Union[str, schemas.Unset]:
         val = self.get("Capital_Snake", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     @property
     def SCA_ETH_Flow_Points(self) -> typing.Union[str, schemas.Unset]:
         val = self.get("SCA_ETH_Flow_Points", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     @property
     def ATT_NAME(self) -> typing.Union[str, schemas.Unset]:
         val = self.get("ATT_NAME", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/cat.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/cat.py
@@ -63,10 +63,7 @@ class _1Dict(schemas.immutabledict[str, bool]):
         val = self.get("declawed", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            bool,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/child_cat.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/child_cat.py
@@ -63,10 +63,7 @@ class _1Dict(schemas.immutabledict[str, str]):
         val = self.get("name", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/class_model.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/class_model.py
@@ -63,10 +63,7 @@ class ClassModelDict(schemas.immutabledict[str, str]):
         val = self.get("_class", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/client.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/client.py
@@ -63,10 +63,7 @@ class ClientDict(schemas.immutabledict[str, str]):
         val = self.get("client", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/dog.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/dog.py
@@ -63,10 +63,7 @@ class _1Dict(schemas.immutabledict[str, str]):
         val = self.get("breed", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/drawing.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/drawing.py
@@ -181,10 +181,7 @@ class DrawingDict(schemas.immutabledict[str, typing.Tuple[schemas.OUTPUT_BASE_TY
         val = self.get("shapes", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            ShapesTuple,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/drawing.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/drawing.py
@@ -181,7 +181,10 @@ class DrawingDict(schemas.immutabledict[str, typing.Tuple[schemas.OUTPUT_BASE_TY
         val = self.get("shapes", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            ShapesTuple,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/file.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/file.py
@@ -63,10 +63,7 @@ class FileDict(schemas.immutabledict[str, str]):
         val = self.get("sourceURI", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/file_schema_test_class.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/file_schema_test_class.py
@@ -139,7 +139,10 @@ class FileSchemaTestClassDict(schemas.immutabledict[str, typing.Tuple[schemas.OU
         val = self.get("files", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            FilesTuple,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/file_schema_test_class.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/file_schema_test_class.py
@@ -139,10 +139,7 @@ class FileSchemaTestClassDict(schemas.immutabledict[str, typing.Tuple[schemas.OU
         val = self.get("files", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            FilesTuple,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/fruit.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/fruit.py
@@ -63,10 +63,7 @@ class FruitDict(schemas.immutabledict[str, str]):
         val = self.get("color", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/gm_fruit.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/gm_fruit.py
@@ -63,10 +63,7 @@ class GmFruitDict(schemas.immutabledict[str, str]):
         val = self.get("color", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/grandparent_animal.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/grandparent_animal.py
@@ -53,10 +53,7 @@ class GrandparentAnimalDict(schemas.immutabledict[str, str]):
     
     @property
     def pet_type(self) -> str:
-        return typing.cast(
-            str,
-            self.__getitem__("pet_type")
-        )
+        return self.__getitem__("pet_type")
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/has_only_read_only.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/has_only_read_only.py
@@ -71,20 +71,14 @@ class HasOnlyReadOnlyDict(schemas.immutabledict[str, str]):
         val = self.get("bar", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     @property
     def foo(self) -> typing.Union[str, schemas.Unset]:
         val = self.get("foo", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/health_check_result.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/health_check_result.py
@@ -105,13 +105,7 @@ class HealthCheckResultDict(schemas.immutabledict[str, typing.Union[
         val = self.get("NullableMessage", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            typing.Union[
-                None,
-                str,
-            ],
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/json_patch_request_add_replace_test.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/json_patch_request_add_replace_test.py
@@ -157,10 +157,7 @@ class JSONPatchRequestAddReplaceTestDict(schemas.immutabledict[str, str]):
     
     @property
     def path(self) -> str:
-        return typing.cast(
-            str,
-            self.__getitem__("path")
-        )
+        return self.__getitem__("path")
     
     @property
     def value(self) -> schemas.OUTPUT_BASE_TYPES:

--- a/samples/client/petstore/python/src/petstore_api/components/schema/json_patch_request_move_copy.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/json_patch_request_move_copy.py
@@ -137,10 +137,7 @@ class JSONPatchRequestMoveCopyDict(schemas.immutabledict[str, str]):
     
     @property
     def path(self) -> str:
-        return typing.cast(
-            str,
-            self.__getitem__("path")
-        )
+        return self.__getitem__("path")
 JSONPatchRequestMoveCopyDictInput = typing.TypedDict(
     'JSONPatchRequestMoveCopyDictInput',
     {

--- a/samples/client/petstore/python/src/petstore_api/components/schema/json_patch_request_remove.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/json_patch_request_remove.py
@@ -119,10 +119,7 @@ class JSONPatchRequestRemoveDict(schemas.immutabledict[str, str]):
     
     @property
     def path(self) -> str:
-        return typing.cast(
-            str,
-            self.__getitem__("path")
-        )
+        return self.__getitem__("path")
 JSONPatchRequestRemoveDictInput = typing.TypedDict(
     'JSONPatchRequestRemoveDictInput',
     {

--- a/samples/client/petstore/python/src/petstore_api/components/schema/number_only.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/number_only.py
@@ -64,10 +64,7 @@ class NumberOnlyDict(schemas.immutabledict[str, typing.Union[int, float]]):
         val = self.get("JustNumber", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            typing.Union[int, float],
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/obj_with_required_props.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/obj_with_required_props.py
@@ -53,10 +53,7 @@ class ObjWithRequiredPropsDict(schemas.immutabledict[str, str]):
     
     @property
     def a(self) -> str:
-        return typing.cast(
-            str,
-            self.__getitem__("a")
-        )
+        return self.__getitem__("a")
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/obj_with_required_props_base.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/obj_with_required_props_base.py
@@ -53,10 +53,7 @@ class ObjWithRequiredPropsBaseDict(schemas.immutabledict[str, str]):
     
     @property
     def b(self) -> str:
-        return typing.cast(
-            str,
-            self.__getitem__("b")
-        )
+        return self.__getitem__("b")
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/object_model_with_arg_and_args_properties.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/object_model_with_arg_and_args_properties.py
@@ -58,17 +58,11 @@ class ObjectModelWithArgAndArgsPropertiesDict(schemas.immutabledict[str, str]):
     
     @property
     def arg(self) -> str:
-        return typing.cast(
-            str,
-            self.__getitem__("arg")
-        )
+        return self.__getitem__("arg")
     
     @property
     def args(self) -> str:
-        return typing.cast(
-            str,
-            self.__getitem__("args")
-        )
+        return self.__getitem__("args")
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/object_with_all_of_with_req_test_prop_from_unset_add_prop.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/object_with_all_of_with_req_test_prop_from_unset_add_prop.py
@@ -77,10 +77,7 @@ class _1Dict(schemas.immutabledict[str, str]):
         val = self.get("name", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/object_with_colliding_properties.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/object_with_colliding_properties.py
@@ -73,20 +73,14 @@ class ObjectWithCollidingPropertiesDict(schemas.immutabledict[str, schemas.immut
         val = self.get("someProp", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES],
-            val
-        )
+        return val
     
     @property
     def someprop(self) -> typing.Union[schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES], schemas.Unset]:
         val = self.get("someprop", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES],
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/object_with_optional_test_prop.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/object_with_optional_test_prop.py
@@ -63,10 +63,7 @@ class ObjectWithOptionalTestPropDict(schemas.immutabledict[str, str]):
         val = self.get("test", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/public_key.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/public_key.py
@@ -63,10 +63,7 @@ class PublicKeyDict(schemas.immutabledict[str, str]):
         val = self.get("key", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/quadrilateral_interface.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/quadrilateral_interface.py
@@ -113,10 +113,7 @@ class QuadrilateralInterfaceDict(schemas.immutabledict[str, str]):
     
     @property
     def quadrilateralType(self) -> str:
-        return typing.cast(
-            str,
-            self.__getitem__("quadrilateralType")
-        )
+        return self.__getitem__("quadrilateralType")
     
     @property
     def shapeType(self) -> typing.Literal["Quadrilateral"]:

--- a/samples/client/petstore/python/src/petstore_api/components/schema/read_only_first.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/read_only_first.py
@@ -71,20 +71,14 @@ class ReadOnlyFirstDict(schemas.immutabledict[str, str]):
         val = self.get("bar", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     @property
     def baz(self) -> typing.Union[str, schemas.Unset]:
         val = self.get("baz", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/req_props_from_explicit_add_props.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/req_props_from_explicit_add_props.py
@@ -48,10 +48,7 @@ class ReqPropsFromExplicitAddPropsDict(schemas.immutabledict[str, str]):
     
     @property
     def validName(self) -> str:
-        return typing.cast(
-            str,
-            self.__getitem__("validName")
-        )
+        return self.__getitem__("validName")
     
     def get_additional_property_(self, name: str) -> typing.Union[str, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/req_props_from_true_add_props.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/req_props_from_true_add_props.py
@@ -51,10 +51,7 @@ class ReqPropsFromTrueAddPropsDict(schemas.immutabledict[str, schemas.OUTPUT_BAS
     
     @property
     def validName(self) -> schemas.OUTPUT_BASE_TYPES:
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            self.__getitem__("validName")
-        )
+        return self.__getitem__("validName")
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/special_model_name.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/special_model_name.py
@@ -63,10 +63,7 @@ class SpecialModelNameDict(schemas.immutabledict[str, str]):
         val = self.get("a", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/triangle_interface.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/triangle_interface.py
@@ -120,10 +120,7 @@ class TriangleInterfaceDict(schemas.immutabledict[str, str]):
     
     @property
     def triangleType(self) -> str:
-        return typing.cast(
-            str,
-            self.__getitem__("triangleType")
-        )
+        return self.__getitem__("triangleType")
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/user.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/user.py
@@ -317,30 +317,21 @@ class UserDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
         val = self.get("anyTypeProp", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     @property
     def anyTypeExceptNullProp(self) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         val = self.get("anyTypeExceptNullProp", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     @property
     def anyTypePropNullable(self) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         val = self.get("anyTypePropNullable", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_json_form_data/get/request_body/content/application_x_www_form_urlencoded/schema.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_json_form_data/get/request_body/content/application_x_www_form_urlencoded/schema.py
@@ -58,17 +58,11 @@ class SchemaDict(schemas.immutabledict[str, str]):
     
     @property
     def param(self) -> str:
-        return typing.cast(
-            str,
-            self.__getitem__("param")
-        )
+        return self.__getitem__("param")
     
     @property
     def param2(self) -> str:
-        return typing.cast(
-            str,
-            self.__getitem__("param2")
-        )
+        return self.__getitem__("param2")
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_multiple_request_body_content_types/post/request_body/content/application_json/schema.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_multiple_request_body_content_types/post/request_body/content/application_json/schema.py
@@ -63,10 +63,7 @@ class SchemaDict(schemas.immutabledict[str, str]):
         val = self.get("a", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_multiple_request_body_content_types/post/request_body/content/multipart_form_data/schema.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_multiple_request_body_content_types/post/request_body/content/multipart_form_data/schema.py
@@ -63,10 +63,7 @@ class SchemaDict(schemas.immutabledict[str, str]):
         val = self.get("b", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_obj_in_query/get/parameters/parameter_0/schema.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_obj_in_query/get/parameters/parameter_0/schema.py
@@ -63,10 +63,7 @@ class SchemaDict(schemas.immutabledict[str, str]):
         val = self.get("keyword", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_pet_id_upload_image_with_required_file/post/request_body/content/multipart_form_data/schema.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_pet_id_upload_image_with_required_file/post/request_body/content/multipart_form_data/schema.py
@@ -81,10 +81,7 @@ class SchemaDict(schemas.immutabledict[str, str]):
         val = self.get("additionalMetadata", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_upload_file/post/request_body/content/multipart_form_data/schema.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_upload_file/post/request_body/content/multipart_form_data/schema.py
@@ -81,10 +81,7 @@ class SchemaDict(schemas.immutabledict[str, str]):
         val = self.get("additionalMetadata", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_upload_files/post/request_body/content/multipart_form_data/schema.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_upload_files/post/request_body/content/multipart_form_data/schema.py
@@ -124,7 +124,10 @@ class SchemaDict(schemas.immutabledict[str, typing.Tuple[schemas.OUTPUT_BASE_TYP
         val = self.get("files", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            FilesTuple,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_upload_files/post/request_body/content/multipart_form_data/schema.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_upload_files/post/request_body/content/multipart_form_data/schema.py
@@ -124,10 +124,7 @@ class SchemaDict(schemas.immutabledict[str, typing.Tuple[schemas.OUTPUT_BASE_TYP
         val = self.get("files", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            FilesTuple,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/paths/pet_pet_id/post/request_body/content/application_x_www_form_urlencoded/schema.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/pet_pet_id/post/request_body/content/application_x_www_form_urlencoded/schema.py
@@ -71,20 +71,14 @@ class SchemaDict(schemas.immutabledict[str, str]):
         val = self.get("name", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     @property
     def status(self) -> typing.Union[str, schemas.Unset]:
         val = self.get("status", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/paths/pet_pet_id_upload_image/post/request_body/content/multipart_form_data/schema.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/pet_pet_id_upload_image/post/request_body/content/multipart_form_data/schema.py
@@ -74,10 +74,7 @@ class SchemaDict(schemas.immutabledict[str, str]):
         val = self.get("additionalMetadata", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
     
     @property
     def file(self) -> typing.Union[bytes, schemas.FileIO, schemas.Unset]:

--- a/samples/client/petstore/python/tests_manual/test_additional_properties_class.py
+++ b/samples/client/petstore/python/tests_manual/test_additional_properties_class.py
@@ -10,8 +10,9 @@
 """
 
 import unittest
+from unittest import mock
 
-from petstore_api.components.schema.additional_properties_class import AdditionalPropertiesClass
+from petstore_api.components.schema import additional_properties_class
 from petstore_api import schemas
 
 
@@ -19,15 +20,26 @@ class TestAdditionalPropertiesClass(unittest.TestCase):
     """AdditionalPropertiesClass unit test stubs"""
 
     def test_additional_properties_class(self):
-        inst = AdditionalPropertiesClass.validate({})
+        inst = additional_properties_class.AdditionalPropertiesClass.validate({})
         with self.assertRaises(KeyError):
             inst["map_property"]
         assert inst.get("map_property", schemas.unset) is schemas.unset
         assert inst.map_property is schemas.unset
 
-        inst = AdditionalPropertiesClass.validate({'map_property': {}})
+        inst = additional_properties_class.AdditionalPropertiesClass.validate({'map_property': {}})
         map_property = inst["map_property"]
         assert map_property == {}
+
+    @mock.patch('petstore_api.components.schema.additional_properties_class.typing.cast')
+    def test_map_property_casting(self, mock_cast):
+        def side_effect(cls, value):
+            return value
+        mock_cast.side_effect = side_effect
+        inst = additional_properties_class.AdditionalPropertiesClass.validate({'map_property': {}})
+        inst.map_property
+        assert mock_cast.mock_calls[-1] == mock.call(
+            additional_properties_class.MapPropertyDict, {}
+        )
 
 
 if __name__ == '__main__':

--- a/samples/client/petstore/python/tests_manual/test_animal.py
+++ b/samples/client/petstore/python/tests_manual/test_animal.py
@@ -11,6 +11,7 @@
 
 
 import unittest
+from unittest import mock
 
 import petstore_api
 from petstore_api.components.schema import animal
@@ -18,12 +19,6 @@ from petstore_api.components.schema import animal
 
 class TestAnimal(unittest.TestCase):
     """Animal unit test stubs"""
-
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
 
     def testAnimal(self):
         """Test Animal"""
@@ -74,6 +69,12 @@ class TestAnimal(unittest.TestCase):
         assert isinstance(inst.className, str)
         assert isinstance(inst["color"], str)
         assert isinstance(inst["breed"], str)
+
+    def test_animal_color_is_not_cast(self):
+        inst = animal.Animal.validate({'className': 'Dog', 'color': 'black'})
+        with mock.patch('petstore_api.components.schema.animal.typing.cast') as mock_cast:
+            assert inst.color == 'black'
+            mock_cast.assert_not_called()
 
 
 if __name__ == '__main__':

--- a/samples/client/petstore/python/tests_manual/test_drawing.py
+++ b/samples/client/petstore/python/tests_manual/test_drawing.py
@@ -11,6 +11,7 @@
 
 
 import unittest
+from unittest import mock
 
 import petstore_api
 from petstore_api import schemas
@@ -22,12 +23,6 @@ from petstore_api.components.schema import drawing
 class TestDrawing(unittest.TestCase):
     """Drawing unit test stubs"""
 
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
     def test_create_instances(self):
         """
         Validate instance can be created
@@ -38,6 +33,28 @@ class TestDrawing(unittest.TestCase):
             'triangleType': "IsoscelesTriangle"
         })
         assert isinstance(inst, schemas.immutabledict)
+
+    @mock.patch('petstore_api.components.schema.drawing.typing.cast')
+    def test_shapes_casting(self, mock_cast):
+        def side_effect(cls, value):
+            return value
+        mock_cast.side_effect = side_effect
+        one_shape = shape.Shape.validate({
+            'shapeType': "Triangle",
+            'triangleType': "EquilateralTriangle"
+        })
+        inst = drawing.Drawing.validate({
+            'shapes': [
+                one_shape,
+            ],
+        })
+        inst.shapes
+        assert mock_cast.mock_calls[-1] == mock.call(
+            drawing.ShapesTuple,
+            (
+                one_shape,
+            ),
+        )
 
     def test_deserialize_oneof_reference(self):
         """

--- a/src/main/java/org/openapijsonschematools/codegen/generators/openapimodels/CodegenSchema.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/openapimodels/CodegenSchema.java
@@ -630,6 +630,7 @@ public class CodegenSchema {
         sb.append(", testCases=").append(testCases);
         sb.append(", instanceType=").append(instanceType);
         sb.append(", jsonPath=").append(jsonPath);
+        sb.append(", arrayOutputJsonPathPiece=").append(arrayOutputJsonPathPiece);
     }
 
     @Override
@@ -689,7 +690,9 @@ public class CodegenSchema {
                 Objects.equals(vendorExtensions, that.vendorExtensions) &&
                 Objects.equals(maxItems, that.maxItems) &&
                 Objects.equals(minItems, that.minItems) &&
-                Objects.equals(multipleOf, that.multipleOf);
+                Objects.equals(multipleOf, that.multipleOf) &&
+                Objects.equals(mapOutputJsonPathPiece, that.mapOutputJsonPathPiece) &&
+                Objects.equals(arrayOutputJsonPathPiece, that.arrayInputJsonPathPiece);
     }
 
     @Override

--- a/src/main/java/org/openapijsonschematools/codegen/generators/openapimodels/CodegenSchema.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/openapimodels/CodegenSchema.java
@@ -124,6 +124,17 @@ public class CodegenSchema {
         return maxItems != null || minItems != null || minProperties != null || maxProperties != null || minLength != null || maxLength != null || multipleOf != null || patternInfo != null || minimum != null || maximum != null || exclusiveMinimum != null || exclusiveMaximum != null || uniqueItems != null;
     }
 
+    public CodegenSchema typeSchema() {
+        CodegenSchema schema = new CodegenSchema();
+        schema.refInfo = refInfo;
+        schema.types = types;
+        schema.format = format;
+        schema.enumInfo = enumInfo;
+        schema.arrayOutputJsonPathPiece = arrayOutputJsonPathPiece;
+        schema.mapOutputJsonPathPiece = mapOutputJsonPathPiece;
+        return schema;
+    }
+
     public boolean hasDiscriminatorWithNonEmptyMapping() {
         if (discriminator == null) {
             return false;

--- a/src/main/resources/python/components/schemas/_object_output_get_property.hbs
+++ b/src/main/resources/python/components/schemas/_object_output_get_property.hbs
@@ -1,22 +1,22 @@
 {{#if required}}
+    {{#and ../../mapValueSchema (eq typeSchema ../../mapValueSchema.typeSchema) }}
+return self.__getitem__("{{{@key.original}}}")
+    {{else}}
 return typing.cast(
-{{#if refInfo.refClass}}
     {{> components/schemas/types/schema_output_type fullRefModule="" mode="unprefixed" endChar="," }}
-{{else}}
-    {{> components/schemas/types/schema_output_type fullRefModule="" mode="unprefixed" endChar="," }}
-{{/if}}
     self.__getitem__("{{{@key.original}}}")
 )
+    {{/and}}
 {{else}}
 val = self.get("{{{@key.original}}}", schemas.unset)
 if isinstance(val, schemas.Unset):
     return val
+    {{#and ../../mapValueSchema (eq typeSchema ../../mapValueSchema.typeSchema) }}
+return val
+    {{else}}
 return typing.cast(
-{{#if refInfo.refClass}}
     {{> components/schemas/types/schema_output_type fullRefModule="" mode="unprefixed" endChar="," }}
-{{else}}
-    {{> components/schemas/types/schema_output_type fullRefModule="" mode="unprefixed" endChar="," }}
-{{/if}}
     val
 )
+    {{/and}}
 {{/if}}


### PR DESCRIPTION
- Fixes mypy redundant casts issue
- verification tests added

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
