### PR TITLE
Improves contains validation

### DIFF
--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/schemas/validation.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/schemas/validation.py
@@ -1151,9 +1151,9 @@ def validate_contains(
     contains_cls_path_to_schemas: typing.Tuple[typing.Type[SchemaValidator], typing.List[PathToSchemasType]],
     cls: typing.Type,
     validation_metadata: ValidationMetadata,
-) -> typing.List[PathToSchemasType]:
+) -> typing.Optional[PathToSchemasType]:
     if not isinstance(arg, tuple):
-        return []
+        return None
     many_path_to_schemas = contains_cls_path_to_schemas[1]
     if not many_path_to_schemas:
         raise exceptions.ApiValueError(

--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/schemas/validation.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/schemas/validation.py
@@ -90,10 +90,10 @@ class SchemaValidator:
             and k
             not in validation_metadata.configuration.disabled_json_schema_python_keywords
         }
-        contains_qty = 0
+        contains_path_to_schemas = []
         path_to_schemas: PathToSchemasType = {}
         if 'contains' in vars(cls_schema):
-            contains_qty = _get_contains_qty(
+            contains_path_to_schemas = _get_contains_path_to_schemas(
                 arg,
                 vars(cls_schema)['contains'],
                 validation_metadata,
@@ -120,7 +120,7 @@ class SchemaValidator:
         for keyword, val in json_schema_data.items():
             used_val: typing.Any
             if keyword in {'contains', 'min_contains', 'max_contains'}:
-                used_val = (val, contains_qty)
+                used_val = (val, contains_path_to_schemas)
             elif keyword == 'items':
                 used_val = (val, prefix_items_length)
             elif keyword in {'unevaluated_items', 'unevaluated_properties'}:
@@ -1116,66 +1116,67 @@ def validate_else(
         raise ex
 
 
-def _get_contains_qty(
+def _get_contains_path_to_schemas(
     arg: typing.Any,
     contains_cls: typing.Type[SchemaValidator],
     validation_metadata: ValidationMetadata,
     path_to_schemas: PathToSchemasType
-) -> int:
+) -> typing.List[PathToSchemasType]:
     if not isinstance(arg, tuple):
-        return 0
+        return []
     contains_cls = _get_class(contains_cls)
-    these_path_to_schemas: PathToSchemasType = {}
-    contains_qty = 0
+    contains_path_to_schemas = []
     for i, value in enumerate(arg):
+        these_path_to_schemas: PathToSchemasType = {}
         item_validation_metadata = ValidationMetadata(
             path_to_item=validation_metadata.path_to_item+(i,),
             configuration=validation_metadata.configuration,
             validated_path_to_schemas=validation_metadata.validated_path_to_schemas
         )
         if item_validation_metadata.validation_ran_earlier(contains_cls):
-            add_deeper_validated_schemas(item_validation_metadata, path_to_schemas)
-            contains_qty += 1
+            add_deeper_validated_schemas(item_validation_metadata, these_path_to_schemas)
+            contains_path_to_schemas.append(these_path_to_schemas)
             continue
         try:
             other_path_to_schemas = contains_cls._validate(
                 value, validation_metadata=item_validation_metadata)
-            update(these_path_to_schemas, other_path_to_schemas)
-            contains_qty += 1
+            contains_path_to_schemas.append(other_path_to_schemas)
         except exceptions.OpenApiException:
             pass
-    if contains_qty:
-        update(path_to_schemas, these_path_to_schemas)
-    return contains_qty
+    return contains_path_to_schemas
 
 
 def validate_contains(
     arg: typing.Any,
-    contains_qty: typing.Tuple[typing.Type[SchemaValidator], int],
+    contains_cls_path_to_schemas: typing.Tuple[typing.Type[SchemaValidator], typing.List[PathToSchemasType]],
     cls: typing.Type,
     validation_metadata: ValidationMetadata,
-) -> typing.Optional[PathToSchemasType]:
+) -> typing.List[PathToSchemasType]:
     if not isinstance(arg, tuple):
-        return None
-    if not contains_qty[1]:
+        return []
+    many_path_to_schemas = contains_cls_path_to_schemas[1]
+    if not many_path_to_schemas:
         raise exceptions.ApiValueError(
             "Validation failed for contains keyword in class={} at path_to_item={}. No "
             "items validated to the contains schema.".format(cls, validation_metadata.path_to_item)
         )
-    return None
+    these_path_to_schemas: PathToSchemasType = {}
+    for other_path_to_schema in many_path_to_schemas:
+        update(these_path_to_schemas, other_path_to_schema)
+    return these_path_to_schemas
 
 
 def validate_min_contains(
     arg: typing.Any,
-    min_contains_and_qty: typing.Tuple[int, int],
+    min_contains_and_contains_path_to_schemas: typing.Tuple[int, typing.List[PathToSchemasType]],
     cls: typing.Type,
     validation_metadata: ValidationMetadata,
 ) -> typing.Optional[PathToSchemasType]:
     if not isinstance(arg, tuple):
         return None
-    min_contains = min_contains_and_qty[0]
-    contains_qty = min_contains_and_qty[1]
-    if not contains_qty or contains_qty < min_contains:
+    min_contains = min_contains_and_contains_path_to_schemas[0]
+    contains_path_to_schemas = min_contains_and_contains_path_to_schemas[1]
+    if len(contains_path_to_schemas) < min_contains:
         raise exceptions.ApiValueError(
             "Validation failed for minContains keyword in class={} at path_to_item={}. No "
             "items validated to the contains schema.".format(cls, validation_metadata.path_to_item)
@@ -1185,15 +1186,15 @@ def validate_min_contains(
 
 def validate_max_contains(
     arg: typing.Any,
-    max_contains_and_qty: typing.Tuple[int, int],
+    max_contains_and_contains_path_to_schemas: typing.Tuple[int, typing.List[PathToSchemasType]],
     cls: typing.Type,
     validation_metadata: ValidationMetadata,
 ) -> typing.Optional[PathToSchemasType]:
     if not isinstance(arg, tuple):
         return None
-    max_contains = max_contains_and_qty[0]
-    contains_qty = max_contains_and_qty[1]
-    if not contains_qty or contains_qty > max_contains:
+    max_contains = max_contains_and_contains_path_to_schemas[0]
+    contains_path_to_schemas = max_contains_and_contains_path_to_schemas[1]
+    if len(contains_path_to_schemas) > max_contains:
         raise exceptions.ApiValueError(
             "Validation failed for maxContains keyword in class={} at path_to_item={}. Too "
             "many items validated to the contains schema.".format(cls, validation_metadata.path_to_item)

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/schemas/validation.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/schemas/validation.py
@@ -1151,9 +1151,9 @@ def validate_contains(
     contains_cls_path_to_schemas: typing.Tuple[typing.Type[SchemaValidator], typing.List[PathToSchemasType]],
     cls: typing.Type,
     validation_metadata: ValidationMetadata,
-) -> typing.List[PathToSchemasType]:
+) -> typing.Optional[PathToSchemasType]:
     if not isinstance(arg, tuple):
-        return []
+        return None
     many_path_to_schemas = contains_cls_path_to_schemas[1]
     if not many_path_to_schemas:
         raise exceptions.ApiValueError(

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/schemas/validation.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/schemas/validation.py
@@ -90,10 +90,10 @@ class SchemaValidator:
             and k
             not in validation_metadata.configuration.disabled_json_schema_python_keywords
         }
-        contains_qty = 0
+        contains_path_to_schemas = []
         path_to_schemas: PathToSchemasType = {}
         if 'contains' in vars(cls_schema):
-            contains_qty = _get_contains_qty(
+            contains_path_to_schemas = _get_contains_path_to_schemas(
                 arg,
                 vars(cls_schema)['contains'],
                 validation_metadata,
@@ -120,7 +120,7 @@ class SchemaValidator:
         for keyword, val in json_schema_data.items():
             used_val: typing.Any
             if keyword in {'contains', 'min_contains', 'max_contains'}:
-                used_val = (val, contains_qty)
+                used_val = (val, contains_path_to_schemas)
             elif keyword == 'items':
                 used_val = (val, prefix_items_length)
             elif keyword in {'unevaluated_items', 'unevaluated_properties'}:
@@ -1116,66 +1116,67 @@ def validate_else(
         raise ex
 
 
-def _get_contains_qty(
+def _get_contains_path_to_schemas(
     arg: typing.Any,
     contains_cls: typing.Type[SchemaValidator],
     validation_metadata: ValidationMetadata,
     path_to_schemas: PathToSchemasType
-) -> int:
+) -> typing.List[PathToSchemasType]:
     if not isinstance(arg, tuple):
-        return 0
+        return []
     contains_cls = _get_class(contains_cls)
-    these_path_to_schemas: PathToSchemasType = {}
-    contains_qty = 0
+    contains_path_to_schemas = []
     for i, value in enumerate(arg):
+        these_path_to_schemas: PathToSchemasType = {}
         item_validation_metadata = ValidationMetadata(
             path_to_item=validation_metadata.path_to_item+(i,),
             configuration=validation_metadata.configuration,
             validated_path_to_schemas=validation_metadata.validated_path_to_schemas
         )
         if item_validation_metadata.validation_ran_earlier(contains_cls):
-            add_deeper_validated_schemas(item_validation_metadata, path_to_schemas)
-            contains_qty += 1
+            add_deeper_validated_schemas(item_validation_metadata, these_path_to_schemas)
+            contains_path_to_schemas.append(these_path_to_schemas)
             continue
         try:
             other_path_to_schemas = contains_cls._validate(
                 value, validation_metadata=item_validation_metadata)
-            update(these_path_to_schemas, other_path_to_schemas)
-            contains_qty += 1
+            contains_path_to_schemas.append(other_path_to_schemas)
         except exceptions.OpenApiException:
             pass
-    if contains_qty:
-        update(path_to_schemas, these_path_to_schemas)
-    return contains_qty
+    return contains_path_to_schemas
 
 
 def validate_contains(
     arg: typing.Any,
-    contains_qty: typing.Tuple[typing.Type[SchemaValidator], int],
+    contains_cls_path_to_schemas: typing.Tuple[typing.Type[SchemaValidator], typing.List[PathToSchemasType]],
     cls: typing.Type,
     validation_metadata: ValidationMetadata,
-) -> typing.Optional[PathToSchemasType]:
+) -> typing.List[PathToSchemasType]:
     if not isinstance(arg, tuple):
-        return None
-    if not contains_qty[1]:
+        return []
+    many_path_to_schemas = contains_cls_path_to_schemas[1]
+    if not many_path_to_schemas:
         raise exceptions.ApiValueError(
             "Validation failed for contains keyword in class={} at path_to_item={}. No "
             "items validated to the contains schema.".format(cls, validation_metadata.path_to_item)
         )
-    return None
+    these_path_to_schemas: PathToSchemasType = {}
+    for other_path_to_schema in many_path_to_schemas:
+        update(these_path_to_schemas, other_path_to_schema)
+    return these_path_to_schemas
 
 
 def validate_min_contains(
     arg: typing.Any,
-    min_contains_and_qty: typing.Tuple[int, int],
+    min_contains_and_contains_path_to_schemas: typing.Tuple[int, typing.List[PathToSchemasType]],
     cls: typing.Type,
     validation_metadata: ValidationMetadata,
 ) -> typing.Optional[PathToSchemasType]:
     if not isinstance(arg, tuple):
         return None
-    min_contains = min_contains_and_qty[0]
-    contains_qty = min_contains_and_qty[1]
-    if not contains_qty or contains_qty < min_contains:
+    min_contains = min_contains_and_contains_path_to_schemas[0]
+    contains_path_to_schemas = min_contains_and_contains_path_to_schemas[1]
+    if len(contains_path_to_schemas) < min_contains:
         raise exceptions.ApiValueError(
             "Validation failed for minContains keyword in class={} at path_to_item={}. No "
             "items validated to the contains schema.".format(cls, validation_metadata.path_to_item)
@@ -1185,15 +1186,15 @@ def validate_min_contains(
 
 def validate_max_contains(
     arg: typing.Any,
-    max_contains_and_qty: typing.Tuple[int, int],
+    max_contains_and_contains_path_to_schemas: typing.Tuple[int, typing.List[PathToSchemasType]],
     cls: typing.Type,
     validation_metadata: ValidationMetadata,
 ) -> typing.Optional[PathToSchemasType]:
     if not isinstance(arg, tuple):
         return None
-    max_contains = max_contains_and_qty[0]
-    contains_qty = max_contains_and_qty[1]
-    if not contains_qty or contains_qty > max_contains:
+    max_contains = max_contains_and_contains_path_to_schemas[0]
+    contains_path_to_schemas = max_contains_and_contains_path_to_schemas[1]
+    if len(contains_path_to_schemas) > max_contains:
         raise exceptions.ApiValueError(
             "Validation failed for maxContains keyword in class={} at path_to_item={}. Too "
             "many items validated to the contains schema.".format(cls, validation_metadata.path_to_item)

--- a/samples/client/openapi_features/nonCompliantUseDiscriminatorIfCompositionFails/python/src/this_package/schemas/validation.py
+++ b/samples/client/openapi_features/nonCompliantUseDiscriminatorIfCompositionFails/python/src/this_package/schemas/validation.py
@@ -1232,9 +1232,9 @@ def validate_contains(
     cls: typing.Type,
     validation_metadata: ValidationMetadata,
     **kwargs
-) -> typing.List[PathToSchemasType]:
+) -> typing.Optional[PathToSchemasType]:
     if not isinstance(arg, tuple):
-        return []
+        return None
     many_path_to_schemas = contains_cls_path_to_schemas[1]
     if not many_path_to_schemas:
         raise exceptions.ApiValueError(

--- a/samples/client/openapi_features/nonCompliantUseDiscriminatorIfCompositionFails/python/src/this_package/schemas/validation.py
+++ b/samples/client/openapi_features/nonCompliantUseDiscriminatorIfCompositionFails/python/src/this_package/schemas/validation.py
@@ -101,10 +101,10 @@ class SchemaValidator:
                 'discriminated_cls': discriminated_cls,
                 'ensure_discriminator_value_present_exc': ensure_discriminator_value_present_exc
             }
-        contains_qty = 0
+        contains_path_to_schemas = []
         path_to_schemas: PathToSchemasType = {}
         if 'contains' in vars(cls_schema):
-            contains_qty = _get_contains_qty(
+            contains_path_to_schemas = _get_contains_path_to_schemas(
                 arg,
                 vars(cls_schema)['contains'],
                 validation_metadata,
@@ -131,7 +131,7 @@ class SchemaValidator:
         for keyword, val in json_schema_data.items():
             used_val: typing.Any
             if keyword in {'contains', 'min_contains', 'max_contains'}:
-                used_val = (val, contains_qty)
+                used_val = (val, contains_path_to_schemas)
             elif keyword == 'items':
                 used_val = (val, prefix_items_length)
             elif keyword in {'unevaluated_items', 'unevaluated_properties'}:
@@ -1196,68 +1196,69 @@ def validate_else(
         raise ex
 
 
-def _get_contains_qty(
+def _get_contains_path_to_schemas(
     arg: typing.Any,
     contains_cls: typing.Type[SchemaValidator],
     validation_metadata: ValidationMetadata,
     path_to_schemas: PathToSchemasType
-) -> int:
+) -> typing.List[PathToSchemasType]:
     if not isinstance(arg, tuple):
-        return 0
+        return []
     contains_cls = _get_class(contains_cls)
-    these_path_to_schemas: PathToSchemasType = {}
-    contains_qty = 0
+    contains_path_to_schemas = []
     for i, value in enumerate(arg):
+        these_path_to_schemas: PathToSchemasType = {}
         item_validation_metadata = ValidationMetadata(
             path_to_item=validation_metadata.path_to_item+(i,),
             configuration=validation_metadata.configuration,
             validated_path_to_schemas=validation_metadata.validated_path_to_schemas
         )
         if item_validation_metadata.validation_ran_earlier(contains_cls):
-            add_deeper_validated_schemas(item_validation_metadata, path_to_schemas)
-            contains_qty += 1
+            add_deeper_validated_schemas(item_validation_metadata, these_path_to_schemas)
+            contains_path_to_schemas.append(these_path_to_schemas)
             continue
         try:
             other_path_to_schemas = contains_cls._validate(
                 value, validation_metadata=item_validation_metadata)
-            update(these_path_to_schemas, other_path_to_schemas)
-            contains_qty += 1
+            contains_path_to_schemas.append(other_path_to_schemas)
         except exceptions.OpenApiException:
             pass
-    if contains_qty:
-        update(path_to_schemas, these_path_to_schemas)
-    return contains_qty
+    return contains_path_to_schemas
 
 
 def validate_contains(
     arg: typing.Any,
-    contains_qty: typing.Tuple[typing.Type[SchemaValidator], int],
+    contains_cls_path_to_schemas: typing.Tuple[typing.Type[SchemaValidator], typing.List[PathToSchemasType]],
     cls: typing.Type,
     validation_metadata: ValidationMetadata,
     **kwargs
-) -> typing.Optional[PathToSchemasType]:
+) -> typing.List[PathToSchemasType]:
     if not isinstance(arg, tuple):
-        return None
-    if not contains_qty[1]:
+        return []
+    many_path_to_schemas = contains_cls_path_to_schemas[1]
+    if not many_path_to_schemas:
         raise exceptions.ApiValueError(
             "Validation failed for contains keyword in class={} at path_to_item={}. No "
             "items validated to the contains schema.".format(cls, validation_metadata.path_to_item)
         )
-    return None
+    these_path_to_schemas: PathToSchemasType = {}
+    for other_path_to_schema in many_path_to_schemas:
+        update(these_path_to_schemas, other_path_to_schema)
+    return these_path_to_schemas
 
 
 def validate_min_contains(
     arg: typing.Any,
-    min_contains_and_qty: typing.Tuple[int, int],
+    min_contains_and_contains_path_to_schemas: typing.Tuple[int, typing.List[PathToSchemasType]],
     cls: typing.Type,
     validation_metadata: ValidationMetadata,
     **kwargs
 ) -> typing.Optional[PathToSchemasType]:
     if not isinstance(arg, tuple):
         return None
-    min_contains = min_contains_and_qty[0]
-    contains_qty = min_contains_and_qty[1]
-    if not contains_qty or contains_qty < min_contains:
+    min_contains = min_contains_and_contains_path_to_schemas[0]
+    contains_path_to_schemas = min_contains_and_contains_path_to_schemas[1]
+    if len(contains_path_to_schemas) < min_contains:
         raise exceptions.ApiValueError(
             "Validation failed for minContains keyword in class={} at path_to_item={}. No "
             "items validated to the contains schema.".format(cls, validation_metadata.path_to_item)
@@ -1267,16 +1268,16 @@ def validate_min_contains(
 
 def validate_max_contains(
     arg: typing.Any,
-    max_contains_and_qty: typing.Tuple[int, int],
+    max_contains_and_contains_path_to_schemas: typing.Tuple[int, typing.List[PathToSchemasType]],
     cls: typing.Type,
     validation_metadata: ValidationMetadata,
     **kwargs
 ) -> typing.Optional[PathToSchemasType]:
     if not isinstance(arg, tuple):
         return None
-    max_contains = max_contains_and_qty[0]
-    contains_qty = max_contains_and_qty[1]
-    if not contains_qty or contains_qty > max_contains:
+    max_contains = max_contains_and_contains_path_to_schemas[0]
+    contains_path_to_schemas = max_contains_and_contains_path_to_schemas[1]
+    if len(contains_path_to_schemas) > max_contains:
         raise exceptions.ApiValueError(
             "Validation failed for maxContains keyword in class={} at path_to_item={}. Too "
             "many items validated to the contains schema.".format(cls, validation_metadata.path_to_item)

--- a/samples/client/openapi_features/security/python/src/this_package/schemas/validation.py
+++ b/samples/client/openapi_features/security/python/src/this_package/schemas/validation.py
@@ -1151,9 +1151,9 @@ def validate_contains(
     contains_cls_path_to_schemas: typing.Tuple[typing.Type[SchemaValidator], typing.List[PathToSchemasType]],
     cls: typing.Type,
     validation_metadata: ValidationMetadata,
-) -> typing.List[PathToSchemasType]:
+) -> typing.Optional[PathToSchemasType]:
     if not isinstance(arg, tuple):
-        return []
+        return None
     many_path_to_schemas = contains_cls_path_to_schemas[1]
     if not many_path_to_schemas:
         raise exceptions.ApiValueError(

--- a/samples/client/openapi_features/security/python/src/this_package/schemas/validation.py
+++ b/samples/client/openapi_features/security/python/src/this_package/schemas/validation.py
@@ -90,10 +90,10 @@ class SchemaValidator:
             and k
             not in validation_metadata.configuration.disabled_json_schema_python_keywords
         }
-        contains_qty = 0
+        contains_path_to_schemas = []
         path_to_schemas: PathToSchemasType = {}
         if 'contains' in vars(cls_schema):
-            contains_qty = _get_contains_qty(
+            contains_path_to_schemas = _get_contains_path_to_schemas(
                 arg,
                 vars(cls_schema)['contains'],
                 validation_metadata,
@@ -120,7 +120,7 @@ class SchemaValidator:
         for keyword, val in json_schema_data.items():
             used_val: typing.Any
             if keyword in {'contains', 'min_contains', 'max_contains'}:
-                used_val = (val, contains_qty)
+                used_val = (val, contains_path_to_schemas)
             elif keyword == 'items':
                 used_val = (val, prefix_items_length)
             elif keyword in {'unevaluated_items', 'unevaluated_properties'}:
@@ -1116,66 +1116,67 @@ def validate_else(
         raise ex
 
 
-def _get_contains_qty(
+def _get_contains_path_to_schemas(
     arg: typing.Any,
     contains_cls: typing.Type[SchemaValidator],
     validation_metadata: ValidationMetadata,
     path_to_schemas: PathToSchemasType
-) -> int:
+) -> typing.List[PathToSchemasType]:
     if not isinstance(arg, tuple):
-        return 0
+        return []
     contains_cls = _get_class(contains_cls)
-    these_path_to_schemas: PathToSchemasType = {}
-    contains_qty = 0
+    contains_path_to_schemas = []
     for i, value in enumerate(arg):
+        these_path_to_schemas: PathToSchemasType = {}
         item_validation_metadata = ValidationMetadata(
             path_to_item=validation_metadata.path_to_item+(i,),
             configuration=validation_metadata.configuration,
             validated_path_to_schemas=validation_metadata.validated_path_to_schemas
         )
         if item_validation_metadata.validation_ran_earlier(contains_cls):
-            add_deeper_validated_schemas(item_validation_metadata, path_to_schemas)
-            contains_qty += 1
+            add_deeper_validated_schemas(item_validation_metadata, these_path_to_schemas)
+            contains_path_to_schemas.append(these_path_to_schemas)
             continue
         try:
             other_path_to_schemas = contains_cls._validate(
                 value, validation_metadata=item_validation_metadata)
-            update(these_path_to_schemas, other_path_to_schemas)
-            contains_qty += 1
+            contains_path_to_schemas.append(other_path_to_schemas)
         except exceptions.OpenApiException:
             pass
-    if contains_qty:
-        update(path_to_schemas, these_path_to_schemas)
-    return contains_qty
+    return contains_path_to_schemas
 
 
 def validate_contains(
     arg: typing.Any,
-    contains_qty: typing.Tuple[typing.Type[SchemaValidator], int],
+    contains_cls_path_to_schemas: typing.Tuple[typing.Type[SchemaValidator], typing.List[PathToSchemasType]],
     cls: typing.Type,
     validation_metadata: ValidationMetadata,
-) -> typing.Optional[PathToSchemasType]:
+) -> typing.List[PathToSchemasType]:
     if not isinstance(arg, tuple):
-        return None
-    if not contains_qty[1]:
+        return []
+    many_path_to_schemas = contains_cls_path_to_schemas[1]
+    if not many_path_to_schemas:
         raise exceptions.ApiValueError(
             "Validation failed for contains keyword in class={} at path_to_item={}. No "
             "items validated to the contains schema.".format(cls, validation_metadata.path_to_item)
         )
-    return None
+    these_path_to_schemas: PathToSchemasType = {}
+    for other_path_to_schema in many_path_to_schemas:
+        update(these_path_to_schemas, other_path_to_schema)
+    return these_path_to_schemas
 
 
 def validate_min_contains(
     arg: typing.Any,
-    min_contains_and_qty: typing.Tuple[int, int],
+    min_contains_and_contains_path_to_schemas: typing.Tuple[int, typing.List[PathToSchemasType]],
     cls: typing.Type,
     validation_metadata: ValidationMetadata,
 ) -> typing.Optional[PathToSchemasType]:
     if not isinstance(arg, tuple):
         return None
-    min_contains = min_contains_and_qty[0]
-    contains_qty = min_contains_and_qty[1]
-    if not contains_qty or contains_qty < min_contains:
+    min_contains = min_contains_and_contains_path_to_schemas[0]
+    contains_path_to_schemas = min_contains_and_contains_path_to_schemas[1]
+    if len(contains_path_to_schemas) < min_contains:
         raise exceptions.ApiValueError(
             "Validation failed for minContains keyword in class={} at path_to_item={}. No "
             "items validated to the contains schema.".format(cls, validation_metadata.path_to_item)
@@ -1185,15 +1186,15 @@ def validate_min_contains(
 
 def validate_max_contains(
     arg: typing.Any,
-    max_contains_and_qty: typing.Tuple[int, int],
+    max_contains_and_contains_path_to_schemas: typing.Tuple[int, typing.List[PathToSchemasType]],
     cls: typing.Type,
     validation_metadata: ValidationMetadata,
 ) -> typing.Optional[PathToSchemasType]:
     if not isinstance(arg, tuple):
         return None
-    max_contains = max_contains_and_qty[0]
-    contains_qty = max_contains_and_qty[1]
-    if not contains_qty or contains_qty > max_contains:
+    max_contains = max_contains_and_contains_path_to_schemas[0]
+    contains_path_to_schemas = max_contains_and_contains_path_to_schemas[1]
+    if len(contains_path_to_schemas) > max_contains:
         raise exceptions.ApiValueError(
             "Validation failed for maxContains keyword in class={} at path_to_item={}. Too "
             "many items validated to the contains schema.".format(cls, validation_metadata.path_to_item)

--- a/samples/client/petstore/python/src/petstore_api/schemas/validation.py
+++ b/samples/client/petstore/python/src/petstore_api/schemas/validation.py
@@ -1151,9 +1151,9 @@ def validate_contains(
     contains_cls_path_to_schemas: typing.Tuple[typing.Type[SchemaValidator], typing.List[PathToSchemasType]],
     cls: typing.Type,
     validation_metadata: ValidationMetadata,
-) -> typing.List[PathToSchemasType]:
+) -> typing.Optional[PathToSchemasType]:
     if not isinstance(arg, tuple):
-        return []
+        return None
     many_path_to_schemas = contains_cls_path_to_schemas[1]
     if not many_path_to_schemas:
         raise exceptions.ApiValueError(

--- a/samples/client/petstore/python/src/petstore_api/schemas/validation.py
+++ b/samples/client/petstore/python/src/petstore_api/schemas/validation.py
@@ -90,10 +90,10 @@ class SchemaValidator:
             and k
             not in validation_metadata.configuration.disabled_json_schema_python_keywords
         }
-        contains_qty = 0
+        contains_path_to_schemas = []
         path_to_schemas: PathToSchemasType = {}
         if 'contains' in vars(cls_schema):
-            contains_qty = _get_contains_qty(
+            contains_path_to_schemas = _get_contains_path_to_schemas(
                 arg,
                 vars(cls_schema)['contains'],
                 validation_metadata,
@@ -120,7 +120,7 @@ class SchemaValidator:
         for keyword, val in json_schema_data.items():
             used_val: typing.Any
             if keyword in {'contains', 'min_contains', 'max_contains'}:
-                used_val = (val, contains_qty)
+                used_val = (val, contains_path_to_schemas)
             elif keyword == 'items':
                 used_val = (val, prefix_items_length)
             elif keyword in {'unevaluated_items', 'unevaluated_properties'}:
@@ -1116,66 +1116,67 @@ def validate_else(
         raise ex
 
 
-def _get_contains_qty(
+def _get_contains_path_to_schemas(
     arg: typing.Any,
     contains_cls: typing.Type[SchemaValidator],
     validation_metadata: ValidationMetadata,
     path_to_schemas: PathToSchemasType
-) -> int:
+) -> typing.List[PathToSchemasType]:
     if not isinstance(arg, tuple):
-        return 0
+        return []
     contains_cls = _get_class(contains_cls)
-    these_path_to_schemas: PathToSchemasType = {}
-    contains_qty = 0
+    contains_path_to_schemas = []
     for i, value in enumerate(arg):
+        these_path_to_schemas: PathToSchemasType = {}
         item_validation_metadata = ValidationMetadata(
             path_to_item=validation_metadata.path_to_item+(i,),
             configuration=validation_metadata.configuration,
             validated_path_to_schemas=validation_metadata.validated_path_to_schemas
         )
         if item_validation_metadata.validation_ran_earlier(contains_cls):
-            add_deeper_validated_schemas(item_validation_metadata, path_to_schemas)
-            contains_qty += 1
+            add_deeper_validated_schemas(item_validation_metadata, these_path_to_schemas)
+            contains_path_to_schemas.append(these_path_to_schemas)
             continue
         try:
             other_path_to_schemas = contains_cls._validate(
                 value, validation_metadata=item_validation_metadata)
-            update(these_path_to_schemas, other_path_to_schemas)
-            contains_qty += 1
+            contains_path_to_schemas.append(other_path_to_schemas)
         except exceptions.OpenApiException:
             pass
-    if contains_qty:
-        update(path_to_schemas, these_path_to_schemas)
-    return contains_qty
+    return contains_path_to_schemas
 
 
 def validate_contains(
     arg: typing.Any,
-    contains_qty: typing.Tuple[typing.Type[SchemaValidator], int],
+    contains_cls_path_to_schemas: typing.Tuple[typing.Type[SchemaValidator], typing.List[PathToSchemasType]],
     cls: typing.Type,
     validation_metadata: ValidationMetadata,
-) -> typing.Optional[PathToSchemasType]:
+) -> typing.List[PathToSchemasType]:
     if not isinstance(arg, tuple):
-        return None
-    if not contains_qty[1]:
+        return []
+    many_path_to_schemas = contains_cls_path_to_schemas[1]
+    if not many_path_to_schemas:
         raise exceptions.ApiValueError(
             "Validation failed for contains keyword in class={} at path_to_item={}. No "
             "items validated to the contains schema.".format(cls, validation_metadata.path_to_item)
         )
-    return None
+    these_path_to_schemas: PathToSchemasType = {}
+    for other_path_to_schema in many_path_to_schemas:
+        update(these_path_to_schemas, other_path_to_schema)
+    return these_path_to_schemas
 
 
 def validate_min_contains(
     arg: typing.Any,
-    min_contains_and_qty: typing.Tuple[int, int],
+    min_contains_and_contains_path_to_schemas: typing.Tuple[int, typing.List[PathToSchemasType]],
     cls: typing.Type,
     validation_metadata: ValidationMetadata,
 ) -> typing.Optional[PathToSchemasType]:
     if not isinstance(arg, tuple):
         return None
-    min_contains = min_contains_and_qty[0]
-    contains_qty = min_contains_and_qty[1]
-    if not contains_qty or contains_qty < min_contains:
+    min_contains = min_contains_and_contains_path_to_schemas[0]
+    contains_path_to_schemas = min_contains_and_contains_path_to_schemas[1]
+    if len(contains_path_to_schemas) < min_contains:
         raise exceptions.ApiValueError(
             "Validation failed for minContains keyword in class={} at path_to_item={}. No "
             "items validated to the contains schema.".format(cls, validation_metadata.path_to_item)
@@ -1185,15 +1186,15 @@ def validate_min_contains(
 
 def validate_max_contains(
     arg: typing.Any,
-    max_contains_and_qty: typing.Tuple[int, int],
+    max_contains_and_contains_path_to_schemas: typing.Tuple[int, typing.List[PathToSchemasType]],
     cls: typing.Type,
     validation_metadata: ValidationMetadata,
 ) -> typing.Optional[PathToSchemasType]:
     if not isinstance(arg, tuple):
         return None
-    max_contains = max_contains_and_qty[0]
-    contains_qty = max_contains_and_qty[1]
-    if not contains_qty or contains_qty > max_contains:
+    max_contains = max_contains_and_contains_path_to_schemas[0]
+    contains_path_to_schemas = max_contains_and_contains_path_to_schemas[1]
+    if len(contains_path_to_schemas) > max_contains:
         raise exceptions.ApiValueError(
             "Validation failed for maxContains keyword in class={} at path_to_item={}. Too "
             "many items validated to the contains schema.".format(cls, validation_metadata.path_to_item)

--- a/src/main/resources/python/schemas/validation.hbs
+++ b/src/main/resources/python/schemas/validation.hbs
@@ -98,10 +98,10 @@ class SchemaValidator:
                 'ensure_discriminator_value_present_exc': ensure_discriminator_value_present_exc
             }
 {{/if}}
-        contains_qty = 0
+        contains_path_to_schemas = 0
         path_to_schemas: PathToSchemasType = {}
         if 'contains' in vars(cls_schema):
-            contains_qty = _get_contains_qty(
+            contains_path_to_schemas = _get_contains_path_to_schemas(
                 arg,
                 vars(cls_schema)['contains'],
                 validation_metadata,
@@ -128,7 +128,7 @@ class SchemaValidator:
         for keyword, val in json_schema_data.items():
             used_val: typing.Any
             if keyword in {'contains', 'min_contains', 'max_contains'}:
-                used_val = (val, contains_qty)
+                used_val = (val, contains_path_to_schemas)
             elif keyword == 'items':
                 used_val = (val, prefix_items_length)
             elif keyword in {'unevaluated_items', 'unevaluated_properties'}:
@@ -1266,61 +1266,62 @@ def validate_else(
         raise ex
 
 
-def _get_contains_qty(
+def _get_contains_path_to_schemas(
     arg: typing.Any,
     contains_cls: typing.Type[SchemaValidator],
     validation_metadata: ValidationMetadata,
     path_to_schemas: PathToSchemasType
-) -> int:
+) -> typing.List[PathToSchemasType]:
     if not isinstance(arg, tuple):
-        return 0
+        return []
     contains_cls = _get_class(contains_cls)
-    these_path_to_schemas: PathToSchemasType = {}
-    contains_qty = 0
+    contains_path_to_schemas = []
     for i, value in enumerate(arg):
+        these_path_to_schemas: PathToSchemasType = {}
         item_validation_metadata = ValidationMetadata(
             path_to_item=validation_metadata.path_to_item+(i,),
             configuration=validation_metadata.configuration,
             validated_path_to_schemas=validation_metadata.validated_path_to_schemas
         )
         if item_validation_metadata.validation_ran_earlier(contains_cls):
-            add_deeper_validated_schemas(item_validation_metadata, path_to_schemas)
-            contains_qty += 1
+            add_deeper_validated_schemas(item_validation_metadata, these_path_to_schemas)
+            contains_path_to_schemas.append(these_path_to_schemas)
             continue
         try:
             other_path_to_schemas = contains_cls._validate(
                 value, validation_metadata=item_validation_metadata)
-            update(these_path_to_schemas, other_path_to_schemas)
-            contains_qty += 1
+            contains_path_to_schemas.append(other_path_to_schemas)
         except exceptions.OpenApiException:
             pass
-    if contains_qty:
-        update(path_to_schemas, these_path_to_schemas)
-    return contains_qty
+    return contains_path_to_schemas
 
 
 def validate_contains(
     arg: typing.Any,
-    contains_qty: typing.Tuple[typing.Type[SchemaValidator], int],
+    contains_cls_path_to_schemas: typing.Tuple[typing.Type[SchemaValidator], typing.List[PathToSchemasType]],
     cls: typing.Type,
     validation_metadata: ValidationMetadata,
 {{#if nonCompliantUseDiscriminatorIfCompositionFails}}
     **kwargs
 {{/if}}
-) -> typing.Optional[PathToSchemasType]:
+) -> typing.List[PathToSchemasType]:
     if not isinstance(arg, tuple):
-        return None
-    if not contains_qty[1]:
+        return []
+    many_path_to_schemas = contains_cls_path_to_schemas[1]
+    if not many_path_to_schemas:
         raise exceptions.ApiValueError(
             "Validation failed for contains keyword in class={} at path_to_item={}. No "
             "items validated to the contains schema.".format(cls, validation_metadata.path_to_item)
         )
-    return None
+    these_path_to_schemas: PathToSchemasType = {}
+    for other_path_to_schema in many_path_to_schemas:
+        update(these_path_to_schemas, other_path_to_schema)
+    return these_path_to_schemas
 
 
 def validate_min_contains(
     arg: typing.Any,
-    min_contains_and_qty: typing.Tuple[int, int],
+    min_contains_and_contains_path_to_schemas: typing.Tuple[int, typing.List[PathToSchemasType]],
     cls: typing.Type,
     validation_metadata: ValidationMetadata,
 {{#if nonCompliantUseDiscriminatorIfCompositionFails}}
@@ -1329,9 +1330,9 @@ def validate_min_contains(
 ) -> typing.Optional[PathToSchemasType]:
     if not isinstance(arg, tuple):
         return None
-    min_contains = min_contains_and_qty[0]
-    contains_qty = min_contains_and_qty[1]
-    if not contains_qty or contains_qty < min_contains:
+    min_contains = min_contains_and_contains_path_to_schemas[0]
+    contains_path_to_schemas = min_contains_and_contains_path_to_schemas[1]
+    if len(contains_path_to_schemas) < min_contains:
         raise exceptions.ApiValueError(
             "Validation failed for minContains keyword in class={} at path_to_item={}. No "
             "items validated to the contains schema.".format(cls, validation_metadata.path_to_item)
@@ -1341,7 +1342,7 @@ def validate_min_contains(
 
 def validate_max_contains(
     arg: typing.Any,
-    max_contains_and_qty: typing.Tuple[int, int],
+    max_contains_and_contains_path_to_schemas: typing.Tuple[int, typing.List[PathToSchemasType]],
     cls: typing.Type,
     validation_metadata: ValidationMetadata,
 {{#if nonCompliantUseDiscriminatorIfCompositionFails}}
@@ -1350,9 +1351,9 @@ def validate_max_contains(
 ) -> typing.Optional[PathToSchemasType]:
     if not isinstance(arg, tuple):
         return None
-    max_contains = max_contains_and_qty[0]
-    contains_qty = max_contains_and_qty[1]
-    if not contains_qty or contains_qty > max_contains:
+    max_contains = max_contains_and_contains_path_to_schemas[0]
+    contains_path_to_schemas = max_contains_and_contains_path_to_schemas[1]
+    if len(contains_path_to_schemas) > max_contains:
         raise exceptions.ApiValueError(
             "Validation failed for maxContains keyword in class={} at path_to_item={}. Too "
             "many items validated to the contains schema.".format(cls, validation_metadata.path_to_item)

--- a/src/main/resources/python/schemas/validation.hbs
+++ b/src/main/resources/python/schemas/validation.hbs
@@ -98,7 +98,7 @@ class SchemaValidator:
                 'ensure_discriminator_value_present_exc': ensure_discriminator_value_present_exc
             }
 {{/if}}
-        contains_path_to_schemas = 0
+        contains_path_to_schemas = []
         path_to_schemas: PathToSchemasType = {}
         if 'contains' in vars(cls_schema):
             contains_path_to_schemas = _get_contains_path_to_schemas(

--- a/src/main/resources/python/schemas/validation.hbs
+++ b/src/main/resources/python/schemas/validation.hbs
@@ -1304,9 +1304,9 @@ def validate_contains(
 {{#if nonCompliantUseDiscriminatorIfCompositionFails}}
     **kwargs
 {{/if}}
-) -> typing.List[PathToSchemasType]:
+) -> typing.Optional[PathToSchemasType]:
     if not isinstance(arg, tuple):
-        return []
+        return None
     many_path_to_schemas = contains_cls_path_to_schemas[1]
     if not many_path_to_schemas:
         raise exceptions.ApiValueError(


### PR DESCRIPTION
Improves contains validation by refactoring the python code for it
- only validation fns should be responsible for storing the fact that a payload is valid against n schemas
- before the PR a preprocessing helper fn was storing that info which it should not have been
- with this refactoring, the contains keyword can now be deactivated via the SchemaConfiguration class

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
