### PR TITLE
Java, adds schema validator test

### DIFF
--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -10,4 +10,5 @@ src/main/java/org/openapijsonschematools/schemas/validators/KeywordValidator.jav
 src/main/java/org/openapijsonschematools/schemas/validators/TypeValidator.java
 src/test/java/org/openapijsonschematools/configurations/JsonSchemaKeywordFlagsTest.java
 src/test/java/org/openapijsonschematools/schemas/CustomIsoparserTest.java
+src/test/java/org/openapijsonschematools/schemas/SchemaValidatorTest.java
 src/test/java/org/openapijsonschematools/schemas/validators/TypeValidatorTest.java

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/SchemaValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/SchemaValidator.java
@@ -3,8 +3,6 @@ package org.openapijsonschematools.schemas;
 import org.openapijsonschematools.schemas.validators.KeywordValidator;
 import org.openapijsonschematools.schemas.validators.TypeValidator;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.RecordComponent;
 import java.util.HashMap;
@@ -15,19 +13,14 @@ public interface SchemaValidator {
     static final HashMap<String, KeywordValidator> keywordToValidator = new HashMap(){{
         put("type", new TypeValidator());
     }};
-
-    static SchemaValidator withDefaults() {
-        return null;
-    }
-
     static PathToSchemasMap _validate(
             SchemaValidator schema,
             Object arg,
             ValidationMetadata validationMetadata
-    ) throws InstantiationException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
-        Class<SchemaValidator> schemaCls = (Class<SchemaValidator>) schema.getClass();
+    ) throws InvocationTargetException, IllegalAccessException {
         HashMap<String, Object> fieldsToValues = new HashMap<>();
         LinkedHashSet<String> disabledKeywords = validationMetadata.configuration().disabledKeywordFlags().getKeywords();
+        Class<SchemaValidator> schemaCls = (Class<SchemaValidator>) schema.getClass();
         RecordComponent[] recordComponents = schemaCls.getRecordComponents();
         for (RecordComponent recordComponent : recordComponents) {
             String fieldName = recordComponent.getName();

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/SchemaValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/SchemaValidatorTest.java
@@ -1,0 +1,49 @@
+package org.openapijsonschematools.schemas;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
+import org.openapijsonschematools.configurations.SchemaConfiguration;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+
+record SomeSchema(LinkedHashSet<Class<?>> type) implements SchemaValidator {
+    static SomeSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        type.add(String.class);
+        return new SomeSchema(type);
+    }
+
+    static PathToSchemasMap _validate(
+            Object arg,
+            ValidationMetadata validationMetadata
+    ) throws InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+        return SchemaValidator._validate(
+                SomeSchema.withDefaults(),
+                arg,
+                validationMetadata
+        );
+    }
+
+
+}
+
+public class SchemaValidatorTest {
+
+
+    @Test
+    public void testValidateSucceeds() throws InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+        ValidationMetadata validationMetadata = new ValidationMetadata(
+                new ArrayList<>(),
+                new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone()),
+                new PathToSchemasMap(),
+                new LinkedHashSet<>()
+        );
+        SomeSchema._validate(
+                "hi",
+                validationMetadata
+        );
+    }
+}

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -281,6 +281,10 @@ public class JavaClientGenerator extends AbstractJavaGenerator
                 "src/main/java/org/openapitools/schemas/SchemaValidator.hbs",
                 packagePath() + File.separatorChar + "schemas",
                 "SchemaValidator.java"));
+        supportingFiles.add(new SupportingFile(
+                "src/test/java/org/openapitools/schemas/SchemaValidatorTest.hbs",
+                testPackagePath() + File.separatorChar + "schemas",
+                "SchemaValidatorTest.java"));
 
         // keyword validators
         supportingFiles.add(new SupportingFile(

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/SchemaValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/SchemaValidator.hbs
@@ -3,30 +3,31 @@ package org.openapijsonschematools.schemas;
 import org.openapijsonschematools.schemas.validators.KeywordValidator;
 import org.openapijsonschematools.schemas.validators.TypeValidator;
 
-import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.RecordComponent;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 
-public class SchemaValidator {
+public interface SchemaValidator {
     static final HashMap<String, KeywordValidator> keywordToValidator = new HashMap()\{{
         put("type", new TypeValidator());
     }};
     static PathToSchemasMap _validate(
-            Class<SchemaValidator> cls,
+            SchemaValidator schema,
             Object arg,
             ValidationMetadata validationMetadata
-    ) throws InstantiationException, IllegalAccessException {
-        SchemaValidator clsSchema = cls.newInstance();
-        Field[] fields = cls.getDeclaredFields();
+    ) throws InvocationTargetException, IllegalAccessException {
         HashMap<String, Object> fieldsToValues = new HashMap<>();
         LinkedHashSet<String> disabledKeywords = validationMetadata.configuration().disabledKeywordFlags().getKeywords();
-        for (Field field : fields) {
-            String fieldName = field.getName();
+        Class<SchemaValidator> schemaCls = (Class<SchemaValidator>) schema.getClass();
+        RecordComponent[] recordComponents = schemaCls.getRecordComponents();
+        for (RecordComponent recordComponent : recordComponents) {
+            String fieldName = recordComponent.getName();
             if (disabledKeywords.contains(fieldName)) {
                 continue;
             }
-            Object value = field.get(clsSchema);
+            Object value = recordComponent.getAccessor().invoke(schema);
             fieldsToValues.put(fieldName, value);
         }
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
@@ -38,7 +39,7 @@ public class SchemaValidator {
                     arg,
                     value,
                     null,
-                    cls,
+                    schemaCls,
                     validationMetadata
             );
         }

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/SchemaValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/SchemaValidatorTest.hbs
@@ -1,8 +1,8 @@
-package org.openapijsonschematools.schemas;
+package {{{packageName}}}.schemas;
 
 import org.junit.Test;
-import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.configurations.SchemaConfiguration;
+import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
+import {{{packageName}}}.configurations.SchemaConfiguration;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;


### PR DESCRIPTION
Java, adds schema validator test

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
