### PR TITLE
Java, adds Schema interface

### DIFF
--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -2,9 +2,13 @@ README.md
 pom.xml
 src/main/java/org/openapijsonschematools/configurations/JsonSchemaKeywordFlags.java
 src/main/java/org/openapijsonschematools/configurations/SchemaConfiguration.java
+src/main/java/org/openapijsonschematools/schemas/AnyTypeSchema.java
 src/main/java/org/openapijsonschematools/schemas/CustomIsoparser.java
 src/main/java/org/openapijsonschematools/schemas/PathToSchemasMap.java
+src/main/java/org/openapijsonschematools/schemas/PathToTypeMap.java
+src/main/java/org/openapijsonschematools/schemas/Schema.java
 src/main/java/org/openapijsonschematools/schemas/SchemaValidator.java
+src/main/java/org/openapijsonschematools/schemas/UnsetAnyTypeSchema.java
 src/main/java/org/openapijsonschematools/schemas/ValidationMetadata.java
 src/main/java/org/openapijsonschematools/schemas/validators/KeywordValidator.java
 src/main/java/org/openapijsonschematools/schemas/validators/TypeValidator.java

--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -13,6 +13,7 @@ src/main/java/org/openapijsonschematools/schemas/ValidationMetadata.java
 src/main/java/org/openapijsonschematools/schemas/validators/KeywordValidator.java
 src/main/java/org/openapijsonschematools/schemas/validators/TypeValidator.java
 src/test/java/org/openapijsonschematools/configurations/JsonSchemaKeywordFlagsTest.java
