### PR TITLE
Issue 246 fix

### DIFF
--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/additionalproperties_allows_a_schema_which_should_validate.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/additionalproperties_allows_a_schema_which_should_validate.md
@@ -34,7 +34,7 @@ Key | Type |  Description | Notes
 
 ## AdditionalpropertiesAllowsASchemaWhichShouldValidateDict
 ```
-base class: schemas.immutabledict[str, bool]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/allof.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/allof.md
@@ -37,7 +37,7 @@ Key | Type |  Description | Notes
 
 ## _0Dict
 ```
-base class: schemas.immutabledict[str, int]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
@@ -78,7 +78,7 @@ Key | Type |  Description | Notes
 
 ## _1Dict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/allof_with_base_schema.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/allof_with_base_schema.md
@@ -20,7 +20,7 @@ Key | Type |  Description | Notes
 
 ## AllofWithBaseSchemaDict
 ```
-base class: schemas.immutabledict[str, int]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
@@ -68,7 +68,7 @@ Key | Type |  Description | Notes
 
 ## _0Dict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
@@ -109,7 +109,7 @@ Key | Type |  Description | Notes
 
 ## _1Dict
 ```
-base class: schemas.immutabledict[str, None]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/anyof_complex_types.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/anyof_complex_types.md
@@ -37,7 +37,7 @@ Key | Type |  Description | Notes
 
 ## _0Dict
 ```
-base class: schemas.immutabledict[str, int]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
@@ -78,7 +78,7 @@ Key | Type |  Description | Notes
 
 ## _1Dict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/enums_in_properties.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/enums_in_properties.md
@@ -21,7 +21,7 @@ Key | Type |  Description | Notes
 
 ## EnumsInPropertiesDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/forbidden_property.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/forbidden_property.md
@@ -21,6 +21,7 @@ Key | Type |  Description | Notes
 ## ForbiddenPropertyDict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/invalid_string_value_for_default.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/invalid_string_value_for_default.md
@@ -20,7 +20,7 @@ Key | Type |  Description | Notes
 
 ## InvalidStringValueForDefaultDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/not_more_complex_schema.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/not_more_complex_schema.md
@@ -36,7 +36,7 @@ Key | Type |  Description | Notes
 
 ## NotDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/oneof_complex_types.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/oneof_complex_types.md
@@ -37,7 +37,7 @@ Key | Type |  Description | Notes
 
 ## _0Dict
 ```
-base class: schemas.immutabledict[str, int]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
@@ -78,7 +78,7 @@ Key | Type |  Description | Notes
 
 ## _1Dict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/oneof_with_required.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/oneof_with_required.md
@@ -39,6 +39,7 @@ Key | Type |  Description | Notes
 ## _0Dict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes
@@ -82,6 +83,7 @@ Key | Type |  Description | Notes
 ## _1Dict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/properties_with_escaped_characters.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/properties_with_escaped_characters.md
@@ -25,7 +25,7 @@ Key | Type |  Description | Notes
 
 ## PropertiesWithEscapedCharactersDict
 ```
-base class: schemas.immutabledict[str, typing.Union[int, float]]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
@@ -37,7 +37,7 @@ Keyword Argument | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [PropertiesWithEscapedCharactersDictInput](#propertieswithescapedcharactersdictinput), [PropertiesWithEscapedCharactersDict](#propertieswithescapedcharactersdict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [PropertiesWithEscapedCharactersDict](#propertieswithescapedcharactersdict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-&lowbar;&lowbar;getitem&lowbar;&lowbar; | str | float, int | This model has invalid python names so this method is used under the hood when you access instance["foo\nbar"], instance["foo\&quot;bar"], instance["foo\\bar"], instance["foo\rbar"], instance["foo\tbar"], instance["foo\fbar"], 
+&lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["foo\nbar"], instance["foo\&quot;bar"], instance["foo\\bar"], instance["foo\rbar"], instance["foo\tbar"], instance["foo\fbar"], 
 get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/property_named_ref_that_is_not_a_reference.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/property_named_ref_that_is_not_a_reference.md
@@ -20,7 +20,7 @@ Key | Type |  Description | Notes
 
 ## PropertyNamedRefThatIsNotAReferenceDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
@@ -32,7 +32,7 @@ Keyword Argument | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [PropertyNamedRefThatIsNotAReferenceDictInput](#propertynamedrefthatisnotareferencedictinput), [PropertyNamedRefThatIsNotAReferenceDict](#propertynamedrefthatisnotareferencedict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [PropertyNamedRefThatIsNotAReferenceDict](#propertynamedrefthatisnotareferencedict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-&lowbar;&lowbar;getitem&lowbar;&lowbar; | str | str | This model has invalid python names so this method is used under the hood when you access instance["$ref"], 
+&lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["$ref"], 
 get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/ref_in_additionalproperties.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/ref_in_additionalproperties.md
@@ -26,6 +26,7 @@ Key | Type |  Description | Notes
 ## RefInAdditionalpropertiesDict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/ref_in_property.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/ref_in_property.md
@@ -21,6 +21,7 @@ Key | Type |  Description | Notes
 ## RefInPropertyDict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/required_with_escaped_characters.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/required_with_escaped_characters.md
@@ -26,6 +26,7 @@ Key | Type |  Description | Notes
 ## RequiredWithEscapedCharactersDict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes
@@ -36,7 +37,7 @@ Keyword Argument | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [RequiredWithEscapedCharactersDictInput](#requiredwithescapedcharactersdictinput), [RequiredWithEscapedCharactersDict](#requiredwithescapedcharactersdict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [RequiredWithEscapedCharactersDict](#requiredwithescapedcharactersdict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-&lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.OUTPUT_BASE_TYPES | This model has invalid python names so this method is used under the hood when you access instance["foo\tbar"], instance["foo\nbar"], instance["foo\fbar"], instance["foo\rbar"], instance["foo\&quot;bar"], instance["foo\\bar"], 
+&lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["foo\tbar"], instance["foo\nbar"], instance["foo\fbar"], instance["foo\rbar"], instance["foo\&quot;bar"], instance["foo\\bar"], 
 get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/the_default_keyword_does_not_do_anything_if_the_property_is_missing.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/the_default_keyword_does_not_do_anything_if_the_property_is_missing.md
@@ -20,7 +20,7 @@ Key | Type |  Description | Notes
 
 ## TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissingDict
 ```
