### PR TITLE
Fixes documentation bug, removes unused braces

### DIFF
--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/additionalproperties_are_allowed_by_default.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/additionalproperties_are_allowed_by_default.md
@@ -41,6 +41,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [AdditionalpropertiesAreAllowedByDefaultDictInput](#additionalpropertiesareallowedbydefaultdictinput), [AdditionalpropertiesAreAllowedByDefaultDict](#additionalpropertiesareallowedbydefaultdict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [AdditionalpropertiesAreAllowedByDefaultDict](#additionalpropertiesareallowedbydefaultdict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/additionalproperties_should_not_look_in_applicators.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/additionalproperties_should_not_look_in_applicators.md
@@ -81,6 +81,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_0DictInput](#_0dictinput), [_0Dict](#_0dict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [_0Dict](#_0dict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/allof.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/allof.md
@@ -55,7 +55,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_0DictInput](#_0dictinput), [_0Dict](#_0dict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [_0Dict](#_0dict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 # _1
 ```
@@ -96,6 +96,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_1DictInput](#_1dictinput), [_1Dict](#_1dict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [_1Dict](#_1dict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/allof_with_base_schema.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/allof_with_base_schema.md
@@ -38,7 +38,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [AllofWithBaseSchemaDictInput](#allofwithbaseschemadictinput), [AllofWithBaseSchemaDict](#allofwithbaseschemadict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [AllofWithBaseSchemaDict](#allofwithbaseschemadict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 ## Composed Schemas (allOf/anyOf/oneOf/not)
 ## allOf
@@ -86,7 +86,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_0DictInput](#_0dictinput), [_0Dict](#_0dict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [_0Dict](#_0dict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 # _1
 ```
@@ -127,6 +127,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_1DictInput](#_1dictinput), [_1Dict](#_1dict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [_1Dict](#_1dict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/anyof_complex_types.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/anyof_complex_types.md
@@ -55,7 +55,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_0DictInput](#_0dictinput), [_0Dict](#_0dict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [_0Dict](#_0dict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 # _1
 ```
@@ -96,6 +96,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_1DictInput](#_1dictinput), [_1Dict](#_1dict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [_1Dict](#_1dict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/enums_in_properties.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/enums_in_properties.md
@@ -41,6 +41,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [EnumsInPropertiesDictInput](#enumsinpropertiesdictinput), [EnumsInPropertiesDict](#enumsinpropertiesdict) | [EnumsInPropertiesDict](#enumsinpropertiesdict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/forbidden_property.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/forbidden_property.md
@@ -38,7 +38,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [ForbiddenPropertyDictInput](#forbiddenpropertydictinput), [ForbiddenPropertyDict](#forbiddenpropertydict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [ForbiddenPropertyDict](#forbiddenpropertydict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 # Foo
 ```

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/invalid_string_value_for_default.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/invalid_string_value_for_default.md
@@ -38,6 +38,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [InvalidStringValueForDefaultDictInput](#invalidstringvaluefordefaultdictinput), [InvalidStringValueForDefaultDict](#invalidstringvaluefordefaultdict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [InvalidStringValueForDefaultDict](#invalidstringvaluefordefaultdict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/not_more_complex_schema.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/not_more_complex_schema.md
@@ -54,6 +54,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [NotDictInput](#notdictinput), [NotDict](#notdict) | [NotDict](#notdict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/object_properties_validation.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/object_properties_validation.md
@@ -41,6 +41,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [ObjectPropertiesValidationDictInput](#objectpropertiesvalidationdictinput), [ObjectPropertiesValidationDict](#objectpropertiesvalidationdict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [ObjectPropertiesValidationDict](#objectpropertiesvalidationdict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/oneof_complex_types.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/oneof_complex_types.md
@@ -55,7 +55,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_0DictInput](#_0dictinput), [_0Dict](#_0dict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [_0Dict](#_0dict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 # _1
 ```
@@ -96,6 +96,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_1DictInput](#_1dictinput), [_1Dict](#_1dict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [_1Dict](#_1dict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/oneof_with_required.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/oneof_with_required.md
@@ -58,7 +58,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_0DictInput](#_0dictinput), [_0Dict](#_0dict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [_0Dict](#_0dict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 # _1
 ```
@@ -102,6 +102,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_1DictInput](#_1dictinput), [_1Dict](#_1dict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [_1Dict](#_1dict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/properties_with_escaped_characters.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/properties_with_escaped_characters.md
@@ -38,6 +38,6 @@ Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [PropertiesWithEscapedCharactersDictInput](#propertieswithescapedcharactersdictinput), [PropertiesWithEscapedCharactersDict](#propertieswithescapedcharactersdict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [PropertiesWithEscapedCharactersDict](#propertieswithescapedcharactersdict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
 &lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["foo\nbar"], instance["foo\&quot;bar"], instance["foo\\bar"], instance["foo\rbar"], instance["foo\tbar"], instance["foo\fbar"], 
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/property_named_ref_that_is_not_a_reference.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/property_named_ref_that_is_not_a_reference.md
@@ -33,6 +33,6 @@ Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [PropertyNamedRefThatIsNotAReferenceDictInput](#propertynamedrefthatisnotareferencedictinput), [PropertyNamedRefThatIsNotAReferenceDict](#propertynamedrefthatisnotareferencedict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [PropertyNamedRefThatIsNotAReferenceDict](#propertynamedrefthatisnotareferencedict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
 &lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["$ref"], 
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/ref_in_property.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/ref_in_property.md
@@ -38,6 +38,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [RefInPropertyDictInput](#refinpropertydictinput), [RefInPropertyDict](#refinpropertydict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [RefInPropertyDict](#refinpropertydict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/required_default_validation.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/required_default_validation.md
@@ -38,6 +38,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [RequiredDefaultValidationDictInput](#requireddefaultvalidationdictinput), [RequiredDefaultValidationDict](#requireddefaultvalidationdict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [RequiredDefaultValidationDict](#requireddefaultvalidationdict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/required_validation.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/required_validation.md
@@ -41,6 +41,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [RequiredValidationDictInput](#requiredvalidationdictinput), [RequiredValidationDict](#requiredvalidationdict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [RequiredValidationDict](#requiredvalidationdict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/required_with_empty_array.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/required_with_empty_array.md
@@ -38,6 +38,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [RequiredWithEmptyArrayDictInput](#requiredwithemptyarraydictinput), [RequiredWithEmptyArrayDict](#requiredwithemptyarraydict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [RequiredWithEmptyArrayDict](#requiredwithemptyarraydict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/required_with_escaped_characters.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/required_with_escaped_characters.md
@@ -38,6 +38,6 @@ Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [RequiredWithEscapedCharactersDictInput](#requiredwithescapedcharactersdictinput), [RequiredWithEscapedCharactersDict](#requiredwithescapedcharactersdict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [RequiredWithEscapedCharactersDict](#requiredwithescapedcharactersdict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
 &lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["foo\tbar"], instance["foo\nbar"], instance["foo\fbar"], instance["foo\rbar"], instance["foo\&quot;bar"], instance["foo\\bar"], 
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/the_default_keyword_does_not_do_anything_if_the_property_is_missing.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/the_default_keyword_does_not_do_anything_if_the_property_is_missing.md
@@ -38,6 +38,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissingDictInput](#thedefaultkeyworddoesnotdoanythingifthepropertyismissingdictinput), [TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissingDict](#thedefaultkeyworddoesnotdoanythingifthepropertyismissingdict) | [TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissingDict](#thedefaultkeyworddoesnotdoanythingifthepropertyismissingdict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_1_0_json_schema/python/docs/components/schema/any_type_unevaluated_properties_false_with_properties.md
+++ b/samples/client/3_1_0_json_schema/python/docs/components/schema/any_type_unevaluated_properties_false_with_properties.md
@@ -38,6 +38,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [AnyTypeUnevaluatedPropertiesFalseWithPropertiesDictInput](#anytypeunevaluatedpropertiesfalsewithpropertiesdictinput), [AnyTypeUnevaluatedPropertiesFalseWithPropertiesDict](#anytypeunevaluatedpropertiesfalsewithpropertiesdict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [AnyTypeUnevaluatedPropertiesFalseWithPropertiesDict](#anytypeunevaluatedpropertiesfalsewithpropertiesdict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_1_0_json_schema/python/docs/components/schema/object_unevaluated_properties_false_with_properties.md
+++ b/samples/client/3_1_0_json_schema/python/docs/components/schema/object_unevaluated_properties_false_with_properties.md
@@ -38,6 +38,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [ObjectUnevaluatedPropertiesFalseWithPropertiesDictInput](#objectunevaluatedpropertiesfalsewithpropertiesdictinput), [ObjectUnevaluatedPropertiesFalseWithPropertiesDict](#objectunevaluatedpropertiesfalsewithpropertiesdict) | [ObjectUnevaluatedPropertiesFalseWithPropertiesDict](#objectunevaluatedpropertiesfalsewithpropertiesdict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/additionalproperties_are_allowed_by_default.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/additionalproperties_are_allowed_by_default.md
@@ -41,6 +41,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [AdditionalpropertiesAreAllowedByDefaultDictInput](#additionalpropertiesareallowedbydefaultdictinput), [AdditionalpropertiesAreAllowedByDefaultDict](#additionalpropertiesareallowedbydefaultdict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [AdditionalpropertiesAreAllowedByDefaultDict](#additionalpropertiesareallowedbydefaultdict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/additionalproperties_does_not_look_in_applicators.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/additionalproperties_does_not_look_in_applicators.md
@@ -81,6 +81,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_0DictInput](#_0dictinput), [_0Dict](#_0dict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [_0Dict](#_0dict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/allof.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/allof.md
@@ -55,7 +55,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_0DictInput](#_0dictinput), [_0Dict](#_0dict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [_0Dict](#_0dict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 # _1
 ```
@@ -96,6 +96,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_1DictInput](#_1dictinput), [_1Dict](#_1dict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [_1Dict](#_1dict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/allof_with_base_schema.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/allof_with_base_schema.md
@@ -38,7 +38,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [AllofWithBaseSchemaDictInput](#allofwithbaseschemadictinput), [AllofWithBaseSchemaDict](#allofwithbaseschemadict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [AllofWithBaseSchemaDict](#allofwithbaseschemadict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 ## Composed Schemas (allOf/anyOf/oneOf/not)
 ## allOf
@@ -86,7 +86,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_0DictInput](#_0dictinput), [_0Dict](#_0dict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [_0Dict](#_0dict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 # _1
 ```
@@ -127,6 +127,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_1DictInput](#_1dictinput), [_1Dict](#_1dict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [_1Dict](#_1dict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/anyof_complex_types.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/anyof_complex_types.md
@@ -55,7 +55,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_0DictInput](#_0dictinput), [_0Dict](#_0dict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [_0Dict](#_0dict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 # _1
 ```
@@ -96,6 +96,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_1DictInput](#_1dictinput), [_1Dict](#_1dict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [_1Dict](#_1dict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/dependent_schemas_dependent_subschema_incompatible_with_root.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/dependent_schemas_dependent_subschema_incompatible_with_root.md
@@ -38,6 +38,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [DependentSchemasDependentSubschemaIncompatibleWithRootDictInput](#dependentschemasdependentsubschemaincompatiblewithrootdictinput), [DependentSchemasDependentSubschemaIncompatibleWithRootDict](#dependentschemasdependentsubschemaincompatiblewithrootdict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [DependentSchemasDependentSubschemaIncompatibleWithRootDict](#dependentschemasdependentsubschemaincompatiblewithrootdict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/enums_in_properties.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/enums_in_properties.md
@@ -41,6 +41,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [EnumsInPropertiesDictInput](#enumsinpropertiesdictinput), [EnumsInPropertiesDict](#enumsinpropertiesdict) | [EnumsInPropertiesDict](#enumsinpropertiesdict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/forbidden_property.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/forbidden_property.md
@@ -38,7 +38,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [ForbiddenPropertyDictInput](#forbiddenpropertydictinput), [ForbiddenPropertyDict](#forbiddenpropertydict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [ForbiddenPropertyDict](#forbiddenpropertydict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 # Foo
 ```

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/not_more_complex_schema.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/not_more_complex_schema.md
@@ -54,6 +54,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [NotDictInput](#notdictinput), [NotDict](#notdict) | [NotDict](#notdict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/object_properties_validation.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/object_properties_validation.md
@@ -41,6 +41,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [ObjectPropertiesValidationDictInput](#objectpropertiesvalidationdictinput), [ObjectPropertiesValidationDict](#objectpropertiesvalidationdict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [ObjectPropertiesValidationDict](#objectpropertiesvalidationdict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/oneof_complex_types.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/oneof_complex_types.md
@@ -55,7 +55,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_0DictInput](#_0dictinput), [_0Dict](#_0dict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [_0Dict](#_0dict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 # _1
 ```
@@ -96,6 +96,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_1DictInput](#_1dictinput), [_1Dict](#_1dict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [_1Dict](#_1dict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/oneof_with_required.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/oneof_with_required.md
@@ -58,7 +58,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_0DictInput](#_0dictinput), [_0Dict](#_0dict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [_0Dict](#_0dict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 # _1
 ```
@@ -102,6 +102,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_1DictInput](#_1dictinput), [_1Dict](#_1dict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [_1Dict](#_1dict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/properties_whose_names_are_javascript_object_property_names.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/properties_whose_names_are_javascript_object_property_names.md
@@ -44,6 +44,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [PropertiesWhoseNamesAreJavascriptObjectPropertyNamesDictInput](#propertieswhosenamesarejavascriptobjectpropertynamesdictinput), [PropertiesWhoseNamesAreJavascriptObjectPropertyNamesDict](#propertieswhosenamesarejavascriptobjectpropertynamesdict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [PropertiesWhoseNamesAreJavascriptObjectPropertyNamesDict](#propertieswhosenamesarejavascriptobjectpropertynamesdict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/properties_with_escaped_characters.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/properties_with_escaped_characters.md
@@ -38,6 +38,6 @@ Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [PropertiesWithEscapedCharactersDictInput](#propertieswithescapedcharactersdictinput), [PropertiesWithEscapedCharactersDict](#propertieswithescapedcharactersdict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [PropertiesWithEscapedCharactersDict](#propertieswithescapedcharactersdict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
 &lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["foo\nbar"], instance["foo\&quot;bar"], instance["foo\\bar"], instance["foo\rbar"], instance["foo\tbar"], instance["foo\fbar"], 
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/properties_with_null_valued_instance_properties.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/properties_with_null_valued_instance_properties.md
@@ -38,6 +38,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [PropertiesWithNullValuedInstancePropertiesDictInput](#propertieswithnullvaluedinstancepropertiesdictinput), [PropertiesWithNullValuedInstancePropertiesDict](#propertieswithnullvaluedinstancepropertiesdict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [PropertiesWithNullValuedInstancePropertiesDict](#propertieswithnullvaluedinstancepropertiesdict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/property_named_ref_that_is_not_a_reference.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/property_named_ref_that_is_not_a_reference.md
@@ -33,6 +33,6 @@ Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [PropertyNamedRefThatIsNotAReferenceDictInput](#propertynamedrefthatisnotareferencedictinput), [PropertyNamedRefThatIsNotAReferenceDict](#propertynamedrefthatisnotareferencedict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [PropertyNamedRefThatIsNotAReferenceDict](#propertynamedrefthatisnotareferencedict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
 &lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["$ref"], 
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/required_default_validation.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/required_default_validation.md
@@ -38,6 +38,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [RequiredDefaultValidationDictInput](#requireddefaultvalidationdictinput), [RequiredDefaultValidationDict](#requireddefaultvalidationdict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [RequiredDefaultValidationDict](#requireddefaultvalidationdict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/required_properties_whose_names_are_javascript_object_property_names.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/required_properties_whose_names_are_javascript_object_property_names.md
@@ -44,6 +44,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesDictInput](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesdictinput), [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesDict](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesdict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesDict](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesdict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/required_validation.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/required_validation.md
@@ -41,6 +41,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [RequiredValidationDictInput](#requiredvalidationdictinput), [RequiredValidationDict](#requiredvalidationdict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [RequiredValidationDict](#requiredvalidationdict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/required_with_empty_array.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/required_with_empty_array.md
@@ -38,6 +38,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [RequiredWithEmptyArrayDictInput](#requiredwithemptyarraydictinput), [RequiredWithEmptyArrayDict](#requiredwithemptyarraydict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [RequiredWithEmptyArrayDict](#requiredwithemptyarraydict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_1_0_unit_test/python/docs/components/schema/required_with_escaped_characters.md
+++ b/samples/client/3_1_0_unit_test/python/docs/components/schema/required_with_escaped_characters.md
@@ -38,6 +38,6 @@ Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [RequiredWithEscapedCharactersDictInput](#requiredwithescapedcharactersdictinput), [RequiredWithEscapedCharactersDict](#requiredwithescapedcharactersdict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [RequiredWithEscapedCharactersDict](#requiredwithescapedcharactersdict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
 &lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["foo\tbar"], instance["foo\nbar"], instance["foo\fbar"], instance["foo\rbar"], instance["foo\&quot;bar"], instance["foo\\bar"], 
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/_200_response.md
+++ b/samples/client/petstore/python/docs/components/schema/_200_response.md
@@ -43,6 +43,6 @@ Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_200ResponseDictInput](#_200responsedictinput), [_200ResponseDict](#_200responsedict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [_200ResponseDict](#_200responsedict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
 &lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["class"], 
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/_return.md
+++ b/samples/client/petstore/python/docs/components/schema/_return.md
@@ -36,6 +36,6 @@ Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [ReturnDictInput](#returndictinput), [ReturnDict](#returndict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [ReturnDict](#returndict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
 &lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["return"], 
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/abstract_step_message.md
+++ b/samples/client/petstore/python/docs/components/schema/abstract_step_message.md
@@ -47,7 +47,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [AbstractStepMessageDictInput](#abstractstepmessagedictinput), [AbstractStepMessageDict](#abstractstepmessagedict) | [AbstractStepMessageDict](#abstractstepmessagedict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 ## Composed Schemas (allOf/anyOf/oneOf/not)
 ## anyOf

--- a/samples/client/petstore/python/docs/components/schema/additional_properties_class.md
+++ b/samples/client/petstore/python/docs/components/schema/additional_properties_class.md
@@ -59,7 +59,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [AdditionalPropertiesClassDictInput](#additionalpropertiesclassdictinput), [AdditionalPropertiesClassDict](#additionalpropertiesclassdict) | [AdditionalPropertiesClassDict](#additionalpropertiesclassdict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 # MapProperty
 ```

--- a/samples/client/petstore/python/docs/components/schema/animal.md
+++ b/samples/client/petstore/python/docs/components/schema/animal.md
@@ -41,6 +41,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [AnimalDictInput](#animaldictinput), [AnimalDict](#animaldict) | [AnimalDict](#animaldict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/any_type_and_format.md
+++ b/samples/client/petstore/python/docs/components/schema/any_type_and_format.md
@@ -59,6 +59,6 @@ Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [AnyTypeAndFormatDictInput](#anytypeandformatdictinput), [AnyTypeAndFormatDict](#anytypeandformatdict) | [AnyTypeAndFormatDict](#anytypeandformatdict) | a constructor
 &lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["date-time"], instance["float"], 
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/api_response.md
+++ b/samples/client/petstore/python/docs/components/schema/api_response.md
@@ -44,6 +44,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [ApiResponseDictInput](#apiresponsedictinput), [ApiResponseDict](#apiresponsedict) | [ApiResponseDict](#apiresponsedict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/apple.md
+++ b/samples/client/petstore/python/docs/components/schema/apple.md
@@ -41,6 +41,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | None, [AppleDictInput](#appledictinput), [AppleDict](#appledict) | None, [AppleDict](#appledict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/array_of_array_of_number_only.md
+++ b/samples/client/petstore/python/docs/components/schema/array_of_array_of_number_only.md
@@ -38,7 +38,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [ArrayOfArrayOfNumberOnlyDictInput](#arrayofarrayofnumberonlydictinput), [ArrayOfArrayOfNumberOnlyDict](#arrayofarrayofnumberonlydict) | [ArrayOfArrayOfNumberOnlyDict](#arrayofarrayofnumberonlydict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 # ArrayArrayNumber
 ```

--- a/samples/client/petstore/python/docs/components/schema/array_of_number_only.md
+++ b/samples/client/petstore/python/docs/components/schema/array_of_number_only.md
@@ -38,7 +38,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [ArrayOfNumberOnlyDictInput](#arrayofnumberonlydictinput), [ArrayOfNumberOnlyDict](#arrayofnumberonlydict) | [ArrayOfNumberOnlyDict](#arrayofnumberonlydict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 # ArrayNumber
 ```

--- a/samples/client/petstore/python/docs/components/schema/array_test.md
+++ b/samples/client/petstore/python/docs/components/schema/array_test.md
@@ -44,7 +44,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [ArrayTestDictInput](#arraytestdictinput), [ArrayTestDict](#arraytestdict) | [ArrayTestDict](#arraytestdict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 # ArrayOfString
 ```

--- a/samples/client/petstore/python/docs/components/schema/banana.md
+++ b/samples/client/petstore/python/docs/components/schema/banana.md
@@ -38,6 +38,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [BananaDictInput](#bananadictinput), [BananaDict](#bananadict) | [BananaDict](#bananadict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/basque_pig.md
+++ b/samples/client/petstore/python/docs/components/schema/basque_pig.md
@@ -38,6 +38,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [BasquePigDictInput](#basquepigdictinput), [BasquePigDict](#basquepigdict) | [BasquePigDict](#basquepigdict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/capitalization.md
+++ b/samples/client/petstore/python/docs/components/schema/capitalization.md
@@ -53,6 +53,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [CapitalizationDictInput](#capitalizationdictinput), [CapitalizationDict](#capitalizationdict) | [CapitalizationDict](#capitalizationdict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/cat.md
+++ b/samples/client/petstore/python/docs/components/schema/cat.md
@@ -55,6 +55,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_1DictInput](#_1dictinput), [_1Dict](#_1dict) | [_1Dict](#_1dict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/category.md
+++ b/samples/client/petstore/python/docs/components/schema/category.md
@@ -41,6 +41,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [CategoryDictInput](#categorydictinput), [CategoryDict](#categorydict) | [CategoryDict](#categorydict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/child_cat.md
+++ b/samples/client/petstore/python/docs/components/schema/child_cat.md
@@ -55,6 +55,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_1DictInput](#_1dictinput), [_1Dict](#_1dict) | [_1Dict](#_1dict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/class_model.md
+++ b/samples/client/petstore/python/docs/components/schema/class_model.md
@@ -41,6 +41,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [ClassModelDictInput](#classmodeldictinput), [ClassModelDict](#classmodeldict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [ClassModelDict](#classmodeldict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/client.md
+++ b/samples/client/petstore/python/docs/components/schema/client.md
@@ -38,6 +38,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [ClientDictInput](#clientdictinput), [ClientDict](#clientdict) | [ClientDict](#clientdict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/complex_quadrilateral.md
+++ b/samples/client/petstore/python/docs/components/schema/complex_quadrilateral.md
@@ -55,6 +55,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_1DictInput](#_1dictinput), [_1Dict](#_1dict) | [_1Dict](#_1dict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/danish_pig.md
+++ b/samples/client/petstore/python/docs/components/schema/danish_pig.md
@@ -38,6 +38,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [DanishPigDictInput](#danishpigdictinput), [DanishPigDict](#danishpigdict) | [DanishPigDict](#danishpigdict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/dog.md
+++ b/samples/client/petstore/python/docs/components/schema/dog.md
@@ -55,6 +55,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_1DictInput](#_1dictinput), [_1Dict](#_1dict) | [_1Dict](#_1dict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/enum_arrays.md
+++ b/samples/client/petstore/python/docs/components/schema/enum_arrays.md
@@ -41,7 +41,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [EnumArraysDictInput](#enumarraysdictinput), [EnumArraysDict](#enumarraysdict) | [EnumArraysDict](#enumarraysdict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 # ArrayEnum
 ```

--- a/samples/client/petstore/python/docs/components/schema/enum_test.md
+++ b/samples/client/petstore/python/docs/components/schema/enum_test.md
@@ -62,6 +62,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [EnumTestDictInput](#enumtestdictinput), [EnumTestDict](#enumtestdict) | [EnumTestDict](#enumtestdict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/equilateral_triangle.md
+++ b/samples/client/petstore/python/docs/components/schema/equilateral_triangle.md
@@ -55,6 +55,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_1DictInput](#_1dictinput), [_1Dict](#_1dict) | [_1Dict](#_1dict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/file.md
+++ b/samples/client/petstore/python/docs/components/schema/file.md
@@ -41,6 +41,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [FileDictInput](#filedictinput), [FileDict](#filedict) | [FileDict](#filedict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/file_schema_test_class.md
+++ b/samples/client/petstore/python/docs/components/schema/file_schema_test_class.md
@@ -41,7 +41,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [FileSchemaTestClassDictInput](#fileschematestclassdictinput), [FileSchemaTestClassDict](#fileschematestclassdict) | [FileSchemaTestClassDict](#fileschematestclassdict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 # Files
 ```

--- a/samples/client/petstore/python/docs/components/schema/foo.md
+++ b/samples/client/petstore/python/docs/components/schema/foo.md
@@ -38,6 +38,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [FooDictInput](#foodictinput), [FooDict](#foodict) | [FooDict](#foodict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/format_test.md
+++ b/samples/client/petstore/python/docs/components/schema/format_test.md
@@ -97,7 +97,7 @@ Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [FormatTestDictInput](#formattestdictinput), [FormatTestDict](#formattestdict) | [FormatTestDict](#formattestdict) | a constructor
 &lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["float"], 
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 # ArrayWithUniqueItems
 ```

--- a/samples/client/petstore/python/docs/components/schema/from_schema.md
+++ b/samples/client/petstore/python/docs/components/schema/from_schema.md
@@ -41,6 +41,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [FromSchemaDictInput](#fromschemadictinput), [FromSchemaDict](#fromschemadict) | [FromSchemaDict](#fromschemadict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/fruit.md
+++ b/samples/client/petstore/python/docs/components/schema/fruit.md
@@ -38,7 +38,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [FruitDictInput](#fruitdictinput), [FruitDict](#fruitdict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [FruitDict](#fruitdict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 ## Composed Schemas (allOf/anyOf/oneOf/not)
 ## oneOf

--- a/samples/client/petstore/python/docs/components/schema/gm_fruit.md
+++ b/samples/client/petstore/python/docs/components/schema/gm_fruit.md
@@ -38,7 +38,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [GmFruitDictInput](#gmfruitdictinput), [GmFruitDict](#gmfruitdict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [GmFruitDict](#gmfruitdict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 ## Composed Schemas (allOf/anyOf/oneOf/not)
 ## anyOf

--- a/samples/client/petstore/python/docs/components/schema/grandparent_animal.md
+++ b/samples/client/petstore/python/docs/components/schema/grandparent_animal.md
@@ -38,6 +38,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [GrandparentAnimalDictInput](#grandparentanimaldictinput), [GrandparentAnimalDict](#grandparentanimaldict) | [GrandparentAnimalDict](#grandparentanimaldict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/has_only_read_only.md
+++ b/samples/client/petstore/python/docs/components/schema/has_only_read_only.md
@@ -41,6 +41,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [HasOnlyReadOnlyDictInput](#hasonlyreadonlydictinput), [HasOnlyReadOnlyDict](#hasonlyreadonlydict) | [HasOnlyReadOnlyDict](#hasonlyreadonlydict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/health_check_result.md
+++ b/samples/client/petstore/python/docs/components/schema/health_check_result.md
@@ -41,6 +41,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [HealthCheckResultDictInput](#healthcheckresultdictinput), [HealthCheckResultDict](#healthcheckresultdict) | [HealthCheckResultDict](#healthcheckresultdict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/isosceles_triangle.md
+++ b/samples/client/petstore/python/docs/components/schema/isosceles_triangle.md
@@ -55,6 +55,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_1DictInput](#_1dictinput), [_1Dict](#_1dict) | [_1Dict](#_1dict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/map_test.md
+++ b/samples/client/petstore/python/docs/components/schema/map_test.md
@@ -47,7 +47,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [MapTestDictInput](#maptestdictinput), [MapTestDict](#maptestdict) | [MapTestDict](#maptestdict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 # MapMapOfString
 ```

--- a/samples/client/petstore/python/docs/components/schema/mixed_properties_and_additional_properties_class.md
+++ b/samples/client/petstore/python/docs/components/schema/mixed_properties_and_additional_properties_class.md
@@ -44,7 +44,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [MixedPropertiesAndAdditionalPropertiesClassDictInput](#mixedpropertiesandadditionalpropertiesclassdictinput), [MixedPropertiesAndAdditionalPropertiesClassDict](#mixedpropertiesandadditionalpropertiesclassdict) | [MixedPropertiesAndAdditionalPropertiesClassDict](#mixedpropertiesandadditionalpropertiesclassdict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 # Map
 ```

--- a/samples/client/petstore/python/docs/components/schema/name.md
+++ b/samples/client/petstore/python/docs/components/schema/name.md
@@ -46,6 +46,6 @@ Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [NameDictInput](#namedictinput), [NameDict](#namedict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [NameDict](#namedict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
 &lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["property"], 
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/number_only.md
+++ b/samples/client/petstore/python/docs/components/schema/number_only.md
@@ -38,6 +38,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [NumberOnlyDictInput](#numberonlydictinput), [NumberOnlyDict](#numberonlydict) | [NumberOnlyDict](#numberonlydict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/obj_with_required_props.md
+++ b/samples/client/petstore/python/docs/components/schema/obj_with_required_props.md
@@ -38,7 +38,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [ObjWithRequiredPropsDictInput](#objwithrequiredpropsdictinput), [ObjWithRequiredPropsDict](#objwithrequiredpropsdict) | [ObjWithRequiredPropsDict](#objwithrequiredpropsdict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 ## Composed Schemas (allOf/anyOf/oneOf/not)
 ## allOf

--- a/samples/client/petstore/python/docs/components/schema/obj_with_required_props_base.md
+++ b/samples/client/petstore/python/docs/components/schema/obj_with_required_props_base.md
@@ -38,6 +38,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [ObjWithRequiredPropsBaseDictInput](#objwithrequiredpropsbasedictinput), [ObjWithRequiredPropsBaseDict](#objwithrequiredpropsbasedict) | [ObjWithRequiredPropsBaseDict](#objwithrequiredpropsbasedict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/object_model_with_arg_and_args_properties.md
+++ b/samples/client/petstore/python/docs/components/schema/object_model_with_arg_and_args_properties.md
@@ -41,6 +41,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [ObjectModelWithArgAndArgsPropertiesDictInput](#objectmodelwithargandargspropertiesdictinput), [ObjectModelWithArgAndArgsPropertiesDict](#objectmodelwithargandargspropertiesdict) | [ObjectModelWithArgAndArgsPropertiesDict](#objectmodelwithargandargspropertiesdict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/object_model_with_ref_props.md
+++ b/samples/client/petstore/python/docs/components/schema/object_model_with_ref_props.md
@@ -47,6 +47,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [ObjectModelWithRefPropsDictInput](#objectmodelwithrefpropsdictinput), [ObjectModelWithRefPropsDict](#objectmodelwithrefpropsdict) | [ObjectModelWithRefPropsDict](#objectmodelwithrefpropsdict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/object_with_all_of_with_req_test_prop_from_unset_add_prop.md
+++ b/samples/client/petstore/python/docs/components/schema/object_with_all_of_with_req_test_prop_from_unset_add_prop.md
@@ -58,6 +58,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_1DictInput](#_1dictinput), [_1Dict](#_1dict) | [_1Dict](#_1dict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/object_with_colliding_properties.md
+++ b/samples/client/petstore/python/docs/components/schema/object_with_colliding_properties.md
@@ -44,7 +44,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [ObjectWithCollidingPropertiesDictInput](#objectwithcollidingpropertiesdictinput), [ObjectWithCollidingPropertiesDict](#objectwithcollidingpropertiesdict) | [ObjectWithCollidingPropertiesDict](#objectwithcollidingpropertiesdict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 # SomeProp
 ```

--- a/samples/client/petstore/python/docs/components/schema/object_with_decimal_properties.md
+++ b/samples/client/petstore/python/docs/components/schema/object_with_decimal_properties.md
@@ -44,6 +44,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [ObjectWithDecimalPropertiesDictInput](#objectwithdecimalpropertiesdictinput), [ObjectWithDecimalPropertiesDict](#objectwithdecimalpropertiesdict) | [ObjectWithDecimalPropertiesDict](#objectwithdecimalpropertiesdict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/object_with_difficultly_named_props.md
+++ b/samples/client/petstore/python/docs/components/schema/object_with_difficultly_named_props.md
@@ -38,6 +38,6 @@ Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [ObjectWithDifficultlyNamedPropsDictInput](#objectwithdifficultlynamedpropsdictinput), [ObjectWithDifficultlyNamedPropsDict](#objectwithdifficultlynamedpropsdict) | [ObjectWithDifficultlyNamedPropsDict](#objectwithdifficultlynamedpropsdict) | a constructor
 &lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["123-list"], instance["$special[property.name]"], instance["123Number"], 
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/object_with_inline_composition_property.md
+++ b/samples/client/petstore/python/docs/components/schema/object_with_inline_composition_property.md
@@ -38,7 +38,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [ObjectWithInlineCompositionPropertyDictInput](#objectwithinlinecompositionpropertydictinput), [ObjectWithInlineCompositionPropertyDict](#objectwithinlinecompositionpropertydict) | [ObjectWithInlineCompositionPropertyDict](#objectwithinlinecompositionpropertydict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 # SomeProp
 ```

--- a/samples/client/petstore/python/docs/components/schema/object_with_invalid_named_refed_properties.md
+++ b/samples/client/petstore/python/docs/components/schema/object_with_invalid_named_refed_properties.md
@@ -34,6 +34,6 @@ Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [ObjectWithInvalidNamedRefedPropertiesDictInput](#objectwithinvalidnamedrefedpropertiesdictinput), [ObjectWithInvalidNamedRefedPropertiesDict](#objectwithinvalidnamedrefedpropertiesdict) | [ObjectWithInvalidNamedRefedPropertiesDict](#objectwithinvalidnamedrefedpropertiesdict) | a constructor
 &lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["!reference"], instance["from"], 
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/object_with_optional_test_prop.md
+++ b/samples/client/petstore/python/docs/components/schema/object_with_optional_test_prop.md
@@ -38,6 +38,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [ObjectWithOptionalTestPropDictInput](#objectwithoptionaltestpropdictinput), [ObjectWithOptionalTestPropDict](#objectwithoptionaltestpropdict) | [ObjectWithOptionalTestPropDict](#objectwithoptionaltestpropdict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/order.md
+++ b/samples/client/petstore/python/docs/components/schema/order.md
@@ -53,6 +53,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [OrderDictInput](#orderdictinput), [OrderDict](#orderdict) | [OrderDict](#orderdict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/pet.md
+++ b/samples/client/petstore/python/docs/components/schema/pet.md
@@ -56,7 +56,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [PetDictInput](#petdictinput), [PetDict](#petdict) | [PetDict](#petdict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 # PhotoUrls
 ```

--- a/samples/client/petstore/python/docs/components/schema/player.md
+++ b/samples/client/petstore/python/docs/components/schema/player.md
@@ -44,6 +44,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [PlayerDictInput](#playerdictinput), [PlayerDict](#playerdict) | [PlayerDict](#playerdict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/public_key.md
+++ b/samples/client/petstore/python/docs/components/schema/public_key.md
@@ -41,6 +41,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [PublicKeyDictInput](#publickeydictinput), [PublicKeyDict](#publickeydict) | [PublicKeyDict](#publickeydict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/quadrilateral_interface.md
+++ b/samples/client/petstore/python/docs/components/schema/quadrilateral_interface.md
@@ -41,6 +41,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [QuadrilateralInterfaceDictInput](#quadrilateralinterfacedictinput), [QuadrilateralInterfaceDict](#quadrilateralinterfacedict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [QuadrilateralInterfaceDict](#quadrilateralinterfacedict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/read_only_first.md
+++ b/samples/client/petstore/python/docs/components/schema/read_only_first.md
@@ -41,6 +41,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [ReadOnlyFirstDictInput](#readonlyfirstdictinput), [ReadOnlyFirstDict](#readonlyfirstdict) | [ReadOnlyFirstDict](#readonlyfirstdict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/req_props_from_unset_add_props.md
+++ b/samples/client/petstore/python/docs/components/schema/req_props_from_unset_add_props.md
@@ -40,6 +40,6 @@ Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [ReqPropsFromUnsetAddPropsDictInput](#reqpropsfromunsetaddpropsdictinput), [ReqPropsFromUnsetAddPropsDict](#reqpropsfromunsetaddpropsdict) | [ReqPropsFromUnsetAddPropsDict](#reqpropsfromunsetaddpropsdict) | a constructor
 &lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["invalid-name"], 
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/scalene_triangle.md
+++ b/samples/client/petstore/python/docs/components/schema/scalene_triangle.md
@@ -55,6 +55,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_1DictInput](#_1dictinput), [_1Dict](#_1dict) | [_1Dict](#_1dict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/simple_quadrilateral.md
+++ b/samples/client/petstore/python/docs/components/schema/simple_quadrilateral.md
@@ -55,6 +55,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [_1DictInput](#_1dictinput), [_1Dict](#_1dict) | [_1Dict](#_1dict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/special_model_name.md
+++ b/samples/client/petstore/python/docs/components/schema/special_model_name.md
@@ -41,6 +41,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [SpecialModelNameDictInput](#specialmodelnamedictinput), [SpecialModelNameDict](#specialmodelnamedict) | [SpecialModelNameDict](#specialmodelnamedict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/tag.md
+++ b/samples/client/petstore/python/docs/components/schema/tag.md
@@ -41,6 +41,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [TagDictInput](#tagdictinput), [TagDict](#tagdict) | [TagDict](#tagdict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/triangle_interface.md
+++ b/samples/client/petstore/python/docs/components/schema/triangle_interface.md
@@ -41,6 +41,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [TriangleInterfaceDictInput](#triangleinterfacedictinput), [TriangleInterfaceDict](#triangleinterfacedict), str, datetime.date, datetime.datetime, uuid.UUID, int, float, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader | [TriangleInterfaceDict](#triangleinterfacedict), str, float, int, bool, None, tuple, bytes, io.FileIO | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/components/schema/user.md
+++ b/samples/client/petstore/python/docs/components/schema/user.md
@@ -74,7 +74,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [UserDictInput](#userdictinput), [UserDict](#userdict) | [UserDict](#userdict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 # ObjectWithNoDeclaredProps
 ```

--- a/samples/client/petstore/python/docs/components/schema/whale.md
+++ b/samples/client/petstore/python/docs/components/schema/whale.md
@@ -44,6 +44,6 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [WhaleDictInput](#whaledictinput), [WhaleDict](#whaledict) | [WhaleDict](#whaledict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/python/docs/paths/fake/get.md
+++ b/samples/client/petstore/python/docs/paths/fake/get.md
@@ -86,7 +86,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [SchemaDictInput](#requestbody-content-applicationxwwwformurlencoded-schema-schemadictinput), [SchemaDict](#requestbody-content-applicationxwwwformurlencoded-schema-schemadict) | [SchemaDict](#requestbody-content-applicationxwwwformurlencoded-schema-schemadict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 #### RequestBody content ApplicationXWwwFormUrlencoded Schema
 ```

--- a/samples/client/petstore/python/docs/paths/fake/get/request_body/content/application_x_www_form_urlencoded/schema.md
+++ b/samples/client/petstore/python/docs/paths/fake/get/request_body/content/application_x_www_form_urlencoded/schema.md
@@ -41,7 +41,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [SchemaDictInput](#schemadictinput), [SchemaDict](#schemadict) | [SchemaDict](#schemadict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 # EnumFormStringArray
 ```

--- a/samples/client/petstore/python/docs/paths/fake/post.md
+++ b/samples/client/petstore/python/docs/paths/fake/post.md
@@ -120,7 +120,7 @@ Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [SchemaDictInput](#requestbody-content-applicationxwwwformurlencoded-schema-schemadictinput), [SchemaDict](#requestbody-content-applicationxwwwformurlencoded-schema-schemadict) | [SchemaDict](#requestbody-content-applicationxwwwformurlencoded-schema-schemadict) | a constructor
 &lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["float"], 
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 ## Return Types
 

--- a/samples/client/petstore/python/docs/paths/fake/post/request_body/content/application_x_www_form_urlencoded/schema.md
+++ b/samples/client/petstore/python/docs/paths/fake/post/request_body/content/application_x_www_form_urlencoded/schema.md
@@ -76,4 +76,4 @@ Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [SchemaDictInput](#schemadictinput), [SchemaDict](#schemadict) | [SchemaDict](#schemadict) | a constructor
 &lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["float"], 
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties

--- a/samples/client/petstore/python/docs/paths/fake_inline_composition/post.md
+++ b/samples/client/petstore/python/docs/paths/fake_inline_composition/post.md
@@ -112,7 +112,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [SchemaDictInput](#requestbody-content-multipartformdata-schema-schemadictinput), [SchemaDict](#requestbody-content-multipartformdata-schema-schemadict) | [SchemaDict](#requestbody-content-multipartformdata-schema-schemadict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 #### RequestBody content MultipartFormData Schema
 ```
@@ -273,7 +273,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [SchemaDictInput](#responsefor200-content-multipartformdata-schema-schemadictinput), [SchemaDict](#responsefor200-content-multipartformdata-schema-schemadict) | [SchemaDict](#responsefor200-content-multipartformdata-schema-schemadict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 #### ResponseFor200 content MultipartFormData Schema
 ```

--- a/samples/client/petstore/python/docs/paths/fake_inline_composition/post/parameters/parameter_1/schema.md
+++ b/samples/client/petstore/python/docs/paths/fake_inline_composition/post/parameters/parameter_1/schema.md
@@ -38,7 +38,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [SchemaDictInput](#schemadictinput), [SchemaDict](#schemadict) | [SchemaDict](#schemadict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 # SomeProp
 ```

--- a/samples/client/petstore/python/docs/paths/fake_inline_composition/post/request_body/content/multipart_form_data/schema.md
+++ b/samples/client/petstore/python/docs/paths/fake_inline_composition/post/request_body/content/multipart_form_data/schema.md
@@ -38,7 +38,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [SchemaDictInput](#schemadictinput), [SchemaDict](#schemadict) | [SchemaDict](#schemadict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 # SomeProp
 ```

--- a/samples/client/petstore/python/docs/paths/fake_inline_composition/post/responses/response_200/content/multipart_form_data/schema.md
+++ b/samples/client/petstore/python/docs/paths/fake_inline_composition/post/responses/response_200/content/multipart_form_data/schema.md
@@ -38,7 +38,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [SchemaDictInput](#schemadictinput), [SchemaDict](#schemadict) | [SchemaDict](#schemadict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 # SomeProp
 ```

--- a/samples/client/petstore/python/docs/paths/fake_json_form_data/get.md
+++ b/samples/client/petstore/python/docs/paths/fake_json_form_data/get.md
@@ -82,7 +82,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [SchemaDictInput](#requestbody-content-applicationxwwwformurlencoded-schema-schemadictinput), [SchemaDict](#requestbody-content-applicationxwwwformurlencoded-schema-schemadict) | [SchemaDict](#requestbody-content-applicationxwwwformurlencoded-schema-schemadict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 ## Return Types
 

--- a/samples/client/petstore/python/docs/paths/fake_json_form_data/get/request_body/content/application_x_www_form_urlencoded/schema.md
+++ b/samples/client/petstore/python/docs/paths/fake_json_form_data/get/request_body/content/application_x_www_form_urlencoded/schema.md
@@ -41,4 +41,4 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [SchemaDictInput](#schemadictinput), [SchemaDict](#schemadict) | [SchemaDict](#schemadict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties

--- a/samples/client/petstore/python/docs/paths/fake_multiple_request_body_content_types/post.md
+++ b/samples/client/petstore/python/docs/paths/fake_multiple_request_body_content_types/post.md
@@ -85,7 +85,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [SchemaDictInput](#requestbody-content-applicationjson-schema-schemadictinput), [SchemaDict](#requestbody-content-applicationjson-schema-schemadict) | [SchemaDict](#requestbody-content-applicationjson-schema-schemadict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 #### RequestBody content MultipartFormData Schema
 petstore_api.paths.fake_multiple_request_body_content_types.post.request_body.content.multipart_form_data.schema
 ```
@@ -126,7 +126,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [SchemaDictInput](#requestbody-content-multipartformdata-schema-schemadictinput), [SchemaDict](#requestbody-content-multipartformdata-schema-schemadict) | [SchemaDict](#requestbody-content-multipartformdata-schema-schemadict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 ## Return Types
 

--- a/samples/client/petstore/python/docs/paths/fake_multiple_request_body_content_types/post/request_body/content/application_json/schema.md
+++ b/samples/client/petstore/python/docs/paths/fake_multiple_request_body_content_types/post/request_body/content/application_json/schema.md
@@ -38,4 +38,4 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [SchemaDictInput](#schemadictinput), [SchemaDict](#schemadict) | [SchemaDict](#schemadict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties

--- a/samples/client/petstore/python/docs/paths/fake_multiple_request_body_content_types/post/request_body/content/multipart_form_data/schema.md
+++ b/samples/client/petstore/python/docs/paths/fake_multiple_request_body_content_types/post/request_body/content/multipart_form_data/schema.md
@@ -38,4 +38,4 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [SchemaDictInput](#schemadictinput), [SchemaDict](#schemadict) | [SchemaDict](#schemadict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties

--- a/samples/client/petstore/python/docs/paths/fake_obj_in_query/get/parameters/parameter_0/schema.md
+++ b/samples/client/petstore/python/docs/paths/fake_obj_in_query/get/parameters/parameter_0/schema.md
@@ -38,4 +38,4 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [SchemaDictInput](#schemadictinput), [SchemaDict](#schemadict) | [SchemaDict](#schemadict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties

--- a/samples/client/petstore/python/docs/paths/fake_pet_id_upload_image_with_required_file/post.md
+++ b/samples/client/petstore/python/docs/paths/fake_pet_id_upload_image_with_required_file/post.md
@@ -86,7 +86,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [SchemaDictInput](#requestbody-content-multipartformdata-schema-schemadictinput), [SchemaDict](#requestbody-content-multipartformdata-schema-schemadict) | [SchemaDict](#requestbody-content-multipartformdata-schema-schemadict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 ### path_params
 ### PathParameters
 ```

--- a/samples/client/petstore/python/docs/paths/fake_pet_id_upload_image_with_required_file/post/request_body/content/multipart_form_data/schema.md
+++ b/samples/client/petstore/python/docs/paths/fake_pet_id_upload_image_with_required_file/post/request_body/content/multipart_form_data/schema.md
@@ -41,4 +41,4 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [SchemaDictInput](#schemadictinput), [SchemaDict](#schemadict) | [SchemaDict](#schemadict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties

--- a/samples/client/petstore/python/docs/paths/fake_upload_file/post.md
+++ b/samples/client/petstore/python/docs/paths/fake_upload_file/post.md
@@ -83,7 +83,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [SchemaDictInput](#requestbody-content-multipartformdata-schema-schemadictinput), [SchemaDict](#requestbody-content-multipartformdata-schema-schemadict) | [SchemaDict](#requestbody-content-multipartformdata-schema-schemadict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 ## Return Types
 

--- a/samples/client/petstore/python/docs/paths/fake_upload_file/post/request_body/content/multipart_form_data/schema.md
+++ b/samples/client/petstore/python/docs/paths/fake_upload_file/post/request_body/content/multipart_form_data/schema.md
@@ -41,4 +41,4 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [SchemaDictInput](#schemadictinput), [SchemaDict](#schemadict) | [SchemaDict](#schemadict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties

--- a/samples/client/petstore/python/docs/paths/fake_upload_files/post.md
+++ b/samples/client/petstore/python/docs/paths/fake_upload_files/post.md
@@ -80,7 +80,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [SchemaDictInput](#requestbody-content-multipartformdata-schema-schemadictinput), [SchemaDict](#requestbody-content-multipartformdata-schema-schemadict) | [SchemaDict](#requestbody-content-multipartformdata-schema-schemadict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 #### RequestBody content MultipartFormData Schema
 ```

--- a/samples/client/petstore/python/docs/paths/fake_upload_files/post/request_body/content/multipart_form_data/schema.md
+++ b/samples/client/petstore/python/docs/paths/fake_upload_files/post/request_body/content/multipart_form_data/schema.md
@@ -38,7 +38,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [SchemaDictInput](#schemadictinput), [SchemaDict](#schemadict) | [SchemaDict](#schemadict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 # Files
 ```

--- a/samples/client/petstore/python/docs/paths/foo/get.md
+++ b/samples/client/petstore/python/docs/paths/foo/get.md
@@ -95,7 +95,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [SchemaDictInput](#default-content-applicationjson-schema-schemadictinput), [SchemaDict](#default-content-applicationjson-schema-schemadict) | [SchemaDict](#default-content-applicationjson-schema-schemadict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 
 ## Servers
 

--- a/samples/client/petstore/python/docs/paths/foo/get/responses/response_default/content/application_json/schema.md
+++ b/samples/client/petstore/python/docs/paths/foo/get/responses/response_default/content/application_json/schema.md
@@ -38,4 +38,4 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [SchemaDictInput](#schemadictinput), [SchemaDict](#schemadict) | [SchemaDict](#schemadict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties

--- a/samples/client/petstore/python/docs/paths/pet_pet_id/post.md
+++ b/samples/client/petstore/python/docs/paths/pet_pet_id/post.md
@@ -85,7 +85,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [SchemaDictInput](#requestbody-content-applicationxwwwformurlencoded-schema-schemadictinput), [SchemaDict](#requestbody-content-applicationxwwwformurlencoded-schema-schemadict) | [SchemaDict](#requestbody-content-applicationxwwwformurlencoded-schema-schemadict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 ### path_params
 ### PathParameters
 ```

--- a/samples/client/petstore/python/docs/paths/pet_pet_id/post/request_body/content/application_x_www_form_urlencoded/schema.md
+++ b/samples/client/petstore/python/docs/paths/pet_pet_id/post/request_body/content/application_x_www_form_urlencoded/schema.md
@@ -41,4 +41,4 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [SchemaDictInput](#schemadictinput), [SchemaDict](#schemadict) | [SchemaDict](#schemadict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties

--- a/samples/client/petstore/python/docs/paths/pet_pet_id_upload_image/post.md
+++ b/samples/client/petstore/python/docs/paths/pet_pet_id_upload_image/post.md
@@ -86,7 +86,7 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [SchemaDictInput](#requestbody-content-multipartformdata-schema-schemadictinput), [SchemaDict](#requestbody-content-multipartformdata-schema-schemadict) | [SchemaDict](#requestbody-content-multipartformdata-schema-schemadict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
 ### path_params
 ### PathParameters
 ```

--- a/samples/client/petstore/python/docs/paths/pet_pet_id_upload_image/post/request_body/content/multipart_form_data/schema.md
+++ b/samples/client/petstore/python/docs/paths/pet_pet_id_upload_image/post/request_body/content/multipart_form_data/schema.md
@@ -41,4 +41,4 @@ Property | Type | Description | Notes
 Method | Input Type | Return Type | Notes
 ------ | ---------- | ----------- | ------
 from_dict_ | [SchemaDictInput](#schemadictinput), [SchemaDict](#schemadict) | [SchemaDict](#schemadict) | a constructor
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties

--- a/src/main/resources/python/components/schemas/schema_doc.hbs
+++ b/src/main/resources/python/components/schemas/schema_doc.hbs
@@ -201,7 +201,7 @@ get_additional_property_ | str | {{> components/schemas/types/docschema_output_t
                 {{/if}}
             {{/unless}}
         {{else}}
-get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset }} | provides type safety for additional properties
+get_additional_property_ | str | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO, schemas.Unset | provides type safety for additional properties
         {{/with}}
     {{/or}}
     {{#if items}}


### PR DESCRIPTION
Fixes documentation bug, removes unused braces

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