+src/test/java/org/openapijsonschematools/schemas/AnyTypeSchemaTest.java
 src/test/java/org/openapijsonschematools/schemas/CustomIsoparserTest.java
 src/test/java/org/openapijsonschematools/schemas/SchemaValidatorTest.java
 src/test/java/org/openapijsonschematools/schemas/validators/TypeValidatorTest.java

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/AnyTypeSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/AnyTypeSchema.java
@@ -13,42 +13,42 @@ record AnyTypeSchema() implements Schema {
     }
 
     public static Void validate(Void arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+        return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }
 
     public static Boolean validate(Boolean arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+        return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }
 
     public static Integer validate(Integer arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+        return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }
 
     public static Float validate(Float arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+        return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }
 
     public static Double validate(Double arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+        return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }
 
     public static String validate(String arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+        return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }
 
     public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+        return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }
 
     public static String validate(LocalDate arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+        return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }
 
     public static <T extends Map> T validate(T arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+        return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }
 
     public static <U extends List> U validate(U arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+        return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/AnyTypeSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/AnyTypeSchema.java
@@ -1,0 +1,54 @@
+package org.openapijsonschematools.schemas;
+
+import org.openapijsonschematools.configurations.SchemaConfiguration;
+
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+
+record AnyTypeSchema() implements Schema {
+    public static AnyTypeSchema withDefaults() {
+        return new AnyTypeSchema();
+    }
+
+    public static Void validate(Void arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+    }
+
+    public static Boolean validate(Boolean arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+    }
+
+    public static Integer validate(Integer arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+    }
+
+    public static Float validate(Float arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+    }
+
+    public static Double validate(Double arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+    }
+
+    public static String validate(String arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+    }
+
+    public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+    }
+
+    public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+    }
+
+    public static <T extends Map> T validate(T arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+    }
+
+    public static <U extends List> U validate(U arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+    }
+}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/PathToSchemasMap.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/PathToSchemasMap.java
@@ -1,8 +1,20 @@
 package org.openapijsonschematools.schemas;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-public class PathToSchemasMap extends HashMap<List<Object>, Map<Class<?>, Void>> {
+public class PathToSchemasMap extends LinkedHashMap<List<Object>, LinkedHashMap<Class<?>, Void>> {
+
+    public void update(PathToSchemasMap other) {
+        for (Map.Entry<List<Object>, LinkedHashMap<Class<?>, Void>> entry: other.entrySet()) {
+            List<Object> pathToItem = entry.getKey();
+            LinkedHashMap<Class<?>, Void> otherSchemas = entry.getValue();
+            if (containsKey(pathToItem)) {
+                get(pathToItem).putAll(otherSchemas);
+            } else {
+                put(pathToItem, otherSchemas);
+            }
+        }
+    }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/PathToTypeMap.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/PathToTypeMap.java
@@ -1,0 +1,8 @@
+package org.openapijsonschematools.schemas;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class PathToTypeMap extends HashMap<List<Object>, Class<?>> {
+}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Schema.java
@@ -14,6 +14,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 public interface Schema<T extends Map, U extends List> extends SchemaValidator {
@@ -23,7 +24,7 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
          return null;
       } else if (arg instanceof String) {
          pathToType.put(pathToItem, String.class);
-         return (String) arg;
+         return arg;
       } else if (arg instanceof Map) {
          pathToType.put(pathToItem, Map.class);
          LinkedHashMap<String, Object> argFixed = new LinkedHashMap<>();
@@ -38,19 +39,19 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
          return argFixed;
       } else if (arg instanceof Boolean) {
          pathToType.put(pathToItem, Boolean.class);
-         return (Boolean) arg;
+         return arg;
       } else if (arg instanceof Integer) {
          pathToType.put(pathToItem, Integer.class);
-         return (Integer) arg;
+         return arg;
       } else if (arg instanceof Float) {
          pathToType.put(pathToItem, Float.class);
-         return (Float) arg;
+         return arg;
       } else if (arg instanceof Double) {
          pathToType.put(pathToItem, Double.class);
-         return (Double) arg;
+         return arg;
       } else if (arg instanceof BigDecimal) {
          pathToType.put(pathToItem, BigDecimal.class);
-         return (BigDecimal) arg;
+         return arg;
       } else if (arg instanceof List) {
          pathToType.put(pathToItem, List.class);
          List<Object> argFixed = new ArrayList<>();
@@ -123,7 +124,7 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
       ArrayList<Object> items = new ArrayList<>();
       List<Object> castItems = (List<Object>) arg;
       int i = 0;
-      for (Object item: items) {
+      for (Object item: castItems) {
          List<Object> itemPathToItem = new ArrayList<>(pathToItem);
          itemPathToItem.add(i);
          Class<Schema> itemClass = (Class<Schema>) pathToSchemas.get(itemPathToItem).entrySet().iterator().next().getKey();
@@ -151,10 +152,8 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
          usedArg = getProperties(arg, pathToItem, pathToSchemas);
       } else if (arg instanceof List) {
          usedArg = getItems(arg, pathToItem, pathToSchemas);
-      } else if (arg instanceof Boolean) {
-         return (Boolean) arg;
       } else {
-         // str, int, float, FileIO, bytes
+         // str, int, float, boolean, null, FileIO, bytes
          return arg;
       }
       Class<?> argType = arg.getClass();
@@ -167,43 +166,43 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
       return null;
    }
 
-   public static Void validateBase(Class<?> cls, Void arg, SchemaConfiguration configuration) {
+   static Void validateBase(Class<?> cls, Void arg, SchemaConfiguration configuration) {
       return (Void) validateObjectBase(cls, arg, configuration);
    }
 
-   public static Boolean validateBase(Class<?> cls, Boolean arg, SchemaConfiguration configuration) {
+   static Boolean validateBase(Class<?> cls, Boolean arg, SchemaConfiguration configuration) {
       return (Boolean) validateObjectBase(cls, arg, configuration);
    }
 
-   public static Integer validateBase(Class<?> cls, Integer arg, SchemaConfiguration configuration) {
+   static Integer validateBase(Class<?> cls, Integer arg, SchemaConfiguration configuration) {
       return (Integer) validateObjectBase(cls, arg, configuration);
    }
 
-   public static Float validateBase(Class<?> cls, Float arg, SchemaConfiguration configuration) {
+   static Float validateBase(Class<?> cls, Float arg, SchemaConfiguration configuration) {
       return (Float) validateObjectBase(cls, arg, configuration);
    }
 
-   public static Double validateBase(Class<?> cls, Double arg, SchemaConfiguration configuration) {
+   static Double validateBase(Class<?> cls, Double arg, SchemaConfiguration configuration) {
       return (Double) validateObjectBase(cls, arg, configuration);
    }
 
-   public static String validateBase(Class<?> cls, String arg, SchemaConfiguration configuration) {
+   static String validateBase(Class<?> cls, String arg, SchemaConfiguration configuration) {
       return (String) validateObjectBase(cls, arg, configuration);
    }
 
-   public static String validateBase(Class<?> cls, ZonedDateTime arg, SchemaConfiguration configuration) {
+   static String validateBase(Class<?> cls, ZonedDateTime arg, SchemaConfiguration configuration) {
       return (String) validateObjectBase(cls, arg, configuration);
    }
 
-   public static String validateBase(Class<?> cls, LocalDate arg, SchemaConfiguration configuration) {
+   static String validateBase(Class<?> cls, LocalDate arg, SchemaConfiguration configuration) {
       return (String) validateObjectBase(cls, arg, configuration);
    }
 
-   public static <T extends Map> T validateBase(Class<?> cls, T arg, SchemaConfiguration configuration) {
+   static <T extends Map> T validateBase(Class<?> cls, T arg, SchemaConfiguration configuration) {
       return (T) validateObjectBase(cls, arg, configuration);
    }
 
-   public static <U extends List> U validateBase(Class<?> cls, U arg, SchemaConfiguration configuration) {
+   static <U extends List> U validateBase(Class<?> cls, U arg, SchemaConfiguration configuration) {
       return (U) validateObjectBase(cls, arg, configuration);
    }
 
@@ -218,12 +217,7 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
       List<Object> pathToItem = new ArrayList<>();
       pathToItem.add("args[0]");
       Object castArg = castToAllowedTypes(arg, pathToItem, pathToType);
-      SchemaConfiguration usedConfiguration;
-      if (configuration != null) {
-         usedConfiguration = configuration;
-      } else {
-         usedConfiguration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
-      }
+      SchemaConfiguration usedConfiguration = Objects.requireNonNullElseGet(configuration, () -> new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone()));
       PathToSchemasMap validatedPathToSchemas = new PathToSchemasMap();
       ValidationMetadata validationMetadata = new ValidationMetadata(
               pathToItem,

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Schema.java
@@ -81,12 +81,8 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
       if (validationMetadata.validationRanEarlier(cls)) {
          // todo add deeper validated schemas
       } else {
-         try {
-            PathToSchemasMap otherPathToSchemas = SchemaValidator._validate(cls, arg, validationMetadata);
-            pathToSchemasMap.update(otherPathToSchemas);
-         } catch (InvocationTargetException | IllegalAccessException e) {
-            throw new RuntimeException(e);
-         }
+         PathToSchemasMap otherPathToSchemas = SchemaValidator.validate(cls, arg, validationMetadata);
+         pathToSchemasMap.update(otherPathToSchemas);
          for (LinkedHashMap<Class<?>, Void> schemas: pathToSchemasMap.values()) {
             Class<?> firstSchema = schemas.entrySet().iterator().next().getKey();
             schemas.clear();
@@ -166,49 +162,49 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
       return null;
    }
 
-   static Void validateBase(Class<?> cls, Void arg, SchemaConfiguration configuration) {
-      return (Void) validateObjectBase(cls, arg, configuration);
+   static Void validate(Class<?> cls, Void arg, SchemaConfiguration configuration) {
+      return (Void) validateObject(cls, arg, configuration);
    }
 
-   static Boolean validateBase(Class<?> cls, Boolean arg, SchemaConfiguration configuration) {
-      return (Boolean) validateObjectBase(cls, arg, configuration);
+   static Boolean validate(Class<?> cls, Boolean arg, SchemaConfiguration configuration) {
+      return (Boolean) validateObject(cls, arg, configuration);
    }
 
-   static Integer validateBase(Class<?> cls, Integer arg, SchemaConfiguration configuration) {
-      return (Integer) validateObjectBase(cls, arg, configuration);
+   static Integer validate(Class<?> cls, Integer arg, SchemaConfiguration configuration) {
+      return (Integer) validateObject(cls, arg, configuration);
    }
 
-   static Float validateBase(Class<?> cls, Float arg, SchemaConfiguration configuration) {
-      return (Float) validateObjectBase(cls, arg, configuration);
+   static Float validate(Class<?> cls, Float arg, SchemaConfiguration configuration) {
+      return (Float) validateObject(cls, arg, configuration);
    }
 
-   static Double validateBase(Class<?> cls, Double arg, SchemaConfiguration configuration) {
-      return (Double) validateObjectBase(cls, arg, configuration);
+   static Double validate(Class<?> cls, Double arg, SchemaConfiguration configuration) {
+      return (Double) validateObject(cls, arg, configuration);
    }
 
-   static String validateBase(Class<?> cls, String arg, SchemaConfiguration configuration) {
-      return (String) validateObjectBase(cls, arg, configuration);
+   static String validate(Class<?> cls, String arg, SchemaConfiguration configuration) {
+      return (String) validateObject(cls, arg, configuration);
    }
 
-   static String validateBase(Class<?> cls, ZonedDateTime arg, SchemaConfiguration configuration) {
-      return (String) validateObjectBase(cls, arg, configuration);
+   static String validate(Class<?> cls, ZonedDateTime arg, SchemaConfiguration configuration) {
+      return (String) validateObject(cls, arg, configuration);
    }
 
-   static String validateBase(Class<?> cls, LocalDate arg, SchemaConfiguration configuration) {
-      return (String) validateObjectBase(cls, arg, configuration);
+   static String validate(Class<?> cls, LocalDate arg, SchemaConfiguration configuration) {
+      return (String) validateObject(cls, arg, configuration);
    }
 
-   static <T extends Map> T validateBase(Class<?> cls, T arg, SchemaConfiguration configuration) {
-      return (T) validateObjectBase(cls, arg, configuration);
+   static <T extends Map> T validate(Class<?> cls, T arg, SchemaConfiguration configuration) {
+      return (T) validateObject(cls, arg, configuration);
    }
 
-   static <U extends List> U validateBase(Class<?> cls, U arg, SchemaConfiguration configuration) {
-      return (U) validateObjectBase(cls, arg, configuration);
+   static <U extends List> U validate(Class<?> cls, U arg, SchemaConfiguration configuration) {
+      return (U) validateObject(cls, arg, configuration);
    }
 
    // todo add bytes and FileIO
 
-   private static Object validateObjectBase(Class<?> cls, Object arg, SchemaConfiguration configuration) {
+   private static Object validateObject(Class<?> cls, Object arg, SchemaConfiguration configuration) {
       Class<Schema> castCls = (Class<Schema>) cls;
       if (arg instanceof Map || arg instanceof List) {
          // todo don't run validation if the instance is one of the class generic types

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Schema.java
@@ -1,0 +1,393 @@
+package org.openapijsonschematools.schemas;
+
+import org.openapijsonschematools.configurations.SchemaConfiguration;
+
+import java.math.BigDecimal;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public interface Schema extends SchemaValidator {
+   static Object castToAllowedTypes(Object arg, List<Object> pathToItem, PathToTypeMap pathToType) {
+      RuntimeException strTypeError = new RuntimeException("Invalid type. Required value type is str and passed type was {type(arg)} at {path_to_item}");
+      if (arg == null) {
+         pathToType.put(pathToItem, Void.class);
+         return null;
+      } else if (arg instanceof String) {
+         pathToType.put(pathToItem, String.class);
+         return (String) arg;
+      } else if (arg instanceof Map) {
+         pathToType.put(pathToItem, Map.class);
+         LinkedHashMap<String, Object> argFixed = new LinkedHashMap<>();
+         for (Map.Entry<?, ?> entry: ((Map<?, ?>) arg).entrySet()) {
+            String key = (String) entry.getKey();
+            Object val = entry.getValue();
+            List<Object> newPathToItem = new ArrayList<>();
+            newPathToItem.addAll(pathToItem);
+            newPathToItem.add(key);
+            Object fixedVal = castToAllowedTypes(val, newPathToItem, pathToType);
+            argFixed.put(key, fixedVal);
+         }
+         return argFixed;
+      } else if (arg instanceof Boolean) {
+         pathToType.put(pathToItem, Boolean.class);
+         return (Boolean) arg;
+      } else if (arg instanceof Integer) {
+         pathToType.put(pathToItem, Integer.class);
+         return (Integer) arg;
+      } else if (arg instanceof Float) {
+         pathToType.put(pathToItem, Float.class);
+         return (Float) arg;
+      } else if (arg instanceof Double) {
+         pathToType.put(pathToItem, Double.class);
+         return (Double) arg;
+      } else if (arg instanceof BigDecimal) {
+         pathToType.put(pathToItem, BigDecimal.class);
+         return (BigDecimal) arg;
+      } else if (arg instanceof List) {
+         pathToType.put(pathToItem, List.class);
+         List<Object> argFixed = new ArrayList<>();
+         int i =0;
+         for (Object item: ((List<?>) arg).toArray()) {
+            List<Object> newPathToItem = new ArrayList<>();
+            newPathToItem.addAll(pathToItem);
+            newPathToItem.add(i);
+            Object fixedVal = castToAllowedTypes(item, newPathToItem, pathToType);
+            argFixed.add(fixedVal);
+            i += 1;
+         }
+         return argFixed;
+      } else if (arg instanceof ZonedDateTime) {
+         pathToType.put(pathToItem, String.class);
+         return arg.toString();
+      } else if (arg instanceof LocalDate) {
+         pathToType.put(pathToItem, String.class);
+         return arg.toString();
+      } else {
+         Class<?> argClass = arg.getClass();
+         throw new RuntimeException("Invalid type passed in got input="+arg+" type="+argClass);
+      }
+   }
+
+   static Object validateBase(Class<Schema> cls, Object arg, SchemaConfiguration configuration) {
+      if (arg instanceof Map || arg instanceof List) {
+         // todo
+      }
+      // todo cast to allowed types
+      PathToTypeMap pathToType = new PathToTypeMap();
+      List<Object> pathToItem = new ArrayList<>();
+      pathToItem.add("args[0]");
+      Object castArg = castToAllowedTypes(arg, pathToItem, pathToType);
+      return null;
+   }
+   /**
+    *         if isinstance(arg, (tuple, validation.immutabledict)):
+    *             type_to_output_cls = cls.__get_type_to_output_cls()
+    *             if type_to_output_cls is not None:
+    *                 for output_cls in type_to_output_cls.values():
+    *                     if isinstance(arg, output_cls):
+    *                         # U + T use case, don't run validations twice
+    *                         return arg
+    *
+    *         from_server = False
+    *         validated_path_to_schemas: typing.Dict[
+    *             typing.Tuple[typing.Union[str, int], ...],
+    *             typing.Set[typing.Union[str, int, float, bool, None, validation.immutabledict, tuple]]
+    *         ] = {}
+    *         path_to_type: typing.Dict[typing.Tuple[typing.Union[str, int], ...], type] = {}
+    *         cast_arg = cast_to_allowed_types(
+    *             arg, from_server, validated_path_to_schemas, ('args[0]',), path_to_type)
+    *         validation_metadata = validation.ValidationMetadata(
+    *             path_to_item=('args[0]',),
+    *             configuration=configuration or schema_configuration.SchemaConfiguration(),
+    *             validated_path_to_schemas=validation.immutabledict(validated_path_to_schemas)
+    *         )
+    *         path_to_schemas = cls.__get_path_to_schemas(cast_arg, validation_metadata, path_to_type)
+    *         return cls._get_new_instance_without_conversion(
+    *             cast_arg,
+    *             validation_metadata.path_to_item,
+    *             path_to_schemas,
+    *         )
+    */
+
+}
+/**
+ * class Schema(typing.Generic[T, U], validation.SchemaValidator, metaclass=SingletonMeta):
+ *
+ *     @classmethod
+ *     def __get_path_to_schemas(
+ *         cls,
+ *         arg,
+ *         validation_metadata: validation.ValidationMetadata,
+ *         path_to_type: typing.Dict[typing.Tuple[typing.Union[str, int], ...], typing.Type]
+ *     ) -> typing.Dict[typing.Tuple[typing.Union[str, int], ...], typing.Type[Schema]]:
+ *         """
+ *         Run all validations in the json schema and return a dict of
+ *         json schema to tuple of validated schemas
+ *         """
+ *         _path_to_schemas: validation.PathToSchemasType = {}
+ *         if validation_metadata.validation_ran_earlier(cls):
+ *             validation.add_deeper_validated_schemas(validation_metadata, _path_to_schemas)
+ *         else:
+ *             other_path_to_schemas = cls._validate(arg, validation_metadata=validation_metadata)
+ *             validation.update(_path_to_schemas, other_path_to_schemas)
+ *         # loop through it make a new class for each entry
+ *         # do not modify the returned result because it is cached and we would be modifying the cached value
+ *         path_to_schemas: typing.Dict[typing.Tuple[typing.Union[str, int], ...], typing.Type[Schema]] = {}
+ *         for path, schema_classes in _path_to_schemas.items():
+ *             schema = typing.cast(typing.Type[Schema], tuple(schema_classes)[-1])
+ *             path_to_schemas[path] = schema
+ *         """
+ *         For locations that validation did not check
+ *         the code still needs to store type + schema information for instantiation
+ *         All of those schemas will be UnsetAnyTypeSchema
+ *         """
+ *         missing_paths = path_to_type.keys() - path_to_schemas.keys()
+ *         for missing_path in missing_paths:
+ *             path_to_schemas[missing_path] = UnsetAnyTypeSchema
+ *
+ *         return path_to_schemas
+ *
+ *     @staticmethod
+ *     def __get_items(
+ *         arg: tuple,
+ *         path_to_item: typing.Tuple[typing.Union[str, int], ...],
+ *         path_to_schemas: typing.Dict[typing.Tuple[typing.Union[str, int], ...], typing.Type[Schema]]
+ *     ):
+ *         '''
+ *         Schema __get_items
+ *         '''
+ *         cast_items = []
+ *
+ *         for i, value in enumerate(arg):
+ *             item_path_to_item = path_to_item + (i,)
+ *             item_cls = path_to_schemas[item_path_to_item]
+ *             new_value = item_cls._get_new_instance_without_conversion(
+ *                 value,
+ *                 item_path_to_item,
+ *                 path_to_schemas
+ *             )
+ *             cast_items.append(new_value)
+ *
+ *         return tuple(cast_items)
+ *
+ *     @staticmethod
+ *     def __get_properties(
+ *         arg: validation.immutabledict[str, typing.Any],
+ *         path_to_item: typing.Tuple[typing.Union[str, int], ...],
+ *         path_to_schemas: typing.Dict[typing.Tuple[typing.Union[str, int], ...], typing.Type[Schema]]
+ *     ):
+ *         """
+ *         Schema __get_properties, this is how properties are set
+ *         These values already passed validation
+ *         """
+ *         dict_items = {}
+ *
+ *         for property_name_js, value in arg.items():
+ *             property_path_to_item = path_to_item + (property_name_js,)
+ *             property_cls = path_to_schemas[property_path_to_item]
+ *             new_value = property_cls._get_new_instance_without_conversion(
+ *                 value,
+ *                 property_path_to_item,
+ *                 path_to_schemas
+ *             )
+ *             dict_items[property_name_js] = new_value
+ *
+ *         return validation.immutabledict(dict_items)
+ *
+ *     @classmethod
+ *     def _get_new_instance_without_conversion(
+ *         cls,
+ *         arg: typing.Union[int, float, None, Bool, str, validation.immutabledict, tuple, FileIO, bytes],
+ *         path_to_item: typing.Tuple[typing.Union[str, int], ...],
+ *         path_to_schemas: typing.Dict[typing.Tuple[typing.Union[str, int], ...], typing.Type[Schema]]
+ *     ):
+ *         # We have a Dynamic class and we are making an instance of it
+ *         if isinstance(arg, validation.immutabledict):
+ *             used_arg = cls.__get_properties(arg, path_to_item, path_to_schemas)
+ *         elif isinstance(arg, tuple):
+ *             used_arg = cls.__get_items(arg, path_to_item, path_to_schemas)
+ *         elif isinstance(arg, Bool):
+ *             return bool(arg)
+ *         else:
+ *             """
+ *             str, int, float, FileIO, bytes
+ *             FileIO = openapi binary type and the user inputs a file
+ *             bytes = openapi binary type and the user inputs bytes
+ *             """
+ *             return arg
+ *         arg_type = type(arg)
+ *         type_to_output_cls = cls.__get_type_to_output_cls()
+ *         if type_to_output_cls is None:
+ *             return used_arg
+ *         if arg_type not in type_to_output_cls:
+ *             return used_arg
+ *         output_cls = type_to_output_cls[arg_type]
+ *         if arg_type is tuple:
+ *             inst = super(output_cls, output_cls).__new__(output_cls, used_arg) # type: ignore
+ *             inst = typing.cast(U, inst)
+ *             return inst
+ *         assert issubclass(output_cls, validation.immutabledict)
+ *         inst = super(output_cls, output_cls).__new__(output_cls, used_arg) # type: ignore
+ *         inst = typing.cast(T, inst)
+ *         return inst
+ *
+ *     @typing.overload
+ *     @classmethod
+ *     def validate_base(
+ *         cls,
+ *         arg: None,
+ *         configuration: typing.Optional[schema_configuration.SchemaConfiguration] = None
+ *     ) -> None: ...
+ *
+ *     @typing.overload
+ *     @classmethod
+ *     def validate_base(
+ *         cls,
+ *         arg: typing.Literal[True],
+ *         configuration: typing.Optional[schema_configuration.SchemaConfiguration] = None
+ *     ) -> typing.Literal[True]: ...
+ *
+ *     @typing.overload
+ *     @classmethod
+ *     def validate_base(
+ *         cls,
+ *         arg: typing.Literal[False],
+ *         configuration: typing.Optional[schema_configuration.SchemaConfiguration] = None
+ *     ) -> typing.Literal[False]: ...
+ *
+ *     @typing.overload
+ *     @classmethod
+ *     def validate_base(
+ *         cls,
+ *         arg: bool,
+ *         configuration: typing.Optional[schema_configuration.SchemaConfiguration] = None
+ *     ) -> bool: ...
+ *
+ *     @typing.overload
+ *     @classmethod
+ *     def validate_base(
+ *         cls,
+ *         arg: int,
+ *         configuration: typing.Optional[schema_configuration.SchemaConfiguration] = None
+ *     ) -> int: ...
+ *
+ *     @typing.overload
+ *     @classmethod
+ *     def validate_base(
+ *         cls,
+ *         arg: float,
+ *         configuration: typing.Optional[schema_configuration.SchemaConfiguration] = None
+ *     ) -> float: ...
+ *
+ *     @typing.overload
+ *     @classmethod
+ *     def validate_base(
+ *         cls,
+ *         arg: typing.Union[str, datetime.date, datetime.datetime, uuid.UUID],
+ *         configuration: typing.Optional[schema_configuration.SchemaConfiguration] = None
+ *     ) -> str: ...
+ *
+ *     @typing.overload
+ *     @classmethod
+ *     def validate_base(
+ *         cls,
+ *         arg: SequenceNotStr[INPUT_TYPES_ALL],
+ *         configuration: typing.Optional[schema_configuration.SchemaConfiguration] = None
+ *     ) -> U: ...
+ *
+ *     @typing.overload
+ *     @classmethod
+ *     def validate_base(
+ *         cls,
+ *         arg: U,
+ *         configuration: typing.Optional[schema_configuration.SchemaConfiguration] = None
+ *     ) -> U: ...
+ *
+ *     @typing.overload
+ *     @classmethod
+ *     def validate_base(
+ *         cls,
+ *         arg: typing.Mapping[str, object],  # object needed as value type for typeddict inputs
+ *         configuration: typing.Optional[schema_configuration.SchemaConfiguration] = None
+ *     ) -> T: ...
+ *
+ *     @typing.overload
+ *     @classmethod
+ *     def validate_base(
+ *         cls,
+ *         arg: typing.Union[
+ *             typing.Mapping[str, INPUT_TYPES_ALL],
+ *             T
+ *         ],
+ *         configuration: typing.Optional[schema_configuration.SchemaConfiguration] = None
+ *     ) -> T: ...
+ *
+ *     @typing.overload
+ *     @classmethod
+ *     def validate_base(
+ *         cls,
+ *         arg: typing.Union[io.FileIO, io.BufferedReader],
+ *         configuration: typing.Optional[schema_configuration.SchemaConfiguration] = None
+ *     ) -> FileIO: ...
+ *
+ *     @typing.overload
+ *     @classmethod
+ *     def validate_base(
+ *         cls,
+ *         arg: bytes,
+ *         configuration: typing.Optional[schema_configuration.SchemaConfiguration] = None
+ *     ) -> bytes: ...
+ *
+ *     @classmethod
+ *     def validate_base(
+ *         cls,
+ *         arg,
+ *         configuration: typing.Optional[schema_configuration.SchemaConfiguration] = None,
+ *     ):
+ *         """
+ *         Schema validate_base
+ *
+ *         Args:
+ *             arg (int/float/str/list/tuple/dict/validation.immutabledict/bool/None): the value
+ *             configuration: contains the schema_configuration.SchemaConfiguration that enables json schema validation keywords
+ *                 like minItems, minLength etc
+ *         """
+ *         if isinstance(arg, (tuple, validation.immutabledict)):
+ *             type_to_output_cls = cls.__get_type_to_output_cls()
+ *             if type_to_output_cls is not None:
+ *                 for output_cls in type_to_output_cls.values():
+ *                     if isinstance(arg, output_cls):
+ *                         # U + T use case, don't run validations twice
+ *                         return arg
+ *
+ *         from_server = False
+ *         validated_path_to_schemas: typing.Dict[
+ *             typing.Tuple[typing.Union[str, int], ...],
+ *             typing.Set[typing.Union[str, int, float, bool, None, validation.immutabledict, tuple]]
+ *         ] = {}
+ *         path_to_type: typing.Dict[typing.Tuple[typing.Union[str, int], ...], type] = {}
+ *         cast_arg = cast_to_allowed_types(
+ *             arg, from_server, validated_path_to_schemas, ('args[0]',), path_to_type)
+ *         validation_metadata = validation.ValidationMetadata(
+ *             path_to_item=('args[0]',),
+ *             configuration=configuration or schema_configuration.SchemaConfiguration(),
+ *             validated_path_to_schemas=validation.immutabledict(validated_path_to_schemas)
+ *         )
+ *         path_to_schemas = cls.__get_path_to_schemas(cast_arg, validation_metadata, path_to_type)
+ *         return cls._get_new_instance_without_conversion(
+ *             cast_arg,
+ *             validation_metadata.path_to_item,
+ *             path_to_schemas,
+ *         )
+ *
+ *     @classmethod
+ *     def __get_type_to_output_cls(cls) -> typing.Optional[typing.Mapping[type, type]]:
+ *         type_to_output_cls = getattr(cls(), 'type_to_output_cls', None)
+ *         type_to_output_cls = typing.cast(typing.Optional[typing.Mapping[type, type]], type_to_output_cls)
+ *         return type_to_output_cls
+ */

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Schema.java
@@ -18,7 +18,7 @@ import java.util.Objects;
 import java.util.Set;
 
 public interface Schema<T extends Map, U extends List> extends SchemaValidator {
-   static Object castToAllowedTypes(Object arg, List<Object> pathToItem, PathToTypeMap pathToType) {
+   private static Object castToAllowedTypes(Object arg, List<Object> pathToItem, PathToTypeMap pathToType) {
       if (arg == null) {
          pathToType.put(pathToItem, Void.class);
          return null;
@@ -76,7 +76,7 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
       }
    }
 
-   static PathToSchemasMap getPathToSchemas(Class<Schema> cls, Object arg, ValidationMetadata validationMetadata, PathToTypeMap pathToType) {
+   private static PathToSchemasMap getPathToSchemas(Class<Schema> cls, Object arg, ValidationMetadata validationMetadata, PathToTypeMap pathToType) {
       PathToSchemasMap pathToSchemasMap = new PathToSchemasMap();
       if (validationMetadata.validationRanEarlier(cls)) {
          // todo add deeper validated schemas
@@ -105,7 +105,7 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
       return pathToSchemasMap;
    }
 
-   static LinkedHashMap<String, Object> getProperties(Object arg, List<Object> pathToItem, PathToSchemasMap pathToSchemas) {
+   private static LinkedHashMap<String, Object> getProperties(Object arg, List<Object> pathToItem, PathToSchemasMap pathToSchemas) {
       LinkedHashMap<String, Object> properties = new LinkedHashMap<>();
       Map<String, Object> castArg = (Map<String, Object>) arg;
       for(Map.Entry<String, Object> entry: castArg.entrySet()) {
@@ -120,7 +120,7 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
       return properties;
    }
 
-   static List<Object> getItems(Object arg, List<Object> pathToItem, PathToSchemasMap pathToSchemas) {
+   private static List<Object> getItems(Object arg, List<Object> pathToItem, PathToSchemasMap pathToSchemas) {
       ArrayList<Object> items = new ArrayList<>();
       List<Object> castItems = (List<Object>) arg;
       int i = 0;
@@ -135,7 +135,7 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
       return items;
    }
 
-   static Map<Class<?>, Class<?>> getTypeToOutputClass(Class<?> cls) {
+   private static Map<Class<?>, Class<?>> getTypeToOutputClass(Class<?> cls) {
       try {
          // This must be implemented in Schemas that are generics as a static method
          Method method = cls.getMethod("typeToOutputClass");
@@ -146,7 +146,7 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
       }
    }
 
-   static Object getNewInstance(Class<Schema> cls, Object arg, List<Object> pathToItem, PathToSchemasMap pathToSchemas) {
+   private static Object getNewInstance(Class<Schema> cls, Object arg, List<Object> pathToItem, PathToSchemasMap pathToSchemas) {
       Object usedArg;
       if (arg instanceof Map) {
          usedArg = getProperties(arg, pathToItem, pathToSchemas);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Schema.java
@@ -13,7 +13,6 @@ import java.util.Map;
 
 public interface Schema extends SchemaValidator {
    static Object castToAllowedTypes(Object arg, List<Object> pathToItem, PathToTypeMap pathToType) {
-      RuntimeException strTypeError = new RuntimeException("Invalid type. Required value type is str and passed type was {type(arg)} at {path_to_item}");
       if (arg == null) {
          pathToType.put(pathToItem, Void.class);
          return null;

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/SchemaValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/SchemaValidator.java
@@ -7,6 +7,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.RecordComponent;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 
 public interface SchemaValidator {
@@ -43,6 +44,14 @@ public interface SchemaValidator {
                     validationMetadata
             );
         }
+        Class<?> baseClass = arg.getClass();
+        List<Object> pathToItem = validationMetadata.pathToItem();
+        if (!pathToSchemas.containsKey(pathToItem)) {
+            pathToSchemas.put(validationMetadata.pathToItem(), new HashMap<>());
+        }
+        pathToSchemas.get(pathToItem).put(baseClass, null);
+        pathToSchemas.get(pathToItem).put(schemaCls, null);
+
         return pathToSchemas;
     }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/SchemaValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/SchemaValidator.java
@@ -7,6 +7,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.RecordComponent;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -54,7 +55,7 @@ public interface SchemaValidator {
         Class<?> baseClass = arg.getClass();
         List<Object> pathToItem = validationMetadata.pathToItem();
         if (!pathToSchemas.containsKey(pathToItem)) {
-            pathToSchemas.put(validationMetadata.pathToItem(), new HashMap<>());
+            pathToSchemas.put(validationMetadata.pathToItem(), new LinkedHashMap<>());
         }
         pathToSchemas.get(pathToItem).put(baseClass, null);
         pathToSchemas.get(pathToItem).put(schemaCls, null);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/SchemaValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/SchemaValidator.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Map;
 
 public interface SchemaValidator {
-    static final HashMap<String, KeywordValidator> keywordToValidator = new HashMap(){{
+    HashMap<String, KeywordValidator> keywordToValidator = new HashMap(){{
         put("type", new TypeValidator());
     }};
 
@@ -22,7 +22,7 @@ public interface SchemaValidator {
             ValidationMetadata validationMetadata
     ) throws InvocationTargetException, IllegalAccessException {
         HashMap<String, Object> fieldsToValues = new HashMap<>();
-        SchemaValidator schema = null;
+        SchemaValidator schema;
         try {
             schema = (SchemaValidator) schemaCls.getMethod("withDefaults").invoke(null);
         } catch (NoSuchMethodException e) {
@@ -51,8 +51,17 @@ public interface SchemaValidator {
                     castSchemaCls,
                     validationMetadata
             );
+            if (otherPathToSchemas == null) {
+                continue;
+            }
+            pathToSchemas.update(otherPathToSchemas);
         }
-        Class<?> baseClass = arg.getClass();
+        Class<?> baseClass;
+        if (arg == null) {
+            baseClass = Void.class;
+        } else {
+            baseClass = arg.getClass();
+        }
         List<Object> pathToItem = validationMetadata.pathToItem();
         if (!pathToSchemas.containsKey(pathToItem)) {
             pathToSchemas.put(validationMetadata.pathToItem(), new LinkedHashMap<>());

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/UnsetAnyTypeSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/UnsetAnyTypeSchema.java
@@ -8,47 +8,47 @@ import java.util.List;
 import java.util.Map;
 
 record UnsetAnyTypeSchema() implements Schema {
-    public static UnsetAnyTypeSchema withDefaults() {
+    static UnsetAnyTypeSchema withDefaults() {
         return new UnsetAnyTypeSchema();
     }
 
-    public static Void validate(Void arg, SchemaConfiguration configuration) {
+    static Void validate(Void arg, SchemaConfiguration configuration) {
         return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
-    public static Boolean validate(Boolean arg, SchemaConfiguration configuration) {
+    static Boolean validate(Boolean arg, SchemaConfiguration configuration) {
         return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
-    public static Integer validate(Integer arg, SchemaConfiguration configuration) {
+    static Integer validate(Integer arg, SchemaConfiguration configuration) {
         return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
-    public static Float validate(Float arg, SchemaConfiguration configuration) {
+    static Float validate(Float arg, SchemaConfiguration configuration) {
         return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
-    public static Double validate(Double arg, SchemaConfiguration configuration) {
+    static Double validate(Double arg, SchemaConfiguration configuration) {
         return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
-    public static String validate(String arg, SchemaConfiguration configuration) {
+    static String validate(String arg, SchemaConfiguration configuration) {
         return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
-    public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+    static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
         return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
-    public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+    static String validate(LocalDate arg, SchemaConfiguration configuration) {
         return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
-    public static <T extends Map> T validate(T arg, SchemaConfiguration configuration) {
+    static <T extends Map> T validate(T arg, SchemaConfiguration configuration) {
         return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
-    public static <U extends List> U validate(U arg, SchemaConfiguration configuration) {
+    static <U extends List> U validate(U arg, SchemaConfiguration configuration) {
         return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
     }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/UnsetAnyTypeSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/UnsetAnyTypeSchema.java
@@ -13,42 +13,42 @@ record UnsetAnyTypeSchema() implements Schema {
     }
 
     static Void validate(Void arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+        return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
     static Boolean validate(Boolean arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+        return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
     static Integer validate(Integer arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+        return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
     static Float validate(Float arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+        return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
     static Double validate(Double arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+        return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
     static String validate(String arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+        return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
     static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+        return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
     static String validate(LocalDate arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+        return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
     static <T extends Map> T validate(T arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+        return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
     static <U extends List> U validate(U arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+        return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/UnsetAnyTypeSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/UnsetAnyTypeSchema.java
@@ -1,0 +1,54 @@
+package org.openapijsonschematools.schemas;
+
+import org.openapijsonschematools.configurations.SchemaConfiguration;
+
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+
+record UnsetAnyTypeSchema() implements Schema {
+    public static UnsetAnyTypeSchema withDefaults() {
+        return new UnsetAnyTypeSchema();
+    }
+
+    public static Void validate(Void arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+    }
+
+    public static Boolean validate(Boolean arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+    }
+
+    public static Integer validate(Integer arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+    }
+
+    public static Float validate(Float arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+    }
+
+    public static Double validate(Double arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+    }
+
+    public static String validate(String arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+    }
+
+    public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+    }
+
+    public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+    }
+
+    public static <T extends Map> T validate(T arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+    }
+
+    public static <U extends List> U validate(U arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+    }
+}

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/AnyTypeSchemaTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/AnyTypeSchemaTest.java
@@ -8,6 +8,10 @@ import org.openapijsonschematools.configurations.SchemaConfiguration;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 public class AnyTypeSchemaTest {
     static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
@@ -61,5 +65,25 @@ public class AnyTypeSchemaTest {
     public void testValidateLocalDate() {
         String validatedValue = AnyTypeSchema.validate(LocalDate.of(2017, 7, 21), configuration);
         Assert.assertEquals(validatedValue, "2017-07-21");
+    }
+
+    @Test
+    public void testValidateMap() {
+        LinkedHashMap<String, LocalDate> inMap = new LinkedHashMap<>();
+        inMap.put("today", LocalDate.of(2017, 7, 21));
+        LinkedHashMap validatedValue = AnyTypeSchema.validate(inMap, configuration);
+        LinkedHashMap<String, String> outMap = new LinkedHashMap<>();
+        outMap.put("today", "2017-07-21");
+        Assert.assertEquals(validatedValue, outMap);
+    }
+
+    @Test
+    public void testValidateList() {
+        ArrayList<LocalDate> inList = new ArrayList<>();
+        inList.add(LocalDate.of(2017, 7, 21));
+        ArrayList validatedValue = AnyTypeSchema.validate(inList, configuration);
+        ArrayList<String> outList = new ArrayList<>();
+        outList.add( "2017-07-21");
+        Assert.assertEquals(validatedValue, outList);
     }
 }

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/AnyTypeSchemaTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/AnyTypeSchemaTest.java
@@ -1,0 +1,65 @@
+package org.openapijsonschematools.schemas;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
+import org.openapijsonschematools.configurations.SchemaConfiguration;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+public class AnyTypeSchemaTest {
+    static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
+
+    @Test
+    public void testValidateNull() {
+        Void validatedValue = AnyTypeSchema.validate((Void) null, configuration);
+        Assert.assertNull(validatedValue);
+    }
+
+    @Test
+    public void testValidateBoolean() {
+        Boolean trueValue = AnyTypeSchema.validate(Boolean.TRUE, configuration);
+        Assert.assertEquals(trueValue, Boolean.TRUE);
+
+        Boolean falseValue = AnyTypeSchema.validate(Boolean.FALSE, configuration);
+        Assert.assertEquals(falseValue, Boolean.FALSE);
+    }
+
+    @Test
+    public void testValidateInt() {
+        Integer validatedValue = AnyTypeSchema.validate(1, configuration);
+        Assert.assertEquals(validatedValue, Integer.valueOf(1));
+    }
+
+    @Test
+    public void testValidateFloat() {
+        Float validatedValue = AnyTypeSchema.validate(3.14f, configuration);
+        Assert.assertEquals(validatedValue, Float.valueOf(3.14f));
+    }
+
+    @Test
+    public void testValidateDouble() {
+        Double validatedValue = AnyTypeSchema.validate(70.6458763d, configuration);
+        Assert.assertEquals(validatedValue, Double.valueOf(70.6458763d));
+    }
+
+    @Test
+    public void testValidateString() {
+        String validatedValue = AnyTypeSchema.validate("a", configuration);
+        Assert.assertEquals(validatedValue, "a");
+    }
+
+    @Test
+    public void testValidateZonedDateTime() {
+        String validatedValue = AnyTypeSchema.validate(ZonedDateTime.of(2017, 7, 21, 17, 32, 28, 0, ZoneId.of("Z")), configuration);
+        Assert.assertEquals(validatedValue, "2017-07-21T17:32:28Z");
+    }
+
+    @Test
+    public void testValidateLocalDate() {
+        String validatedValue = AnyTypeSchema.validate(LocalDate.of(2017, 7, 21), configuration);
+        Assert.assertEquals(validatedValue, "2017-07-21");
+    }
+}

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/SchemaValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/SchemaValidatorTest.java
@@ -6,36 +6,38 @@ import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 
 record SomeSchema(LinkedHashSet<Class<?>> type) implements SchemaValidator {
-    static SomeSchema withDefaults() {
+    public static SomeSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
         type.add(String.class);
         return new SomeSchema(type);
     }
 
-    static PathToSchemasMap _validate(
-            Object arg,
-            ValidationMetadata validationMetadata
-    ) throws InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
-        return SchemaValidator._validate(
-                SomeSchema.withDefaults(),
-                arg,
-                validationMetadata
-        );
-    }
-
-
+//    static PathToSchemasMap _validate(
+//            Object arg,
+//            ValidationMetadata validationMetadata
+//    ) throws InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+//        return SchemaValidator._validate(
+//                SomeSchema.class,
+//                arg,
+//                validationMetadata
+//        );
+//    }
 }
 
 public class SchemaValidatorTest {
 
     @Test
     public void testValidateSucceeds() throws InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+        Class<?> cls = SomeSchema.class;
+        Method method = cls.getMethod("withDefaults");
+        SomeSchema schema = (SomeSchema) method.invoke(null);
         List<Object> pathToItem = new ArrayList<>();
         pathToItem.add("args[0");
         ValidationMetadata validationMetadata = new ValidationMetadata(
@@ -44,7 +46,8 @@ public class SchemaValidatorTest {
                 new PathToSchemasMap(),
                 new LinkedHashSet<>()
         );
-        PathToSchemasMap pathToSchemas = SomeSchema._validate(
+        PathToSchemasMap pathToSchemas = SchemaValidator._validate(
+                SomeSchema.class,
                 "hi",
                 validationMetadata
         );

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/SchemaValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/SchemaValidatorTest.java
@@ -1,12 +1,15 @@
 package org.openapijsonschematools.schemas;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 
 record SomeSchema(LinkedHashSet<Class<?>> type) implements SchemaValidator {
     static SomeSchema withDefaults() {
@@ -31,18 +34,25 @@ record SomeSchema(LinkedHashSet<Class<?>> type) implements SchemaValidator {
 
 public class SchemaValidatorTest {
 
-
     @Test
     public void testValidateSucceeds() throws InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+        List<Object> pathToItem = new ArrayList<>();
+        pathToItem.add("args[0");
         ValidationMetadata validationMetadata = new ValidationMetadata(
-                new ArrayList<>(),
+                pathToItem,
                 new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone()),
                 new PathToSchemasMap(),
                 new LinkedHashSet<>()
         );
-        SomeSchema._validate(
+        PathToSchemasMap pathToSchemas = SomeSchema._validate(
                 "hi",
                 validationMetadata
         );
+        PathToSchemasMap expectedPathToSchemas = new PathToSchemasMap();
+        HashMap<Class<?>, Void> validatedClasses = new HashMap<>();
+        validatedClasses.put(SomeSchema.class, null);
+        validatedClasses.put(String.class, null);
+        expectedPathToSchemas.put(pathToItem, validatedClasses);
+        Assert.assertEquals(pathToSchemas, expectedPathToSchemas);
     }
 }

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/SchemaValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/SchemaValidatorTest.java
@@ -6,9 +6,8 @@ import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 
@@ -38,7 +37,7 @@ public class SchemaValidatorTest {
                 validationMetadata
         );
         PathToSchemasMap expectedPathToSchemas = new PathToSchemasMap();
-        HashMap<Class<?>, Void> validatedClasses = new HashMap<>();
+        LinkedHashMap<Class<?>, Void> validatedClasses = new LinkedHashMap<>();
         validatedClasses.put(SomeSchema.class, null);
         validatedClasses.put(String.class, null);
         expectedPathToSchemas.put(pathToItem, validatedClasses);

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/SchemaValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/SchemaValidatorTest.java
@@ -22,7 +22,7 @@ record SomeSchema(LinkedHashSet<Class<?>> type) implements SchemaValidator {
 public class SchemaValidatorTest {
 
     @Test
-    public void testValidateSucceeds() throws InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+    public void testValidateSucceeds() {
         List<Object> pathToItem = new ArrayList<>();
         pathToItem.add("args[0");
         ValidationMetadata validationMetadata = new ValidationMetadata(
@@ -31,7 +31,7 @@ public class SchemaValidatorTest {
                 new PathToSchemasMap(),
                 new LinkedHashSet<>()
         );
-        PathToSchemasMap pathToSchemas = SchemaValidator._validate(
+        PathToSchemasMap pathToSchemas = SchemaValidator.validate(
                 SomeSchema.class,
                 "hi",
                 validationMetadata

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/SchemaValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/SchemaValidatorTest.java
@@ -18,26 +18,12 @@ record SomeSchema(LinkedHashSet<Class<?>> type) implements SchemaValidator {
         type.add(String.class);
         return new SomeSchema(type);
     }
-
-//    static PathToSchemasMap _validate(
-//            Object arg,
-//            ValidationMetadata validationMetadata
-//    ) throws InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
-//        return SchemaValidator._validate(
-//                SomeSchema.class,
-//                arg,
-//                validationMetadata
-//        );
-//    }
 }
 
 public class SchemaValidatorTest {
 
     @Test
     public void testValidateSucceeds() throws InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
-        Class<?> cls = SomeSchema.class;
-        Method method = cls.getMethod("withDefaults");
-        SomeSchema schema = (SomeSchema) method.invoke(null);
         List<Object> pathToItem = new ArrayList<>();
         pathToItem.add("args[0");
         ValidationMetadata validationMetadata = new ValidationMetadata(

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -262,25 +262,42 @@ public class JavaClientGenerator extends AbstractJavaGenerator
         HashMap<String, String> schemaDocs = new HashMap<>();
         additionalProperties.put(CodegenConstants.PACKAGE_NAME, packageName);
         supportingFiles.add(new SupportingFile(
+                "src/main/java/org/openapitools/schemas/AnyTypeSchema.hbs",
+                packagePath() + File.separatorChar + "schemas",
+                "AnyTypeSchema.java"));
+        supportingFiles.add(new SupportingFile(
                 "src/main/java/org/openapitools/schemas/CustomIsoparser.hbs",
                 packagePath() + File.separatorChar + "schemas",
                 "CustomIsoparser.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/test/java/org/openapitools/schemas/CustomIsoparserTest.hbs",
-                testPackagePath() + File.separatorChar + "schemas",
-                "CustomIsoparserTest.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/main/java/org/openapitools/schemas/ValidationMetadata.hbs",
-                packagePath() + File.separatorChar + "schemas",
-                "ValidationMetadata.java"));
         supportingFiles.add(new SupportingFile(
                 "src/main/java/org/openapitools/schemas/PathToSchemasMap.hbs",
                 packagePath() + File.separatorChar + "schemas",
                 "PathToSchemasMap.java"));
         supportingFiles.add(new SupportingFile(
+                "src/main/java/org/openapitools/schemas/PathToTypeMap.hbs",
+                packagePath() + File.separatorChar + "schemas",
+                "PathToTypeMap.java"));
+        supportingFiles.add(new SupportingFile(
+                "src/main/java/org/openapitools/schemas/Schema.hbs",
+                packagePath() + File.separatorChar + "schemas",
+                "Schema.java"));
+        supportingFiles.add(new SupportingFile(
                 "src/main/java/org/openapitools/schemas/SchemaValidator.hbs",
                 packagePath() + File.separatorChar + "schemas",
                 "SchemaValidator.java"));
+        supportingFiles.add(new SupportingFile(
+                "src/main/java/org/openapitools/schemas/UnsetAnyTypeSchema.hbs",
+                packagePath() + File.separatorChar + "schemas",
+                "UnsetAnyTypeSchema.java"));
+        supportingFiles.add(new SupportingFile(
+                "src/main/java/org/openapitools/schemas/ValidationMetadata.hbs",
+                packagePath() + File.separatorChar + "schemas",
+                "ValidationMetadata.java"));
+        // tests
+        supportingFiles.add(new SupportingFile(
+                "src/test/java/org/openapitools/schemas/CustomIsoparserTest.hbs",
+                testPackagePath() + File.separatorChar + "schemas",
+                "CustomIsoparserTest.java"));
         supportingFiles.add(new SupportingFile(
                 "src/test/java/org/openapitools/schemas/SchemaValidatorTest.hbs",
                 testPackagePath() + File.separatorChar + "schemas",
@@ -291,11 +308,11 @@ public class JavaClientGenerator extends AbstractJavaGenerator
                 "src/main/java/org/openapitools/schemas/validators/KeywordValidator.hbs",
                 packagePath() + File.separatorChar + "schemas" + File.separatorChar + "validators",
                 "KeywordValidator.java"));
-        // type
         supportingFiles.add(new SupportingFile(
                 "src/main/java/org/openapitools/schemas/validators/TypeValidator.hbs",
                 packagePath() + File.separatorChar + "schemas" + File.separatorChar + "validators",
                 "TypeValidator.java"));
+        // tests
         supportingFiles.add(new SupportingFile(
                 "src/test/java/org/openapitools/schemas/validators/TypeValidatorTest.hbs",
                 testPackagePath() + File.separatorChar + "schemas" + File.separatorChar + "validators",

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -295,6 +295,10 @@ public class JavaClientGenerator extends AbstractJavaGenerator
                 "ValidationMetadata.java"));
         // tests
         supportingFiles.add(new SupportingFile(
+                "src/test/java/org/openapitools/schemas/AnyTypeSchemaTest.hbs",
+                testPackagePath() + File.separatorChar + "schemas",
+                "AnyTypeSchemaTest.java"));
+        supportingFiles.add(new SupportingFile(
                 "src/test/java/org/openapitools/schemas/CustomIsoparserTest.hbs",
                 testPackagePath() + File.separatorChar + "schemas",
                 "CustomIsoparserTest.java"));

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/AnyTypeSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/AnyTypeSchema.hbs
@@ -13,42 +13,42 @@ record AnyTypeSchema() implements Schema {
     }
 
     public static Void validate(Void arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+        return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }
 
     public static Boolean validate(Boolean arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+        return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }
 
     public static Integer validate(Integer arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+        return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }
 
     public static Float validate(Float arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+        return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }
 
     public static Double validate(Double arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+        return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }
 
     public static String validate(String arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+        return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }
 
     public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+        return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }
 
     public static String validate(LocalDate arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+        return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }
 
     public static <T extends Map> T validate(T arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+        return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }
 
     public static <U extends List> U validate(U arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+        return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/AnyTypeSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/AnyTypeSchema.hbs
@@ -1,0 +1,54 @@
+package {{{packageName}}}.schemas;
+
+import {{{packageName}}}.configurations.SchemaConfiguration;
+
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+
+record AnyTypeSchema() implements Schema {
+    public static AnyTypeSchema withDefaults() {
+        return new AnyTypeSchema();
+    }
+
+    public static Void validate(Void arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+    }
+
+    public static Boolean validate(Boolean arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+    }
+
+    public static Integer validate(Integer arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+    }
+
+    public static Float validate(Float arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+    }
+
+    public static Double validate(Double arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+    }
+
+    public static String validate(String arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+    }
+
+    public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+    }
+
+    public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+    }
+
+    public static <T extends Map> T validate(T arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+    }
+
+    public static <U extends List> U validate(U arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(AnyTypeSchema.class, arg, configuration);
+    }
+}

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/PathToSchemasMap.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/PathToSchemasMap.hbs
@@ -1,8 +1,20 @@
 package {{{packageName}}}.schemas;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-public class PathToSchemasMap extends HashMap<List<Object>, Map<Class<?>, Void>> {
+public class PathToSchemasMap extends LinkedHashMap<List<Object>, LinkedHashMap<Class<?>, Void>> {
+
+    public void update(PathToSchemasMap other) {
+        for (Map.Entry<List<Object>, LinkedHashMap<Class<?>, Void>> entry: other.entrySet()) {
+            List<Object> pathToItem = entry.getKey();
+            LinkedHashMap<Class<?>, Void> otherSchemas = entry.getValue();
+            if (containsKey(pathToItem)) {
+                get(pathToItem).putAll(otherSchemas);
+            } else {
+                put(pathToItem, otherSchemas);
+            }
+        }
+    }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/PathToTypeMap.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/PathToTypeMap.hbs
@@ -1,0 +1,8 @@
+package {{{packageName}}}.schemas;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class PathToTypeMap extends HashMap<List<Object>, Class<?>> {
+}

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/Schema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/Schema.hbs
@@ -14,6 +14,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 public interface Schema<T extends Map, U extends List> extends SchemaValidator {
@@ -23,7 +24,7 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
          return null;
       } else if (arg instanceof String) {
          pathToType.put(pathToItem, String.class);
-         return (String) arg;
+         return arg;
       } else if (arg instanceof Map) {
          pathToType.put(pathToItem, Map.class);
          LinkedHashMap<String, Object> argFixed = new LinkedHashMap<>();
@@ -38,19 +39,19 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
          return argFixed;
       } else if (arg instanceof Boolean) {
          pathToType.put(pathToItem, Boolean.class);
-         return (Boolean) arg;
+         return arg;
       } else if (arg instanceof Integer) {
          pathToType.put(pathToItem, Integer.class);
-         return (Integer) arg;
+         return arg;
       } else if (arg instanceof Float) {
          pathToType.put(pathToItem, Float.class);
-         return (Float) arg;
+         return arg;
       } else if (arg instanceof Double) {
          pathToType.put(pathToItem, Double.class);
-         return (Double) arg;
+         return arg;
       } else if (arg instanceof BigDecimal) {
          pathToType.put(pathToItem, BigDecimal.class);
-         return (BigDecimal) arg;
+         return arg;
       } else if (arg instanceof List) {
          pathToType.put(pathToItem, List.class);
          List<Object> argFixed = new ArrayList<>();
@@ -87,7 +88,7 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
             throw new RuntimeException(e);
          }
          for (LinkedHashMap<Class<?>, Void> schemas: pathToSchemasMap.values()) {
-            Class<?> firstSchema = schemas.firstEntry().getKey();
+            Class<?> firstSchema = schemas.entrySet().iterator().next().getKey();
             schemas.clear();
             schemas.put(firstSchema, null);
          }
@@ -111,7 +112,7 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
          String propertyName = entry.getKey();
          List<Object> propertyPathToItem = new ArrayList<>(pathToItem);
          propertyPathToItem.add(propertyName);
-         Class<Schema> propertyClass = (Class<Schema>) pathToSchemas.get(propertyPathToItem).firstEntry().getKey();
+         Class<Schema> propertyClass = (Class<Schema>) pathToSchemas.get(propertyPathToItem).entrySet().iterator().next().getKey();
          Object value = entry.getValue();
          Object castValue = getNewInstance(propertyClass, value, propertyPathToItem, pathToSchemas);
          properties.put(propertyName, castValue);
@@ -123,10 +124,10 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
       ArrayList<Object> items = new ArrayList<>();
       List<Object> castItems = (List<Object>) arg;
       int i = 0;
-      for (Object item: items) {
+      for (Object item: castItems) {
          List<Object> itemPathToItem = new ArrayList<>(pathToItem);
          itemPathToItem.add(i);
-         Class<Schema> itemClass = (Class<Schema>) pathToSchemas.get(itemPathToItem).firstEntry().getKey();
+         Class<Schema> itemClass = (Class<Schema>) pathToSchemas.get(itemPathToItem).entrySet().iterator().next().getKey();
          Object castItem = getNewInstance(itemClass, item, itemPathToItem, pathToSchemas);
          items.add(castItem);
          i += 1;
@@ -151,10 +152,8 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
          usedArg = getProperties(arg, pathToItem, pathToSchemas);
       } else if (arg instanceof List) {
          usedArg = getItems(arg, pathToItem, pathToSchemas);
-      } else if (arg instanceof Boolean) {
-         return (Boolean) arg;
       } else {
-         // str, int, float, FileIO, bytes
+         // str, int, float, boolean, null, FileIO, bytes
          return arg;
       }
       Class<?> argType = arg.getClass();
@@ -167,43 +166,43 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
       return null;
    }
 
-   public static Void validateBase(Class<?> cls, Void arg, SchemaConfiguration configuration) {
+   static Void validateBase(Class<?> cls, Void arg, SchemaConfiguration configuration) {
       return (Void) validateObjectBase(cls, arg, configuration);
    }
 
-   public static Boolean validateBase(Class<?> cls, Boolean arg, SchemaConfiguration configuration) {
+   static Boolean validateBase(Class<?> cls, Boolean arg, SchemaConfiguration configuration) {
       return (Boolean) validateObjectBase(cls, arg, configuration);
    }
 
-   public static Integer validateBase(Class<?> cls, Integer arg, SchemaConfiguration configuration) {
+   static Integer validateBase(Class<?> cls, Integer arg, SchemaConfiguration configuration) {
       return (Integer) validateObjectBase(cls, arg, configuration);
    }
 
-   public static Float validateBase(Class<?> cls, Float arg, SchemaConfiguration configuration) {
+   static Float validateBase(Class<?> cls, Float arg, SchemaConfiguration configuration) {
       return (Float) validateObjectBase(cls, arg, configuration);
    }
 
-   public static Double validateBase(Class<?> cls, Double arg, SchemaConfiguration configuration) {
+   static Double validateBase(Class<?> cls, Double arg, SchemaConfiguration configuration) {
       return (Double) validateObjectBase(cls, arg, configuration);
    }
 
-   public static String validateBase(Class<?> cls, String arg, SchemaConfiguration configuration) {
+   static String validateBase(Class<?> cls, String arg, SchemaConfiguration configuration) {
       return (String) validateObjectBase(cls, arg, configuration);
    }
 
-   public static String validateBase(Class<?> cls, ZonedDateTime arg, SchemaConfiguration configuration) {
+   static String validateBase(Class<?> cls, ZonedDateTime arg, SchemaConfiguration configuration) {
       return (String) validateObjectBase(cls, arg, configuration);
    }
 
-   public static String validateBase(Class<?> cls, LocalDate arg, SchemaConfiguration configuration) {
+   static String validateBase(Class<?> cls, LocalDate arg, SchemaConfiguration configuration) {
       return (String) validateObjectBase(cls, arg, configuration);
    }
 
-   public static <T extends Map> T validateBase(Class<?> cls, T arg, SchemaConfiguration configuration) {
+   static <T extends Map> T validateBase(Class<?> cls, T arg, SchemaConfiguration configuration) {
       return (T) validateObjectBase(cls, arg, configuration);
    }
 
-   public static <U extends List> U validateBase(Class<?> cls, U arg, SchemaConfiguration configuration) {
+   static <U extends List> U validateBase(Class<?> cls, U arg, SchemaConfiguration configuration) {
       return (U) validateObjectBase(cls, arg, configuration);
    }
 
@@ -218,12 +217,7 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
       List<Object> pathToItem = new ArrayList<>();
       pathToItem.add("args[0]");
       Object castArg = castToAllowedTypes(arg, pathToItem, pathToType);
-      SchemaConfiguration usedConfiguration;
-      if (configuration != null) {
-         usedConfiguration = configuration;
-      } else {
-         usedConfiguration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
-      }
+      SchemaConfiguration usedConfiguration = Objects.requireNonNullElseGet(configuration, () -> new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone()));
       PathToSchemasMap validatedPathToSchemas = new PathToSchemasMap();
       ValidationMetadata validationMetadata = new ValidationMetadata(
               pathToItem,

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/Schema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/Schema.hbs
@@ -81,12 +81,8 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
       if (validationMetadata.validationRanEarlier(cls)) {
          // todo add deeper validated schemas
       } else {
-         try {
-            PathToSchemasMap otherPathToSchemas = SchemaValidator._validate(cls, arg, validationMetadata);
-            pathToSchemasMap.update(otherPathToSchemas);
-         } catch (InvocationTargetException | IllegalAccessException e) {
-            throw new RuntimeException(e);
-         }
+         PathToSchemasMap otherPathToSchemas = SchemaValidator.validate(cls, arg, validationMetadata);
+         pathToSchemasMap.update(otherPathToSchemas);
          for (LinkedHashMap<Class<?>, Void> schemas: pathToSchemasMap.values()) {
             Class<?> firstSchema = schemas.entrySet().iterator().next().getKey();
             schemas.clear();
@@ -166,49 +162,49 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
       return null;
    }
 
-   static Void validateBase(Class<?> cls, Void arg, SchemaConfiguration configuration) {
-      return (Void) validateObjectBase(cls, arg, configuration);
+   static Void validate(Class<?> cls, Void arg, SchemaConfiguration configuration) {
+      return (Void) validateObject(cls, arg, configuration);
    }
 
-   static Boolean validateBase(Class<?> cls, Boolean arg, SchemaConfiguration configuration) {
-      return (Boolean) validateObjectBase(cls, arg, configuration);
+   static Boolean validate(Class<?> cls, Boolean arg, SchemaConfiguration configuration) {
+      return (Boolean) validateObject(cls, arg, configuration);
    }
 
-   static Integer validateBase(Class<?> cls, Integer arg, SchemaConfiguration configuration) {
-      return (Integer) validateObjectBase(cls, arg, configuration);
+   static Integer validate(Class<?> cls, Integer arg, SchemaConfiguration configuration) {
+      return (Integer) validateObject(cls, arg, configuration);
    }
 
-   static Float validateBase(Class<?> cls, Float arg, SchemaConfiguration configuration) {
-      return (Float) validateObjectBase(cls, arg, configuration);
+   static Float validate(Class<?> cls, Float arg, SchemaConfiguration configuration) {
+      return (Float) validateObject(cls, arg, configuration);
    }
 
-   static Double validateBase(Class<?> cls, Double arg, SchemaConfiguration configuration) {
-      return (Double) validateObjectBase(cls, arg, configuration);
+   static Double validate(Class<?> cls, Double arg, SchemaConfiguration configuration) {
+      return (Double) validateObject(cls, arg, configuration);
    }
 
-   static String validateBase(Class<?> cls, String arg, SchemaConfiguration configuration) {
-      return (String) validateObjectBase(cls, arg, configuration);
+   static String validate(Class<?> cls, String arg, SchemaConfiguration configuration) {
+      return (String) validateObject(cls, arg, configuration);
    }
 
-   static String validateBase(Class<?> cls, ZonedDateTime arg, SchemaConfiguration configuration) {
-      return (String) validateObjectBase(cls, arg, configuration);
+   static String validate(Class<?> cls, ZonedDateTime arg, SchemaConfiguration configuration) {
+      return (String) validateObject(cls, arg, configuration);
    }
 
-   static String validateBase(Class<?> cls, LocalDate arg, SchemaConfiguration configuration) {
-      return (String) validateObjectBase(cls, arg, configuration);
+   static String validate(Class<?> cls, LocalDate arg, SchemaConfiguration configuration) {
+      return (String) validateObject(cls, arg, configuration);
    }
 
-   static <T extends Map> T validateBase(Class<?> cls, T arg, SchemaConfiguration configuration) {
-      return (T) validateObjectBase(cls, arg, configuration);
+   static <T extends Map> T validate(Class<?> cls, T arg, SchemaConfiguration configuration) {
+      return (T) validateObject(cls, arg, configuration);
    }
 
-   static <U extends List> U validateBase(Class<?> cls, U arg, SchemaConfiguration configuration) {
-      return (U) validateObjectBase(cls, arg, configuration);
+   static <U extends List> U validate(Class<?> cls, U arg, SchemaConfiguration configuration) {
+      return (U) validateObject(cls, arg, configuration);
    }
 
    // todo add bytes and FileIO
 
-   private static Object validateObjectBase(Class<?> cls, Object arg, SchemaConfiguration configuration) {
+   private static Object validateObject(Class<?> cls, Object arg, SchemaConfiguration configuration) {
       Class<Schema> castCls = (Class<Schema>) cls;
       if (arg instanceof Map || arg instanceof List) {
          // todo don't run validation if the instance is one of the class generic types

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/Schema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/Schema.hbs
@@ -18,7 +18,7 @@ import java.util.Objects;
 import java.util.Set;
 
 public interface Schema<T extends Map, U extends List> extends SchemaValidator {
-   static Object castToAllowedTypes(Object arg, List<Object> pathToItem, PathToTypeMap pathToType) {
+   private static Object castToAllowedTypes(Object arg, List<Object> pathToItem, PathToTypeMap pathToType) {
       if (arg == null) {
          pathToType.put(pathToItem, Void.class);
          return null;
@@ -76,7 +76,7 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
       }
    }
 
-   static PathToSchemasMap getPathToSchemas(Class<Schema> cls, Object arg, ValidationMetadata validationMetadata, PathToTypeMap pathToType) {
+   private static PathToSchemasMap getPathToSchemas(Class<Schema> cls, Object arg, ValidationMetadata validationMetadata, PathToTypeMap pathToType) {
       PathToSchemasMap pathToSchemasMap = new PathToSchemasMap();
       if (validationMetadata.validationRanEarlier(cls)) {
          // todo add deeper validated schemas
@@ -105,7 +105,7 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
       return pathToSchemasMap;
    }
 
-   static LinkedHashMap<String, Object> getProperties(Object arg, List<Object> pathToItem, PathToSchemasMap pathToSchemas) {
+   private static LinkedHashMap<String, Object> getProperties(Object arg, List<Object> pathToItem, PathToSchemasMap pathToSchemas) {
       LinkedHashMap<String, Object> properties = new LinkedHashMap<>();
       Map<String, Object> castArg = (Map<String, Object>) arg;
       for(Map.Entry<String, Object> entry: castArg.entrySet()) {
@@ -120,7 +120,7 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
       return properties;
    }
 
-   static List<Object> getItems(Object arg, List<Object> pathToItem, PathToSchemasMap pathToSchemas) {
+   private static List<Object> getItems(Object arg, List<Object> pathToItem, PathToSchemasMap pathToSchemas) {
       ArrayList<Object> items = new ArrayList<>();
       List<Object> castItems = (List<Object>) arg;
       int i = 0;
@@ -135,7 +135,7 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
       return items;
    }
 
-   static Map<Class<?>, Class<?>> getTypeToOutputClass(Class<?> cls) {
+   private static Map<Class<?>, Class<?>> getTypeToOutputClass(Class<?> cls) {
       try {
          // This must be implemented in Schemas that are generics as a static method
          Method method = cls.getMethod("typeToOutputClass");
@@ -146,7 +146,7 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
       }
    }
 
-   static Object getNewInstance(Class<Schema> cls, Object arg, List<Object> pathToItem, PathToSchemasMap pathToSchemas) {
+   private static Object getNewInstance(Class<Schema> cls, Object arg, List<Object> pathToItem, PathToSchemasMap pathToSchemas) {
       Object usedArg;
       if (arg instanceof Map) {
          usedArg = getProperties(arg, pathToItem, pathToSchemas);

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/Schema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/Schema.hbs
@@ -1,7 +1,7 @@
-package org.openapijsonschematools.schemas;
+package {{{packageName}}}.schemas;
 
-import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.configurations.SchemaConfiguration;
+import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
+import {{{packageName}}}.configurations.SchemaConfiguration;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -87,7 +87,7 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
             throw new RuntimeException(e);
          }
          for (LinkedHashMap<Class<?>, Void> schemas: pathToSchemasMap.values()) {
-            Class<?> firstSchema = schemas.entrySet().iterator().next().getKey();
+            Class<?> firstSchema = schemas.firstEntry().getKey();
             schemas.clear();
             schemas.put(firstSchema, null);
          }
@@ -111,7 +111,7 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
          String propertyName = entry.getKey();
          List<Object> propertyPathToItem = new ArrayList<>(pathToItem);
          propertyPathToItem.add(propertyName);
-         Class<Schema> propertyClass = (Class<Schema>) pathToSchemas.get(propertyPathToItem).entrySet().iterator().next().getKey();
+         Class<Schema> propertyClass = (Class<Schema>) pathToSchemas.get(propertyPathToItem).firstEntry().getKey();
          Object value = entry.getValue();
          Object castValue = getNewInstance(propertyClass, value, propertyPathToItem, pathToSchemas);
          properties.put(propertyName, castValue);
@@ -126,7 +126,7 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
       for (Object item: items) {
          List<Object> itemPathToItem = new ArrayList<>(pathToItem);
          itemPathToItem.add(i);
-         Class<Schema> itemClass = (Class<Schema>) pathToSchemas.get(itemPathToItem).entrySet().iterator().next().getKey();
+         Class<Schema> itemClass = (Class<Schema>) pathToSchemas.get(itemPathToItem).firstEntry().getKey();
          Object castItem = getNewInstance(itemClass, item, itemPathToItem, pathToSchemas);
          items.add(castItem);
          i += 1;

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/SchemaValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/SchemaValidator.hbs
@@ -1,12 +1,13 @@
-package org.openapijsonschematools.schemas;
+package {{{packageName}}}.schemas;
 
-import org.openapijsonschematools.schemas.validators.KeywordValidator;
-import org.openapijsonschematools.schemas.validators.TypeValidator;
+import {{{packageName}}}.schemas.validators.KeywordValidator;
+import {{{packageName}}}.schemas.validators.TypeValidator;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.RecordComponent;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -54,7 +55,7 @@ public interface SchemaValidator {
         Class<?> baseClass = arg.getClass();
         List<Object> pathToItem = validationMetadata.pathToItem();
         if (!pathToSchemas.containsKey(pathToItem)) {
-            pathToSchemas.put(validationMetadata.pathToItem(), new HashMap<>());
+            pathToSchemas.put(validationMetadata.pathToItem(), new LinkedHashMap<>());
         }
         pathToSchemas.get(pathToItem).put(baseClass, null);
         pathToSchemas.get(pathToItem).put(schemaCls, null);

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/SchemaValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/SchemaValidator.hbs
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Map;
 
 public interface SchemaValidator {
-    static final HashMap<String, KeywordValidator> keywordToValidator = new HashMap()\{{
+    HashMap<String, KeywordValidator> keywordToValidator = new HashMap()\{{
         put("type", new TypeValidator());
     }};
 
@@ -22,7 +22,7 @@ public interface SchemaValidator {
             ValidationMetadata validationMetadata
     ) throws InvocationTargetException, IllegalAccessException {
         HashMap<String, Object> fieldsToValues = new HashMap<>();
-        SchemaValidator schema = null;
+        SchemaValidator schema;
         try {
             schema = (SchemaValidator) schemaCls.getMethod("withDefaults").invoke(null);
         } catch (NoSuchMethodException e) {
@@ -51,8 +51,17 @@ public interface SchemaValidator {
                     castSchemaCls,
                     validationMetadata
             );
+            if (otherPathToSchemas == null) {
+                continue;
+            }
+            pathToSchemas.update(otherPathToSchemas);
         }
-        Class<?> baseClass = arg.getClass();
+        Class<?> baseClass;
+        if (arg == null) {
+            baseClass = Void.class;
+        } else {
+            baseClass = arg.getClass();
+        }
         List<Object> pathToItem = validationMetadata.pathToItem();
         if (!pathToSchemas.containsKey(pathToItem)) {
             pathToSchemas.put(validationMetadata.pathToItem(), new LinkedHashMap<>());

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/SchemaValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/SchemaValidator.hbs
@@ -7,6 +7,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.RecordComponent;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 
 public interface SchemaValidator {
@@ -43,6 +44,14 @@ public interface SchemaValidator {
                     validationMetadata
             );
         }
+        Class<?> baseClass = arg.getClass();
+        List<Object> pathToItem = validationMetadata.pathToItem();
+        if (!pathToSchemas.containsKey(pathToItem)) {
+            pathToSchemas.put(validationMetadata.pathToItem(), new HashMap<>());
+        }
+        pathToSchemas.get(pathToItem).put(baseClass, null);
+        pathToSchemas.get(pathToItem).put(schemaCls, null);
+
         return pathToSchemas;
     }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/SchemaValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/SchemaValidator.hbs
@@ -14,14 +14,20 @@ public interface SchemaValidator {
     static final HashMap<String, KeywordValidator> keywordToValidator = new HashMap()\{{
         put("type", new TypeValidator());
     }};
+
     static PathToSchemasMap _validate(
-            SchemaValidator schema,
+            Class<?> schemaCls,
             Object arg,
             ValidationMetadata validationMetadata
     ) throws InvocationTargetException, IllegalAccessException {
         HashMap<String, Object> fieldsToValues = new HashMap<>();
+        SchemaValidator schema = null;
+        try {
+            schema = (SchemaValidator) schemaCls.getMethod("withDefaults").invoke(null);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
         LinkedHashSet<String> disabledKeywords = validationMetadata.configuration().disabledKeywordFlags().getKeywords();
-        Class<SchemaValidator> schemaCls = (Class<SchemaValidator>) schema.getClass();
         RecordComponent[] recordComponents = schemaCls.getRecordComponents();
         for (RecordComponent recordComponent : recordComponents) {
             String fieldName = recordComponent.getName();
@@ -32,6 +38,7 @@ public interface SchemaValidator {
             fieldsToValues.put(fieldName, value);
         }
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
+        Class<SchemaValidator> castSchemaCls = (Class<SchemaValidator>) schemaCls;
         for (Map.Entry<String, Object> entry: fieldsToValues.entrySet()) {
             String jsonKeyword = entry.getKey();
             Object value = entry.getValue();
@@ -40,7 +47,7 @@ public interface SchemaValidator {
                     arg,
                     value,
                     null,
-                    schemaCls,
+                    castSchemaCls,
                     validationMetadata
             );
         }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/UnsetAnyTypeSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/UnsetAnyTypeSchema.hbs
@@ -8,47 +8,47 @@ import java.util.List;
 import java.util.Map;
 
 record UnsetAnyTypeSchema() implements Schema {
-    public static UnsetAnyTypeSchema withDefaults() {
+    static UnsetAnyTypeSchema withDefaults() {
         return new UnsetAnyTypeSchema();
     }
 
-    public static Void validate(Void arg, SchemaConfiguration configuration) {
+    static Void validate(Void arg, SchemaConfiguration configuration) {
         return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
-    public static Boolean validate(Boolean arg, SchemaConfiguration configuration) {
+    static Boolean validate(Boolean arg, SchemaConfiguration configuration) {
         return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
-    public static Integer validate(Integer arg, SchemaConfiguration configuration) {
+    static Integer validate(Integer arg, SchemaConfiguration configuration) {
         return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
-    public static Float validate(Float arg, SchemaConfiguration configuration) {
+    static Float validate(Float arg, SchemaConfiguration configuration) {
         return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
-    public static Double validate(Double arg, SchemaConfiguration configuration) {
+    static Double validate(Double arg, SchemaConfiguration configuration) {
         return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
-    public static String validate(String arg, SchemaConfiguration configuration) {
+    static String validate(String arg, SchemaConfiguration configuration) {
         return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
-    public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+    static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
         return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
-    public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+    static String validate(LocalDate arg, SchemaConfiguration configuration) {
         return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
-    public static <T extends Map> T validate(T arg, SchemaConfiguration configuration) {
+    static <T extends Map> T validate(T arg, SchemaConfiguration configuration) {
         return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
-    public static <U extends List> U validate(U arg, SchemaConfiguration configuration) {
+    static <U extends List> U validate(U arg, SchemaConfiguration configuration) {
         return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
     }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/UnsetAnyTypeSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/UnsetAnyTypeSchema.hbs
@@ -1,0 +1,54 @@
+package {{{packageName}}}.schemas;
+
+import {{{packageName}}}.configurations.SchemaConfiguration;
+
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+
+record UnsetAnyTypeSchema() implements Schema {
+    public static UnsetAnyTypeSchema withDefaults() {
+        return new UnsetAnyTypeSchema();
+    }
+
+    public static Void validate(Void arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+    }
+
+    public static Boolean validate(Boolean arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+    }
+
+    public static Integer validate(Integer arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+    }
+
+    public static Float validate(Float arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+    }
+
+    public static Double validate(Double arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+    }
+
+    public static String validate(String arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+    }
+
+    public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+    }
+
+    public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+    }
+
+    public static <T extends Map> T validate(T arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+    }
+
+    public static <U extends List> U validate(U arg, SchemaConfiguration configuration) {
+        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+    }
+}

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/UnsetAnyTypeSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/UnsetAnyTypeSchema.hbs
@@ -13,42 +13,42 @@ record UnsetAnyTypeSchema() implements Schema {
     }
 
     static Void validate(Void arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+        return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
     static Boolean validate(Boolean arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+        return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
     static Integer validate(Integer arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+        return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
     static Float validate(Float arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+        return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
     static Double validate(Double arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+        return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
     static String validate(String arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+        return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
     static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+        return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
     static String validate(LocalDate arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+        return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
     static <T extends Map> T validate(T arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+        return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
     static <U extends List> U validate(U arg, SchemaConfiguration configuration) {
-        return Schema.validateBase(UnsetAnyTypeSchema.class, arg, configuration);
+        return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }
 }

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/AnyTypeSchemaTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/AnyTypeSchemaTest.hbs
@@ -1,9 +1,9 @@
-package org.openapijsonschematools.schemas;
+package {{{packageName}}}.schemas;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.configurations.SchemaConfiguration;
+import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
+import {{{packageName}}}.configurations.SchemaConfiguration;
 
 import java.time.LocalDate;
 import java.time.ZoneId;

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/SchemaValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/SchemaValidatorTest.hbs
@@ -7,12 +7,12 @@ import {{{packageName}}}.configurations.SchemaConfiguration;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 
 record SomeSchema(LinkedHashSet<Class<?>> type) implements SchemaValidator {
-    static SomeSchema withDefaults() {
+    public static SomeSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
         type.add(String.class);
         return new SomeSchema(type);
@@ -37,7 +37,7 @@ public class SchemaValidatorTest {
                 validationMetadata
         );
         PathToSchemasMap expectedPathToSchemas = new PathToSchemasMap();
-        HashMap<Class<?>, Void> validatedClasses = new HashMap<>();
+        LinkedHashMap<Class<?>, Void> validatedClasses = new LinkedHashMap<>();
         validatedClasses.put(SomeSchema.class, null);
         validatedClasses.put(String.class, null);
         expectedPathToSchemas.put(pathToItem, validatedClasses);

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/SchemaValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/SchemaValidatorTest.hbs
@@ -17,19 +17,6 @@ record SomeSchema(LinkedHashSet<Class<?>> type) implements SchemaValidator {
         type.add(String.class);
         return new SomeSchema(type);
     }
-
-    static PathToSchemasMap _validate(
-            Object arg,
-            ValidationMetadata validationMetadata
-    ) throws InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
-        return SchemaValidator._validate(
-                SomeSchema.withDefaults(),
-                arg,
-                validationMetadata
-        );
-    }
-
-
 }
 
 public class SchemaValidatorTest {
@@ -44,7 +31,8 @@ public class SchemaValidatorTest {
                 new PathToSchemasMap(),
                 new LinkedHashSet<>()
         );
-        PathToSchemasMap pathToSchemas = SomeSchema._validate(
+        PathToSchemasMap pathToSchemas = SchemaValidator._validate(
+                SomeSchema.class,
                 "hi",
                 validationMetadata
         );

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/SchemaValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/SchemaValidatorTest.hbs
@@ -1,12 +1,15 @@
 package {{{packageName}}}.schemas;
 
+import org.junit.Assert;
 import org.junit.Test;
 import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
 import {{{packageName}}}.configurations.SchemaConfiguration;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 
 record SomeSchema(LinkedHashSet<Class<?>> type) implements SchemaValidator {
     static SomeSchema withDefaults() {
@@ -31,18 +34,25 @@ record SomeSchema(LinkedHashSet<Class<?>> type) implements SchemaValidator {
 
 public class SchemaValidatorTest {
 
-
     @Test
     public void testValidateSucceeds() throws InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+        List<Object> pathToItem = new ArrayList<>();
+        pathToItem.add("args[0");
         ValidationMetadata validationMetadata = new ValidationMetadata(
-                new ArrayList<>(),
+                pathToItem,
                 new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone()),
                 new PathToSchemasMap(),
                 new LinkedHashSet<>()
         );
-        SomeSchema._validate(
+        PathToSchemasMap pathToSchemas = SomeSchema._validate(
                 "hi",
                 validationMetadata
         );
+        PathToSchemasMap expectedPathToSchemas = new PathToSchemasMap();
+        HashMap<Class<?>, Void> validatedClasses = new HashMap<>();
+        validatedClasses.put(SomeSchema.class, null);
+        validatedClasses.put(String.class, null);
+        expectedPathToSchemas.put(pathToItem, validatedClasses);
+        Assert.assertEquals(pathToSchemas, expectedPathToSchemas);
     }
 }

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/SchemaValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/SchemaValidatorTest.hbs
@@ -22,7 +22,7 @@ record SomeSchema(LinkedHashSet<Class<?>> type) implements SchemaValidator {
 public class SchemaValidatorTest {
 
     @Test
-    public void testValidateSucceeds() throws InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+    public void testValidateSucceeds() {
         List<Object> pathToItem = new ArrayList<>();
         pathToItem.add("args[0");
         ValidationMetadata validationMetadata = new ValidationMetadata(
@@ -31,7 +31,7 @@ public class SchemaValidatorTest {
                 new PathToSchemasMap(),
                 new LinkedHashSet<>()
         );
-        PathToSchemasMap pathToSchemas = SchemaValidator._validate(
+        PathToSchemasMap pathToSchemas = SchemaValidator.validate(
                 SomeSchema.class,
                 "hi",
                 validationMetadata


### PR DESCRIPTION
Java:
- adds Schema interface
- adds AnyTypeSchema, UnsetAnyTypeSchema
- adds tests of AnyTypeSchema which uses the schema interface

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