-base class: schemas.immutabledict[str, typing.Union[int, float]]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/api_response.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/api_response.py
@@ -14,27 +14,15 @@ import urllib3
 from unit_test_api import schemas
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse:
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Union[schemas.Unset, schemas.OUTPUT_BASE_TYPES] = schemas.unset,
-        headers: typing.Union[schemas.Unset, typing.Mapping[str, schemas.OUTPUT_BASE_TYPES]] = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self. headers = headers
+    response: urllib3.HTTPResponse
+    body: typing.Union[schemas.Unset, schemas.OUTPUT_BASE_TYPES]
+    headers: typing.Union[schemas.Unset, typing.Mapping[str, schemas.OUTPUT_BASE_TYPES]]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponseWithoutDeserialization(ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self. headers = headers
+    response: urllib3.HTTPResponse
+    body: schemas.Unset = schemas.unset
+    headers: schemas.Unset = schemas.unset

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/additionalproperties_allows_a_schema_which_should_validate.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/additionalproperties_allows_a_schema_which_should_validate.py
@@ -22,7 +22,7 @@ Properties = typing.TypedDict(
 )
 
 
-class AdditionalpropertiesAllowsASchemaWhichShouldValidateDict(schemas.immutabledict[str, bool]):
+class AdditionalpropertiesAllowsASchemaWhichShouldValidateDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -74,20 +74,14 @@ class AdditionalpropertiesAllowsASchemaWhichShouldValidateDict(schemas.immutable
         val = self.get("foo", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     @property
     def bar(self) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         val = self.get("bar", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[bool, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/allof.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/allof.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class _0Dict(schemas.immutabledict[str, int]):
+class _0Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "bar",
@@ -91,7 +91,7 @@ Properties2 = typing.TypedDict(
 )
 
 
-class _1Dict(schemas.immutabledict[str, str]):
+class _1Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "foo",
@@ -125,7 +125,10 @@ class _1Dict(schemas.immutabledict[str, str]):
     
     @property
     def foo(self) -> str:
-        return self.__getitem__("foo")
+        return typing.cast(
+            str,
+            self.__getitem__("foo")
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/allof_with_base_schema.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/allof_with_base_schema.py
@@ -19,7 +19,7 @@ Properties2 = typing.TypedDict(
 )
 
 
-class _0Dict(schemas.immutabledict[str, str]):
+class _0Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "foo",
@@ -53,7 +53,10 @@ class _0Dict(schemas.immutabledict[str, str]):
     
     @property
     def foo(self) -> str:
-        return self.__getitem__("foo")
+        return typing.cast(
+            str,
+            self.__getitem__("foo")
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)
@@ -88,7 +91,7 @@ Properties3 = typing.TypedDict(
 )
 
 
-class _1Dict(schemas.immutabledict[str, None]):
+class _1Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "baz",
@@ -122,7 +125,10 @@ class _1Dict(schemas.immutabledict[str, None]):
     
     @property
     def baz(self) -> None:
-        return self.__getitem__("baz")
+        return typing.cast(
+            None,
+            self.__getitem__("baz")
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)
@@ -161,7 +167,7 @@ Properties = typing.TypedDict(
 )
 
 
-class AllofWithBaseSchemaDict(schemas.immutabledict[str, int]):
+class AllofWithBaseSchemaDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "bar",

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/anyof_complex_types.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/anyof_complex_types.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class _0Dict(schemas.immutabledict[str, int]):
+class _0Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "bar",
@@ -91,7 +91,7 @@ Properties2 = typing.TypedDict(
 )
 
 
-class _1Dict(schemas.immutabledict[str, str]):
+class _1Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "foo",
@@ -125,7 +125,10 @@ class _1Dict(schemas.immutabledict[str, str]):
     
     @property
     def foo(self) -> str:
-        return self.__getitem__("foo")
+        return typing.cast(
+            str,
+            self.__getitem__("foo")
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/enums_in_properties.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/enums_in_properties.py
@@ -127,7 +127,7 @@ Properties = typing.TypedDict(
 )
 
 
-class EnumsInPropertiesDict(schemas.immutabledict[str, str]):
+class EnumsInPropertiesDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "bar",

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/forbidden_property.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/forbidden_property.py
@@ -20,6 +20,7 @@ Properties = typing.TypedDict(
 
 
 class ForbiddenPropertyDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
     __optional_keys__: typing.FrozenSet[str] = frozenset({
@@ -63,10 +64,7 @@ class ForbiddenPropertyDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES
         val = self.get("foo", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/invalid_string_value_for_default.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/invalid_string_value_for_default.py
@@ -29,7 +29,7 @@ Properties = typing.TypedDict(
 )
 
 
-class InvalidStringValueForDefaultDict(schemas.immutabledict[str, str]):
+class InvalidStringValueForDefaultDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -73,7 +73,10 @@ class InvalidStringValueForDefaultDict(schemas.immutabledict[str, str]):
         val = self.get("bar", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/not_more_complex_schema.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/not_more_complex_schema.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class NotDict(schemas.immutabledict[str, str]):
+class NotDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -63,7 +63,10 @@ class NotDict(schemas.immutabledict[str, str]):
         val = self.get("foo", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/oneof_complex_types.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/oneof_complex_types.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class _0Dict(schemas.immutabledict[str, int]):
+class _0Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "bar",
@@ -91,7 +91,7 @@ Properties2 = typing.TypedDict(
 )
 
 
-class _1Dict(schemas.immutabledict[str, str]):
+class _1Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "foo",
@@ -125,7 +125,10 @@ class _1Dict(schemas.immutabledict[str, str]):
     
     @property
     def foo(self) -> str:
-        return self.__getitem__("foo")
+        return typing.cast(
+            str,
+            self.__getitem__("foo")
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/oneof_with_required.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/oneof_with_required.py
@@ -13,6 +13,7 @@ from unit_test_api.shared_imports.schema_imports import *  # pyright: ignore [re
 
 
 class _0Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "bar",
         "foo",
@@ -54,17 +55,11 @@ class _0Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
     
     @property
     def bar(self) -> schemas.OUTPUT_BASE_TYPES:
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            self.__getitem__("bar")
-        )
+        return self.__getitem__("bar")
     
     @property
     def foo(self) -> schemas.OUTPUT_BASE_TYPES:
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            self.__getitem__("foo")
-        )
+        return self.__getitem__("foo")
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)
@@ -93,6 +88,7 @@ class _0(
 
 
 class _1Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "baz",
         "foo",
@@ -134,17 +130,11 @@ class _1Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
     
     @property
     def baz(self) -> schemas.OUTPUT_BASE_TYPES:
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            self.__getitem__("baz")
-        )
+        return self.__getitem__("baz")
     
     @property
     def foo(self) -> schemas.OUTPUT_BASE_TYPES:
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            self.__getitem__("foo")
-        )
+        return self.__getitem__("foo")
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/properties_with_escaped_characters.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/properties_with_escaped_characters.py
@@ -29,7 +29,7 @@ Properties = typing.TypedDict(
 )
 
 
-class PropertiesWithEscapedCharactersDict(schemas.immutabledict[str, typing.Union[int, float]]):
+class PropertiesWithEscapedCharactersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/property_named_ref_that_is_not_a_reference.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/property_named_ref_that_is_not_a_reference.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class PropertyNamedRefThatIsNotAReferenceDict(schemas.immutabledict[str, str]):
+class PropertyNamedRefThatIsNotAReferenceDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/ref_in_additionalproperties.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/ref_in_additionalproperties.py
@@ -15,6 +15,7 @@ from unit_test_api.components.schema import property_named_ref_that_is_not_a_ref
 
 
 class RefInAdditionalpropertiesDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
     __optional_keys__: typing.FrozenSet[str] = frozenset({

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/ref_in_property.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/ref_in_property.py
@@ -21,6 +21,7 @@ Properties = typing.TypedDict(
 
 
 class RefInPropertyDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
     __optional_keys__: typing.FrozenSet[str] = frozenset({

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/required_with_escaped_characters.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/required_with_escaped_characters.py
@@ -13,6 +13,7 @@ from unit_test_api.shared_imports.schema_imports import *  # pyright: ignore [re
 
 
 class RequiredWithEscapedCharactersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "foo\tbar",
         "foo\nbar",

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/the_default_keyword_does_not_do_anything_if_the_property_is_missing.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/components/schema/the_default_keyword_does_not_do_anything_if_the_property_is_missing.py
@@ -29,7 +29,7 @@ Properties = typing.TypedDict(
 )
 
 
-class TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissingDict(schemas.immutabledict[str, typing.Union[int, float]]):
+class TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissingDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -74,7 +74,10 @@ class TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissingDict(schemas.immut
         val = self.get("alpha", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            typing.Union[int, float],
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_additionalproperties_allows_a_schema_which_should_validate_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_additionalproperties_allows_a_schema_which_should_validate_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_additionalproperties_are_allowed_by_default_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_additionalproperties_are_allowed_by_default_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_additionalproperties_can_exist_by_itself_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_additionalproperties_can_exist_by_itself_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_additionalproperties_should_not_look_in_applicators_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_additionalproperties_should_not_look_in_applicators_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_allof_combined_with_anyof_oneof_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_allof_combined_with_anyof_oneof_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_allof_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_allof_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_allof_simple_types_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_allof_simple_types_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_allof_with_base_schema_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_allof_with_base_schema_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_allof_with_one_empty_schema_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_allof_with_one_empty_schema_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_allof_with_the_first_empty_schema_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_allof_with_the_first_empty_schema_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_allof_with_the_last_empty_schema_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_allof_with_the_last_empty_schema_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_allof_with_two_empty_schemas_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_allof_with_two_empty_schemas_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_anyof_complex_types_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_anyof_complex_types_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_anyof_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_anyof_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_anyof_with_base_schema_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_anyof_with_base_schema_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_anyof_with_one_empty_schema_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_anyof_with_one_empty_schema_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_array_type_matches_arrays_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_array_type_matches_arrays_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_boolean_type_matches_booleans_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_boolean_type_matches_booleans_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_by_int_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_by_int_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_by_number_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_by_number_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_by_small_number_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_by_small_number_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_date_time_format_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_date_time_format_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_email_format_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_email_format_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_enum_with0_does_not_match_false_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_enum_with0_does_not_match_false_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_enum_with1_does_not_match_true_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_enum_with1_does_not_match_true_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_enum_with_escaped_characters_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_enum_with_escaped_characters_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_enum_with_false_does_not_match0_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_enum_with_false_does_not_match0_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_enum_with_true_does_not_match1_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_enum_with_true_does_not_match1_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_enums_in_properties_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_enums_in_properties_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_forbidden_property_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_forbidden_property_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_hostname_format_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_hostname_format_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_integer_type_matches_integers_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_integer_type_matches_integers_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_invalid_instance_should_not_raise_error_when_float_division_inf_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_invalid_instance_should_not_raise_error_when_float_division_inf_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_invalid_string_value_for_default_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_invalid_string_value_for_default_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_ipv4_format_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_ipv4_format_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_ipv6_format_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_ipv6_format_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_json_pointer_format_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_json_pointer_format_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_maximum_validation_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_maximum_validation_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_maximum_validation_with_unsigned_integer_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_maximum_validation_with_unsigned_integer_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_maxitems_validation_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_maxitems_validation_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_maxlength_validation_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_maxlength_validation_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_maxproperties0_means_the_object_is_empty_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_maxproperties0_means_the_object_is_empty_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_maxproperties_validation_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_maxproperties_validation_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_minimum_validation_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_minimum_validation_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_minimum_validation_with_signed_integer_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_minimum_validation_with_signed_integer_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_minitems_validation_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_minitems_validation_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_minlength_validation_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_minlength_validation_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_minproperties_validation_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_minproperties_validation_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_nested_allof_to_check_validation_semantics_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_nested_allof_to_check_validation_semantics_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_nested_anyof_to_check_validation_semantics_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_nested_anyof_to_check_validation_semantics_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_nested_items_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_nested_items_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_nested_oneof_to_check_validation_semantics_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_nested_oneof_to_check_validation_semantics_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_not_more_complex_schema_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_not_more_complex_schema_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_not_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_not_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_nul_characters_in_strings_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_nul_characters_in_strings_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_null_type_matches_only_the_null_object_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_null_type_matches_only_the_null_object_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_number_type_matches_numbers_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_number_type_matches_numbers_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_object_properties_validation_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_object_properties_validation_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_object_type_matches_objects_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_object_type_matches_objects_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_oneof_complex_types_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_oneof_complex_types_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_oneof_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_oneof_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_oneof_with_base_schema_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_oneof_with_base_schema_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_oneof_with_empty_schema_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_oneof_with_empty_schema_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_oneof_with_required_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_oneof_with_required_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_pattern_is_not_anchored_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_pattern_is_not_anchored_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_pattern_validation_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_pattern_validation_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_properties_with_escaped_characters_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_properties_with_escaped_characters_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_property_named_ref_that_is_not_a_reference_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_property_named_ref_that_is_not_a_reference_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_ref_in_additionalproperties_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_ref_in_additionalproperties_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_ref_in_allof_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_ref_in_allof_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_ref_in_anyof_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_ref_in_anyof_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_ref_in_items_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_ref_in_items_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_ref_in_not_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_ref_in_not_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_ref_in_oneof_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_ref_in_oneof_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_ref_in_property_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_ref_in_property_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_required_default_validation_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_required_default_validation_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_required_validation_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_required_validation_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_required_with_empty_array_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_required_with_empty_array_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_required_with_escaped_characters_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_required_with_escaped_characters_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_simple_enum_validation_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_simple_enum_validation_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_string_type_matches_strings_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_string_type_matches_strings_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_the_default_keyword_does_not_do_anything_if_the_property_is_missing_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_the_default_keyword_does_not_do_anything_if_the_property_is_missing_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_uniqueitems_false_validation_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_uniqueitems_false_validation_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_uniqueitems_validation_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_uniqueitems_validation_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_uri_format_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_uri_format_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_uri_reference_format_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_uri_reference_format_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_uri_template_format_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/request_body_post_uri_template_format_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_additionalproperties_allows_a_schema_which_should_validate_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_additionalproperties_allows_a_schema_which_should_validate_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.additionalproperties_allows_a_schema_which_should_validate.AdditionalpropertiesAllowsASchemaWhichShouldValidateDict,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.additionalproperties_allows_a_schema_which_should_validate.AdditionalpropertiesAllowsASchemaWhichShouldValidateDict
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_additionalproperties_are_allowed_by_default_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_additionalproperties_are_allowed_by_default_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_additionalproperties_can_exist_by_itself_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_additionalproperties_can_exist_by_itself_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.additionalproperties_can_exist_by_itself.AdditionalpropertiesCanExistByItselfDict,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.additionalproperties_can_exist_by_itself.AdditionalpropertiesCanExistByItselfDict
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_additionalproperties_should_not_look_in_applicators_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_additionalproperties_should_not_look_in_applicators_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_allof_combined_with_anyof_oneof_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_allof_combined_with_anyof_oneof_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_allof_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_allof_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_allof_simple_types_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_allof_simple_types_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_allof_with_base_schema_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_allof_with_base_schema_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_allof_with_one_empty_schema_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_allof_with_one_empty_schema_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_allof_with_the_first_empty_schema_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_allof_with_the_first_empty_schema_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_allof_with_the_last_empty_schema_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_allof_with_the_last_empty_schema_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_allof_with_two_empty_schemas_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_allof_with_two_empty_schemas_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_anyof_complex_types_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_anyof_complex_types_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_anyof_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_anyof_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_anyof_with_base_schema_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_anyof_with_base_schema_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: str,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: str
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_anyof_with_one_empty_schema_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_anyof_with_one_empty_schema_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_array_type_matches_arrays_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_array_type_matches_arrays_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.array_type_matches_arrays.ArrayTypeMatchesArraysTuple,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.array_type_matches_arrays.ArrayTypeMatchesArraysTuple
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_boolean_type_matches_booleans_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_boolean_type_matches_booleans_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: bool,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: bool
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_by_int_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_by_int_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_by_number_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_by_number_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_by_small_number_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_by_small_number_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_date_time_format_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_date_time_format_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_email_format_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_email_format_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_enum_with0_does_not_match_false_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_enum_with0_does_not_match_false_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Union[int, float],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: typing.Union[int, float]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_enum_with1_does_not_match_true_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_enum_with1_does_not_match_true_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Union[int, float],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: typing.Union[int, float]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_enum_with_escaped_characters_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_enum_with_escaped_characters_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Literal["foo\nbar", "foo\rbar"],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: typing.Literal["foo\nbar", "foo\rbar"]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_enum_with_false_does_not_match0_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_enum_with_false_does_not_match0_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Literal[False],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: typing.Literal[False]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_enum_with_true_does_not_match1_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_enum_with_true_does_not_match1_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Literal[True],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: typing.Literal[True]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_enums_in_properties_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_enums_in_properties_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.enums_in_properties.EnumsInPropertiesDict,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.enums_in_properties.EnumsInPropertiesDict
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_forbidden_property_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_forbidden_property_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_hostname_format_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_hostname_format_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_integer_type_matches_integers_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_integer_type_matches_integers_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: int,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: int
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_invalid_instance_should_not_raise_error_when_float_division_inf_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_invalid_instance_should_not_raise_error_when_float_division_inf_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: int,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: int
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_invalid_string_value_for_default_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_invalid_string_value_for_default_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_ipv4_format_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_ipv4_format_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_ipv6_format_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_ipv6_format_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_json_pointer_format_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_json_pointer_format_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_maximum_validation_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_maximum_validation_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_maximum_validation_with_unsigned_integer_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_maximum_validation_with_unsigned_integer_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_maxitems_validation_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_maxitems_validation_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_maxlength_validation_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_maxlength_validation_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_maxproperties0_means_the_object_is_empty_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_maxproperties0_means_the_object_is_empty_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_maxproperties_validation_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_maxproperties_validation_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_minimum_validation_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_minimum_validation_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_minimum_validation_with_signed_integer_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_minimum_validation_with_signed_integer_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_minitems_validation_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_minitems_validation_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_minlength_validation_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_minlength_validation_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_minproperties_validation_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_minproperties_validation_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_nested_allof_to_check_validation_semantics_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_nested_allof_to_check_validation_semantics_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_nested_anyof_to_check_validation_semantics_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_nested_anyof_to_check_validation_semantics_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_nested_items_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_nested_items_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.nested_items.NestedItemsTuple,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.nested_items.NestedItemsTuple
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_nested_oneof_to_check_validation_semantics_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_nested_oneof_to_check_validation_semantics_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_not_more_complex_schema_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_not_more_complex_schema_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_not_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_not_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_nul_characters_in_strings_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_nul_characters_in_strings_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Literal["hello\x00there"],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: typing.Literal["hello\x00there"]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_null_type_matches_only_the_null_object_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_null_type_matches_only_the_null_object_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: None,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: None
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_number_type_matches_numbers_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_number_type_matches_numbers_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Union[int, float],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: typing.Union[int, float]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_object_properties_validation_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_object_properties_validation_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_object_type_matches_objects_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_object_type_matches_objects_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_oneof_complex_types_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_oneof_complex_types_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_oneof_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_oneof_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_oneof_with_base_schema_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_oneof_with_base_schema_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: str,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: str
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_oneof_with_empty_schema_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_oneof_with_empty_schema_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_oneof_with_required_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_oneof_with_required_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_pattern_is_not_anchored_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_pattern_is_not_anchored_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_pattern_validation_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_pattern_validation_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_properties_with_escaped_characters_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_properties_with_escaped_characters_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_property_named_ref_that_is_not_a_reference_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_property_named_ref_that_is_not_a_reference_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_ref_in_additionalproperties_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_ref_in_additionalproperties_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.ref_in_additionalproperties.RefInAdditionalpropertiesDict,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.ref_in_additionalproperties.RefInAdditionalpropertiesDict
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_ref_in_allof_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_ref_in_allof_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_ref_in_anyof_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_ref_in_anyof_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_ref_in_items_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_ref_in_items_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.ref_in_items.RefInItemsTuple,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.ref_in_items.RefInItemsTuple
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_ref_in_not_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_ref_in_not_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_ref_in_oneof_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_ref_in_oneof_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_ref_in_property_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_ref_in_property_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_required_default_validation_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_required_default_validation_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_required_validation_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_required_validation_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_required_with_empty_array_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_required_with_empty_array_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_required_with_escaped_characters_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_required_with_escaped_characters_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_simple_enum_validation_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_simple_enum_validation_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Union[int, float],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: typing.Union[int, float]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_string_type_matches_strings_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_string_type_matches_strings_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: str,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: str
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_the_default_keyword_does_not_do_anything_if_the_property_is_missing_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_the_default_keyword_does_not_do_anything_if_the_property_is_missing_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.the_default_keyword_does_not_do_anything_if_the_property_is_missing.TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissingDict,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.the_default_keyword_does_not_do_anything_if_the_property_is_missing.TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissingDict
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_uniqueitems_false_validation_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_uniqueitems_false_validation_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_uniqueitems_validation_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_uniqueitems_validation_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_uri_format_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_uri_format_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_uri_reference_format_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_uri_reference_format_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_uri_template_format_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/paths/response_body_post_uri_template_format_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_json_schema/python/docs/components/schema/any_type_unevaluated_properties_false_with_properties.md
+++ b/samples/client/3_1_0_json_schema/python/docs/components/schema/any_type_unevaluated_properties_false_with_properties.md
@@ -20,7 +20,7 @@ Key | Type |  Description | Notes
 
 ## AnyTypeUnevaluatedPropertiesFalseWithPropertiesDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/3_1_0_json_schema/python/docs/components/schema/object_unevaluated_properties_false_with_properties.md
+++ b/samples/client/3_1_0_json_schema/python/docs/components/schema/object_unevaluated_properties_false_with_properties.md
@@ -20,7 +20,7 @@ Key | Type |  Description | Notes
 
 ## ObjectUnevaluatedPropertiesFalseWithPropertiesDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/3_1_0_json_schema/python/src/json_schema_api/api_response.py
+++ b/samples/client/3_1_0_json_schema/python/src/json_schema_api/api_response.py
@@ -14,27 +14,15 @@ import urllib3
 from json_schema_api import schemas
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse:
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Union[schemas.Unset, schemas.OUTPUT_BASE_TYPES] = schemas.unset,
-        headers: typing.Union[schemas.Unset, typing.Mapping[str, schemas.OUTPUT_BASE_TYPES]] = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self. headers = headers
+    response: urllib3.HTTPResponse
+    body: typing.Union[schemas.Unset, schemas.OUTPUT_BASE_TYPES]
+    headers: typing.Union[schemas.Unset, typing.Mapping[str, schemas.OUTPUT_BASE_TYPES]]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponseWithoutDeserialization(ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self. headers = headers
+    response: urllib3.HTTPResponse
+    body: schemas.Unset = schemas.unset
+    headers: schemas.Unset = schemas.unset

--- a/samples/client/3_1_0_json_schema/python/src/json_schema_api/components/schema/any_type_unevaluated_properties_false_with_properties.py
+++ b/samples/client/3_1_0_json_schema/python/src/json_schema_api/components/schema/any_type_unevaluated_properties_false_with_properties.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class AnyTypeUnevaluatedPropertiesFalseWithPropertiesDict(schemas.immutabledict[str, str]):
+class AnyTypeUnevaluatedPropertiesFalseWithPropertiesDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -63,7 +63,10 @@ class AnyTypeUnevaluatedPropertiesFalseWithPropertiesDict(schemas.immutabledict[
         val = self.get("someProp", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_1_0_json_schema/python/src/json_schema_api/components/schema/object_unevaluated_properties_false_with_properties.py
+++ b/samples/client/3_1_0_json_schema/python/src/json_schema_api/components/schema/object_unevaluated_properties_false_with_properties.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class ObjectUnevaluatedPropertiesFalseWithPropertiesDict(schemas.immutabledict[str, str]):
+class ObjectUnevaluatedPropertiesFalseWithPropertiesDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -63,7 +63,10 @@ class ObjectUnevaluatedPropertiesFalseWithPropertiesDict(schemas.immutabledict[s
         val = self.get("someProp", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_1_0_json_schema/python/src/json_schema_api/paths/some_path/get/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_json_schema/python/src/json_schema_api/paths/some_path/get/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from json_schema_api.shared_imports.response_imports import *  # pyright: ignore
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/additionalproperties_with_schema.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/additionalproperties_with_schema.md
@@ -34,7 +34,7 @@ Key | Type |  Description | Notes
 
 ## AdditionalpropertiesWithSchemaDict
 ```
-base class: schemas.immutabledict[str, bool]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/allof.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/allof.md
@@ -37,7 +37,7 @@ Key | Type |  Description | Notes
 
 ## _0Dict
 ```
-base class: schemas.immutabledict[str, int]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
@@ -78,7 +78,7 @@ Key | Type |  Description | Notes
 
 ## _1Dict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/allof_with_base_schema.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/allof_with_base_schema.md
@@ -20,7 +20,7 @@ Key | Type |  Description | Notes
 
 ## AllofWithBaseSchemaDict
 ```
-base class: schemas.immutabledict[str, int]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
@@ -68,7 +68,7 @@ Key | Type |  Description | Notes
 
 ## _0Dict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
@@ -109,7 +109,7 @@ Key | Type |  Description | Notes
 
 ## _1Dict
 ```
-base class: schemas.immutabledict[str, None]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/anyof_complex_types.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/anyof_complex_types.md
@@ -37,7 +37,7 @@ Key | Type |  Description | Notes
 
 ## _0Dict
 ```
-base class: schemas.immutabledict[str, int]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
@@ -78,7 +78,7 @@ Key | Type |  Description | Notes
 
 ## _1Dict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/enums_in_properties.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/enums_in_properties.md
@@ -21,7 +21,7 @@ Key | Type |  Description | Notes
 
 ## EnumsInPropertiesDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/forbidden_property.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/forbidden_property.md
@@ -21,6 +21,7 @@ Key | Type |  Description | Notes
 ## ForbiddenPropertyDict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/not_more_complex_schema.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/not_more_complex_schema.md
@@ -36,7 +36,7 @@ Key | Type |  Description | Notes
 
 ## NotDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/oneof_complex_types.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/oneof_complex_types.md
@@ -37,7 +37,7 @@ Key | Type |  Description | Notes
 
 ## _0Dict
 ```
-base class: schemas.immutabledict[str, int]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
@@ -78,7 +78,7 @@ Key | Type |  Description | Notes
 
 ## _1Dict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/oneof_with_required.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/oneof_with_required.md
@@ -39,6 +39,7 @@ Key | Type |  Description | Notes
 ## _0Dict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes
@@ -82,6 +83,7 @@ Key | Type |  Description | Notes
 ## _1Dict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/properties_patternproperties_additionalproperties_interaction.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/properties_patternproperties_additionalproperties_interaction.md
@@ -34,7 +34,10 @@ Key | Type |  Description | Notes
 
 ## PropertiesPatternpropertiesAdditionalpropertiesInteractionDict
 ```
-base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+base class: schemas.immutabledict[str, typing.Union[
+    typing.Tuple[schemas.OUTPUT_BASE_TYPES],
+    int,
+]]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/properties_whose_names_are_javascript_object_property_names.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/properties_whose_names_are_javascript_object_property_names.md
@@ -22,7 +22,7 @@ Key | Type |  Description | Notes
 
 ## PropertiesWhoseNamesAreJavascriptObjectPropertyNamesDict
 ```
-base class: schemas.immutabledict[str, typing.Union[int, float]]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/properties_with_escaped_characters.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/properties_with_escaped_characters.md
@@ -25,7 +25,7 @@ Key | Type |  Description | Notes
 
 ## PropertiesWithEscapedCharactersDict
 ```
-base class: schemas.immutabledict[str, typing.Union[int, float]]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
@@ -37,7 +37,7 @@ Keyword Argument | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [PropertiesWithEscapedCharactersDictInput](#propertieswithescapedcharactersdictinput), [PropertiesWithEscapedCharactersDict](#propertieswithescapedcharactersdict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [PropertiesWithEscapedCharactersDict](#propertieswithescapedcharactersdict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-&lowbar;&lowbar;getitem&lowbar;&lowbar; | str | float, int | This model has invalid python names so this method is used under the hood when you access instance["foo\nbar"], instance["foo\&quot;bar"], instance["foo\\bar"], instance["foo\rbar"], instance["foo\tbar"], instance["foo\fbar"], 
+&lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["foo\nbar"], instance["foo\&quot;bar"], instance["foo\\bar"], instance["foo\rbar"], instance["foo\tbar"], instance["foo\fbar"], 
 get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/properties_with_null_valued_instance_properties.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/properties_with_null_valued_instance_properties.md
@@ -20,7 +20,7 @@ Key | Type |  Description | Notes
 
 ## PropertiesWithNullValuedInstancePropertiesDict
 ```
-base class: schemas.immutabledict[str, None]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/property_named_ref_that_is_not_a_reference.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/property_named_ref_that_is_not_a_reference.md
@@ -20,7 +20,7 @@ Key | Type |  Description | Notes
 
 ## PropertyNamedRefThatIsNotAReferenceDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
@@ -32,7 +32,7 @@ Keyword Argument | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [PropertyNamedRefThatIsNotAReferenceDictInput](#propertynamedrefthatisnotareferencedictinput), [PropertyNamedRefThatIsNotAReferenceDict](#propertynamedrefthatisnotareferencedict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [PropertyNamedRefThatIsNotAReferenceDict](#propertynamedrefthatisnotareferencedict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-&lowbar;&lowbar;getitem&lowbar;&lowbar; | str | str | This model has invalid python names so this method is used under the hood when you access instance["$ref"], 
+&lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["$ref"], 
 get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/required_properties_whose_names_are_javascript_object_property_names.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/required_properties_whose_names_are_javascript_object_property_names.md
@@ -23,6 +23,7 @@ Key | Type |  Description | Notes
 ## RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesDict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/required_with_escaped_characters.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/required_with_escaped_characters.md
@@ -26,6 +26,7 @@ Key | Type |  Description | Notes
 ## RequiredWithEscapedCharactersDict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes
@@ -36,7 +37,7 @@ Keyword Argument | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [RequiredWithEscapedCharactersDictInput](#requiredwithescapedcharactersdictinput), [RequiredWithEscapedCharactersDict](#requiredwithescapedcharactersdict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [RequiredWithEscapedCharactersDict](#requiredwithescapedcharactersdict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-&lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.OUTPUT_BASE_TYPES | This model has invalid python names so this method is used under the hood when you access instance["foo\tbar"], instance["foo\nbar"], instance["foo\fbar"], instance["foo\rbar"], instance["foo\&quot;bar"], instance["foo\\bar"], 
+&lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["foo\tbar"], instance["foo\nbar"], instance["foo\fbar"], instance["foo\rbar"], instance["foo\&quot;bar"], instance["foo\\bar"], 
 get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/unevaluatedproperties_with_adjacent_additionalproperties.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/unevaluatedproperties_with_adjacent_additionalproperties.md
@@ -20,7 +20,7 @@ Key | Type |  Description | Notes
 
 ## UnevaluatedpropertiesWithAdjacentAdditionalpropertiesDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/api_response.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/api_response.py
@@ -14,27 +14,15 @@ import urllib3
 from unit_test_api import schemas
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse:
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Union[schemas.Unset, schemas.OUTPUT_BASE_TYPES] = schemas.unset,
-        headers: typing.Union[schemas.Unset, typing.Mapping[str, schemas.OUTPUT_BASE_TYPES]] = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self. headers = headers
+    response: urllib3.HTTPResponse
+    body: typing.Union[schemas.Unset, schemas.OUTPUT_BASE_TYPES]
+    headers: typing.Union[schemas.Unset, typing.Mapping[str, schemas.OUTPUT_BASE_TYPES]]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponseWithoutDeserialization(ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self. headers = headers
+    response: urllib3.HTTPResponse
+    body: schemas.Unset = schemas.unset
+    headers: schemas.Unset = schemas.unset

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/additionalproperties_with_schema.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/additionalproperties_with_schema.py
@@ -22,7 +22,7 @@ Properties = typing.TypedDict(
 )
 
 
-class AdditionalpropertiesWithSchemaDict(schemas.immutabledict[str, bool]):
+class AdditionalpropertiesWithSchemaDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -74,20 +74,14 @@ class AdditionalpropertiesWithSchemaDict(schemas.immutabledict[str, bool]):
         val = self.get("foo", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     @property
     def bar(self) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         val = self.get("bar", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[bool, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/allof.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/allof.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class _0Dict(schemas.immutabledict[str, int]):
+class _0Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "bar",
@@ -91,7 +91,7 @@ Properties2 = typing.TypedDict(
 )
 
 
-class _1Dict(schemas.immutabledict[str, str]):
+class _1Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "foo",
@@ -125,7 +125,10 @@ class _1Dict(schemas.immutabledict[str, str]):
     
     @property
     def foo(self) -> str:
-        return self.__getitem__("foo")
+        return typing.cast(
+            str,
+            self.__getitem__("foo")
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/allof_with_base_schema.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/allof_with_base_schema.py
@@ -19,7 +19,7 @@ Properties2 = typing.TypedDict(
 )
 
 
-class _0Dict(schemas.immutabledict[str, str]):
+class _0Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "foo",
@@ -53,7 +53,10 @@ class _0Dict(schemas.immutabledict[str, str]):
     
     @property
     def foo(self) -> str:
-        return self.__getitem__("foo")
+        return typing.cast(
+            str,
+            self.__getitem__("foo")
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)
@@ -88,7 +91,7 @@ Properties3 = typing.TypedDict(
 )
 
 
-class _1Dict(schemas.immutabledict[str, None]):
+class _1Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "baz",
@@ -122,7 +125,10 @@ class _1Dict(schemas.immutabledict[str, None]):
     
     @property
     def baz(self) -> None:
-        return self.__getitem__("baz")
+        return typing.cast(
+            None,
+            self.__getitem__("baz")
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)
@@ -161,7 +167,7 @@ Properties = typing.TypedDict(
 )
 
 
-class AllofWithBaseSchemaDict(schemas.immutabledict[str, int]):
+class AllofWithBaseSchemaDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "bar",

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/anyof_complex_types.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/anyof_complex_types.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class _0Dict(schemas.immutabledict[str, int]):
+class _0Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "bar",
@@ -91,7 +91,7 @@ Properties2 = typing.TypedDict(
 )
 
 
-class _1Dict(schemas.immutabledict[str, str]):
+class _1Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "foo",
@@ -125,7 +125,10 @@ class _1Dict(schemas.immutabledict[str, str]):
     
     @property
     def foo(self) -> str:
-        return self.__getitem__("foo")
+        return typing.cast(
+            str,
+            self.__getitem__("foo")
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/dependent_schemas_dependencies_with_escaped_characters.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/dependent_schemas_dependencies_with_escaped_characters.py
@@ -22,6 +22,7 @@ class FooTbar(
 
 
 class FoobarDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "foo\"bar",
     })

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/dependent_schemas_single_dependency.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/dependent_schemas_single_dependency.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class BarDict(schemas.immutabledict[str, int]):
+class BarDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/enums_in_properties.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/enums_in_properties.py
@@ -127,7 +127,7 @@ Properties = typing.TypedDict(
 )
 
 
-class EnumsInPropertiesDict(schemas.immutabledict[str, str]):
+class EnumsInPropertiesDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "bar",

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/forbidden_property.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/forbidden_property.py
@@ -29,6 +29,7 @@ Properties = typing.TypedDict(
 
 
 class ForbiddenPropertyDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
     __optional_keys__: typing.FrozenSet[str] = frozenset({
@@ -72,10 +73,7 @@ class ForbiddenPropertyDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES
         val = self.get("foo", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/not_more_complex_schema.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/not_more_complex_schema.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class NotDict(schemas.immutabledict[str, str]):
+class NotDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -63,7 +63,10 @@ class NotDict(schemas.immutabledict[str, str]):
         val = self.get("foo", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/oneof_complex_types.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/oneof_complex_types.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class _0Dict(schemas.immutabledict[str, int]):
+class _0Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "bar",
@@ -91,7 +91,7 @@ Properties2 = typing.TypedDict(
 )
 
 
-class _1Dict(schemas.immutabledict[str, str]):
+class _1Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "foo",
@@ -125,7 +125,10 @@ class _1Dict(schemas.immutabledict[str, str]):
     
     @property
     def foo(self) -> str:
-        return self.__getitem__("foo")
+        return typing.cast(
+            str,
+            self.__getitem__("foo")
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/oneof_with_required.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/oneof_with_required.py
@@ -13,6 +13,7 @@ from unit_test_api.shared_imports.schema_imports import *  # pyright: ignore [re
 
 
 class _0Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "bar",
         "foo",
@@ -54,17 +55,11 @@ class _0Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
     
     @property
     def bar(self) -> schemas.OUTPUT_BASE_TYPES:
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            self.__getitem__("bar")
-        )
+        return self.__getitem__("bar")
     
     @property
     def foo(self) -> schemas.OUTPUT_BASE_TYPES:
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            self.__getitem__("foo")
-        )
+        return self.__getitem__("foo")
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)
@@ -93,6 +88,7 @@ class _0(
 
 
 class _1Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "baz",
         "foo",
@@ -134,17 +130,11 @@ class _1Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
     
     @property
     def baz(self) -> schemas.OUTPUT_BASE_TYPES:
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            self.__getitem__("baz")
-        )
+        return self.__getitem__("baz")
     
     @property
     def foo(self) -> schemas.OUTPUT_BASE_TYPES:
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            self.__getitem__("foo")
-        )
+        return self.__getitem__("foo")
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/properties_patternproperties_additionalproperties_interaction.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/properties_patternproperties_additionalproperties_interaction.py
@@ -52,7 +52,10 @@ Properties = typing.TypedDict(
 )
 
 
-class PropertiesPatternpropertiesAdditionalpropertiesInteractionDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+class PropertiesPatternpropertiesAdditionalpropertiesInteractionDict(schemas.immutabledict[str, typing.Union[
+    typing.Tuple[schemas.OUTPUT_BASE_TYPES],
+    int,
+]]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/properties_whose_names_are_javascript_object_property_names.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/properties_whose_names_are_javascript_object_property_names.py
@@ -20,7 +20,7 @@ Properties = typing.TypedDict(
 )
 
 
-class ToStringDict(schemas.immutabledict[str, str]):
+class ToStringDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -64,7 +64,10 @@ class ToStringDict(schemas.immutabledict[str, str]):
         val = self.get("length", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)
@@ -98,7 +101,7 @@ Properties2 = typing.TypedDict(
 )
 
 
-class PropertiesWhoseNamesAreJavascriptObjectPropertyNamesDict(schemas.immutabledict[str, typing.Union[int, float]]):
+class PropertiesWhoseNamesAreJavascriptObjectPropertyNamesDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -157,7 +160,10 @@ class PropertiesWhoseNamesAreJavascriptObjectPropertyNamesDict(schemas.immutable
         val = self.get("__proto__", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            typing.Union[int, float],
+            val
+        )
     
     @property
     def toString(self) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
@@ -174,7 +180,10 @@ class PropertiesWhoseNamesAreJavascriptObjectPropertyNamesDict(schemas.immutable
         val = self.get("constructor", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            typing.Union[int, float],
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/properties_with_escaped_characters.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/properties_with_escaped_characters.py
@@ -29,7 +29,7 @@ Properties = typing.TypedDict(
 )
 
 
-class PropertiesWithEscapedCharactersDict(schemas.immutabledict[str, typing.Union[int, float]]):
+class PropertiesWithEscapedCharactersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/properties_with_null_valued_instance_properties.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/properties_with_null_valued_instance_properties.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class PropertiesWithNullValuedInstancePropertiesDict(schemas.immutabledict[str, None]):
+class PropertiesWithNullValuedInstancePropertiesDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -63,7 +63,10 @@ class PropertiesWithNullValuedInstancePropertiesDict(schemas.immutabledict[str, 
         val = self.get("foo", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            None,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/property_named_ref_that_is_not_a_reference.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/property_named_ref_that_is_not_a_reference.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class PropertyNamedRefThatIsNotAReferenceDict(schemas.immutabledict[str, str]):
+class PropertyNamedRefThatIsNotAReferenceDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/required_properties_whose_names_are_javascript_object_property_names.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/required_properties_whose_names_are_javascript_object_property_names.py
@@ -13,6 +13,7 @@ from unit_test_api.shared_imports.schema_imports import *  # pyright: ignore [re
 
 
 class RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "__proto__",
         "constructor",
@@ -60,24 +61,15 @@ class RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesDict(schemas.i
     
     @property
     def __proto__(self) -> schemas.OUTPUT_BASE_TYPES:
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            self.__getitem__("__proto__")
-        )
+        return self.__getitem__("__proto__")
     
     @property
     def constructor(self) -> schemas.OUTPUT_BASE_TYPES:
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            self.__getitem__("constructor")
-        )
+        return self.__getitem__("constructor")
     
     @property
     def toString(self) -> schemas.OUTPUT_BASE_TYPES:
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            self.__getitem__("toString")
-        )
+        return self.__getitem__("toString")
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/required_with_escaped_characters.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/required_with_escaped_characters.py
@@ -13,6 +13,7 @@ from unit_test_api.shared_imports.schema_imports import *  # pyright: ignore [re
 
 
 class RequiredWithEscapedCharactersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "foo\tbar",
         "foo\nbar",

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/unevaluatedproperties_with_adjacent_additionalproperties.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/components/schema/unevaluatedproperties_with_adjacent_additionalproperties.py
@@ -20,7 +20,7 @@ Properties = typing.TypedDict(
 )
 
 
-class UnevaluatedpropertiesWithAdjacentAdditionalpropertiesDict(schemas.immutabledict[str, str]):
+class UnevaluatedpropertiesWithAdjacentAdditionalpropertiesDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -64,7 +64,10 @@ class UnevaluatedpropertiesWithAdjacentAdditionalpropertiesDict(schemas.immutabl
         val = self.get("foo", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_a_schema_given_for_prefixitems_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_a_schema_given_for_prefixitems_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_additional_items_are_allowed_by_default_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_additional_items_are_allowed_by_default_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_additionalproperties_are_allowed_by_default_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_additionalproperties_are_allowed_by_default_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_additionalproperties_can_exist_by_itself_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_additionalproperties_can_exist_by_itself_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_additionalproperties_does_not_look_in_applicators_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_additionalproperties_does_not_look_in_applicators_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_additionalproperties_with_null_valued_instance_properties_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_additionalproperties_with_null_valued_instance_properties_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_additionalproperties_with_schema_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_additionalproperties_with_schema_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_allof_combined_with_anyof_oneof_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_allof_combined_with_anyof_oneof_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_allof_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_allof_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_allof_simple_types_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_allof_simple_types_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_allof_with_base_schema_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_allof_with_base_schema_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_allof_with_one_empty_schema_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_allof_with_one_empty_schema_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_allof_with_the_first_empty_schema_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_allof_with_the_first_empty_schema_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_allof_with_the_last_empty_schema_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_allof_with_the_last_empty_schema_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_allof_with_two_empty_schemas_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_allof_with_two_empty_schemas_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_anyof_complex_types_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_anyof_complex_types_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_anyof_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_anyof_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_anyof_with_base_schema_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_anyof_with_base_schema_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_anyof_with_one_empty_schema_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_anyof_with_one_empty_schema_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_array_type_matches_arrays_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_array_type_matches_arrays_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_boolean_type_matches_booleans_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_boolean_type_matches_booleans_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_by_int_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_by_int_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_by_number_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_by_number_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_by_small_number_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_by_small_number_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_const_nul_characters_in_strings_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_const_nul_characters_in_strings_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_contains_keyword_validation_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_contains_keyword_validation_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_contains_with_null_instance_elements_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_contains_with_null_instance_elements_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_date_format_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_date_format_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_date_time_format_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_date_time_format_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_dependent_schemas_dependencies_with_escaped_characters_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_dependent_schemas_dependencies_with_escaped_characters_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_dependent_schemas_dependent_subschema_incompatible_with_root_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_dependent_schemas_dependent_subschema_incompatible_with_root_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_dependent_schemas_single_dependency_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_dependent_schemas_single_dependency_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_duration_format_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_duration_format_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_email_format_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_email_format_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_empty_dependents_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_empty_dependents_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_enum_with0_does_not_match_false_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_enum_with0_does_not_match_false_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_enum_with1_does_not_match_true_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_enum_with1_does_not_match_true_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_enum_with_escaped_characters_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_enum_with_escaped_characters_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_enum_with_false_does_not_match0_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_enum_with_false_does_not_match0_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_enum_with_true_does_not_match1_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_enum_with_true_does_not_match1_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_enums_in_properties_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_enums_in_properties_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_float_division_inf_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_float_division_inf_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_forbidden_property_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_forbidden_property_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_hostname_format_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_hostname_format_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_idn_email_format_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_idn_email_format_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_idn_hostname_format_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_idn_hostname_format_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_integer_type_matches_integers_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_integer_type_matches_integers_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_ipv4_format_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_ipv4_format_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_ipv6_format_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_ipv6_format_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_iri_format_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_iri_format_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_iri_reference_format_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_iri_reference_format_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_items_contains_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_items_contains_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_items_does_not_look_in_applicators_valid_case_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_items_does_not_look_in_applicators_valid_case_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_items_with_null_instance_elements_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_items_with_null_instance_elements_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_json_pointer_format_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_json_pointer_format_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_maxcontains_without_contains_is_ignored_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_maxcontains_without_contains_is_ignored_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_maximum_validation_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_maximum_validation_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_maximum_validation_with_unsigned_integer_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_maximum_validation_with_unsigned_integer_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_maxitems_validation_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_maxitems_validation_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_maxlength_validation_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_maxlength_validation_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_maxproperties0_means_the_object_is_empty_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_maxproperties0_means_the_object_is_empty_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_maxproperties_validation_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_maxproperties_validation_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_mincontains_without_contains_is_ignored_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_mincontains_without_contains_is_ignored_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_minimum_validation_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_minimum_validation_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_minimum_validation_with_signed_integer_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_minimum_validation_with_signed_integer_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_minitems_validation_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_minitems_validation_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_minlength_validation_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_minlength_validation_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_minproperties_validation_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_minproperties_validation_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_multiple_dependents_required_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_multiple_dependents_required_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_multiple_simultaneous_patternproperties_are_validated_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_multiple_simultaneous_patternproperties_are_validated_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_multiple_types_can_be_specified_in_an_array_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_multiple_types_can_be_specified_in_an_array_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_nested_allof_to_check_validation_semantics_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_nested_allof_to_check_validation_semantics_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_nested_anyof_to_check_validation_semantics_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_nested_anyof_to_check_validation_semantics_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_nested_items_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_nested_items_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_nested_oneof_to_check_validation_semantics_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_nested_oneof_to_check_validation_semantics_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_non_ascii_pattern_with_additionalproperties_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_non_ascii_pattern_with_additionalproperties_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_not_more_complex_schema_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_not_more_complex_schema_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_not_multiple_types_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_not_multiple_types_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_not_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_not_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_nul_characters_in_strings_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_nul_characters_in_strings_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_null_type_matches_only_the_null_object_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_null_type_matches_only_the_null_object_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_number_type_matches_numbers_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_number_type_matches_numbers_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_object_properties_validation_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_object_properties_validation_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_object_type_matches_objects_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_object_type_matches_objects_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_oneof_complex_types_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_oneof_complex_types_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_oneof_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_oneof_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_oneof_with_base_schema_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_oneof_with_base_schema_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_oneof_with_empty_schema_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_oneof_with_empty_schema_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_oneof_with_required_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_oneof_with_required_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_pattern_is_not_anchored_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_pattern_is_not_anchored_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_pattern_validation_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_pattern_validation_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_patternproperties_validates_properties_matching_a_regex_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_patternproperties_validates_properties_matching_a_regex_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_patternproperties_with_null_valued_instance_properties_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_patternproperties_with_null_valued_instance_properties_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_prefixitems_validation_adjusts_the_starting_index_for_items_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_prefixitems_validation_adjusts_the_starting_index_for_items_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_prefixitems_with_null_instance_elements_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_prefixitems_with_null_instance_elements_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_properties_patternproperties_additionalproperties_interaction_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_properties_patternproperties_additionalproperties_interaction_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_properties_whose_names_are_javascript_object_property_names_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_properties_whose_names_are_javascript_object_property_names_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_properties_with_escaped_characters_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_properties_with_escaped_characters_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_properties_with_null_valued_instance_properties_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_properties_with_null_valued_instance_properties_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_property_named_ref_that_is_not_a_reference_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_property_named_ref_that_is_not_a_reference_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_propertynames_validation_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_propertynames_validation_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_regex_format_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_regex_format_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_regexes_are_not_anchored_by_default_and_are_case_sensitive_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_regexes_are_not_anchored_by_default_and_are_case_sensitive_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_relative_json_pointer_format_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_relative_json_pointer_format_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_required_default_validation_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_required_default_validation_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_required_properties_whose_names_are_javascript_object_property_names_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_required_properties_whose_names_are_javascript_object_property_names_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_required_validation_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_required_validation_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_required_with_empty_array_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_required_with_empty_array_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_required_with_escaped_characters_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_required_with_escaped_characters_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_simple_enum_validation_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_simple_enum_validation_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_single_dependency_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_single_dependency_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_small_multiple_of_large_integer_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_small_multiple_of_large_integer_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_string_type_matches_strings_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_string_type_matches_strings_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_time_format_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_time_format_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_type_array_object_or_null_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_type_array_object_or_null_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_type_array_or_object_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_type_array_or_object_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_type_as_array_with_one_item_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_type_as_array_with_one_item_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_unevaluateditems_as_schema_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_unevaluateditems_as_schema_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_unevaluateditems_depends_on_multiple_nested_contains_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_unevaluateditems_depends_on_multiple_nested_contains_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_unevaluateditems_with_items_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_unevaluateditems_with_items_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_unevaluateditems_with_null_instance_elements_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_unevaluateditems_with_null_instance_elements_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_unevaluatedproperties_not_affected_by_propertynames_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_unevaluatedproperties_not_affected_by_propertynames_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_unevaluatedproperties_schema_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_unevaluatedproperties_schema_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_unevaluatedproperties_with_adjacent_additionalproperties_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_unevaluatedproperties_with_adjacent_additionalproperties_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_unevaluatedproperties_with_null_valued_instance_properties_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_unevaluatedproperties_with_null_valued_instance_properties_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_uniqueitems_false_validation_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_uniqueitems_false_validation_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_uniqueitems_false_with_an_array_of_items_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_uniqueitems_false_with_an_array_of_items_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_uniqueitems_validation_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_uniqueitems_validation_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_uniqueitems_with_an_array_of_items_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_uniqueitems_with_an_array_of_items_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_uri_format_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_uri_format_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_uri_reference_format_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_uri_reference_format_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_uri_template_format_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_uri_template_format_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_uuid_format_request_body/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/request_body_post_uuid_format_request_body/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_a_schema_given_for_prefixitems_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_a_schema_given_for_prefixitems_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_additional_items_are_allowed_by_default_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_additional_items_are_allowed_by_default_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_additionalproperties_are_allowed_by_default_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_additionalproperties_are_allowed_by_default_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_additionalproperties_can_exist_by_itself_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_additionalproperties_can_exist_by_itself_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.additionalproperties_can_exist_by_itself.AdditionalpropertiesCanExistByItselfDict,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.additionalproperties_can_exist_by_itself.AdditionalpropertiesCanExistByItselfDict
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_additionalproperties_does_not_look_in_applicators_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_additionalproperties_does_not_look_in_applicators_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_additionalproperties_with_null_valued_instance_properties_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_additionalproperties_with_null_valued_instance_properties_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.additionalproperties_with_null_valued_instance_properties.AdditionalpropertiesWithNullValuedInstancePropertiesDict,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.additionalproperties_with_null_valued_instance_properties.AdditionalpropertiesWithNullValuedInstancePropertiesDict
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_additionalproperties_with_schema_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_additionalproperties_with_schema_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.additionalproperties_with_schema.AdditionalpropertiesWithSchemaDict,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.additionalproperties_with_schema.AdditionalpropertiesWithSchemaDict
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_allof_combined_with_anyof_oneof_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_allof_combined_with_anyof_oneof_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_allof_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_allof_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_allof_simple_types_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_allof_simple_types_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_allof_with_base_schema_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_allof_with_base_schema_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_allof_with_one_empty_schema_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_allof_with_one_empty_schema_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_allof_with_the_first_empty_schema_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_allof_with_the_first_empty_schema_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_allof_with_the_last_empty_schema_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_allof_with_the_last_empty_schema_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_allof_with_two_empty_schemas_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_allof_with_two_empty_schemas_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_anyof_complex_types_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_anyof_complex_types_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_anyof_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_anyof_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_anyof_with_base_schema_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_anyof_with_base_schema_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: str,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: str
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_anyof_with_one_empty_schema_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_anyof_with_one_empty_schema_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_array_type_matches_arrays_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_array_type_matches_arrays_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Tuple[schemas.OUTPUT_BASE_TYPES],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: typing.Tuple[schemas.OUTPUT_BASE_TYPES]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_boolean_type_matches_booleans_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_boolean_type_matches_booleans_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: bool,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: bool
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_by_int_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_by_int_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_by_number_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_by_number_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_by_small_number_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_by_small_number_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_const_nul_characters_in_strings_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_const_nul_characters_in_strings_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_contains_keyword_validation_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_contains_keyword_validation_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_contains_with_null_instance_elements_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_contains_with_null_instance_elements_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_date_format_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_date_format_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_date_time_format_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_date_time_format_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_dependent_schemas_dependencies_with_escaped_characters_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_dependent_schemas_dependencies_with_escaped_characters_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_dependent_schemas_dependent_subschema_incompatible_with_root_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_dependent_schemas_dependent_subschema_incompatible_with_root_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_dependent_schemas_single_dependency_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_dependent_schemas_single_dependency_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_duration_format_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_duration_format_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_email_format_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_email_format_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_empty_dependents_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_empty_dependents_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_enum_with0_does_not_match_false_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_enum_with0_does_not_match_false_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Union[int, float],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: typing.Union[int, float]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_enum_with1_does_not_match_true_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_enum_with1_does_not_match_true_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Union[int, float],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: typing.Union[int, float]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_enum_with_escaped_characters_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_enum_with_escaped_characters_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Literal["foo\nbar", "foo\rbar"],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: typing.Literal["foo\nbar", "foo\rbar"]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_enum_with_false_does_not_match0_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_enum_with_false_does_not_match0_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Literal[False],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: typing.Literal[False]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_enum_with_true_does_not_match1_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_enum_with_true_does_not_match1_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Literal[True],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: typing.Literal[True]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_enums_in_properties_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_enums_in_properties_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.enums_in_properties.EnumsInPropertiesDict,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.enums_in_properties.EnumsInPropertiesDict
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_float_division_inf_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_float_division_inf_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: int,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: int
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_forbidden_property_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_forbidden_property_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_hostname_format_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_hostname_format_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_idn_email_format_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_idn_email_format_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_idn_hostname_format_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_idn_hostname_format_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_integer_type_matches_integers_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_integer_type_matches_integers_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: int,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: int
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_ipv4_format_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_ipv4_format_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_ipv6_format_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_ipv6_format_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_iri_format_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_iri_format_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_iri_reference_format_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_iri_reference_format_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_items_contains_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_items_contains_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.items_contains.ItemsContainsTuple,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.items_contains.ItemsContainsTuple
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_items_does_not_look_in_applicators_valid_case_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_items_does_not_look_in_applicators_valid_case_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.items_does_not_look_in_applicators_valid_case.ItemsDoesNotLookInApplicatorsValidCaseTuple,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.items_does_not_look_in_applicators_valid_case.ItemsDoesNotLookInApplicatorsValidCaseTuple
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_items_with_null_instance_elements_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_items_with_null_instance_elements_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.items_with_null_instance_elements.ItemsWithNullInstanceElementsTuple,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.items_with_null_instance_elements.ItemsWithNullInstanceElementsTuple
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_json_pointer_format_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_json_pointer_format_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_maxcontains_without_contains_is_ignored_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_maxcontains_without_contains_is_ignored_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_maximum_validation_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_maximum_validation_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_maximum_validation_with_unsigned_integer_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_maximum_validation_with_unsigned_integer_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_maxitems_validation_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_maxitems_validation_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_maxlength_validation_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_maxlength_validation_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_maxproperties0_means_the_object_is_empty_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_maxproperties0_means_the_object_is_empty_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_maxproperties_validation_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_maxproperties_validation_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_mincontains_without_contains_is_ignored_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_mincontains_without_contains_is_ignored_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_minimum_validation_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_minimum_validation_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_minimum_validation_with_signed_integer_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_minimum_validation_with_signed_integer_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_minitems_validation_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_minitems_validation_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_minlength_validation_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_minlength_validation_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_minproperties_validation_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_minproperties_validation_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_multiple_dependents_required_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_multiple_dependents_required_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_multiple_simultaneous_patternproperties_are_validated_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_multiple_simultaneous_patternproperties_are_validated_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_multiple_types_can_be_specified_in_an_array_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_multiple_types_can_be_specified_in_an_array_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,20 +9,13 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Union[
-            int,
-            str,
-        ],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: typing.Union[
+        int,
+        str,
+    ]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_nested_allof_to_check_validation_semantics_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_nested_allof_to_check_validation_semantics_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_nested_anyof_to_check_validation_semantics_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_nested_anyof_to_check_validation_semantics_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_nested_items_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_nested_items_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.nested_items.NestedItemsTuple,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.nested_items.NestedItemsTuple
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_nested_oneof_to_check_validation_semantics_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_nested_oneof_to_check_validation_semantics_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_non_ascii_pattern_with_additionalproperties_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_non_ascii_pattern_with_additionalproperties_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.non_ascii_pattern_with_additionalproperties.NonAsciiPatternWithAdditionalpropertiesDict,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.non_ascii_pattern_with_additionalproperties.NonAsciiPatternWithAdditionalpropertiesDict
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_not_more_complex_schema_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_not_more_complex_schema_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_not_multiple_types_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_not_multiple_types_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_not_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_not_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_nul_characters_in_strings_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_nul_characters_in_strings_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Literal["hello\x00there"],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: typing.Literal["hello\x00there"]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_null_type_matches_only_the_null_object_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_null_type_matches_only_the_null_object_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: None,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: None
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_number_type_matches_numbers_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_number_type_matches_numbers_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Union[int, float],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: typing.Union[int, float]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_object_properties_validation_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_object_properties_validation_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_object_type_matches_objects_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_object_type_matches_objects_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_oneof_complex_types_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_oneof_complex_types_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_oneof_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_oneof_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_oneof_with_base_schema_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_oneof_with_base_schema_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: str,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: str
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_oneof_with_empty_schema_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_oneof_with_empty_schema_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_oneof_with_required_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_oneof_with_required_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_pattern_is_not_anchored_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_pattern_is_not_anchored_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_pattern_validation_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_pattern_validation_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_patternproperties_validates_properties_matching_a_regex_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_patternproperties_validates_properties_matching_a_regex_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_patternproperties_with_null_valued_instance_properties_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_patternproperties_with_null_valued_instance_properties_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_prefixitems_validation_adjusts_the_starting_index_for_items_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_prefixitems_validation_adjusts_the_starting_index_for_items_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.prefixitems_validation_adjusts_the_starting_index_for_items.PrefixitemsValidationAdjustsTheStartingIndexForItemsTuple,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.prefixitems_validation_adjusts_the_starting_index_for_items.PrefixitemsValidationAdjustsTheStartingIndexForItemsTuple
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_prefixitems_with_null_instance_elements_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_prefixitems_with_null_instance_elements_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_properties_patternproperties_additionalproperties_interaction_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_properties_patternproperties_additionalproperties_interaction_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.properties_patternproperties_additionalproperties_interaction.PropertiesPatternpropertiesAdditionalpropertiesInteractionDict,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.properties_patternproperties_additionalproperties_interaction.PropertiesPatternpropertiesAdditionalpropertiesInteractionDict
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_properties_whose_names_are_javascript_object_property_names_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_properties_whose_names_are_javascript_object_property_names_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_properties_with_escaped_characters_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_properties_with_escaped_characters_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_properties_with_null_valued_instance_properties_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_properties_with_null_valued_instance_properties_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_property_named_ref_that_is_not_a_reference_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_property_named_ref_that_is_not_a_reference_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_propertynames_validation_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_propertynames_validation_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_regex_format_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_regex_format_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_regexes_are_not_anchored_by_default_and_are_case_sensitive_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_regexes_are_not_anchored_by_default_and_are_case_sensitive_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_relative_json_pointer_format_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_relative_json_pointer_format_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_required_default_validation_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_required_default_validation_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_required_properties_whose_names_are_javascript_object_property_names_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_required_properties_whose_names_are_javascript_object_property_names_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_required_validation_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_required_validation_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_required_with_empty_array_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_required_with_empty_array_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_required_with_escaped_characters_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_required_with_escaped_characters_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_simple_enum_validation_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_simple_enum_validation_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Union[int, float],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: typing.Union[int, float]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_single_dependency_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_single_dependency_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_small_multiple_of_large_integer_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_small_multiple_of_large_integer_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: int,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: int
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_string_type_matches_strings_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_string_type_matches_strings_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: str,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: str
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_time_format_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_time_format_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_type_array_object_or_null_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_type_array_object_or_null_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,21 +9,14 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Union[
-            typing.Tuple[schemas.OUTPUT_BASE_TYPES],
-            schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES],
-            None,
-        ],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: typing.Union[
+        typing.Tuple[schemas.OUTPUT_BASE_TYPES],
+        schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES],
+        None,
+    ]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_type_array_or_object_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_type_array_or_object_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,20 +9,13 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Union[
-            typing.Tuple[schemas.OUTPUT_BASE_TYPES],
-            schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES],
-        ],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: typing.Union[
+        typing.Tuple[schemas.OUTPUT_BASE_TYPES],
+        schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES],
+    ]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_type_as_array_with_one_item_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_type_as_array_with_one_item_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: str,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: str
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_unevaluateditems_as_schema_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_unevaluateditems_as_schema_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_unevaluateditems_depends_on_multiple_nested_contains_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_unevaluateditems_depends_on_multiple_nested_contains_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_unevaluateditems_with_items_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_unevaluateditems_with_items_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.unevaluateditems_with_items.UnevaluateditemsWithItemsTuple,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.unevaluateditems_with_items.UnevaluateditemsWithItemsTuple
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_unevaluateditems_with_null_instance_elements_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_unevaluateditems_with_null_instance_elements_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_unevaluatedproperties_not_affected_by_propertynames_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_unevaluatedproperties_not_affected_by_propertynames_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_unevaluatedproperties_schema_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_unevaluatedproperties_schema_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_unevaluatedproperties_with_adjacent_additionalproperties_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_unevaluatedproperties_with_adjacent_additionalproperties_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.unevaluatedproperties_with_adjacent_additionalproperties.UnevaluatedpropertiesWithAdjacentAdditionalpropertiesDict,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.unevaluatedproperties_with_adjacent_additionalproperties.UnevaluatedpropertiesWithAdjacentAdditionalpropertiesDict
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_unevaluatedproperties_with_null_valued_instance_properties_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_unevaluatedproperties_with_null_valued_instance_properties_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_uniqueitems_false_validation_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_uniqueitems_false_validation_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_uniqueitems_false_with_an_array_of_items_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_uniqueitems_false_with_an_array_of_items_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_uniqueitems_validation_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_uniqueitems_validation_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_uniqueitems_with_an_array_of_items_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_uniqueitems_with_an_array_of_items_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_uri_format_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_uri_format_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_uri_reference_format_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_uri_reference_format_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_uri_template_format_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_uri_template_format_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_uuid_format_response_body_for_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/paths/response_body_post_uuid_format_response_body_for_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from unit_test_api.shared_imports.response_imports import *  # pyright: ignore [
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/openapi_features/nonCompliantUseDiscriminatorIfCompositionFails/python/docs/components/schema/addition_operator.md
+++ b/samples/client/openapi_features/nonCompliantUseDiscriminatorIfCompositionFails/python/docs/components/schema/addition_operator.md
@@ -21,7 +21,10 @@ Key | Type |  Description | Notes
 
 ## AdditionOperatorDict
 ```
-base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+base class: schemas.immutabledict[str, typing.Union[
+    str,
+    typing.Union[int, float],
+]]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/openapi_features/nonCompliantUseDiscriminatorIfCompositionFails/python/docs/components/schema/subtraction_operator.md
+++ b/samples/client/openapi_features/nonCompliantUseDiscriminatorIfCompositionFails/python/docs/components/schema/subtraction_operator.md
@@ -21,7 +21,10 @@ Key | Type |  Description | Notes
 
 ## SubtractionOperatorDict
 ```
-base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+base class: schemas.immutabledict[str, typing.Union[
+    str,
+    typing.Union[int, float],
+]]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/openapi_features/nonCompliantUseDiscriminatorIfCompositionFails/python/src/this_package/api_response.py
+++ b/samples/client/openapi_features/nonCompliantUseDiscriminatorIfCompositionFails/python/src/this_package/api_response.py
@@ -14,27 +14,15 @@ import urllib3
 from this_package import schemas
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse:
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Union[schemas.Unset, schemas.OUTPUT_BASE_TYPES] = schemas.unset,
-        headers: typing.Union[schemas.Unset, typing.Mapping[str, schemas.OUTPUT_BASE_TYPES]] = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self. headers = headers
+    response: urllib3.HTTPResponse
+    body: typing.Union[schemas.Unset, schemas.OUTPUT_BASE_TYPES]
+    headers: typing.Union[schemas.Unset, typing.Mapping[str, schemas.OUTPUT_BASE_TYPES]]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponseWithoutDeserialization(ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self. headers = headers
+    response: urllib3.HTTPResponse
+    body: schemas.Unset = schemas.unset
+    headers: schemas.Unset = schemas.unset

--- a/samples/client/openapi_features/nonCompliantUseDiscriminatorIfCompositionFails/python/src/this_package/components/schema/addition_operator.py
+++ b/samples/client/openapi_features/nonCompliantUseDiscriminatorIfCompositionFails/python/src/this_package/components/schema/addition_operator.py
@@ -33,7 +33,10 @@ Properties = typing.TypedDict(
 )
 
 
-class AdditionOperatorDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+class AdditionOperatorDict(schemas.immutabledict[str, typing.Union[
+    str,
+    typing.Union[int, float],
+]]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "a",

--- a/samples/client/openapi_features/nonCompliantUseDiscriminatorIfCompositionFails/python/src/this_package/components/schema/subtraction_operator.py
+++ b/samples/client/openapi_features/nonCompliantUseDiscriminatorIfCompositionFails/python/src/this_package/components/schema/subtraction_operator.py
@@ -33,7 +33,10 @@ Properties = typing.TypedDict(
 )
 
 
-class SubtractionOperatorDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+class SubtractionOperatorDict(schemas.immutabledict[str, typing.Union[
+    str,
+    typing.Union[int, float],
+]]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "a",

--- a/samples/client/openapi_features/nonCompliantUseDiscriminatorIfCompositionFails/python/src/this_package/paths/operators/post/responses/response_200/__init__.py
+++ b/samples/client/openapi_features/nonCompliantUseDiscriminatorIfCompositionFails/python/src/this_package/paths/operators/post/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from this_package.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/openapi_features/security/python/src/this_package/api_response.py
+++ b/samples/client/openapi_features/security/python/src/this_package/api_response.py
@@ -14,27 +14,15 @@ import urllib3
 from this_package import schemas
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse:
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Union[schemas.Unset, schemas.OUTPUT_BASE_TYPES] = schemas.unset,
-        headers: typing.Union[schemas.Unset, typing.Mapping[str, schemas.OUTPUT_BASE_TYPES]] = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self. headers = headers
+    response: urllib3.HTTPResponse
+    body: typing.Union[schemas.Unset, schemas.OUTPUT_BASE_TYPES]
+    headers: typing.Union[schemas.Unset, typing.Mapping[str, schemas.OUTPUT_BASE_TYPES]]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponseWithoutDeserialization(ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self. headers = headers
+    response: urllib3.HTTPResponse
+    body: schemas.Unset = schemas.unset
+    headers: schemas.Unset = schemas.unset

--- a/samples/client/openapi_features/security/python/src/this_package/paths/path_with_no_explicit_security/get/responses/response_200/__init__.py
+++ b/samples/client/openapi_features/security/python/src/this_package/paths/path_with_no_explicit_security/get/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from this_package.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/openapi_features/security/python/src/this_package/paths/path_with_one_explicit_security/get/responses/response_200/__init__.py
+++ b/samples/client/openapi_features/security/python/src/this_package/paths/path_with_one_explicit_security/get/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from this_package.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/openapi_features/security/python/src/this_package/paths/path_with_security_from_root/get/responses/response_200/__init__.py
+++ b/samples/client/openapi_features/security/python/src/this_package/paths/path_with_security_from_root/get/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from this_package.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/openapi_features/security/python/src/this_package/paths/path_with_two_explicit_security/get/responses/response_200/__init__.py
+++ b/samples/client/openapi_features/security/python/src/this_package/paths/path_with_two_explicit_security/get/responses/response_200/__init__.py
@@ -7,17 +7,10 @@
 from this_package.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/docs/components/responses/response_headers_with_no_body.md
+++ b/samples/client/petstore/python/docs/components/responses/response_headers_with_no_body.md
@@ -32,7 +32,7 @@ Key | Type |  Description | Notes
 
 #### Headers HeadersDict
 ```
-base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+base class: schemas.immutabledict[str, str]
 
 ```
 ##### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/responses/response_success_inline_content_and_header.md
+++ b/samples/client/petstore/python/docs/components/responses/response_success_inline_content_and_header.md
@@ -76,7 +76,7 @@ Key | Type |  Description | Notes
 
 #### Headers HeadersDict
 ```
-base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+base class: schemas.immutabledict[str, str]
 
 ```
 ##### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/_200_response.md
+++ b/samples/client/petstore/python/docs/components/schema/_200_response.md
@@ -42,7 +42,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_200ResponseDictInput](#_200responsedictinput), [_200ResponseDict](#_200responsedict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [_200ResponseDict](#_200responsedict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-&lowbar;&lowbar;getitem&lowbar;&lowbar; | str |  | This model has invalid python names so this method is used under the hood when you access instance["class"], 
+&lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["class"], 
 get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/_return.md
+++ b/samples/client/petstore/python/docs/components/schema/_return.md
@@ -23,7 +23,7 @@ Key | Type |  Description | Notes
 
 ## ReturnDict
 ```
-base class: schemas.immutabledict[str, int]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
@@ -35,7 +35,7 @@ Keyword Argument | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [ReturnDictInput](#returndictinput), [ReturnDict](#returndict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [ReturnDict](#returndict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-&lowbar;&lowbar;getitem&lowbar;&lowbar; | str | int | This model has invalid python names so this method is used under the hood when you access instance["return"], 
+&lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["return"], 
 get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/abstract_step_message.md
+++ b/samples/client/petstore/python/docs/components/schema/abstract_step_message.md
@@ -25,7 +25,7 @@ Key | Type |  Description | Notes
 
 ## AbstractStepMessageDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/additional_properties_class.md
+++ b/samples/client/petstore/python/docs/components/schema/additional_properties_class.md
@@ -27,7 +27,7 @@ Key | Type |  Description | Notes
 
 ## AdditionalPropertiesClassDict
 ```
-base class: schemas.immutabledict[str, schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
@@ -124,7 +124,7 @@ Key | Type |  Description | Notes
 
 ## MapOfMapPropertyDict
 ```
-base class: schemas.immutabledict[str, schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]]
+base class: schemas.immutabledict[str, AdditionalPropertiesDict]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/additional_properties_with_array_of_enums.md
+++ b/samples/client/petstore/python/docs/components/schema/additional_properties_with_array_of_enums.md
@@ -25,7 +25,7 @@ Key | Type |  Description | Notes
 
 ## AdditionalPropertiesWithArrayOfEnumsDict
 ```
-base class: schemas.immutabledict[str, typing.Tuple[schemas.OUTPUT_BASE_TYPES]]
+base class: schemas.immutabledict[str, AdditionalPropertiesTuple]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/animal.md
+++ b/samples/client/petstore/python/docs/components/schema/animal.md
@@ -21,7 +21,7 @@ Key | Type |  Description | Notes
 
 ## AnimalDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/apple.md
+++ b/samples/client/petstore/python/docs/components/schema/apple.md
@@ -21,7 +21,7 @@ Key | Type |  Description | Notes
 
 ## AppleDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/apple_req.md
+++ b/samples/client/petstore/python/docs/components/schema/apple_req.md
@@ -20,7 +20,10 @@ Key | Type |  Description | Notes
 
 ## AppleReqDict
 ```
-base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+base class: schemas.immutabledict[str, typing.Union[
+    bool,
+    str,
+]]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/array_of_array_of_number_only.md
+++ b/samples/client/petstore/python/docs/components/schema/array_of_array_of_number_only.md
@@ -20,7 +20,7 @@ Key | Type |  Description | Notes
 
 ## ArrayOfArrayOfNumberOnlyDict
 ```
-base class: schemas.immutabledict[str, typing.Tuple[schemas.OUTPUT_BASE_TYPES]]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/array_of_number_only.md
+++ b/samples/client/petstore/python/docs/components/schema/array_of_number_only.md
@@ -20,7 +20,7 @@ Key | Type |  Description | Notes
 
 ## ArrayOfNumberOnlyDict
 ```
-base class: schemas.immutabledict[str, typing.Tuple[schemas.OUTPUT_BASE_TYPES]]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/array_test.md
+++ b/samples/client/petstore/python/docs/components/schema/array_test.md
@@ -22,7 +22,7 @@ Key | Type |  Description | Notes
 
 ## ArrayTestDict
 ```
-base class: schemas.immutabledict[str, typing.Tuple[schemas.OUTPUT_BASE_TYPES]]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/banana.md
+++ b/samples/client/petstore/python/docs/components/schema/banana.md
@@ -20,7 +20,7 @@ Key | Type |  Description | Notes
 
 ## BananaDict
 ```
-base class: schemas.immutabledict[str, typing.Union[int, float]]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/banana_req.md
+++ b/samples/client/petstore/python/docs/components/schema/banana_req.md
@@ -20,7 +20,10 @@ Key | Type |  Description | Notes
 
 ## BananaReqDict
 ```
-base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+base class: schemas.immutabledict[str, typing.Union[
+    bool,
+    typing.Union[int, float],
+]]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/basque_pig.md
+++ b/samples/client/petstore/python/docs/components/schema/basque_pig.md
@@ -20,7 +20,7 @@ Key | Type |  Description | Notes
 
 ## BasquePigDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/capitalization.md
+++ b/samples/client/petstore/python/docs/components/schema/capitalization.md
@@ -25,7 +25,7 @@ Key | Type |  Description | Notes
 
 ## CapitalizationDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/cat.md
+++ b/samples/client/petstore/python/docs/components/schema/cat.md
@@ -37,7 +37,7 @@ Key | Type |  Description | Notes
 
 ## _1Dict
 ```
-base class: schemas.immutabledict[str, bool]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/child_cat.md
+++ b/samples/client/petstore/python/docs/components/schema/child_cat.md
@@ -37,7 +37,7 @@ Key | Type |  Description | Notes
 
 ## _1Dict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/class_model.md
+++ b/samples/client/petstore/python/docs/components/schema/class_model.md
@@ -23,7 +23,7 @@ Key | Type |  Description | Notes
 
 ## ClassModelDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/client.md
+++ b/samples/client/petstore/python/docs/components/schema/client.md
@@ -20,7 +20,7 @@ Key | Type |  Description | Notes
 
 ## ClientDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/complex_quadrilateral.md
+++ b/samples/client/petstore/python/docs/components/schema/complex_quadrilateral.md
@@ -37,7 +37,7 @@ Key | Type |  Description | Notes
 
 ## _1Dict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/danish_pig.md
+++ b/samples/client/petstore/python/docs/components/schema/danish_pig.md
@@ -20,7 +20,7 @@ Key | Type |  Description | Notes
 
 ## DanishPigDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/dog.md
+++ b/samples/client/petstore/python/docs/components/schema/dog.md
@@ -37,7 +37,7 @@ Key | Type |  Description | Notes
 
 ## _1Dict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/drawing.md
+++ b/samples/client/petstore/python/docs/components/schema/drawing.md
@@ -47,7 +47,7 @@ Key | Type |  Description | Notes
 
 ## DrawingDict
 ```
-base class: schemas.immutabledict[str, typing.Tuple[schemas.OUTPUT_BASE_TYPES]]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/enum_test.md
+++ b/samples/client/petstore/python/docs/components/schema/enum_test.md
@@ -29,6 +29,7 @@ Key | Type |  Description | Notes
 ## EnumTestDict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes

--- a/samples/client/petstore/python/docs/components/schema/equilateral_triangle.md
+++ b/samples/client/petstore/python/docs/components/schema/equilateral_triangle.md
@@ -37,7 +37,7 @@ Key | Type |  Description | Notes
 
 ## _1Dict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/file.md
+++ b/samples/client/petstore/python/docs/components/schema/file.md
@@ -23,7 +23,7 @@ Key | Type |  Description | Notes
 
 ## FileDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/file_schema_test_class.md
+++ b/samples/client/petstore/python/docs/components/schema/file_schema_test_class.md
@@ -21,7 +21,7 @@ Key | Type |  Description | Notes
 
 ## FileSchemaTestClassDict
 ```
-base class: schemas.immutabledict[str, typing.Tuple[schemas.OUTPUT_BASE_TYPES]]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/foo.md
+++ b/samples/client/petstore/python/docs/components/schema/foo.md
@@ -21,6 +21,7 @@ Key | Type |  Description | Notes
 ## FooDict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes

--- a/samples/client/petstore/python/docs/components/schema/format_test.md
+++ b/samples/client/petstore/python/docs/components/schema/format_test.md
@@ -96,7 +96,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [FormatTestDictInput](#formattestdictinput), [FormatTestDict](#formattestdict) | [FormatTestDict](#formattestdict) | a constructor
-&lowbar;&lowbar;getitem&lowbar;&lowbar; | str |  | This model has invalid python names so this method is used under the hood when you access instance["float"], 
+&lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["float"], 
 get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
 
 # ArrayWithUniqueItems

--- a/samples/client/petstore/python/docs/components/schema/fruit.md
+++ b/samples/client/petstore/python/docs/components/schema/fruit.md
@@ -20,7 +20,7 @@ Key | Type |  Description | Notes
 
 ## FruitDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/gm_fruit.md
+++ b/samples/client/petstore/python/docs/components/schema/gm_fruit.md
@@ -20,7 +20,7 @@ Key | Type |  Description | Notes
 
 ## GmFruitDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/grandparent_animal.md
+++ b/samples/client/petstore/python/docs/components/schema/grandparent_animal.md
@@ -20,7 +20,7 @@ Key | Type |  Description | Notes
 
 ## GrandparentAnimalDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/has_only_read_only.md
+++ b/samples/client/petstore/python/docs/components/schema/has_only_read_only.md
@@ -21,7 +21,7 @@ Key | Type |  Description | Notes
 
 ## HasOnlyReadOnlyDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/health_check_result.md
+++ b/samples/client/petstore/python/docs/components/schema/health_check_result.md
@@ -23,10 +23,7 @@ Key | Type |  Description | Notes
 
 ## HealthCheckResultDict
 ```
-base class: schemas.immutabledict[str, typing.Union[
-    None,
-    str,
-]]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/isosceles_triangle.md
+++ b/samples/client/petstore/python/docs/components/schema/isosceles_triangle.md
@@ -37,7 +37,7 @@ Key | Type |  Description | Notes
 
 ## _1Dict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/json_patch_request_add_replace_test.md
+++ b/samples/client/petstore/python/docs/components/schema/json_patch_request_add_replace_test.md
@@ -21,7 +21,7 @@ Key | Type |  Description | Notes
 
 ## JSONPatchRequestAddReplaceTestDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/map_test.md
+++ b/samples/client/petstore/python/docs/components/schema/map_test.md
@@ -24,6 +24,7 @@ Key | Type |  Description | Notes
 ## MapTestDict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes
@@ -74,7 +75,7 @@ Key | Type |  Description | Notes
 
 ## MapMapOfStringDict
 ```
-base class: schemas.immutabledict[str, schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]]
+base class: schemas.immutabledict[str, AdditionalPropertiesDict]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
@@ -151,7 +152,7 @@ Key | Type |  Description | Notes
 
 ## MapOfEnumStringDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, typing.Literal["UPPER", "lower"]]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/mixed_properties_and_additional_properties_class.md
+++ b/samples/client/petstore/python/docs/components/schema/mixed_properties_and_additional_properties_class.md
@@ -72,7 +72,8 @@ Key | Type |  Description | Notes
 
 ## MapDict
 ```
-base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+base class: schemas.immutabledict[str, AnimalDict]
+
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes

--- a/samples/client/petstore/python/docs/components/schema/money.md
+++ b/samples/client/petstore/python/docs/components/schema/money.md
@@ -21,6 +21,7 @@ Key | Type |  Description | Notes
 ## MoneyDict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes

--- a/samples/client/petstore/python/docs/components/schema/name.md
+++ b/samples/client/petstore/python/docs/components/schema/name.md
@@ -45,7 +45,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [NameDictInput](#namedictinput), [NameDict](#namedict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [NameDict](#namedict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-&lowbar;&lowbar;getitem&lowbar;&lowbar; | str |  | This model has invalid python names so this method is used under the hood when you access instance["property"], 
+&lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["property"], 
 get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/nullable_class.md
+++ b/samples/client/petstore/python/docs/components/schema/nullable_class.md
@@ -111,7 +111,15 @@ Key | Type |  Description | Notes
 
 ## NullableClassDict
 ```
-base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+base class: schemas.immutabledict[str, typing.Union[
+    schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES],
+    None,
+    typing.Tuple[schemas.OUTPUT_BASE_TYPES],
+    str,
+    bool,
+    typing.Union[int, float],
+    int,
+]]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/number_only.md
+++ b/samples/client/petstore/python/docs/components/schema/number_only.md
@@ -20,7 +20,7 @@ Key | Type |  Description | Notes
 
 ## NumberOnlyDict
 ```
-base class: schemas.immutabledict[str, typing.Union[int, float]]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/obj_with_required_props.md
+++ b/samples/client/petstore/python/docs/components/schema/obj_with_required_props.md
@@ -20,7 +20,7 @@ Key | Type |  Description | Notes
 
 ## ObjWithRequiredPropsDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/obj_with_required_props_base.md
+++ b/samples/client/petstore/python/docs/components/schema/obj_with_required_props_base.md
@@ -20,7 +20,7 @@ Key | Type |  Description | Notes
 
 ## ObjWithRequiredPropsBaseDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/object_model_with_arg_and_args_properties.md
+++ b/samples/client/petstore/python/docs/components/schema/object_model_with_arg_and_args_properties.md
@@ -21,7 +21,7 @@ Key | Type |  Description | Notes
 
 ## ObjectModelWithArgAndArgsPropertiesDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/object_model_with_ref_props.md
+++ b/samples/client/petstore/python/docs/components/schema/object_model_with_ref_props.md
@@ -26,6 +26,7 @@ Key | Type |  Description | Notes
 ## ObjectModelWithRefPropsDict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes

--- a/samples/client/petstore/python/docs/components/schema/object_with_all_of_with_req_test_prop_from_unset_add_prop.md
+++ b/samples/client/petstore/python/docs/components/schema/object_with_all_of_with_req_test_prop_from_unset_add_prop.md
@@ -38,7 +38,7 @@ Key | Type |  Description | Notes
 
 ## _1Dict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/object_with_colliding_properties.md
+++ b/samples/client/petstore/python/docs/components/schema/object_with_colliding_properties.md
@@ -24,7 +24,7 @@ Key | Type |  Description | Notes
 
 ## ObjectWithCollidingPropertiesDict
 ```
-base class: schemas.immutabledict[str, schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/object_with_decimal_properties.md
+++ b/samples/client/petstore/python/docs/components/schema/object_with_decimal_properties.md
@@ -23,6 +23,7 @@ Key | Type |  Description | Notes
 ## ObjectWithDecimalPropertiesDict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes

--- a/samples/client/petstore/python/docs/components/schema/object_with_difficultly_named_props.md
+++ b/samples/client/petstore/python/docs/components/schema/object_with_difficultly_named_props.md
@@ -37,7 +37,7 @@ Keyword Argument | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [ObjectWithDifficultlyNamedPropsDictInput](#objectwithdifficultlynamedpropsdictinput), [ObjectWithDifficultlyNamedPropsDict](#objectwithdifficultlynamedpropsdict) | [ObjectWithDifficultlyNamedPropsDict](#objectwithdifficultlynamedpropsdict) | a constructor
-&lowbar;&lowbar;getitem&lowbar;&lowbar; | str |  | This model has invalid python names so this method is used under the hood when you access instance["123-list"], instance["$special[property.name]"], instance["123Number"], 
+&lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["123-list"], instance["$special[property.name]"], instance["123Number"], 
 get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/object_with_inline_composition_property.md
+++ b/samples/client/petstore/python/docs/components/schema/object_with_inline_composition_property.md
@@ -21,6 +21,7 @@ Key | Type |  Description | Notes
 ## ObjectWithInlineCompositionPropertyDict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes

--- a/samples/client/petstore/python/docs/components/schema/object_with_non_intersecting_values.md
+++ b/samples/client/petstore/python/docs/components/schema/object_with_non_intersecting_values.md
@@ -29,7 +29,10 @@ Key | Type |  Description | Notes
 
 ## ObjectWithNonIntersectingValuesDict
 ```
-base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+base class: schemas.immutabledict[str, typing.Union[
+    typing.Union[int, float],
+    str,
+]]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/object_with_only_optional_props.md
+++ b/samples/client/petstore/python/docs/components/schema/object_with_only_optional_props.md
@@ -20,7 +20,10 @@ Key | Type |  Description | Notes
 
 ## ObjectWithOnlyOptionalPropsDict
 ```
-base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+base class: schemas.immutabledict[str, typing.Union[
+    typing.Union[int, float],
+    str,
+]]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/object_with_optional_test_prop.md
+++ b/samples/client/petstore/python/docs/components/schema/object_with_optional_test_prop.md
@@ -20,7 +20,7 @@ Key | Type |  Description | Notes
 
 ## ObjectWithOptionalTestPropDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/player.md
+++ b/samples/client/petstore/python/docs/components/schema/player.md
@@ -25,6 +25,7 @@ Key | Type |  Description | Notes
 ## PlayerDict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes

--- a/samples/client/petstore/python/docs/components/schema/public_key.md
+++ b/samples/client/petstore/python/docs/components/schema/public_key.md
@@ -23,7 +23,7 @@ Key | Type |  Description | Notes
 
 ## PublicKeyDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/quadrilateral_interface.md
+++ b/samples/client/petstore/python/docs/components/schema/quadrilateral_interface.md
@@ -21,7 +21,7 @@ Key | Type |  Description | Notes
 
 ## QuadrilateralInterfaceDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/read_only_first.md
+++ b/samples/client/petstore/python/docs/components/schema/read_only_first.md
@@ -21,7 +21,7 @@ Key | Type |  Description | Notes
 
 ## ReadOnlyFirstDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/req_props_from_unset_add_props.md
+++ b/samples/client/petstore/python/docs/components/schema/req_props_from_unset_add_props.md
@@ -22,6 +22,7 @@ Key | Type |  Description | Notes
 ## ReqPropsFromUnsetAddPropsDict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes
@@ -38,7 +39,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [ReqPropsFromUnsetAddPropsDictInput](#reqpropsfromunsetaddpropsdictinput), [ReqPropsFromUnsetAddPropsDict](#reqpropsfromunsetaddpropsdict) | [ReqPropsFromUnsetAddPropsDict](#reqpropsfromunsetaddpropsdict) | a constructor
-&lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.OUTPUT_BASE_TYPES | This model has invalid python names so this method is used under the hood when you access instance["invalid-name"], 
+&lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["invalid-name"], 
 get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/scalene_triangle.md
+++ b/samples/client/petstore/python/docs/components/schema/scalene_triangle.md
@@ -37,7 +37,7 @@ Key | Type |  Description | Notes
 
 ## _1Dict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/simple_quadrilateral.md
+++ b/samples/client/petstore/python/docs/components/schema/simple_quadrilateral.md
@@ -37,7 +37,7 @@ Key | Type |  Description | Notes
 
 ## _1Dict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/special_model_name.md
+++ b/samples/client/petstore/python/docs/components/schema/special_model_name.md
@@ -23,7 +23,7 @@ Key | Type |  Description | Notes
 
 ## SpecialModelNameDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/triangle_interface.md
+++ b/samples/client/petstore/python/docs/components/schema/triangle_interface.md
@@ -21,7 +21,7 @@ Key | Type |  Description | Notes
 
 ## TriangleInterfaceDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/components/schema/zebra.md
+++ b/samples/client/petstore/python/docs/components/schema/zebra.md
@@ -21,7 +21,7 @@ Key | Type |  Description | Notes
 
 ## ZebraDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/paths/fake/delete.md
+++ b/samples/client/petstore/python/docs/paths/fake/delete.md
@@ -59,6 +59,7 @@ Key | Type |  Description | Notes
 #### QueryParameters QueryParametersDict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ##### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes
@@ -103,6 +104,7 @@ Key | Type |  Description | Notes
 #### HeaderParameters HeaderParametersDict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ##### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes

--- a/samples/client/petstore/python/docs/paths/fake/get.md
+++ b/samples/client/petstore/python/docs/paths/fake/get.md
@@ -165,6 +165,7 @@ Key | Type |  Description | Notes
 #### QueryParameters QueryParametersDict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ##### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes
@@ -209,6 +210,7 @@ Key | Type |  Description | Notes
 #### HeaderParameters HeaderParametersDict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ##### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes

--- a/samples/client/petstore/python/docs/paths/fake/post.md
+++ b/samples/client/petstore/python/docs/paths/fake/post.md
@@ -119,7 +119,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [SchemaDictInput](#requestbody-content-applicationxwwwformurlencoded-schema-schemadictinput), [SchemaDict](#requestbody-content-applicationxwwwformurlencoded-schema-schemadict) | [SchemaDict](#requestbody-content-applicationxwwwformurlencoded-schema-schemadict) | a constructor
-&lowbar;&lowbar;getitem&lowbar;&lowbar; | str |  | This model has invalid python names so this method is used under the hood when you access instance["float"], 
+&lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["float"], 
 get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
 
 ## Return Types

--- a/samples/client/petstore/python/docs/paths/fake/post/request_body/content/application_x_www_form_urlencoded/schema.md
+++ b/samples/client/petstore/python/docs/paths/fake/post/request_body/content/application_x_www_form_urlencoded/schema.md
@@ -75,5 +75,5 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [SchemaDictInput](#schemadictinput), [SchemaDict](#schemadict) | [SchemaDict](#schemadict) | a constructor
-&lowbar;&lowbar;getitem&lowbar;&lowbar; | str |  | This model has invalid python names so this method is used under the hood when you access instance["float"], 
+&lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["float"], 
 get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties

--- a/samples/client/petstore/python/docs/paths/fake_body_with_query_params/put.md
+++ b/samples/client/petstore/python/docs/paths/fake_body_with_query_params/put.md
@@ -70,7 +70,7 @@ Key | Type |  Description | Notes
 
 #### QueryParameters QueryParametersDict
 ```
-base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+base class: schemas.immutabledict[str, str]
 
 ```
 ##### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/paths/fake_delete_coffee_id/delete.md
+++ b/samples/client/petstore/python/docs/paths/fake_delete_coffee_id/delete.md
@@ -52,7 +52,7 @@ Key | Type |  Description | Notes
 
 #### PathParameters PathParametersDict
 ```
-base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+base class: schemas.immutabledict[str, str]
 
 ```
 ##### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/paths/fake_inline_composition/post.md
+++ b/samples/client/petstore/python/docs/paths/fake_inline_composition/post.md
@@ -95,6 +95,7 @@ Key | Type |  Description | Notes
 ##### RequestBody content MultipartFormData Schema SchemaDict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ###### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes
@@ -161,6 +162,7 @@ Key | Type |  Description | Notes
 #### QueryParameters QueryParametersDict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ##### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes
@@ -254,6 +256,7 @@ Key | Type |  Description | Notes
 ##### ResponseFor200 content MultipartFormData Schema SchemaDict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ###### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes

--- a/samples/client/petstore/python/docs/paths/fake_inline_composition/post/parameters/parameter_1/schema.md
+++ b/samples/client/petstore/python/docs/paths/fake_inline_composition/post/parameters/parameter_1/schema.md
@@ -21,6 +21,7 @@ Key | Type |  Description | Notes
 ## SchemaDict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes

--- a/samples/client/petstore/python/docs/paths/fake_inline_composition/post/request_body/content/multipart_form_data/schema.md
+++ b/samples/client/petstore/python/docs/paths/fake_inline_composition/post/request_body/content/multipart_form_data/schema.md
@@ -21,6 +21,7 @@ Key | Type |  Description | Notes
 ## SchemaDict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes

--- a/samples/client/petstore/python/docs/paths/fake_inline_composition/post/responses/response_200/content/multipart_form_data/schema.md
+++ b/samples/client/petstore/python/docs/paths/fake_inline_composition/post/responses/response_200/content/multipart_form_data/schema.md
@@ -21,6 +21,7 @@ Key | Type |  Description | Notes
 ## SchemaDict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes

--- a/samples/client/petstore/python/docs/paths/fake_json_form_data/get.md
+++ b/samples/client/petstore/python/docs/paths/fake_json_form_data/get.md
@@ -62,7 +62,7 @@ Key | Type |  Description | Notes
 
 ##### RequestBody content ApplicationXWwwFormUrlencoded Schema SchemaDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ###### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/paths/fake_json_form_data/get/request_body/content/application_x_www_form_urlencoded/schema.md
+++ b/samples/client/petstore/python/docs/paths/fake_json_form_data/get/request_body/content/application_x_www_form_urlencoded/schema.md
@@ -21,7 +21,7 @@ Key | Type |  Description | Notes
 
 ## SchemaDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/paths/fake_multiple_request_body_content_types/post.md
+++ b/samples/client/petstore/python/docs/paths/fake_multiple_request_body_content_types/post.md
@@ -67,7 +67,7 @@ Key | Type |  Description | Notes
 
 ##### RequestBody content ApplicationJson Schema SchemaDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ###### &lowbar;&lowbar;new&lowbar;&lowbar; method
@@ -108,7 +108,7 @@ Key | Type |  Description | Notes
 
 ##### RequestBody content MultipartFormData Schema SchemaDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ###### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/paths/fake_multiple_request_body_content_types/post/request_body/content/application_json/schema.md
+++ b/samples/client/petstore/python/docs/paths/fake_multiple_request_body_content_types/post/request_body/content/application_json/schema.md
@@ -20,7 +20,7 @@ Key | Type |  Description | Notes
 
 ## SchemaDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/paths/fake_multiple_request_body_content_types/post/request_body/content/multipart_form_data/schema.md
+++ b/samples/client/petstore/python/docs/paths/fake_multiple_request_body_content_types/post/request_body/content/multipart_form_data/schema.md
@@ -20,7 +20,7 @@ Key | Type |  Description | Notes
 
 ## SchemaDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/paths/fake_obj_in_query/get.md
+++ b/samples/client/petstore/python/docs/paths/fake_obj_in_query/get.md
@@ -51,7 +51,7 @@ Key | Type |  Description | Notes
 
 #### QueryParameters QueryParametersDict
 ```
-base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+base class: schemas.immutabledict[str, SchemaDict]
 
 ```
 ##### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/paths/fake_obj_in_query/get/parameters/parameter_0/schema.md
+++ b/samples/client/petstore/python/docs/paths/fake_obj_in_query/get/parameters/parameter_0/schema.md
@@ -20,7 +20,7 @@ Key | Type |  Description | Notes
 
 ## SchemaDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/paths/fake_parameter_collisions1_abab_self_ab/post.md
+++ b/samples/client/petstore/python/docs/paths/fake_parameter_collisions1_abab_self_ab/post.md
@@ -124,6 +124,7 @@ Key | Type |  Description | Notes
 #### HeaderParameters HeaderParametersDict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ##### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes
@@ -139,7 +140,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [HeaderParametersDictInput](#headerparameters-headerparametersdictinput), [HeaderParametersDict](#headerparameters-headerparametersdict) | [HeaderParametersDict](#headerparameters-headerparametersdict) | a constructor
-&lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.OUTPUT_BASE_TYPES | This model has invalid python names so this method is used under the hood when you access instance["1"], instance["A-B"], instance["self"], 
+&lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["1"], instance["A-B"], instance["self"], 
 ### path_params
 ### PathParameters
 ```

--- a/samples/client/petstore/python/docs/paths/fake_pet_id_upload_image_with_required_file/post.md
+++ b/samples/client/petstore/python/docs/paths/fake_pet_id_upload_image_with_required_file/post.md
@@ -66,7 +66,7 @@ Key | Type |  Description | Notes
 
 ##### RequestBody content MultipartFormData Schema SchemaDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ###### &lowbar;&lowbar;new&lowbar;&lowbar; method
@@ -108,7 +108,7 @@ Key | Type |  Description | Notes
 
 #### PathParameters PathParametersDict
 ```
-base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+base class: schemas.immutabledict[str, int]
 
 ```
 ##### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/paths/fake_pet_id_upload_image_with_required_file/post/request_body/content/multipart_form_data/schema.md
+++ b/samples/client/petstore/python/docs/paths/fake_pet_id_upload_image_with_required_file/post/request_body/content/multipart_form_data/schema.md
@@ -21,7 +21,7 @@ Key | Type |  Description | Notes
 
 ## SchemaDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/paths/fake_ref_obj_in_query/get.md
+++ b/samples/client/petstore/python/docs/paths/fake_ref_obj_in_query/get.md
@@ -51,7 +51,7 @@ Key | Type |  Description | Notes
 
 #### QueryParameters QueryParametersDict
 ```
-base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+base class: schemas.immutabledict[str, FooDict]
 
 ```
 ##### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/paths/fake_test_query_paramters/put.md
+++ b/samples/client/petstore/python/docs/paths/fake_test_query_paramters/put.md
@@ -57,6 +57,7 @@ Key | Type |  Description | Notes
 #### QueryParameters QueryParametersDict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ##### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes

--- a/samples/client/petstore/python/docs/paths/fake_upload_file/post.md
+++ b/samples/client/petstore/python/docs/paths/fake_upload_file/post.md
@@ -63,7 +63,7 @@ Key | Type |  Description | Notes
 
 ##### RequestBody content MultipartFormData Schema SchemaDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ###### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/paths/fake_upload_file/post/request_body/content/multipart_form_data/schema.md
+++ b/samples/client/petstore/python/docs/paths/fake_upload_file/post/request_body/content/multipart_form_data/schema.md
@@ -21,7 +21,7 @@ Key | Type |  Description | Notes
 
 ## SchemaDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/paths/fake_upload_files/post.md
+++ b/samples/client/petstore/python/docs/paths/fake_upload_files/post.md
@@ -62,7 +62,7 @@ Key | Type |  Description | Notes
 
 ##### RequestBody content MultipartFormData Schema SchemaDict
 ```
-base class: schemas.immutabledict[str, typing.Tuple[schemas.OUTPUT_BASE_TYPES]]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ###### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/paths/fake_upload_files/post/request_body/content/multipart_form_data/schema.md
+++ b/samples/client/petstore/python/docs/paths/fake_upload_files/post/request_body/content/multipart_form_data/schema.md
@@ -20,7 +20,7 @@ Key | Type |  Description | Notes
 
 ## SchemaDict
 ```
-base class: schemas.immutabledict[str, typing.Tuple[schemas.OUTPUT_BASE_TYPES]]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/paths/foo/get.md
+++ b/samples/client/petstore/python/docs/paths/foo/get.md
@@ -78,6 +78,7 @@ Key | Type |  Description | Notes
 ##### Default content ApplicationJson Schema SchemaDict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ###### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes

--- a/samples/client/petstore/python/docs/paths/foo/get/responses/response_default/content/application_json/schema.md
+++ b/samples/client/petstore/python/docs/paths/foo/get/responses/response_default/content/application_json/schema.md
@@ -21,6 +21,7 @@ Key | Type |  Description | Notes
 ## SchemaDict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes

--- a/samples/client/petstore/python/docs/paths/pet_find_by_status/get.md
+++ b/samples/client/petstore/python/docs/paths/pet_find_by_status/get.md
@@ -55,7 +55,7 @@ Key | Type |  Description | Notes
 
 #### QueryParameters QueryParametersDict
 ```
-base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+base class: schemas.immutabledict[str, SchemaTuple]
 
 ```
 ##### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/paths/pet_find_by_tags/get.md
+++ b/samples/client/petstore/python/docs/paths/pet_find_by_tags/get.md
@@ -54,7 +54,7 @@ Key | Type |  Description | Notes
 
 #### QueryParameters QueryParametersDict
 ```
-base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+base class: schemas.immutabledict[str, SchemaTuple]
 
 ```
 ##### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/paths/pet_pet_id/delete.md
+++ b/samples/client/petstore/python/docs/paths/pet_pet_id/delete.md
@@ -54,7 +54,7 @@ Key | Type |  Description | Notes
 
 #### HeaderParameters HeaderParametersDict
 ```
-base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+base class: schemas.immutabledict[str, str]
 
 ```
 ##### &lowbar;&lowbar;new&lowbar;&lowbar; method
@@ -92,7 +92,7 @@ Key | Type |  Description | Notes
 
 #### PathParameters PathParametersDict
 ```
-base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+base class: schemas.immutabledict[str, int]
 
 ```
 ##### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/paths/pet_pet_id/get.md
+++ b/samples/client/petstore/python/docs/paths/pet_pet_id/get.md
@@ -55,7 +55,7 @@ Key | Type |  Description | Notes
 
 #### PathParameters PathParametersDict
 ```
-base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+base class: schemas.immutabledict[str, int]
 
 ```
 ##### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/paths/pet_pet_id/post.md
+++ b/samples/client/petstore/python/docs/paths/pet_pet_id/post.md
@@ -65,7 +65,7 @@ Key | Type |  Description | Notes
 
 ##### RequestBody content ApplicationXWwwFormUrlencoded Schema SchemaDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ###### &lowbar;&lowbar;new&lowbar;&lowbar; method
@@ -107,7 +107,7 @@ Key | Type |  Description | Notes
 
 #### PathParameters PathParametersDict
 ```
-base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+base class: schemas.immutabledict[str, int]
 
 ```
 ##### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/paths/pet_pet_id/post/request_body/content/application_x_www_form_urlencoded/schema.md
+++ b/samples/client/petstore/python/docs/paths/pet_pet_id/post/request_body/content/application_x_www_form_urlencoded/schema.md
@@ -21,7 +21,7 @@ Key | Type |  Description | Notes
 
 ## SchemaDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/paths/pet_pet_id_upload_image/post.md
+++ b/samples/client/petstore/python/docs/paths/pet_pet_id_upload_image/post.md
@@ -66,7 +66,7 @@ Key | Type |  Description | Notes
 
 ##### RequestBody content MultipartFormData Schema SchemaDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ###### &lowbar;&lowbar;new&lowbar;&lowbar; method
@@ -108,7 +108,7 @@ Key | Type |  Description | Notes
 
 #### PathParameters PathParametersDict
 ```
-base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+base class: schemas.immutabledict[str, int]
 
 ```
 ##### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/paths/pet_pet_id_upload_image/post/request_body/content/multipart_form_data/schema.md
+++ b/samples/client/petstore/python/docs/paths/pet_pet_id_upload_image/post/request_body/content/multipart_form_data/schema.md
@@ -21,7 +21,7 @@ Key | Type |  Description | Notes
 
 ## SchemaDict
 ```
-base class: schemas.immutabledict[str, str]
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 
 ```
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/paths/store_order_order_id/delete.md
+++ b/samples/client/petstore/python/docs/paths/store_order_order_id/delete.md
@@ -52,7 +52,7 @@ Key | Type |  Description | Notes
 
 #### PathParameters PathParametersDict
 ```
-base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+base class: schemas.immutabledict[str, str]
 
 ```
 ##### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/paths/store_order_order_id/get.md
+++ b/samples/client/petstore/python/docs/paths/store_order_order_id/get.md
@@ -53,7 +53,7 @@ Key | Type |  Description | Notes
 
 #### PathParameters PathParametersDict
 ```
-base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+base class: schemas.immutabledict[str, int]
 
 ```
 ##### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/paths/user_login/get.md
+++ b/samples/client/petstore/python/docs/paths/user_login/get.md
@@ -54,6 +54,7 @@ Key | Type |  Description | Notes
 #### QueryParameters QueryParametersDict
 ```
 base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
 ```
 ##### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes

--- a/samples/client/petstore/python/docs/paths/user_username/delete.md
+++ b/samples/client/petstore/python/docs/paths/user_username/delete.md
@@ -52,7 +52,7 @@ Key | Type |  Description | Notes
 
 #### PathParameters PathParametersDict
 ```
-base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+base class: schemas.immutabledict[str, str]
 
 ```
 ##### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/paths/user_username/get.md
+++ b/samples/client/petstore/python/docs/paths/user_username/get.md
@@ -52,7 +52,7 @@ Key | Type |  Description | Notes
 
 #### PathParameters PathParametersDict
 ```
-base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+base class: schemas.immutabledict[str, str]
 
 ```
 ##### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/docs/paths/user_username/put.md
+++ b/samples/client/petstore/python/docs/paths/user_username/put.md
@@ -75,7 +75,7 @@ Key | Type |  Description | Notes
 
 #### PathParameters PathParametersDict
 ```
-base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+base class: schemas.immutabledict[str, str]
 
 ```
 ##### &lowbar;&lowbar;new&lowbar;&lowbar; method

--- a/samples/client/petstore/python/src/petstore_api/api_response.py
+++ b/samples/client/petstore/python/src/petstore_api/api_response.py
@@ -14,27 +14,15 @@ import urllib3
 from petstore_api import schemas
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse:
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Union[schemas.Unset, schemas.OUTPUT_BASE_TYPES] = schemas.unset,
-        headers: typing.Union[schemas.Unset, typing.Mapping[str, schemas.OUTPUT_BASE_TYPES]] = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self. headers = headers
+    response: urllib3.HTTPResponse
+    body: typing.Union[schemas.Unset, schemas.OUTPUT_BASE_TYPES]
+    headers: typing.Union[schemas.Unset, typing.Mapping[str, schemas.OUTPUT_BASE_TYPES]]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponseWithoutDeserialization(ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self. headers = headers
+    response: urllib3.HTTPResponse
+    body: schemas.Unset = schemas.unset
+    headers: schemas.Unset = schemas.unset

--- a/samples/client/petstore/python/src/petstore_api/components/responses/response_headers_with_no_body/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/components/responses/response_headers_with_no_body/__init__.py
@@ -13,17 +13,10 @@ parameters: typing.Dict[str, typing.Type[api_client.HeaderParameterWithoutName]]
 }
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        headers: header_parameters.HeadersDict,
-        body: schemas.Unset = schemas.unset,
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    headers: header_parameters.HeadersDict
+    body: schemas.Unset
 
 
 class HeadersWithNoBody(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/components/responses/response_headers_with_no_body/header_parameters.py
+++ b/samples/client/petstore/python/src/petstore_api/components/responses/response_headers_with_no_body/header_parameters.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class HeadersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+class HeadersDict(schemas.immutabledict[str, str]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -63,10 +63,7 @@ class HeadersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
         val = self.get("location", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
 HeadersDictInput = typing.TypedDict(
     'HeadersDictInput',
     {

--- a/samples/client/petstore/python/src/petstore_api/components/responses/response_success_description_only/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/components/responses/response_success_description_only/__init__.py
@@ -7,17 +7,10 @@
 from petstore_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class SuccessDescriptionOnly(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/components/responses/response_success_inline_content_and_header/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/components/responses/response_success_inline_content_and_header/__init__.py
@@ -14,17 +14,10 @@ parameters: typing.Dict[str, typing.Type[api_client.HeaderParameterWithoutName]]
 }
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.SchemaDict,
-        headers: header_parameters.HeadersDict
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.SchemaDict
+    headers: header_parameters.HeadersDict
 
 
 class SuccessInlineContentAndHeader(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/components/responses/response_success_inline_content_and_header/header_parameters.py
+++ b/samples/client/petstore/python/src/petstore_api/components/responses/response_success_inline_content_and_header/header_parameters.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class HeadersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+class HeadersDict(schemas.immutabledict[str, str]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -63,10 +63,7 @@ class HeadersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
         val = self.get("someHeader", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
 HeadersDictInput = typing.TypedDict(
     'HeadersDictInput',
     {

--- a/samples/client/petstore/python/src/petstore_api/components/responses/response_success_with_json_api_response/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/components/responses/response_success_with_json_api_response/__init__.py
@@ -22,17 +22,10 @@ parameters: typing.Dict[str, typing.Type[api_client.HeaderParameterWithoutName]]
 }
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.api_response.ApiResponseDict,
-        headers: header_parameters.HeadersDict
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.api_response.ApiResponseDict
+    headers: header_parameters.HeadersDict
 
 
 class SuccessWithJsonApiResponse(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/components/responses/response_successful_xml_and_json_array_of_pet/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/components/responses/response_successful_xml_and_json_array_of_pet/__init__.py
@@ -10,20 +10,13 @@ from .content.application_xml import schema as application_xml_schema
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Union[
-            application_xml_schema.SchemaTuple,
-            application_json_schema.SchemaTuple,
-        ],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: typing.Union[
+        application_xml_schema.SchemaTuple,
+        application_json_schema.SchemaTuple,
+    ]
+    headers: schemas.Unset
 
 
 class SuccessfulXmlAndJsonArrayOfPet(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/components/schema/_return.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/_return.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class ReturnDict(schemas.immutabledict[str, int]):
+class ReturnDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })

--- a/samples/client/petstore/python/src/petstore_api/components/schema/abstract_step_message.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/abstract_step_message.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class AbstractStepMessageDict(schemas.immutabledict[str, str]):
+class AbstractStepMessageDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "description",
@@ -65,21 +65,18 @@ class AbstractStepMessageDict(schemas.immutabledict[str, str]):
     
     @property
     def description(self) -> schemas.OUTPUT_BASE_TYPES:
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            self.__getitem__("description")
-        )
+        return self.__getitem__("description")
     
     @property
     def discriminator(self) -> str:
-        return self.__getitem__("discriminator")
+        return typing.cast(
+            str,
+            self.__getitem__("discriminator")
+        )
     
     @property
     def sequenceNumber(self) -> schemas.OUTPUT_BASE_TYPES:
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            self.__getitem__("sequenceNumber")
-        )
+        return self.__getitem__("sequenceNumber")
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/additional_properties_class.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/additional_properties_class.py
@@ -154,7 +154,7 @@ class AdditionalProperties2(
 
 
 
-class MapOfMapPropertyDict(schemas.immutabledict[str, schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]]):
+class MapOfMapPropertyDict(schemas.immutabledict[str, AdditionalPropertiesDict]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -442,7 +442,7 @@ Properties = typing.TypedDict(
 )
 
 
-class AdditionalPropertiesClassDict(schemas.immutabledict[str, schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]]):
+class AdditionalPropertiesClassDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -556,24 +556,27 @@ class AdditionalPropertiesClassDict(schemas.immutabledict[str, schemas.immutable
         val = self.get("anytype_1", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     @property
     def map_with_undeclared_properties_anytype_1(self) -> typing.Union[schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES], schemas.Unset]:
         val = self.get("map_with_undeclared_properties_anytype_1", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES],
+            val
+        )
     
     @property
     def map_with_undeclared_properties_anytype_2(self) -> typing.Union[schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES], schemas.Unset]:
         val = self.get("map_with_undeclared_properties_anytype_2", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES],
+            val
+        )
     
     @property
     def map_with_undeclared_properties_anytype_3(self) -> typing.Union[MapWithUndeclaredPropertiesAnytype3Dict, schemas.Unset]:

--- a/samples/client/petstore/python/src/petstore_api/components/schema/additional_properties_with_array_of_enums.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/additional_properties_with_array_of_enums.py
@@ -76,7 +76,7 @@ class AdditionalProperties(
         )
 
 
-class AdditionalPropertiesWithArrayOfEnumsDict(schemas.immutabledict[str, typing.Tuple[schemas.OUTPUT_BASE_TYPES]]):
+class AdditionalPropertiesWithArrayOfEnumsDict(schemas.immutabledict[str, AdditionalPropertiesTuple]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })

--- a/samples/client/petstore/python/src/petstore_api/components/schema/animal.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/animal.py
@@ -30,7 +30,7 @@ Properties = typing.TypedDict(
 )
 
 
-class AnimalDict(schemas.immutabledict[str, str]):
+class AnimalDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "className",
@@ -75,14 +75,20 @@ class AnimalDict(schemas.immutabledict[str, str]):
     
     @property
     def className(self) -> str:
-        return self.__getitem__("className")
+        return typing.cast(
+            str,
+            self.__getitem__("className")
+        )
     
     @property
     def color(self) -> typing.Union[str, schemas.Unset]:
         val = self.get("color", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/any_type_and_format.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/any_type_and_format.py
@@ -196,70 +196,49 @@ class AnyTypeAndFormatDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
         val = self.get("uuid", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     @property
     def date(self) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         val = self.get("date", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     @property
     def number(self) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         val = self.get("number", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     @property
     def binary(self) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         val = self.get("binary", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     @property
     def int32(self) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         val = self.get("int32", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     @property
     def int64(self) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         val = self.get("int64", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     @property
     def double(self) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         val = self.get("double", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/apple.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/apple.py
@@ -44,7 +44,7 @@ Properties = typing.TypedDict(
 )
 
 
-class AppleDict(schemas.immutabledict[str, str]):
+class AppleDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "cultivar",
@@ -89,14 +89,20 @@ class AppleDict(schemas.immutabledict[str, str]):
     
     @property
     def cultivar(self) -> str:
-        return self.__getitem__("cultivar")
+        return typing.cast(
+            str,
+            self.__getitem__("cultivar")
+        )
     
     @property
     def origin(self) -> typing.Union[str, schemas.Unset]:
         val = self.get("origin", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/apple_req.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/apple_req.py
@@ -35,7 +35,10 @@ AppleReqOptionalDictInput = typing.TypedDict(
 )
 
 
-class AppleReqDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+class AppleReqDict(schemas.immutabledict[str, typing.Union[
+    bool,
+    str,
+]]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "cultivar",

--- a/samples/client/petstore/python/src/petstore_api/components/schema/array_of_array_of_number_only.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/array_of_array_of_number_only.py
@@ -131,7 +131,7 @@ Properties = typing.TypedDict(
 )
 
 
-class ArrayOfArrayOfNumberOnlyDict(schemas.immutabledict[str, typing.Tuple[schemas.OUTPUT_BASE_TYPES]]):
+class ArrayOfArrayOfNumberOnlyDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })

--- a/samples/client/petstore/python/src/petstore_api/components/schema/array_of_number_only.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/array_of_number_only.py
@@ -75,7 +75,7 @@ Properties = typing.TypedDict(
 )
 
 
-class ArrayOfNumberOnlyDict(schemas.immutabledict[str, typing.Tuple[schemas.OUTPUT_BASE_TYPES]]):
+class ArrayOfNumberOnlyDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })

--- a/samples/client/petstore/python/src/petstore_api/components/schema/array_test.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/array_test.py
@@ -292,7 +292,7 @@ Properties = typing.TypedDict(
 )
 
 
-class ArrayTestDict(schemas.immutabledict[str, typing.Tuple[schemas.OUTPUT_BASE_TYPES]]):
+class ArrayTestDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })

--- a/samples/client/petstore/python/src/petstore_api/components/schema/banana.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/banana.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class BananaDict(schemas.immutabledict[str, typing.Union[int, float]]):
+class BananaDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "lengthCm",
@@ -56,7 +56,10 @@ class BananaDict(schemas.immutabledict[str, typing.Union[int, float]]):
     
     @property
     def lengthCm(self) -> typing.Union[int, float]:
-        return self.__getitem__("lengthCm")
+        return typing.cast(
+            typing.Union[int, float],
+            self.__getitem__("lengthCm")
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/banana_req.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/banana_req.py
@@ -38,7 +38,10 @@ BananaReqOptionalDictInput = typing.TypedDict(
 )
 
 
-class BananaReqDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+class BananaReqDict(schemas.immutabledict[str, typing.Union[
+    bool,
+    typing.Union[int, float],
+]]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "lengthCm",

--- a/samples/client/petstore/python/src/petstore_api/components/schema/basque_pig.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/basque_pig.py
@@ -72,7 +72,7 @@ Properties = typing.TypedDict(
 )
 
 
-class BasquePigDict(schemas.immutabledict[str, str]):
+class BasquePigDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "className",

--- a/samples/client/petstore/python/src/petstore_api/components/schema/capitalization.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/capitalization.py
@@ -29,7 +29,7 @@ Properties = typing.TypedDict(
 )
 
 
-class CapitalizationDict(schemas.immutabledict[str, str]):
+class CapitalizationDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -103,42 +103,60 @@ class CapitalizationDict(schemas.immutabledict[str, str]):
         val = self.get("smallCamel", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     @property
     def CapitalCamel(self) -> typing.Union[str, schemas.Unset]:
         val = self.get("CapitalCamel", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     @property
     def small_Snake(self) -> typing.Union[str, schemas.Unset]:
         val = self.get("small_Snake", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     @property
     def Capital_Snake(self) -> typing.Union[str, schemas.Unset]:
         val = self.get("Capital_Snake", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     @property
     def SCA_ETH_Flow_Points(self) -> typing.Union[str, schemas.Unset]:
         val = self.get("SCA_ETH_Flow_Points", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     @property
     def ATT_NAME(self) -> typing.Union[str, schemas.Unset]:
         val = self.get("ATT_NAME", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/cat.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/cat.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class _1Dict(schemas.immutabledict[str, bool]):
+class _1Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -63,7 +63,10 @@ class _1Dict(schemas.immutabledict[str, bool]):
         val = self.get("declawed", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            bool,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/child_cat.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/child_cat.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class _1Dict(schemas.immutabledict[str, str]):
+class _1Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -63,7 +63,10 @@ class _1Dict(schemas.immutabledict[str, str]):
         val = self.get("name", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/class_model.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/class_model.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class ClassModelDict(schemas.immutabledict[str, str]):
+class ClassModelDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -63,7 +63,10 @@ class ClassModelDict(schemas.immutabledict[str, str]):
         val = self.get("_class", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/client.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/client.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class ClientDict(schemas.immutabledict[str, str]):
+class ClientDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -63,7 +63,10 @@ class ClientDict(schemas.immutabledict[str, str]):
         val = self.get("client", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/complex_quadrilateral.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/complex_quadrilateral.py
@@ -72,7 +72,7 @@ Properties = typing.TypedDict(
 )
 
 
-class _1Dict(schemas.immutabledict[str, str]):
+class _1Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })

--- a/samples/client/petstore/python/src/petstore_api/components/schema/danish_pig.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/danish_pig.py
@@ -72,7 +72,7 @@ Properties = typing.TypedDict(
 )
 
 
-class DanishPigDict(schemas.immutabledict[str, str]):
+class DanishPigDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "className",

--- a/samples/client/petstore/python/src/petstore_api/components/schema/dog.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/dog.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class _1Dict(schemas.immutabledict[str, str]):
+class _1Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -63,7 +63,10 @@ class _1Dict(schemas.immutabledict[str, str]):
         val = self.get("breed", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/drawing.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/drawing.py
@@ -82,7 +82,7 @@ Properties = typing.TypedDict(
 )
 
 
-class DrawingDict(schemas.immutabledict[str, typing.Tuple[schemas.OUTPUT_BASE_TYPES]]):
+class DrawingDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })

--- a/samples/client/petstore/python/src/petstore_api/components/schema/enum_test.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/enum_test.py
@@ -307,6 +307,7 @@ Properties = typing.TypedDict(
 
 
 class EnumTestDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "enum_string_required",
     })

--- a/samples/client/petstore/python/src/petstore_api/components/schema/equilateral_triangle.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/equilateral_triangle.py
@@ -72,7 +72,7 @@ Properties = typing.TypedDict(
 )
 
 
-class _1Dict(schemas.immutabledict[str, str]):
+class _1Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })

--- a/samples/client/petstore/python/src/petstore_api/components/schema/file.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/file.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class FileDict(schemas.immutabledict[str, str]):
+class FileDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -63,7 +63,10 @@ class FileDict(schemas.immutabledict[str, str]):
         val = self.get("sourceURI", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/file_schema_test_class.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/file_schema_test_class.py
@@ -77,7 +77,7 @@ Properties = typing.TypedDict(
 )
 
 
-class FileSchemaTestClassDict(schemas.immutabledict[str, typing.Tuple[schemas.OUTPUT_BASE_TYPES]]):
+class FileSchemaTestClassDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })

--- a/samples/client/petstore/python/src/petstore_api/components/schema/foo.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/foo.py
@@ -21,6 +21,7 @@ Properties = typing.TypedDict(
 
 
 class FooDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
     __optional_keys__: typing.FrozenSet[str] = frozenset({

--- a/samples/client/petstore/python/src/petstore_api/components/schema/fruit.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/fruit.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class FruitDict(schemas.immutabledict[str, str]):
+class FruitDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -63,7 +63,10 @@ class FruitDict(schemas.immutabledict[str, str]):
         val = self.get("color", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/gm_fruit.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/gm_fruit.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class GmFruitDict(schemas.immutabledict[str, str]):
+class GmFruitDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -63,7 +63,10 @@ class GmFruitDict(schemas.immutabledict[str, str]):
         val = self.get("color", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/grandparent_animal.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/grandparent_animal.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class GrandparentAnimalDict(schemas.immutabledict[str, str]):
+class GrandparentAnimalDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "pet_type",
@@ -53,7 +53,10 @@ class GrandparentAnimalDict(schemas.immutabledict[str, str]):
     
     @property
     def pet_type(self) -> str:
-        return self.__getitem__("pet_type")
+        return typing.cast(
+            str,
+            self.__getitem__("pet_type")
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/has_only_read_only.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/has_only_read_only.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class HasOnlyReadOnlyDict(schemas.immutabledict[str, str]):
+class HasOnlyReadOnlyDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -71,14 +71,20 @@ class HasOnlyReadOnlyDict(schemas.immutabledict[str, str]):
         val = self.get("bar", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     @property
     def foo(self) -> typing.Union[str, schemas.Unset]:
         val = self.get("foo", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/health_check_result.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/health_check_result.py
@@ -54,10 +54,7 @@ Properties = typing.TypedDict(
 )
 
 
-class HealthCheckResultDict(schemas.immutabledict[str, typing.Union[
-    None,
-    str,
-]]):
+class HealthCheckResultDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -105,7 +102,13 @@ class HealthCheckResultDict(schemas.immutabledict[str, typing.Union[
         val = self.get("NullableMessage", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            typing.Union[
+                None,
+                str,
+            ],
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/isosceles_triangle.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/isosceles_triangle.py
@@ -72,7 +72,7 @@ Properties = typing.TypedDict(
 )
 
 
-class _1Dict(schemas.immutabledict[str, str]):
+class _1Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })

--- a/samples/client/petstore/python/src/petstore_api/components/schema/json_patch_request_add_replace_test.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/json_patch_request_add_replace_test.py
@@ -105,7 +105,7 @@ Properties = typing.TypedDict(
 )
 
 
-class JSONPatchRequestAddReplaceTestDict(schemas.immutabledict[str, str]):
+class JSONPatchRequestAddReplaceTestDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "op",
@@ -157,14 +157,14 @@ class JSONPatchRequestAddReplaceTestDict(schemas.immutabledict[str, str]):
     
     @property
     def path(self) -> str:
-        return self.__getitem__("path")
+        return typing.cast(
+            str,
+            self.__getitem__("path")
+        )
     
     @property
     def value(self) -> schemas.OUTPUT_BASE_TYPES:
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            self.__getitem__("value")
-        )
+        return self.__getitem__("value")
 JSONPatchRequestAddReplaceTestDictInput = typing.TypedDict(
     'JSONPatchRequestAddReplaceTestDictInput',
     {

--- a/samples/client/petstore/python/src/petstore_api/components/schema/map_test.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/map_test.py
@@ -83,7 +83,7 @@ class AdditionalProperties(
 
 
 
-class MapMapOfStringDict(schemas.immutabledict[str, schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]]):
+class MapMapOfStringDict(schemas.immutabledict[str, AdditionalPropertiesDict]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -227,7 +227,7 @@ class AdditionalProperties3(
         )
 
 
-class MapOfEnumStringDict(schemas.immutabledict[str, str]):
+class MapOfEnumStringDict(schemas.immutabledict[str, typing.Literal["UPPER", "lower"]]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -386,6 +386,7 @@ Properties = typing.TypedDict(
 
 
 class MapTestDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
     __optional_keys__: typing.FrozenSet[str] = frozenset({

--- a/samples/client/petstore/python/src/petstore_api/components/schema/mixed_properties_and_additional_properties_class.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/mixed_properties_and_additional_properties_class.py
@@ -16,7 +16,7 @@ DateTime: typing_extensions.TypeAlias = schemas.DateTimeSchema
 from petstore_api.components.schema import animal
 
 
-class MapDict(schemas.immutabledict[str, AnimalDict]):
+class MapDict(schemas.immutabledict[str, animal.AnimalDict]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })

--- a/samples/client/petstore/python/src/petstore_api/components/schema/mixed_properties_and_additional_properties_class.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/mixed_properties_and_additional_properties_class.py
@@ -16,7 +16,8 @@ DateTime: typing_extensions.TypeAlias = schemas.DateTimeSchema
 from petstore_api.components.schema import animal
 
 
-class MapDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+class MapDict(schemas.immutabledict[str, AnimalDict]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
     __optional_keys__: typing.FrozenSet[str] = frozenset({

--- a/samples/client/petstore/python/src/petstore_api/components/schema/money.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/money.py
@@ -24,6 +24,7 @@ Properties = typing.TypedDict(
 
 
 class MoneyDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "amount",
         "currency",

--- a/samples/client/petstore/python/src/petstore_api/components/schema/no_additional_properties.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/no_additional_properties.py
@@ -78,20 +78,14 @@ class NoAdditionalPropertiesDict(schemas.immutabledict[str, int]):
     
     @property
     def id(self) -> int:
-        return typing.cast(
-            int,
-            self.__getitem__("id")
-        )
+        return self.__getitem__("id")
     
     @property
     def petId(self) -> typing.Union[int, schemas.Unset]:
         val = self.get("petId", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            int,
-            val
-        )
+        return val
 
 
 class NoAdditionalPropertiesDictInput(NoAdditionalPropertiesRequiredDictInput, NoAdditionalPropertiesOptionalDictInput):

--- a/samples/client/petstore/python/src/petstore_api/components/schema/nullable_class.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/nullable_class.py
@@ -945,7 +945,15 @@ Properties = typing.TypedDict(
 )
 
 
-class NullableClassDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+class NullableClassDict(schemas.immutabledict[str, typing.Union[
+    schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES],
+    None,
+    typing.Tuple[schemas.OUTPUT_BASE_TYPES],
+    str,
+    bool,
+    typing.Union[int, float],
+    int,
+]]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })

--- a/samples/client/petstore/python/src/petstore_api/components/schema/number_only.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/number_only.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class NumberOnlyDict(schemas.immutabledict[str, typing.Union[int, float]]):
+class NumberOnlyDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -64,7 +64,10 @@ class NumberOnlyDict(schemas.immutabledict[str, typing.Union[int, float]]):
         val = self.get("JustNumber", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            typing.Union[int, float],
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/obj_with_required_props.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/obj_with_required_props.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class ObjWithRequiredPropsDict(schemas.immutabledict[str, str]):
+class ObjWithRequiredPropsDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "a",
@@ -53,7 +53,10 @@ class ObjWithRequiredPropsDict(schemas.immutabledict[str, str]):
     
     @property
     def a(self) -> str:
-        return self.__getitem__("a")
+        return typing.cast(
+            str,
+            self.__getitem__("a")
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/obj_with_required_props_base.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/obj_with_required_props_base.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class ObjWithRequiredPropsBaseDict(schemas.immutabledict[str, str]):
+class ObjWithRequiredPropsBaseDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "b",
@@ -53,7 +53,10 @@ class ObjWithRequiredPropsBaseDict(schemas.immutabledict[str, str]):
     
     @property
     def b(self) -> str:
-        return self.__getitem__("b")
+        return typing.cast(
+            str,
+            self.__getitem__("b")
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/object_model_with_arg_and_args_properties.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/object_model_with_arg_and_args_properties.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class ObjectModelWithArgAndArgsPropertiesDict(schemas.immutabledict[str, str]):
+class ObjectModelWithArgAndArgsPropertiesDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "arg",
@@ -58,11 +58,17 @@ class ObjectModelWithArgAndArgsPropertiesDict(schemas.immutabledict[str, str]):
     
     @property
     def arg(self) -> str:
-        return self.__getitem__("arg")
+        return typing.cast(
+            str,
+            self.__getitem__("arg")
+        )
     
     @property
     def args(self) -> str:
-        return self.__getitem__("args")
+        return typing.cast(
+            str,
+            self.__getitem__("args")
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/object_model_with_ref_props.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/object_model_with_ref_props.py
@@ -25,6 +25,7 @@ Properties = typing.TypedDict(
 
 
 class ObjectModelWithRefPropsDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
     __optional_keys__: typing.FrozenSet[str] = frozenset({

--- a/samples/client/petstore/python/src/petstore_api/components/schema/object_with_all_of_with_req_test_prop_from_unset_add_prop.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/object_with_all_of_with_req_test_prop_from_unset_add_prop.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class _1Dict(schemas.immutabledict[str, str]):
+class _1Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "test",
@@ -67,17 +67,17 @@ class _1Dict(schemas.immutabledict[str, str]):
     
     @property
     def test(self) -> schemas.OUTPUT_BASE_TYPES:
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            self.__getitem__("test")
-        )
+        return self.__getitem__("test")
     
     @property
     def name(self) -> typing.Union[str, schemas.Unset]:
         val = self.get("name", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/object_with_colliding_properties.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/object_with_colliding_properties.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class ObjectWithCollidingPropertiesDict(schemas.immutabledict[str, schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]]):
+class ObjectWithCollidingPropertiesDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -73,14 +73,20 @@ class ObjectWithCollidingPropertiesDict(schemas.immutabledict[str, schemas.immut
         val = self.get("someProp", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES],
+            val
+        )
     
     @property
     def someprop(self) -> typing.Union[schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES], schemas.Unset]:
         val = self.get("someprop", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES],
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/object_with_decimal_properties.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/object_with_decimal_properties.py
@@ -25,6 +25,7 @@ Properties = typing.TypedDict(
 
 
 class ObjectWithDecimalPropertiesDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
     __optional_keys__: typing.FrozenSet[str] = frozenset({

--- a/samples/client/petstore/python/src/petstore_api/components/schema/object_with_inline_composition_property.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/object_with_inline_composition_property.py
@@ -41,6 +41,7 @@ Properties = typing.TypedDict(
 
 
 class ObjectWithInlineCompositionPropertyDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
     __optional_keys__: typing.FrozenSet[str] = frozenset({
@@ -84,10 +85,7 @@ class ObjectWithInlineCompositionPropertyDict(schemas.immutabledict[str, schemas
         val = self.get("someProp", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/object_with_non_intersecting_values.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/object_with_non_intersecting_values.py
@@ -20,7 +20,10 @@ Properties = typing.TypedDict(
 )
 
 
-class ObjectWithNonIntersectingValuesDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+class ObjectWithNonIntersectingValuesDict(schemas.immutabledict[str, typing.Union[
+    typing.Union[int, float],
+    str,
+]]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })

--- a/samples/client/petstore/python/src/petstore_api/components/schema/object_with_only_optional_props.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/object_with_only_optional_props.py
@@ -22,7 +22,10 @@ Properties = typing.TypedDict(
 )
 
 
-class ObjectWithOnlyOptionalPropsDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+class ObjectWithOnlyOptionalPropsDict(schemas.immutabledict[str, typing.Union[
+    typing.Union[int, float],
+    str,
+]]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })

--- a/samples/client/petstore/python/src/petstore_api/components/schema/object_with_optional_test_prop.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/object_with_optional_test_prop.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class ObjectWithOptionalTestPropDict(schemas.immutabledict[str, str]):
+class ObjectWithOptionalTestPropDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -63,7 +63,10 @@ class ObjectWithOptionalTestPropDict(schemas.immutabledict[str, str]):
         val = self.get("test", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/player.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/player.py
@@ -21,6 +21,7 @@ Properties = typing.TypedDict(
 
 
 class PlayerDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
     __optional_keys__: typing.FrozenSet[str] = frozenset({

--- a/samples/client/petstore/python/src/petstore_api/components/schema/public_key.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/public_key.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class PublicKeyDict(schemas.immutabledict[str, str]):
+class PublicKeyDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -63,7 +63,10 @@ class PublicKeyDict(schemas.immutabledict[str, str]):
         val = self.get("key", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/quadrilateral_interface.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/quadrilateral_interface.py
@@ -74,7 +74,7 @@ Properties = typing.TypedDict(
 )
 
 
-class QuadrilateralInterfaceDict(schemas.immutabledict[str, str]):
+class QuadrilateralInterfaceDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "quadrilateralType",
@@ -113,7 +113,10 @@ class QuadrilateralInterfaceDict(schemas.immutabledict[str, str]):
     
     @property
     def quadrilateralType(self) -> str:
-        return self.__getitem__("quadrilateralType")
+        return typing.cast(
+            str,
+            self.__getitem__("quadrilateralType")
+        )
     
     @property
     def shapeType(self) -> typing.Literal["Quadrilateral"]:

--- a/samples/client/petstore/python/src/petstore_api/components/schema/read_only_first.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/read_only_first.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class ReadOnlyFirstDict(schemas.immutabledict[str, str]):
+class ReadOnlyFirstDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -71,14 +71,20 @@ class ReadOnlyFirstDict(schemas.immutabledict[str, str]):
         val = self.get("bar", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     @property
     def baz(self) -> typing.Union[str, schemas.Unset]:
         val = self.get("baz", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/req_props_from_unset_add_props.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/req_props_from_unset_add_props.py
@@ -13,6 +13,7 @@ from petstore_api.shared_imports.schema_imports import *  # pyright: ignore [rep
 
 
 class ReqPropsFromUnsetAddPropsDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "invalid-name",
         "validName",
@@ -49,10 +50,7 @@ class ReqPropsFromUnsetAddPropsDict(schemas.immutabledict[str, schemas.OUTPUT_BA
     
     @property
     def validName(self) -> schemas.OUTPUT_BASE_TYPES:
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            self.__getitem__("validName")
-        )
+        return self.__getitem__("validName")
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/scalene_triangle.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/scalene_triangle.py
@@ -72,7 +72,7 @@ Properties = typing.TypedDict(
 )
 
 
-class _1Dict(schemas.immutabledict[str, str]):
+class _1Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })

--- a/samples/client/petstore/python/src/petstore_api/components/schema/simple_quadrilateral.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/simple_quadrilateral.py
@@ -72,7 +72,7 @@ Properties = typing.TypedDict(
 )
 
 
-class _1Dict(schemas.immutabledict[str, str]):
+class _1Dict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })

--- a/samples/client/petstore/python/src/petstore_api/components/schema/special_model_name.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/special_model_name.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class SpecialModelNameDict(schemas.immutabledict[str, str]):
+class SpecialModelNameDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -63,7 +63,10 @@ class SpecialModelNameDict(schemas.immutabledict[str, str]):
         val = self.get("a", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/triangle_interface.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/triangle_interface.py
@@ -74,7 +74,7 @@ Properties = typing.TypedDict(
 )
 
 
-class TriangleInterfaceDict(schemas.immutabledict[str, str]):
+class TriangleInterfaceDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "shapeType",
@@ -120,7 +120,10 @@ class TriangleInterfaceDict(schemas.immutabledict[str, str]):
     
     @property
     def triangleType(self) -> str:
-        return self.__getitem__("triangleType")
+        return typing.cast(
+            str,
+            self.__getitem__("triangleType")
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/components/schema/zebra.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/zebra.py
@@ -156,7 +156,7 @@ Properties = typing.TypedDict(
 )
 
 
-class ZebraDict(schemas.immutabledict[str, str]):
+class ZebraDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "className",

--- a/samples/client/petstore/python/src/petstore_api/paths/another_fake_dummy/patch/responses/response_200/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/another_fake_dummy/patch/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.client.ClientDict,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.client.ClientDict
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake/delete/header_parameters.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake/delete/header_parameters.py
@@ -43,6 +43,7 @@ HeaderParametersOptionalDictInput = typing.TypedDict(
 
 
 class HeaderParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "required_boolean_group",
     })

--- a/samples/client/petstore/python/src/petstore_api/paths/fake/delete/query_parameters.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake/delete/query_parameters.py
@@ -43,6 +43,7 @@ QueryParametersOptionalDictInput = typing.TypedDict(
 
 
 class QueryParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "required_int64_group",
         "required_string_group",

--- a/samples/client/petstore/python/src/petstore_api/paths/fake/get/header_parameters.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake/get/header_parameters.py
@@ -24,6 +24,7 @@ Properties = typing.TypedDict(
 
 
 class HeaderParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
     __optional_keys__: typing.FrozenSet[str] = frozenset({

--- a/samples/client/petstore/python/src/petstore_api/paths/fake/get/query_parameters.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake/get/query_parameters.py
@@ -28,6 +28,7 @@ Properties = typing.TypedDict(
 
 
 class QueryParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
     __optional_keys__: typing.FrozenSet[str] = frozenset({

--- a/samples/client/petstore/python/src/petstore_api/paths/fake/get/responses/response_404/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake/get/responses/response_404/__init__.py
@@ -9,17 +9,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+    headers: schemas.Unset
 
 
 class ResponseFor404(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake/patch/responses/response_200/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake/patch/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.client.ClientDict,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.client.ClientDict
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake/post/responses/response_404/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake/post/responses/response_404/__init__.py
@@ -7,17 +7,10 @@
 from petstore_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor404(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_additional_properties_with_array_of_enums/get/responses/response_200/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_additional_properties_with_array_of_enums/get/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.additional_properties_with_array_of_enums.AdditionalPropertiesWithArrayOfEnumsDict,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.additional_properties_with_array_of_enums.AdditionalPropertiesWithArrayOfEnumsDict
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_body_with_query_params/put/query_parameters.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_body_with_query_params/put/query_parameters.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class QueryParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+class QueryParametersDict(schemas.immutabledict[str, str]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "query",
@@ -53,10 +53,7 @@ class QueryParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES])
     
     @property
     def query(self) -> str:
-        return typing.cast(
-            str,
-            self.__getitem__("query")
-        )
+        return self.__getitem__("query")
 QueryParametersDictInput = typing.TypedDict(
     'QueryParametersDictInput',
     {

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_classname_test/patch/responses/response_200/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_classname_test/patch/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.client.ClientDict,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.client.ClientDict
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_delete_coffee_id/delete/path_parameters.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_delete_coffee_id/delete/path_parameters.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class PathParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+class PathParametersDict(schemas.immutabledict[str, str]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "id",
@@ -53,10 +53,7 @@ class PathParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
     
     @property
     def id(self) -> str:
-        return typing.cast(
-            str,
-            self.__getitem__("id")
-        )
+        return self.__getitem__("id")
 PathParametersDictInput = typing.TypedDict(
     'PathParametersDictInput',
     {

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_delete_coffee_id/delete/responses/response_default/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_delete_coffee_id/delete/responses/response_default/__init__.py
@@ -7,17 +7,10 @@
 from petstore_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class Default(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_health/get/responses/response_200/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_health/get/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.health_check_result.HealthCheckResultDict,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.health_check_result.HealthCheckResultDict
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_inline_composition/post/parameters/parameter_1/schema.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_inline_composition/post/parameters/parameter_1/schema.py
@@ -41,6 +41,7 @@ Properties = typing.TypedDict(
 
 
 class SchemaDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
     __optional_keys__: typing.FrozenSet[str] = frozenset({
@@ -84,10 +85,7 @@ class SchemaDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
         val = self.get("someProp", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_inline_composition/post/query_parameters.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_inline_composition/post/query_parameters.py
@@ -24,6 +24,7 @@ Properties = typing.TypedDict(
 
 
 class QueryParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
     __optional_keys__: typing.FrozenSet[str] = frozenset({

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_inline_composition/post/request_body/content/multipart_form_data/schema.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_inline_composition/post/request_body/content/multipart_form_data/schema.py
@@ -41,6 +41,7 @@ Properties = typing.TypedDict(
 
 
 class SchemaDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
     __optional_keys__: typing.FrozenSet[str] = frozenset({
@@ -84,10 +85,7 @@ class SchemaDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
         val = self.get("someProp", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_inline_composition/post/responses/response_200/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_inline_composition/post/responses/response_200/__init__.py
@@ -10,20 +10,13 @@ from .content.application_json import schema as application_json_schema
 from .content.multipart_form_data import schema as multipart_form_data_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Union[
-            schemas.OUTPUT_BASE_TYPES,
-            multipart_form_data_schema.SchemaDict,
-        ],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: typing.Union[
+        schemas.OUTPUT_BASE_TYPES,
+        multipart_form_data_schema.SchemaDict,
+    ]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_inline_composition/post/responses/response_200/content/multipart_form_data/schema.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_inline_composition/post/responses/response_200/content/multipart_form_data/schema.py
@@ -41,6 +41,7 @@ Properties = typing.TypedDict(
 
 
 class SchemaDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
     __optional_keys__: typing.FrozenSet[str] = frozenset({
@@ -84,10 +85,7 @@ class SchemaDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
         val = self.get("someProp", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            val
-        )
+        return val
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_json_form_data/get/request_body/content/application_x_www_form_urlencoded/schema.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_json_form_data/get/request_body/content/application_x_www_form_urlencoded/schema.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class SchemaDict(schemas.immutabledict[str, str]):
+class SchemaDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "param",
@@ -58,11 +58,17 @@ class SchemaDict(schemas.immutabledict[str, str]):
     
     @property
     def param(self) -> str:
-        return self.__getitem__("param")
+        return typing.cast(
+            str,
+            self.__getitem__("param")
+        )
     
     @property
     def param2(self) -> str:
-        return self.__getitem__("param2")
+        return typing.cast(
+            str,
+            self.__getitem__("param2")
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_json_with_charset/post/responses/response_200/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_json_with_charset/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_json_charsetutf8 import schema as application_json_charsetutf8_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_multiple_request_body_content_types/post/request_body/content/application_json/schema.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_multiple_request_body_content_types/post/request_body/content/application_json/schema.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class SchemaDict(schemas.immutabledict[str, str]):
+class SchemaDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -63,7 +63,10 @@ class SchemaDict(schemas.immutabledict[str, str]):
         val = self.get("a", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_multiple_request_body_content_types/post/request_body/content/multipart_form_data/schema.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_multiple_request_body_content_types/post/request_body/content/multipart_form_data/schema.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class SchemaDict(schemas.immutabledict[str, str]):
+class SchemaDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -63,7 +63,10 @@ class SchemaDict(schemas.immutabledict[str, str]):
         val = self.get("b", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_multiple_request_body_content_types/post/responses/response_200/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_multiple_request_body_content_types/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_multiple_response_bodies/get/responses/response_200/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_multiple_response_bodies/get/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_multiple_response_bodies/get/responses/response_202/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_multiple_response_bodies/get/responses/response_202/__init__.py
@@ -9,17 +9,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor202(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_multiple_securities/get/responses/response_200/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_multiple_securities/get/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_obj_in_query/get/parameters/parameter_0/schema.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_obj_in_query/get/parameters/parameter_0/schema.py
@@ -19,7 +19,7 @@ Properties = typing.TypedDict(
 )
 
 
-class SchemaDict(schemas.immutabledict[str, str]):
+class SchemaDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -63,7 +63,10 @@ class SchemaDict(schemas.immutabledict[str, str]):
         val = self.get("keyword", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_obj_in_query/get/query_parameters.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_obj_in_query/get/query_parameters.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class QueryParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+class QueryParametersDict(schemas.immutabledict[str, SchemaDict]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -64,10 +64,7 @@ class QueryParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES])
         val = self.get("mapBean", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            schema.SchemaDict,
-            val
-        )
+        return val
 QueryParametersDictInput = typing.TypedDict(
     'QueryParametersDictInput',
     {

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_obj_in_query/get/query_parameters.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_obj_in_query/get/query_parameters.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class QueryParametersDict(schemas.immutabledict[str, SchemaDict]):
+class QueryParametersDict(schemas.immutabledict[str, schema.SchemaDict]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_parameter_collisions1_abab_self_ab/post/header_parameters.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_parameter_collisions1_abab_self_ab/post/header_parameters.py
@@ -28,6 +28,7 @@ Properties = typing.TypedDict(
 
 
 class HeaderParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
     __optional_keys__: typing.FrozenSet[str] = frozenset({

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_parameter_collisions1_abab_self_ab/post/responses/response_200/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_parameter_collisions1_abab_self_ab/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_pet_id_upload_image_with_required_file/post/path_parameters.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_pet_id_upload_image_with_required_file/post/path_parameters.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class PathParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+class PathParametersDict(schemas.immutabledict[str, int]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "petId",
@@ -53,10 +53,7 @@ class PathParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
     
     @property
     def petId(self) -> int:
-        return typing.cast(
-            int,
-            self.__getitem__("petId")
-        )
+        return self.__getitem__("petId")
 PathParametersDictInput = typing.TypedDict(
     'PathParametersDictInput',
     {

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_pet_id_upload_image_with_required_file/post/request_body/content/multipart_form_data/schema.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_pet_id_upload_image_with_required_file/post/request_body/content/multipart_form_data/schema.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class SchemaDict(schemas.immutabledict[str, str]):
+class SchemaDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "requiredFile",
@@ -81,7 +81,10 @@ class SchemaDict(schemas.immutabledict[str, str]):
         val = self.get("additionalMetadata", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_pet_id_upload_image_with_required_file/post/responses/response_200/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_pet_id_upload_image_with_required_file/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.api_response.ApiResponseDict,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.api_response.ApiResponseDict
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_query_param_with_json_content_type/get/query_parameters.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_query_param_with_json_content_type/get/query_parameters.py
@@ -56,10 +56,7 @@ class QueryParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES])
     
     @property
     def someParam(self) -> schemas.OUTPUT_BASE_TYPES:
-        return typing.cast(
-            schemas.OUTPUT_BASE_TYPES,
-            self.__getitem__("someParam")
-        )
+        return self.__getitem__("someParam")
 QueryParametersDictInput = typing.TypedDict(
     'QueryParametersDictInput',
     {

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_query_param_with_json_content_type/get/responses/response_200/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_query_param_with_json_content_type/get/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_redirection/get/responses/response_303/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_redirection/get/responses/response_303/__init__.py
@@ -7,17 +7,10 @@
 from petstore_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor303(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_redirection/get/responses/response_3xx/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_redirection/get/responses/response_3xx/__init__.py
@@ -7,17 +7,10 @@
 from petstore_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor3XX(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_ref_obj_in_query/get/query_parameters.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_ref_obj_in_query/get/query_parameters.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class QueryParametersDict(schemas.immutabledict[str, FooDict]):
+class QueryParametersDict(schemas.immutabledict[str, foo.FooDict]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_ref_obj_in_query/get/query_parameters.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_ref_obj_in_query/get/query_parameters.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class QueryParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+class QueryParametersDict(schemas.immutabledict[str, FooDict]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -64,10 +64,7 @@ class QueryParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES])
         val = self.get("mapBean", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            foo.FooDict,
-            val
-        )
+        return val
 QueryParametersDictInput = typing.TypedDict(
     'QueryParametersDictInput',
     {

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_refs_array_of_enums/post/responses/response_200/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_refs_array_of_enums/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.array_of_enums.ArrayOfEnumsTuple,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.array_of_enums.ArrayOfEnumsTuple
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_refs_arraymodel/post/responses/response_200/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_refs_arraymodel/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.animal_farm.AnimalFarmTuple,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.animal_farm.AnimalFarmTuple
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_refs_boolean/post/responses/response_200/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_refs_boolean/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: bool,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: bool
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_refs_composed_one_of_number_with_validations/post/responses/response_200/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_refs_composed_one_of_number_with_validations/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_refs_enum/post/responses/response_200/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_refs_enum/post/responses/response_200/__init__.py
@@ -9,20 +9,13 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Union[
-            None,
-            typing.Literal["placed", "approved", "delivered", "single quoted", "multiple\nlines", "double quote \n with newline"],
-        ],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: typing.Union[
+        None,
+        typing.Literal["placed", "approved", "delivered", "single quoted", "multiple\nlines", "double quote \n with newline"],
+    ]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_refs_mammal/post/responses/response_200/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_refs_mammal/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_refs_number/post/responses/response_200/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_refs_number/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Union[int, float],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: typing.Union[int, float]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_refs_object_model_with_ref_props/post/responses/response_200/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_refs_object_model_with_ref_props/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.object_model_with_ref_props.ObjectModelWithRefPropsDict,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.object_model_with_ref_props.ObjectModelWithRefPropsDict
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_refs_string/post/responses/response_200/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_refs_string/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: str,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: str
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_response_without_schema/get/responses/response_200/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_response_without_schema/get/responses/response_200/__init__.py
@@ -8,17 +8,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_test_query_paramters/put/query_parameters.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_test_query_paramters/put/query_parameters.py
@@ -32,6 +32,7 @@ Properties = typing.TypedDict(
 
 
 class QueryParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "context",
         "http",

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_upload_download_file/post/responses/response_200/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_upload_download_file/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_octet_stream import schema as application_octet_stream_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Union[bytes, schemas.FileIO],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: typing.Union[bytes, schemas.FileIO]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_upload_file/post/request_body/content/multipart_form_data/schema.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_upload_file/post/request_body/content/multipart_form_data/schema.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class SchemaDict(schemas.immutabledict[str, str]):
+class SchemaDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "file",
@@ -81,7 +81,10 @@ class SchemaDict(schemas.immutabledict[str, str]):
         val = self.get("additionalMetadata", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_upload_file/post/responses/response_200/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_upload_file/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.api_response.ApiResponseDict,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.api_response.ApiResponseDict
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_upload_files/post/request_body/content/multipart_form_data/schema.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_upload_files/post/request_body/content/multipart_form_data/schema.py
@@ -79,7 +79,7 @@ Properties = typing.TypedDict(
 )
 
 
-class SchemaDict(schemas.immutabledict[str, typing.Tuple[schemas.OUTPUT_BASE_TYPES]]):
+class SchemaDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_upload_files/post/responses/response_200/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_upload_files/post/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.api_response.ApiResponseDict,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.api_response.ApiResponseDict
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_wild_card_responses/get/responses/response_1xx/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_wild_card_responses/get/responses/response_1xx/__init__.py
@@ -9,17 +9,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor1XX(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_wild_card_responses/get/responses/response_200/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_wild_card_responses/get/responses/response_200/__init__.py
@@ -9,17 +9,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_wild_card_responses/get/responses/response_2xx/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_wild_card_responses/get/responses/response_2xx/__init__.py
@@ -9,17 +9,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor2XX(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_wild_card_responses/get/responses/response_3xx/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_wild_card_responses/get/responses/response_3xx/__init__.py
@@ -9,17 +9,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor3XX(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_wild_card_responses/get/responses/response_4xx/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_wild_card_responses/get/responses/response_4xx/__init__.py
@@ -9,17 +9,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor4XX(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/fake_wild_card_responses/get/responses/response_5xx/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake_wild_card_responses/get/responses/response_5xx/__init__.py
@@ -9,17 +9,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.OUTPUT_BASE_TYPES,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.OUTPUT_BASE_TYPES
+    headers: schemas.Unset
 
 
 class ResponseFor5XX(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/foo/get/responses/response_default/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/foo/get/responses/response_default/__init__.py
@@ -9,17 +9,10 @@ from petstore_api.shared_imports.response_imports import *  # pyright: ignore [r
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: application_json_schema.SchemaDict,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: application_json_schema.SchemaDict
+    headers: schemas.Unset
 
 
 class Default(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/foo/get/responses/response_default/content/application_json/schema.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/foo/get/responses/response_default/content/application_json/schema.py
@@ -21,6 +21,7 @@ Properties = typing.TypedDict(
 
 
 class SchemaDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
     __optional_keys__: typing.FrozenSet[str] = frozenset({

--- a/samples/client/petstore/python/src/petstore_api/paths/foo/get/servers/server_1.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/foo/get/servers/server_1.py
@@ -84,7 +84,7 @@ Properties = typing.TypedDict(
 )
 
 
-class VariablesDict(schemas.immutabledict[str, str]):
+class VariablesDict(schemas.immutabledict[str, typing.Literal["v1", "v2"]]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "version",
@@ -119,10 +119,7 @@ class VariablesDict(schemas.immutabledict[str, str]):
     
     @property
     def version(self) -> typing.Literal["v1", "v2"]:
-        return typing.cast(
-            typing.Literal["v1", "v2"],
-            self.__getitem__("version")
-        )
+        return self.__getitem__("version")
 VariablesDictInput = typing.TypedDict(
     'VariablesDictInput',
     {

--- a/samples/client/petstore/python/src/petstore_api/paths/pet/post/responses/response_405/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/pet/post/responses/response_405/__init__.py
@@ -7,17 +7,10 @@
 from petstore_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor405(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/pet/put/responses/response_400/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/pet/put/responses/response_400/__init__.py
@@ -7,17 +7,10 @@
 from petstore_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor400(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/pet/put/responses/response_404/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/pet/put/responses/response_404/__init__.py
@@ -7,17 +7,10 @@
 from petstore_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor404(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/pet/put/responses/response_405/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/pet/put/responses/response_405/__init__.py
@@ -7,17 +7,10 @@
 from petstore_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor405(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/pet_find_by_status/get/query_parameters.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/pet_find_by_status/get/query_parameters.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class QueryParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+class QueryParametersDict(schemas.immutabledict[str, SchemaTuple]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "status",
@@ -56,10 +56,7 @@ class QueryParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES])
     
     @property
     def status(self) -> schema.SchemaTuple:
-        return typing.cast(
-            schema.SchemaTuple,
-            self.__getitem__("status")
-        )
+        return self.__getitem__("status")
 QueryParametersDictInput = typing.TypedDict(
     'QueryParametersDictInput',
     {

--- a/samples/client/petstore/python/src/petstore_api/paths/pet_find_by_status/get/query_parameters.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/pet_find_by_status/get/query_parameters.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class QueryParametersDict(schemas.immutabledict[str, SchemaTuple]):
+class QueryParametersDict(schemas.immutabledict[str, schema.SchemaTuple]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "status",

--- a/samples/client/petstore/python/src/petstore_api/paths/pet_find_by_status/get/responses/response_400/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/pet_find_by_status/get/responses/response_400/__init__.py
@@ -7,17 +7,10 @@
 from petstore_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor400(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/pet_find_by_status/servers/server_1.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/pet_find_by_status/servers/server_1.py
@@ -84,7 +84,7 @@ Properties = typing.TypedDict(
 )
 
 
-class VariablesDict(schemas.immutabledict[str, str]):
+class VariablesDict(schemas.immutabledict[str, typing.Literal["v1", "v2"]]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "version",
@@ -119,10 +119,7 @@ class VariablesDict(schemas.immutabledict[str, str]):
     
     @property
     def version(self) -> typing.Literal["v1", "v2"]:
-        return typing.cast(
-            typing.Literal["v1", "v2"],
-            self.__getitem__("version")
-        )
+        return self.__getitem__("version")
 VariablesDictInput = typing.TypedDict(
     'VariablesDictInput',
     {

--- a/samples/client/petstore/python/src/petstore_api/paths/pet_find_by_tags/get/query_parameters.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/pet_find_by_tags/get/query_parameters.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class QueryParametersDict(schemas.immutabledict[str, SchemaTuple]):
+class QueryParametersDict(schemas.immutabledict[str, schema.SchemaTuple]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "tags",

--- a/samples/client/petstore/python/src/petstore_api/paths/pet_find_by_tags/get/query_parameters.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/pet_find_by_tags/get/query_parameters.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class QueryParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+class QueryParametersDict(schemas.immutabledict[str, SchemaTuple]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "tags",
@@ -56,10 +56,7 @@ class QueryParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES])
     
     @property
     def tags(self) -> schema.SchemaTuple:
-        return typing.cast(
-            schema.SchemaTuple,
-            self.__getitem__("tags")
-        )
+        return self.__getitem__("tags")
 QueryParametersDictInput = typing.TypedDict(
     'QueryParametersDictInput',
     {

--- a/samples/client/petstore/python/src/petstore_api/paths/pet_find_by_tags/get/responses/response_400/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/pet_find_by_tags/get/responses/response_400/__init__.py
@@ -7,17 +7,10 @@
 from petstore_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor400(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/pet_pet_id/delete/header_parameters.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/pet_pet_id/delete/header_parameters.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class HeaderParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+class HeaderParametersDict(schemas.immutabledict[str, str]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -63,10 +63,7 @@ class HeaderParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
         val = self.get("api_key", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return typing.cast(
-            str,
-            val
-        )
+        return val
 HeaderParametersDictInput = typing.TypedDict(
     'HeaderParametersDictInput',
     {

--- a/samples/client/petstore/python/src/petstore_api/paths/pet_pet_id/delete/path_parameters.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/pet_pet_id/delete/path_parameters.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class PathParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+class PathParametersDict(schemas.immutabledict[str, int]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "petId",
@@ -53,10 +53,7 @@ class PathParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
     
     @property
     def petId(self) -> int:
-        return typing.cast(
-            int,
-            self.__getitem__("petId")
-        )
+        return self.__getitem__("petId")
 PathParametersDictInput = typing.TypedDict(
     'PathParametersDictInput',
     {

--- a/samples/client/petstore/python/src/petstore_api/paths/pet_pet_id/delete/responses/response_400/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/pet_pet_id/delete/responses/response_400/__init__.py
@@ -7,17 +7,10 @@
 from petstore_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor400(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/pet_pet_id/get/path_parameters.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/pet_pet_id/get/path_parameters.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class PathParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+class PathParametersDict(schemas.immutabledict[str, int]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "petId",
@@ -53,10 +53,7 @@ class PathParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
     
     @property
     def petId(self) -> int:
-        return typing.cast(
-            int,
-            self.__getitem__("petId")
-        )
+        return self.__getitem__("petId")
 PathParametersDictInput = typing.TypedDict(
     'PathParametersDictInput',
     {

--- a/samples/client/petstore/python/src/petstore_api/paths/pet_pet_id/get/responses/response_200/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/pet_pet_id/get/responses/response_200/__init__.py
@@ -10,20 +10,13 @@ from .content.application_xml import schema as application_xml_schema
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Union[
-            application_xml_schema.pet.PetDict,
-            application_json_schema.ref_pet.pet.PetDict,
-        ],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: typing.Union[
+        application_xml_schema.pet.PetDict,
+        application_json_schema.ref_pet.pet.PetDict,
+    ]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/pet_pet_id/get/responses/response_400/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/pet_pet_id/get/responses/response_400/__init__.py
@@ -7,17 +7,10 @@
 from petstore_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor400(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/pet_pet_id/get/responses/response_404/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/pet_pet_id/get/responses/response_404/__init__.py
@@ -7,17 +7,10 @@
 from petstore_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor404(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/pet_pet_id/post/path_parameters.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/pet_pet_id/post/path_parameters.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class PathParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+class PathParametersDict(schemas.immutabledict[str, int]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "petId",
@@ -53,10 +53,7 @@ class PathParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
     
     @property
     def petId(self) -> int:
-        return typing.cast(
-            int,
-            self.__getitem__("petId")
-        )
+        return self.__getitem__("petId")
 PathParametersDictInput = typing.TypedDict(
     'PathParametersDictInput',
     {

--- a/samples/client/petstore/python/src/petstore_api/paths/pet_pet_id/post/request_body/content/application_x_www_form_urlencoded/schema.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/pet_pet_id/post/request_body/content/application_x_www_form_urlencoded/schema.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class SchemaDict(schemas.immutabledict[str, str]):
+class SchemaDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -71,14 +71,20 @@ class SchemaDict(schemas.immutabledict[str, str]):
         val = self.get("name", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     @property
     def status(self) -> typing.Union[str, schemas.Unset]:
         val = self.get("status", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
         schemas.raise_if_key_known(name, self.__required_keys__, self.__optional_keys__)

--- a/samples/client/petstore/python/src/petstore_api/paths/pet_pet_id/post/responses/response_405/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/pet_pet_id/post/responses/response_405/__init__.py
@@ -7,17 +7,10 @@
 from petstore_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor405(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/pet_pet_id_upload_image/post/path_parameters.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/pet_pet_id_upload_image/post/path_parameters.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class PathParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+class PathParametersDict(schemas.immutabledict[str, int]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "petId",
@@ -53,10 +53,7 @@ class PathParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
     
     @property
     def petId(self) -> int:
-        return typing.cast(
-            int,
-            self.__getitem__("petId")
-        )
+        return self.__getitem__("petId")
 PathParametersDictInput = typing.TypedDict(
     'PathParametersDictInput',
     {

--- a/samples/client/petstore/python/src/petstore_api/paths/pet_pet_id_upload_image/post/request_body/content/multipart_form_data/schema.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/pet_pet_id_upload_image/post/request_body/content/multipart_form_data/schema.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class SchemaDict(schemas.immutabledict[str, str]):
+class SchemaDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -74,7 +74,10 @@ class SchemaDict(schemas.immutabledict[str, str]):
         val = self.get("additionalMetadata", schemas.unset)
         if isinstance(val, schemas.Unset):
             return val
-        return val
+        return typing.cast(
+            str,
+            val
+        )
     
     @property
     def file(self) -> typing.Union[bytes, schemas.FileIO, schemas.Unset]:

--- a/samples/client/petstore/python/src/petstore_api/paths/store_order/post/responses/response_200/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/store_order/post/responses/response_200/__init__.py
@@ -10,20 +10,13 @@ from .content.application_xml import schema as application_xml_schema
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Union[
-            application_xml_schema.order.OrderDict,
-            application_json_schema.order.OrderDict,
-        ],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: typing.Union[
+        application_xml_schema.order.OrderDict,
+        application_json_schema.order.OrderDict,
+    ]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/store_order/post/responses/response_400/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/store_order/post/responses/response_400/__init__.py
@@ -7,17 +7,10 @@
 from petstore_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor400(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/store_order_order_id/delete/path_parameters.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/store_order_order_id/delete/path_parameters.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class PathParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+class PathParametersDict(schemas.immutabledict[str, str]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "order_id",
@@ -53,10 +53,7 @@ class PathParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
     
     @property
     def order_id(self) -> str:
-        return typing.cast(
-            str,
-            self.__getitem__("order_id")
-        )
+        return self.__getitem__("order_id")
 PathParametersDictInput = typing.TypedDict(
     'PathParametersDictInput',
     {

--- a/samples/client/petstore/python/src/petstore_api/paths/store_order_order_id/delete/responses/response_400/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/store_order_order_id/delete/responses/response_400/__init__.py
@@ -7,17 +7,10 @@
 from petstore_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor400(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/store_order_order_id/delete/responses/response_404/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/store_order_order_id/delete/responses/response_404/__init__.py
@@ -7,17 +7,10 @@
 from petstore_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor404(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/store_order_order_id/get/path_parameters.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/store_order_order_id/get/path_parameters.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class PathParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+class PathParametersDict(schemas.immutabledict[str, int]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "order_id",
@@ -53,10 +53,7 @@ class PathParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
     
     @property
     def order_id(self) -> int:
-        return typing.cast(
-            int,
-            self.__getitem__("order_id")
-        )
+        return self.__getitem__("order_id")
 PathParametersDictInput = typing.TypedDict(
     'PathParametersDictInput',
     {

--- a/samples/client/petstore/python/src/petstore_api/paths/store_order_order_id/get/responses/response_200/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/store_order_order_id/get/responses/response_200/__init__.py
@@ -10,20 +10,13 @@ from .content.application_xml import schema as application_xml_schema
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Union[
-            application_xml_schema.order.OrderDict,
-            application_json_schema.order.OrderDict,
-        ],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: typing.Union[
+        application_xml_schema.order.OrderDict,
+        application_json_schema.order.OrderDict,
+    ]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/store_order_order_id/get/responses/response_400/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/store_order_order_id/get/responses/response_400/__init__.py
@@ -7,17 +7,10 @@
 from petstore_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor400(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/store_order_order_id/get/responses/response_404/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/store_order_order_id/get/responses/response_404/__init__.py
@@ -7,17 +7,10 @@
 from petstore_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor404(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/user/post/responses/response_default/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/user/post/responses/response_default/__init__.py
@@ -7,17 +7,10 @@
 from petstore_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class Default(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/user_create_with_array/post/responses/response_default/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/user_create_with_array/post/responses/response_default/__init__.py
@@ -7,17 +7,10 @@
 from petstore_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class Default(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/user_create_with_list/post/responses/response_default/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/user_create_with_list/post/responses/response_default/__init__.py
@@ -7,17 +7,10 @@
 from petstore_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class Default(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/user_login/get/query_parameters.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/user_login/get/query_parameters.py
@@ -24,6 +24,7 @@ Properties = typing.TypedDict(
 
 
 class QueryParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "password",
         "username",

--- a/samples/client/petstore/python/src/petstore_api/paths/user_login/get/responses/response_200/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/user_login/get/responses/response_200/__init__.py
@@ -23,20 +23,13 @@ parameters: typing.Dict[str, typing.Type[api_client.HeaderParameterWithoutName]]
 }
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Union[
-            str,
-            str,
-        ],
-        headers: header_parameters.HeadersDict
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: typing.Union[
+        str,
+        str,
+    ]
+    headers: header_parameters.HeadersDict
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/user_login/get/responses/response_400/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/user_login/get/responses/response_400/__init__.py
@@ -7,17 +7,10 @@
 from petstore_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor400(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/user_username/delete/path_parameters.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/user_username/delete/path_parameters.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class PathParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+class PathParametersDict(schemas.immutabledict[str, str]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "username",
@@ -53,10 +53,7 @@ class PathParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
     
     @property
     def username(self) -> str:
-        return typing.cast(
-            str,
-            self.__getitem__("username")
-        )
+        return self.__getitem__("username")
 PathParametersDictInput = typing.TypedDict(
     'PathParametersDictInput',
     {

--- a/samples/client/petstore/python/src/petstore_api/paths/user_username/delete/responses/response_404/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/user_username/delete/responses/response_404/__init__.py
@@ -7,17 +7,10 @@
 from petstore_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor404(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/user_username/get/path_parameters.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/user_username/get/path_parameters.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class PathParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+class PathParametersDict(schemas.immutabledict[str, str]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "username",
@@ -53,10 +53,7 @@ class PathParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
     
     @property
     def username(self) -> str:
-        return typing.cast(
-            str,
-            self.__getitem__("username")
-        )
+        return self.__getitem__("username")
 PathParametersDictInput = typing.TypedDict(
     'PathParametersDictInput',
     {

--- a/samples/client/petstore/python/src/petstore_api/paths/user_username/get/responses/response_200/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/user_username/get/responses/response_200/__init__.py
@@ -10,20 +10,13 @@ from .content.application_xml import schema as application_xml_schema
 from .content.application_json import schema as application_json_schema
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Union[
-            application_xml_schema.user.UserDict,
-            application_json_schema.user.UserDict,
-        ],
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: typing.Union[
+        application_xml_schema.user.UserDict,
+        application_json_schema.user.UserDict,
+    ]
+    headers: schemas.Unset
 
 
 class ResponseFor200(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/user_username/get/responses/response_400/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/user_username/get/responses/response_400/__init__.py
@@ -7,17 +7,10 @@
 from petstore_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor400(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/user_username/get/responses/response_404/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/user_username/get/responses/response_404/__init__.py
@@ -7,17 +7,10 @@
 from petstore_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor404(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/user_username/put/path_parameters.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/user_username/put/path_parameters.py
@@ -21,7 +21,7 @@ Properties = typing.TypedDict(
 )
 
 
-class PathParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
+class PathParametersDict(schemas.immutabledict[str, str]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "username",
@@ -53,10 +53,7 @@ class PathParametersDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
     
     @property
     def username(self) -> str:
-        return typing.cast(
-            str,
-            self.__getitem__("username")
-        )
+        return self.__getitem__("username")
 PathParametersDictInput = typing.TypedDict(
     'PathParametersDictInput',
     {

--- a/samples/client/petstore/python/src/petstore_api/paths/user_username/put/responses/response_400/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/user_username/put/responses/response_400/__init__.py
@@ -7,17 +7,10 @@
 from petstore_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor400(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/paths/user_username/put/responses/response_404/__init__.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/user_username/put/responses/response_404/__init__.py
@@ -7,17 +7,10 @@
 from petstore_api.shared_imports.response_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    body: schemas.Unset
+    headers: schemas.Unset
 
 
 class ResponseFor404(api_client.OpenApiResponse[ApiResponse]):

--- a/samples/client/petstore/python/src/petstore_api/servers/server_1.py
+++ b/samples/client/petstore/python/src/petstore_api/servers/server_1.py
@@ -84,7 +84,7 @@ Properties = typing.TypedDict(
 )
 
 
-class VariablesDict(schemas.immutabledict[str, str]):
+class VariablesDict(schemas.immutabledict[str, typing.Literal["v1", "v2"]]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
         "version",
@@ -119,10 +119,7 @@ class VariablesDict(schemas.immutabledict[str, str]):
     
     @property
     def version(self) -> typing.Literal["v1", "v2"]:
-        return typing.cast(
-            typing.Literal["v1", "v2"],
-            self.__getitem__("version")
-        )
+        return self.__getitem__("version")
 VariablesDictInput = typing.TypedDict(
     'VariablesDictInput',
     {

--- a/samples/client/petstore/python/tests_manual/test_animal.py
+++ b/samples/client/petstore/python/tests_manual/test_animal.py
@@ -70,11 +70,14 @@ class TestAnimal(unittest.TestCase):
         assert isinstance(inst["color"], str)
         assert isinstance(inst["breed"], str)
 
-    def test_animal_color_is_not_cast(self):
+    def test_animal_color_is_cast(self):
         inst = animal.Animal.validate({'className': 'Dog', 'color': 'black'})
+        def mock_typing_cast(cls, val):
+            return val
         with mock.patch('petstore_api.components.schema.animal.typing.cast') as mock_cast:
+            mock_cast.side_effect = mock_typing_cast
             assert inst.color == 'black'
-            mock_cast.assert_not_called()
+            mock_cast.assert_called_with(str, 'black')
 
 
 if __name__ == '__main__':

--- a/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
@@ -2470,6 +2470,8 @@ public class DefaultGenerator implements Generator {
                 }
             }
             property.mapValueSchema = mapValueSchema;
+        } else {
+            property.mapValueSchema = new CodegenSchema();
         }
 
         if (currentJsonPath != null) {

--- a/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
@@ -2459,19 +2459,25 @@ public class DefaultGenerator implements Generator {
         // end of properties that need to be ordered to set correct camelCase jsonPathPieces
         CodegenSchema additionalProperties = property.additionalProperties;
         LinkedHashMapWithContext<CodegenSchema> properties = property.properties;
-        if (additionalProperties != null || properties != null) {
-            CodegenSchema mapValueSchema = new CodegenSchema();
-            if (additionalProperties != null && !additionalProperties.isBooleanSchemaFalse) {
-                mapValueSchema = mapValueSchema.add(additionalProperties);
-            }
-            if (properties != null) {
-                for (CodegenSchema prop: properties.values()) {
-                    mapValueSchema = prop.add(mapValueSchema);
+        if (additionalProperties == null) {
+            property.mapValueSchema = new CodegenSchema();
+        } else {
+            CodegenSchema mapValueSchema = null;
+            if (additionalProperties.isBooleanSchemaFalse) {
+                if (properties != null && !properties.isEmpty()) {
+                    for (CodegenSchema prop: properties.values()) {
+                        mapValueSchema = prop.add(mapValueSchema);
+                    }
+                }
+            } else {
+                mapValueSchema = additionalProperties;
+                if (properties != null && !properties.isEmpty()) {
+                    for (CodegenSchema prop: properties.values()) {
+                        mapValueSchema = prop.add(mapValueSchema);
+                    }
                 }
             }
             property.mapValueSchema = mapValueSchema;
-        } else {
-            property.mapValueSchema = new CodegenSchema();
         }
 
         if (currentJsonPath != null) {

--- a/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
@@ -2461,7 +2461,7 @@ public class DefaultGenerator implements Generator {
         LinkedHashMapWithContext<CodegenSchema> properties = property.properties;
         if (additionalProperties != null || properties != null) {
             CodegenSchema mapValueSchema = new CodegenSchema();
-            if (additionalProperties != null) {
+            if (additionalProperties != null && !additionalProperties.isBooleanSchemaFalse) {
                 mapValueSchema = mapValueSchema.add(additionalProperties);
             }
             if (properties != null) {

--- a/src/main/java/org/openapijsonschematools/codegen/generators/openapimodels/CodegenSchema.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/openapimodels/CodegenSchema.java
@@ -128,7 +128,6 @@ public class CodegenSchema {
         CodegenSchema schema = new CodegenSchema();
         schema.refInfo = refInfo;
         schema.types = types;
-        schema.format = format;
         schema.enumInfo = enumInfo;
         schema.arrayOutputJsonPathPiece = arrayOutputJsonPathPiece;
         schema.mapOutputJsonPathPiece = mapOutputJsonPathPiece;
@@ -167,28 +166,45 @@ public class CodegenSchema {
     }
 
     public CodegenSchema add(CodegenSchema other) {
+        /*
+        must be most permissive addition so dict.get returns possible type
+        stored properties are:
+        types
+        enumInfo
+        refInfo
+         */
         CodegenSchema newSchema = new CodegenSchema();
         if (other == null) {
             newSchema.types = types;
+            newSchema.refInfo = refInfo;
+            newSchema.enumInfo = enumInfo;
             return newSchema;
         }
-        if (refInfo != null || oneOf != null || anyOf != null || allOf != null || not != null) {
-            return null;
+        if (types == null || other.types == null) {
+            newSchema.types = null;
+        } else {
+            LinkedHashSet<String> sumTypes = new LinkedHashSet<>(types);
+            sumTypes.addAll(other.types);
+            newSchema.types = sumTypes;
         }
-        if (other.refInfo != null || other.oneOf != null || other.anyOf != null || other.allOf != null || other.not != null) {
-            return null;
+        if (refInfo == null || other.refInfo == null) {
+            newSchema.refInfo = null;
+        } else {
+            if (refInfo == other.refInfo) {
+                newSchema.refInfo = refInfo;
+            } else {
+                newSchema.refInfo = null;
+            }
         }
-        if (types == null) {
-            newSchema.types = other.types;
-            return newSchema;
+        if (enumInfo == null || other.enumInfo == null) {
+            newSchema.enumInfo = null;
+        } else {
+            if (enumInfo == other.enumInfo) {
+                newSchema.enumInfo = enumInfo;
+            } else {
+                newSchema.enumInfo = null;
+            }
         }
-        if (other.types == null) {
-            newSchema.types = types;
-            return newSchema;
-        }
-        LinkedHashSet<String> interSectionTypes = new LinkedHashSet<>(types);
-        interSectionTypes.retainAll(other.types);
-        newSchema.types = interSectionTypes;
         return newSchema;
     }
 

--- a/src/main/resources/python/api_response.hbs
+++ b/src/main/resources/python/api_response.hbs
@@ -9,27 +9,15 @@ import urllib3
 from {{packageName}} import schemas
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse:
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: typing.Union[schemas.Unset, schemas.OUTPUT_BASE_TYPES] = schemas.unset,
-        headers: typing.Union[schemas.Unset, typing.Mapping[str, schemas.OUTPUT_BASE_TYPES]] = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    response: urllib3.HTTPResponse
+    body: typing.Union[schemas.Unset, schemas.OUTPUT_BASE_TYPES]
+    headers: typing.Union[schemas.Unset, typing.Mapping[str, schemas.OUTPUT_BASE_TYPES]]
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponseWithoutDeserialization(ApiResponse):
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
+    response: urllib3.HTTPResponse
+    body: schemas.Unset = schemas.unset
+    headers: schemas.Unset = schemas.unset

--- a/src/main/resources/python/api_response.hbs
+++ b/src/main/resources/python/api_response.hbs
@@ -19,7 +19,7 @@ class ApiResponse:
     ):
         self.response = response
         self.body = body
-        self. headers = headers
+        self.headers = headers
 
 
 class ApiResponseWithoutDeserialization(ApiResponse):
@@ -32,4 +32,4 @@ class ApiResponseWithoutDeserialization(ApiResponse):
     ):
         self.response = response
         self.body = body
-        self. headers = headers
+        self.headers = headers

--- a/src/main/resources/python/components/responses/response.hbs
+++ b/src/main/resources/python/components/responses/response.hbs
@@ -37,6 +37,79 @@ parameters: typing.Dict[str, typing.Type[api_client.HeaderParameterWithoutName]]
 
 
 class ApiResponse(api_response.ApiResponse):
+    {{#and headers content}}
+        {{#if hasContentSchema}}
+            {{#gt content.size 1}}
+    body: typing.Union[
+                {{#each content}}
+                    {{#if this.schema}}
+                        {{#with this.schema}}
+        {{> components/_helper_content_schema_output_type paramName=null modulePrefix=../@key.snakeCase endChar="," }}
+                        {{/with}}
+                    {{else}}
+        schemas.Unset,
+                    {{/if}}
+                {{/each}}
+    ]
+            {{else}}
+                {{#each content}}
+                    {{#if this.schema}}
+                        {{#with this.schema}}
+    {{> components/_helper_content_schema_output_type paramName="body" modulePrefix=../@key.snakeCase endChar="" }}
+                        {{/with}}
+                    {{else}}
+    body: schemas.Unset
+                    {{/if}}
+                {{/each}}
+            {{/gt}}
+        {{else}}
+    body: schemas.Unset = schemas.unset
+        {{/if}}
+    headers: header_parameters.{{headersObjectSchema.mapOutputJsonPathPiece.camelCase}}
+    {{else}}
+        {{#or headers content}}
+            {{#if headers}}
+    headers: header_parameters.{{headersObjectSchema.mapOutputJsonPathPiece.camelCase}}
+    body: schemas.Unset = schemas.unset
+            {{else}}
+                {{#if hasContentSchema}}
+                    {{#gt content.size 1}}
+    body: typing.Union[
+                        {{#each content}}
+                            {{#if this.schema}}
+                                {{#with this.schema}}
+        {{> components/_helper_content_schema_output_type paramName=null modulePrefix=../@key.snakeCase endChar="," }}
+                                {{/with}}
+                            {{else}}
+        schemas.Unset,
+                            {{/if}}
+                        {{/each}}
+    ]
+                    {{else}}
+                        {{#each content}}
+                            {{#if this.schema}}
+                                {{#with this.schema}}
+    {{> components/_helper_content_schema_output_type paramName="body" modulePrefix=../@key.snakeCase endChar="" }}
+                                {{/with}}
+                            {{else}}
+    body: schemas.Unset
+                            {{/if}}
+                        {{/each}}
+                    {{/gt}}
+                {{else}}
+    body: schemas.Unset = schemas.unset
+                {{/if}}
+    headers: schemas.Unset = schemas.unset
+            {{/if}}
+        {{/or}}
+    {{/and}}
+    {{#unless headers}}
+    {{#unless content}}
+    body: schemas.Unset = schemas.unset,
+    headers: schemas.Unset = schemas.unset
+    {{/unless}}
+    {{/unless}}
+
     def __init__(
         self,
         *,

--- a/src/main/resources/python/components/responses/response.hbs
+++ b/src/main/resources/python/components/responses/response.hbs
@@ -36,6 +36,7 @@ parameters: typing.Dict[str, typing.Type[api_client.HeaderParameterWithoutName]]
     {{/if}}
 
 
+@dataclasses.dataclass(frozen=True)
 class ApiResponse(api_response.ApiResponse):
     {{#and headers content}}
         {{#if hasContentSchema}}
@@ -63,14 +64,14 @@ class ApiResponse(api_response.ApiResponse):
                 {{/each}}
             {{/gt}}
         {{else}}
-    body: schemas.Unset = schemas.unset
+    body: schemas.Unset
         {{/if}}
     headers: header_parameters.{{headersObjectSchema.mapOutputJsonPathPiece.camelCase}}
     {{else}}
         {{#or headers content}}
             {{#if headers}}
     headers: header_parameters.{{headersObjectSchema.mapOutputJsonPathPiece.camelCase}}
-    body: schemas.Unset = schemas.unset
+    body: schemas.Unset
             {{else}}
                 {{#if hasContentSchema}}
                     {{#gt content.size 1}}
@@ -97,99 +98,18 @@ class ApiResponse(api_response.ApiResponse):
                         {{/each}}
                     {{/gt}}
                 {{else}}
-    body: schemas.Unset = schemas.unset
+    body: schemas.Unset
                 {{/if}}
-    headers: schemas.Unset = schemas.unset
+    headers: schemas.Unset
             {{/if}}
         {{/or}}
     {{/and}}
     {{#unless headers}}
     {{#unless content}}
-    body: schemas.Unset = schemas.unset,
-    headers: schemas.Unset = schemas.unset
+    body: schemas.Unset
+    headers: schemas.Unset
     {{/unless}}
     {{/unless}}
-
-    def __init__(
-        self,
-        *,
-        response: urllib3.HTTPResponse,
-    {{#and headers content}}
-        {{#if hasContentSchema}}
-            {{#gt content.size 1}}
-        body: typing.Union[
-                {{#each content}}
-                    {{#if this.schema}}
-                        {{#with this.schema}}
-            {{> components/_helper_content_schema_output_type paramName=null modulePrefix=../@key.snakeCase endChar="," }}
-                        {{/with}}
-                    {{else}}
-            schemas.Unset,
-                    {{/if}}
-                {{/each}}
-        ],
-            {{else}}
-                {{#each content}}
-                    {{#if this.schema}}
-                        {{#with this.schema}}
-        {{> components/_helper_content_schema_output_type paramName="body" modulePrefix=../@key.snakeCase endChar="," }}
-                        {{/with}}
-                    {{else}}
-        body: schemas.Unset,
-                    {{/if}}
-                {{/each}}
-            {{/gt}}
-        {{else}}
-        body: schemas.Unset = schemas.unset,
-        {{/if}}
-        headers: header_parameters.{{headersObjectSchema.mapOutputJsonPathPiece.camelCase}}
-    {{else}}
-        {{#or headers content}}
-            {{#if headers}}
-        headers: header_parameters.{{headersObjectSchema.mapOutputJsonPathPiece.camelCase}},
-        body: schemas.Unset = schemas.unset,
-            {{else}}
-                {{#if hasContentSchema}}
-                    {{#gt content.size 1}}
-        body: typing.Union[
-                        {{#each content}}
-                            {{#if this.schema}}
-                                {{#with this.schema}}
-            {{> components/_helper_content_schema_output_type paramName=null modulePrefix=../@key.snakeCase endChar="," }}
-                                {{/with}}
-                            {{else}}
-            schemas.Unset,
-                            {{/if}}
-                        {{/each}}
-        ],
-                    {{else}}
-                        {{#each content}}
-                            {{#if this.schema}}
-                                {{#with this.schema}}
-        {{> components/_helper_content_schema_output_type paramName="body" modulePrefix=../@key.snakeCase endChar="," }}
-                                {{/with}}
-                            {{else}}
-        body: schemas.Unset,
-                            {{/if}}
-                        {{/each}}
-                    {{/gt}}
-                {{else}}
-        body: schemas.Unset = schemas.unset,
-                {{/if}}
-        headers: schemas.Unset = schemas.unset
-            {{/if}}
-        {{/or}}
-    {{/and}}
-    {{#unless headers}}
-    {{#unless content}}
-        body: schemas.Unset = schemas.unset,
-        headers: schemas.Unset = schemas.unset
-    {{/unless}}
-    {{/unless}}
-    ):
-        self.response = response
-        self.body = body
-        self.headers = headers
 
 
 class {{jsonPathPiece.camelCase}}(api_client.OpenApiResponse[ApiResponse]):

--- a/src/main/resources/python/components/schemas/_object_output_get_property.hbs
+++ b/src/main/resources/python/components/schemas/_object_output_get_property.hbs
@@ -14,12 +14,6 @@ if isinstance(val, schemas.Unset):
     {{#and ../../mapValueSchema (eq typeSchema ../../mapValueSchema.typeSchema) }}
 return val
     {{else}}
-        {{#if ../../mapValueSchema}}
-# mapValueSchema.typeSchema
-{{../../mapValueSchema.typeSchema}}
-# typeSchema
-{{typeSchema}}
-        {{/if}}
 return typing.cast(
     {{> components/schemas/types/schema_output_type fullRefModule="" mode="unprefixed" endChar="," }}
     val

--- a/src/main/resources/python/components/schemas/_object_output_get_property.hbs
+++ b/src/main/resources/python/components/schemas/_object_output_get_property.hbs
@@ -14,6 +14,12 @@ if isinstance(val, schemas.Unset):
     {{#and ../../mapValueSchema (eq typeSchema ../../mapValueSchema.typeSchema) }}
 return val
     {{else}}
+        {{#if ../../mapValueSchema}}
+# mapValueSchema.typeSchema
+{{../../mapValueSchema.typeSchema}}
+# typeSchema
+{{typeSchema}}
+        {{/if}}
 return typing.cast(
     {{> components/schemas/types/schema_output_type fullRefModule="" mode="unprefixed" endChar="," }}
     val

--- a/src/main/resources/python/components/schemas/_object_output_type.hbs
+++ b/src/main/resources/python/components/schemas/_object_output_type.hbs
@@ -1,7 +1,11 @@
 
 
 {{#if mapValueSchema}}
+    {{#if mapValueSchema.refInfo.refClass}}
+class {{mapOutputJsonPathPiece.camelCase}}(schemas.immutabledict[str, {{#with mapValueSchema}}{{> components/schemas/types/schema_output_type mode="unprefixed" fullRefModule="" endChar="]):" }}{{/with}}
+    {{else}}
 class {{mapOutputJsonPathPiece.camelCase}}(schemas.immutabledict[str, {{#with mapValueSchema}}{{> components/schemas/types/schema_output_type mode="unprefixed" fullRefModule=null endChar="]):" }}{{/with}}
+    {{/if}}
 {{else}}
 class {{mapOutputJsonPathPiece.camelCase}}(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 {{/if}}

--- a/src/test/java/org/openapijsonschematools/codegen/generators/DefaultGeneratorTest.java
+++ b/src/test/java/org/openapijsonschematools/codegen/generators/DefaultGeneratorTest.java
@@ -71,6 +71,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -3860,6 +3861,48 @@ public class DefaultGeneratorTest {
         assertEquals(openAPI, codegen.openAPI);
     }
 
+    @Test
+    public void testMapValueSchemaTypes() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/246_map_values.yaml");
+        final DefaultGenerator codegen = new DefaultGenerator();
+        codegen.setOpenAPI(openAPI);
+
+        String schemaName = "NoPropsNoAddProps";
+        String schemaPrefix = "#/components/schemas/";
+        Schema sourceSchema = codegen.openAPI.getComponents().getSchemas().get(schemaName);
+        CodegenSchema schema = codegen.fromSchema(sourceSchema, schemaPrefix + schemaName, schemaPrefix + schemaName);
+        assertEquals(schema.mapValueSchema.types, null);
+
+        schemaName = "NoPropsHasAddProps";
+        sourceSchema = codegen.openAPI.getComponents().getSchemas().get(schemaName);
+        schema = codegen.fromSchema(sourceSchema, schemaPrefix + schemaName, schemaPrefix + schemaName);
+        LinkedHashSet<String> expectedTypes = new LinkedHashSet<>();
+        expectedTypes.add("string");
+        assertEquals(schema.mapValueSchema.types, expectedTypes);
+
+        schemaName = "PropsAndAddProps";
+        sourceSchema = codegen.openAPI.getComponents().getSchemas().get(schemaName);
+        schema = codegen.fromSchema(sourceSchema, schemaPrefix + schemaName, schemaPrefix + schemaName);
+        expectedTypes.clear();;
+        expectedTypes.add("string");
+        expectedTypes.add("number");
+        assertEquals(schema.mapValueSchema.types, expectedTypes);
+
+        schemaName = "PropsNoAddProps";
+        sourceSchema = codegen.openAPI.getComponents().getSchemas().get(schemaName);
+        schema = codegen.fromSchema(sourceSchema, schemaPrefix + schemaName, schemaPrefix + schemaName);
+        assertEquals(schema.mapValueSchema.types, null);
+
+        schemaName = "PropsFalseAddProps";
+        sourceSchema = codegen.openAPI.getComponents().getSchemas().get(schemaName);
+        schema = codegen.fromSchema(sourceSchema, schemaPrefix + schemaName, schemaPrefix + schemaName);
+        expectedTypes.clear();;
+        expectedTypes.add("string");
+        expectedTypes.add("number");
+        assertEquals(schema.mapValueSchema.types, expectedTypes);
+    }
+
+    
     public static class FromParameter {
         private CodegenParameter codegenParameter(String path) {
             final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/fromParameter.yaml");

--- a/src/test/resources/3_0/246_map_values.yaml
+++ b/src/test/resources/3_0/246_map_values.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0-SNAPSHOT
+paths: {}
+components:
+  schemas:
+    NoPropsNoAddProps:
+      type: object
+    NoPropsHasAddProps:
+      type: object
+      additionalProperties:
+        type: string
+    PropsAndAddProps:
+      type: object
+      properties:
+        a:
+          type: number
+      additionalProperties:
+        type: string
+    PropsNoAddProps:
+      type: object
+      properties:
+        a:
+          type: number
+    PropsFalseAddProps:
+      type: object
+      properties:
+        a:
+          type: number
+        b:
+          type: string
+      additionalProperties: false


### PR DESCRIPTION
Issue 246 fix
- converts ApiResponses back to dataclasses to fix mypy errors when accessing properties in them
    - removes defaults except for ApiResponseWithoutDeserialization 
- removed format property from schemaType CodegenSchema
- makes schema addition use the most permissive information because addition is used to generate mapValueSchema
- adds java tests of mapValueSchema.types which the python code uses to determine if casting is needed for properties

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
