### PR TITLE
Java, adds schema classes

### DIFF
--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -5,6 +5,7 @@ src/main/java/org/openapijsonschematools/configurations/SchemaConfiguration.java
 src/main/java/org/openapijsonschematools/schemas/AnyTypeSchema.java
 src/main/java/org/openapijsonschematools/schemas/BooleanSchema.java
 src/main/java/org/openapijsonschematools/schemas/CustomIsoparser.java
+src/main/java/org/openapijsonschematools/schemas/Int32Schema.java
 src/main/java/org/openapijsonschematools/schemas/NullSchema.java
 src/main/java/org/openapijsonschematools/schemas/NumberSchema.java
 src/main/java/org/openapijsonschematools/schemas/PathToSchemasMap.java

--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -4,6 +4,7 @@ src/main/java/org/openapijsonschematools/configurations/JsonSchemaKeywordFlags.j
 src/main/java/org/openapijsonschematools/configurations/SchemaConfiguration.java
 src/main/java/org/openapijsonschematools/schemas/AnyTypeSchema.java
 src/main/java/org/openapijsonschematools/schemas/CustomIsoparser.java
+src/main/java/org/openapijsonschematools/schemas/NullSchema.java
 src/main/java/org/openapijsonschematools/schemas/PathToSchemasMap.java
 src/main/java/org/openapijsonschematools/schemas/PathToTypeMap.java
 src/main/java/org/openapijsonschematools/schemas/Schema.java

--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -6,6 +6,7 @@ src/main/java/org/openapijsonschematools/schemas/AnyTypeSchema.java
 src/main/java/org/openapijsonschematools/schemas/BooleanSchema.java
 src/main/java/org/openapijsonschematools/schemas/CustomIsoparser.java
 src/main/java/org/openapijsonschematools/schemas/NullSchema.java
+src/main/java/org/openapijsonschematools/schemas/NumberSchema.java
 src/main/java/org/openapijsonschematools/schemas/PathToSchemasMap.java
 src/main/java/org/openapijsonschematools/schemas/PathToTypeMap.java
 src/main/java/org/openapijsonschematools/schemas/Schema.java
@@ -19,5 +20,6 @@ src/test/java/org/openapijsonschematools/schemas/AnyTypeSchemaTest.java
 src/test/java/org/openapijsonschematools/schemas/BooleanSchemaTest.java
 src/test/java/org/openapijsonschematools/schemas/CustomIsoparserTest.java
 src/test/java/org/openapijsonschematools/schemas/NullSchemaTest.java
+src/test/java/org/openapijsonschematools/schemas/NumberSchemaTest.java
 src/test/java/org/openapijsonschematools/schemas/SchemaValidatorTest.java
 src/test/java/org/openapijsonschematools/schemas/validators/TypeValidatorTest.java

--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -7,6 +7,7 @@ src/main/java/org/openapijsonschematools/schemas/BooleanSchema.java
 src/main/java/org/openapijsonschematools/schemas/CustomIsoparser.java
 src/main/java/org/openapijsonschematools/schemas/Int32Schema.java
 src/main/java/org/openapijsonschematools/schemas/Int64Schema.java
+src/main/java/org/openapijsonschematools/schemas/IntSchema.java
 src/main/java/org/openapijsonschematools/schemas/NullSchema.java
 src/main/java/org/openapijsonschematools/schemas/NumberSchema.java
 src/main/java/org/openapijsonschematools/schemas/PathToSchemasMap.java

--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -13,6 +13,7 @@ src/main/java/org/openapijsonschematools/schemas/Schema.java
 src/main/java/org/openapijsonschematools/schemas/SchemaValidator.java
 src/main/java/org/openapijsonschematools/schemas/UnsetAnyTypeSchema.java
 src/main/java/org/openapijsonschematools/schemas/ValidationMetadata.java
+src/main/java/org/openapijsonschematools/schemas/validators/FormatValidator.java
 src/main/java/org/openapijsonschematools/schemas/validators/KeywordValidator.java
 src/main/java/org/openapijsonschematools/schemas/validators/TypeValidator.java
 src/test/java/org/openapijsonschematools/configurations/JsonSchemaKeywordFlagsTest.java

--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -6,6 +6,7 @@ src/main/java/org/openapijsonschematools/schemas/AnyTypeSchema.java
 src/main/java/org/openapijsonschematools/schemas/BooleanSchema.java
 src/main/java/org/openapijsonschematools/schemas/CustomIsoparser.java
 src/main/java/org/openapijsonschematools/schemas/Int32Schema.java
+src/main/java/org/openapijsonschematools/schemas/Int64Schema.java
 src/main/java/org/openapijsonschematools/schemas/NullSchema.java
 src/main/java/org/openapijsonschematools/schemas/NumberSchema.java
 src/main/java/org/openapijsonschematools/schemas/PathToSchemasMap.java

--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -23,4 +23,5 @@ src/test/java/org/openapijsonschematools/schemas/CustomIsoparserTest.java
 src/test/java/org/openapijsonschematools/schemas/NullSchemaTest.java
 src/test/java/org/openapijsonschematools/schemas/NumberSchemaTest.java
 src/test/java/org/openapijsonschematools/schemas/SchemaValidatorTest.java
+src/test/java/org/openapijsonschematools/schemas/validators/FormatValidatorTest.java
 src/test/java/org/openapijsonschematools/schemas/validators/TypeValidatorTest.java

--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -5,6 +5,8 @@ src/main/java/org/openapijsonschematools/configurations/SchemaConfiguration.java
 src/main/java/org/openapijsonschematools/schemas/AnyTypeSchema.java
 src/main/java/org/openapijsonschematools/schemas/BooleanSchema.java
 src/main/java/org/openapijsonschematools/schemas/CustomIsoparser.java
+src/main/java/org/openapijsonschematools/schemas/DoubleSchema.java
+src/main/java/org/openapijsonschematools/schemas/FloatSchema.java
 src/main/java/org/openapijsonschematools/schemas/Int32Schema.java
 src/main/java/org/openapijsonschematools/schemas/Int64Schema.java
 src/main/java/org/openapijsonschematools/schemas/IntSchema.java

--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -3,6 +3,7 @@ pom.xml
 src/main/java/org/openapijsonschematools/configurations/JsonSchemaKeywordFlags.java
 src/main/java/org/openapijsonschematools/configurations/SchemaConfiguration.java
 src/main/java/org/openapijsonschematools/schemas/AnyTypeSchema.java
+src/main/java/org/openapijsonschematools/schemas/BooleanSchema.java
 src/main/java/org/openapijsonschematools/schemas/CustomIsoparser.java
 src/main/java/org/openapijsonschematools/schemas/NullSchema.java
 src/main/java/org/openapijsonschematools/schemas/PathToSchemasMap.java
@@ -15,6 +16,7 @@ src/main/java/org/openapijsonschematools/schemas/validators/KeywordValidator.jav
 src/main/java/org/openapijsonschematools/schemas/validators/TypeValidator.java
 src/test/java/org/openapijsonschematools/configurations/JsonSchemaKeywordFlagsTest.java
 src/test/java/org/openapijsonschematools/schemas/AnyTypeSchemaTest.java
+src/test/java/org/openapijsonschematools/schemas/BooleanSchemaTest.java
 src/test/java/org/openapijsonschematools/schemas/CustomIsoparserTest.java
 src/test/java/org/openapijsonschematools/schemas/NullSchemaTest.java
 src/test/java/org/openapijsonschematools/schemas/SchemaValidatorTest.java

--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -16,5 +16,6 @@ src/main/java/org/openapijsonschematools/schemas/validators/TypeValidator.java
 src/test/java/org/openapijsonschematools/configurations/JsonSchemaKeywordFlagsTest.java
 src/test/java/org/openapijsonschematools/schemas/AnyTypeSchemaTest.java
 src/test/java/org/openapijsonschematools/schemas/CustomIsoparserTest.java
+src/test/java/org/openapijsonschematools/schemas/NullSchemaTest.java
 src/test/java/org/openapijsonschematools/schemas/SchemaValidatorTest.java
 src/test/java/org/openapijsonschematools/schemas/validators/TypeValidatorTest.java

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/AnyTypeSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/AnyTypeSchema.java
@@ -24,6 +24,10 @@ record AnyTypeSchema() implements Schema {
         return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }
 
+    public static Long validate(Long arg, SchemaConfiguration configuration) {
+        return Schema.validate(AnyTypeSchema.class, arg, configuration);
+    }
+
     public static Float validate(Float arg, SchemaConfiguration configuration) {
         return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/BooleanSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/BooleanSchema.java
@@ -1,0 +1,17 @@
+package org.openapijsonschematools.schemas;
+
+import org.openapijsonschematools.configurations.SchemaConfiguration;
+
+import java.util.LinkedHashSet;
+
+record BooleanSchema(LinkedHashSet<Class<?>> type) implements Schema {
+    public static BooleanSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        type.add(Boolean.class);
+        return new BooleanSchema(type);
+    }
+
+    public static Boolean validate(Boolean arg, SchemaConfiguration configuration) {
+        return Schema.validate(BooleanSchema.class, arg, configuration);
+    }
+}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/DoubleSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/DoubleSchema.java
@@ -1,0 +1,19 @@
+package org.openapijsonschematools.schemas;
+
+import org.openapijsonschematools.configurations.SchemaConfiguration;
+
+import java.util.LinkedHashSet;
+import java.math.BigDecimal;
+
+record DoubleSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
+    public static DoubleSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        type.add(BigDecimal.class);
+        String format = "float";
+        return new DoubleSchema(type, format);
+    }
+
+    public static Double validate(Double arg, SchemaConfiguration configuration) {
+        return Schema.validate(DoubleSchema.class, arg, configuration);
+    }
+}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/FloatSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/FloatSchema.java
@@ -1,0 +1,19 @@
+package org.openapijsonschematools.schemas;
+
+import org.openapijsonschematools.configurations.SchemaConfiguration;
+
+import java.util.LinkedHashSet;
+import java.math.BigDecimal;
+
+record FloatSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
+    public static FloatSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        type.add(BigDecimal.class);
+        String format = "float";
+        return new FloatSchema(type, format);
+    }
+
+    public static Float validate(Float arg, SchemaConfiguration configuration) {
+        return Schema.validate(FloatSchema.class, arg, configuration);
+    }
+}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Int32Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Int32Schema.java
@@ -1,0 +1,23 @@
+package org.openapijsonschematools.schemas;
+
+import org.openapijsonschematools.configurations.SchemaConfiguration;
+
+import java.util.LinkedHashSet;
+import java.math.BigDecimal;
+
+record Int32Schema(LinkedHashSet<Class<?>> type, String format) implements Schema {
+    public static Int32Schema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        type.add(BigDecimal.class);
+        String format = "int32";
+        return new Int32Schema(type, format);
+    }
+
+    public static Integer validate(Integer arg, SchemaConfiguration configuration) {
+        return Schema.validate(NumberSchema.class, arg, configuration);
+    }
+
+    public static Integer validate(Float arg, SchemaConfiguration configuration) {
+        return Schema.validate(NumberSchema.class, Integer.parseInt(arg.toString()), configuration);
+    }
+}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Int32Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Int32Schema.java
@@ -14,10 +14,10 @@ record Int32Schema(LinkedHashSet<Class<?>> type, String format) implements Schem
     }
 
     public static Integer validate(Integer arg, SchemaConfiguration configuration) {
-        return Schema.validate(NumberSchema.class, arg, configuration);
+        return Schema.validate(Int32Schema.class, arg, configuration);
     }
 
     public static Integer validate(Float arg, SchemaConfiguration configuration) {
-        return Schema.validate(NumberSchema.class, Integer.parseInt(arg.toString()), configuration);
+        return Schema.validate(Int32Schema.class, Integer.parseInt(arg.toString()), configuration);
     }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Int64Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Int64Schema.java
@@ -1,0 +1,31 @@
+package org.openapijsonschematools.schemas;
+
+import org.openapijsonschematools.configurations.SchemaConfiguration;
+
+import java.util.LinkedHashSet;
+import java.math.BigDecimal;
+
+record Int64Schema(LinkedHashSet<Class<?>> type, String format) implements Schema {
+    public static Int64Schema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        type.add(BigDecimal.class);
+        String format = "int64";
+        return new Int64Schema(type, format);
+    }
+
+    public static Long validate(Integer arg, SchemaConfiguration configuration) {
+        return Schema.validate(Int64Schema.class, Long.valueOf(arg), configuration);
+    }
+
+    public static Long validate(Float arg, SchemaConfiguration configuration) {
+        return Schema.validate(Int64Schema.class, Long.parseLong(arg.toString()), configuration);
+    }
+
+    public static Long validate(Long arg, SchemaConfiguration configuration) {
+        return Schema.validate(Int64Schema.class, arg, configuration);
+    }
+
+    public static Long validate(Double arg, SchemaConfiguration configuration) {
+        return Schema.validate(Int64Schema.class, Long.parseLong(arg.toString()), configuration);
+    }
+}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/IntSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/IntSchema.java
@@ -1,0 +1,31 @@
+package org.openapijsonschematools.schemas;
+
+import org.openapijsonschematools.configurations.SchemaConfiguration;
+
+import java.util.LinkedHashSet;
+import java.math.BigDecimal;
+
+record IntSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
+    public static IntSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        type.add(BigDecimal.class);
+        String format = "int";
+        return new IntSchema(type, format);
+    }
+
+    public static Long validate(Integer arg, SchemaConfiguration configuration) {
+        return Schema.validate(IntSchema.class, Long.valueOf(arg), configuration);
+    }
+
+    public static Long validate(Float arg, SchemaConfiguration configuration) {
+        return Schema.validate(IntSchema.class, Long.parseLong(arg.toString()), configuration);
+    }
+
+    public static Long validate(Long arg, SchemaConfiguration configuration) {
+        return Schema.validate(IntSchema.class, arg, configuration);
+    }
+
+    public static Long validate(Double arg, SchemaConfiguration configuration) {
+        return Schema.validate(IntSchema.class, Long.parseLong(arg.toString()), configuration);
+    }
+}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/NullSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/NullSchema.java
@@ -1,0 +1,17 @@
+package org.openapijsonschematools.schemas;
+
+import org.openapijsonschematools.configurations.SchemaConfiguration;
+
+import java.util.LinkedHashSet;
+
+record NullSchema(LinkedHashSet<Class<?>> type) implements Schema {
+    public static NullSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        type.add(Void.class);
+        return new NullSchema(type);
+    }
+
+    public static Void validate(Void arg, SchemaConfiguration configuration) {
+        return Schema.validate(NullSchema.class, arg, configuration);
+    }
+}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/NumberSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/NumberSchema.java
@@ -1,0 +1,30 @@
+package org.openapijsonschematools.schemas;
+
+import org.openapijsonschematools.configurations.SchemaConfiguration;
+
+import java.util.LinkedHashSet;
+import java.math.BigDecimal;
+
+record NumberSchema(LinkedHashSet<Class<?>> type) implements Schema {
+    public static NumberSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        type.add(BigDecimal.class);
+        return new NumberSchema(type);
+    }
+
+    public static BigDecimal validate(Integer arg, SchemaConfiguration configuration) {
+        return Schema.validate(NumberSchema.class, BigDecimal.valueOf(arg), configuration);
+    }
+
+    public static BigDecimal validate(Long arg, SchemaConfiguration configuration) {
+        return Schema.validate(NumberSchema.class, BigDecimal.valueOf(arg), configuration);
+    }
+
+    public static BigDecimal validate(Float arg, SchemaConfiguration configuration) {
+        return Schema.validate(NumberSchema.class, BigDecimal.valueOf(arg), configuration);
+    }
+
+    public static BigDecimal validate(Double arg, SchemaConfiguration configuration) {
+        return Schema.validate(NumberSchema.class, BigDecimal.valueOf(arg), configuration);
+    }
+}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Schema.java
@@ -40,6 +40,9 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
       } else if (arg instanceof Boolean) {
          pathToType.put(pathToItem, Boolean.class);
          return arg;
+      } else if (arg instanceof BigDecimal) {
+         pathToType.put(pathToItem, BigDecimal.class);
+         return arg;
       } else if (arg instanceof Integer) {
          pathToType.put(pathToItem, BigDecimal.class);
          return BigDecimal.valueOf((Integer) arg);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Schema.java
@@ -41,17 +41,17 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
          pathToType.put(pathToItem, Boolean.class);
          return arg;
       } else if (arg instanceof Integer) {
-         pathToType.put(pathToItem, Integer.class);
-         return arg;
+         pathToType.put(pathToItem, BigDecimal.class);
+         return BigDecimal.valueOf((Integer) arg);
       } else if (arg instanceof Long) {
-         pathToType.put(pathToItem, Long.class);
-         return arg;
+         pathToType.put(pathToItem, BigDecimal.class);
+         return BigDecimal.valueOf((Long) arg);
       } else if (arg instanceof Float) {
-         pathToType.put(pathToItem, Float.class);
-         return arg;
+         pathToType.put(pathToItem, BigDecimal.class);
+         return BigDecimal.valueOf((Float) arg);
       } else if (arg instanceof Double) {
-         pathToType.put(pathToItem, Double.class);
-         return arg;
+         pathToType.put(pathToItem, BigDecimal.class);
+         return BigDecimal.valueOf((Double) arg);
       } else if (arg instanceof List) {
          pathToType.put(pathToItem, List.class);
          List<Object> argFixed = new ArrayList<>();
@@ -171,19 +171,23 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
    }
 
    static Integer validate(Class<?> cls, Integer arg, SchemaConfiguration configuration) {
-      return (Integer) validateObject(cls, arg, configuration);
+      BigDecimal val = (BigDecimal) validateObject(cls, arg, configuration);
+      return val.intValue();
    }
 
    static Long validate(Class<?> cls, Long arg, SchemaConfiguration configuration) {
-      return (Long) validateObject(cls, arg, configuration);
+      BigDecimal val = (BigDecimal) validateObject(cls, arg, configuration);
+      return val.longValue();
    }
 
    static Float validate(Class<?> cls, Float arg, SchemaConfiguration configuration) {
-      return (Float) validateObject(cls, arg, configuration);
+      BigDecimal val = (BigDecimal) validateObject(cls, arg, configuration);
+      return val.floatValue();
    }
 
    static Double validate(Class<?> cls, Double arg, SchemaConfiguration configuration) {
-      return (Double) validateObject(cls, arg, configuration);
+      BigDecimal val = (BigDecimal) validateObject(cls, arg, configuration);
+      return val.doubleValue();
    }
 
    static String validate(Class<?> cls, String arg, SchemaConfiguration configuration) {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Schema.java
@@ -173,6 +173,10 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
       return (Boolean) validateObject(cls, arg, configuration);
    }
 
+   static BigDecimal validate(Class<?> cls, BigDecimal arg, SchemaConfiguration configuration) {
+      return (BigDecimal) validateObject(cls, arg, configuration);
+   }
+
    static Integer validate(Class<?> cls, Integer arg, SchemaConfiguration configuration) {
       BigDecimal val = (BigDecimal) validateObject(cls, arg, configuration);
       return val.intValue();

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Schema.java
@@ -43,14 +43,14 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
       } else if (arg instanceof Integer) {
          pathToType.put(pathToItem, Integer.class);
          return arg;
+      } else if (arg instanceof Long) {
+         pathToType.put(pathToItem, Long.class);
+         return arg;
       } else if (arg instanceof Float) {
          pathToType.put(pathToItem, Float.class);
          return arg;
       } else if (arg instanceof Double) {
          pathToType.put(pathToItem, Double.class);
-         return arg;
-      } else if (arg instanceof BigDecimal) {
-         pathToType.put(pathToItem, BigDecimal.class);
          return arg;
       } else if (arg instanceof List) {
          pathToType.put(pathToItem, List.class);
@@ -172,6 +172,10 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
 
    static Integer validate(Class<?> cls, Integer arg, SchemaConfiguration configuration) {
       return (Integer) validateObject(cls, arg, configuration);
+   }
+
+   static Long validate(Class<?> cls, Long arg, SchemaConfiguration configuration) {
+      return (Long) validateObject(cls, arg, configuration);
    }
 
    static Float validate(Class<?> cls, Float arg, SchemaConfiguration configuration) {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/SchemaValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/SchemaValidator.java
@@ -2,6 +2,7 @@ package org.openapijsonschematools.schemas;
 
 import org.openapijsonschematools.schemas.validators.KeywordValidator;
 import org.openapijsonschematools.schemas.validators.TypeValidator;
+import org.openapijsonschematools.schemas.validators.FormatValidator;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.RecordComponent;
@@ -14,6 +15,7 @@ import java.util.Map;
 public interface SchemaValidator {
     HashMap<String, KeywordValidator> keywordToValidator = new HashMap(){{
         put("type", new TypeValidator());
+        put("format", new FormatValidator());
     }};
 
     static PathToSchemasMap validate(

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/UnsetAnyTypeSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/UnsetAnyTypeSchema.java
@@ -24,6 +24,10 @@ record UnsetAnyTypeSchema() implements Schema {
         return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
+    public static Long validate(Long arg, SchemaConfiguration configuration) {
+        return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
+    }
+
     static Float validate(Float arg, SchemaConfiguration configuration) {
         return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/FormatValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/FormatValidator.java
@@ -27,14 +27,14 @@ public class FormatValidator implements KeywordValidator {
                 );
             }
             if (format.equals("int32")) {
-                if (arg.compareTo(int32InclusiveMinimum) < 0  || arg.compareTo(int32InclusiveMaximum) > 1 ){
+                if (arg.compareTo(int32InclusiveMinimum) < 0  || arg.compareTo(int32InclusiveMaximum) > 0 ){
                     throw new RuntimeException(
                         "Invalid value "+arg+" for format int32 at "+validationMetadata.pathToItem()
                     );
                 }
                 return null;
             } else if (format.equals("int64")) {
-                if (arg.compareTo(int64InclusiveMinimum) < 0  || arg.compareTo(int64InclusiveMaximum) > 1 ){
+                if (arg.compareTo(int64InclusiveMinimum) < 0  || arg.compareTo(int64InclusiveMaximum) > 0 ){
                     throw new RuntimeException(
                         "Invalid value "+arg+" for format int64 at "+validationMetadata.pathToItem()
                     );
@@ -43,14 +43,14 @@ public class FormatValidator implements KeywordValidator {
             }
             return null;
         } else if (format.equals("float")) {
-            if (arg.compareTo(floatInclusiveMinimum) < 0  || arg.compareTo(floatInclusiveMaximum) > 1 ){
+            if (arg.compareTo(floatInclusiveMinimum) < 0  || arg.compareTo(floatInclusiveMaximum) > 0 ){
                 throw new RuntimeException(
                     "Invalid value "+arg+" for format float at "+validationMetadata.pathToItem()
                 );
             }
             return null;
         } else if (format.equals("double")) {
-            if (arg.compareTo(doubleInclusiveMinimum) < 0  || arg.compareTo(doubleInclusiveMaximum) > 1 ){
+            if (arg.compareTo(doubleInclusiveMinimum) < 0  || arg.compareTo(doubleInclusiveMaximum) > 0 ){
                 throw new RuntimeException(
                     "Invalid value "+arg+" for format double at "+validationMetadata.pathToItem()
                 );

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/FormatValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/FormatValidator.java
@@ -9,14 +9,14 @@ import java.math.BigDecimal;
 import java.time.format.DateTimeParseException;
 
 public class FormatValidator implements KeywordValidator {
-    private static BigDecimal int32InclusiveMinimum = BigDecimal.valueOf(-2147483648);
-    private static BigDecimal int32InclusiveMaximum = BigDecimal.valueOf(2147483647);
-    private static BigDecimal int64InclusiveMinimum = BigDecimal.valueOf(-9223372036854775808L);
-    private static BigDecimal int64InclusiveMaximum = BigDecimal.valueOf(9223372036854775807L);
-    private static BigDecimal floatInclusiveMinimum = BigDecimal.valueOf(-3.4028234663852886e+38);
-    private static BigDecimal floatInclusiveMaximum = BigDecimal.valueOf(3.4028234663852886e+38);
-    private static BigDecimal doubleInclusiveMinimum = BigDecimal.valueOf(-1.7976931348623157E+308d);
-    private static BigDecimal doubleInclusiveMaximum = BigDecimal.valueOf(1.7976931348623157E+308d);
+    private final static BigDecimal int32InclusiveMinimum = BigDecimal.valueOf(-2147483648);
+    private final static BigDecimal int32InclusiveMaximum = BigDecimal.valueOf(2147483647);
+    private final static BigDecimal int64InclusiveMinimum = BigDecimal.valueOf(-9223372036854775808L);
+    private final static BigDecimal int64InclusiveMaximum = BigDecimal.valueOf(9223372036854775807L);
+    private final static BigDecimal floatInclusiveMinimum = BigDecimal.valueOf(-3.4028234663852886e+38);
+    private final static BigDecimal floatInclusiveMaximum = BigDecimal.valueOf(3.4028234663852886e+38);
+    private final static BigDecimal doubleInclusiveMinimum = BigDecimal.valueOf(-1.7976931348623157E+308d);
+    private final static BigDecimal doubleInclusiveMaximum = BigDecimal.valueOf(1.7976931348623157E+308d);
 
     private Void validateNumericFormat(BigDecimal arg, String format, ValidationMetadata validationMetadata) {
         if (format.startsWith("int")) {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/FormatValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/FormatValidator.java
@@ -21,7 +21,7 @@ public class FormatValidator implements KeywordValidator {
     private Void validateNumericFormat(BigDecimal arg, String format, ValidationMetadata validationMetadata) {
         if (format.startsWith("int")) {
             // there is a json schema test where 1.0 validates as an integer
-            if (arg.longValue() != Long.valueOf(arg.toString())) {
+            if (arg.stripTrailingZeros().scale() > 0) {
                 throw new RuntimeException(
                         "Invalid non-integer value " + arg + " for format " + format + " at " + validationMetadata.pathToItem()
                 );

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/FormatValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/FormatValidator.java
@@ -1,0 +1,121 @@
+package org.openapijsonschematools.schemas.validators;
+
+import org.openapijsonschematools.schemas.CustomIsoparser;
+import org.openapijsonschematools.schemas.PathToSchemasMap;
+import org.openapijsonschematools.schemas.SchemaValidator;
+import org.openapijsonschematools.schemas.ValidationMetadata;
+
+import java.math.BigDecimal;
+import java.time.format.DateTimeParseException;
+
+public class FormatValidator implements KeywordValidator {
+    private static BigDecimal int32InclusiveMinimum = BigDecimal.valueOf(-2147483648);
+    private static BigDecimal int32InclusiveMaximum = BigDecimal.valueOf(2147483647);
+    private static BigDecimal int64InclusiveMinimum = BigDecimal.valueOf(-9223372036854775808L);
+    private static BigDecimal int64InclusiveMaximum = BigDecimal.valueOf(9223372036854775807L);
+    private static BigDecimal floatInclusiveMinimum = BigDecimal.valueOf(-3.4028234663852886e+38);
+    private static BigDecimal floatInclusiveMaximum = BigDecimal.valueOf(3.4028234663852886e+38);
+    private static BigDecimal doubleInclusiveMinimum = BigDecimal.valueOf(-1.7976931348623157E+308d);
+    private static BigDecimal doubleInclusiveMaximum = BigDecimal.valueOf(1.7976931348623157E+308d);
+
+    private Void validateNumericFormat(BigDecimal arg, String format, ValidationMetadata validationMetadata) {
+        if (format.startsWith("int")) {
+            // there is a json schema test where 1.0 validates as an integer
+            if (arg.longValue() != Long.valueOf(arg.toString())) {
+                throw new RuntimeException(
+                        "Invalid non-integer value " + arg + " for format " + format + " at " + validationMetadata.pathToItem()
+                );
+            }
+            if (format.equals("int32")) {
+                if (arg.compareTo(int32InclusiveMinimum) < 0  || arg.compareTo(int32InclusiveMaximum) > 1 ){
+                    throw new RuntimeException(
+                        "Invalid value "+arg+" for format int32 at "+validationMetadata.pathToItem()
+                    );
+                }
+                return null;
+            } else if (format.equals("int64")) {
+                if (arg.compareTo(int64InclusiveMinimum) < 0  || arg.compareTo(int64InclusiveMaximum) > 1 ){
+                    throw new RuntimeException(
+                        "Invalid value "+arg+" for format int64 at "+validationMetadata.pathToItem()
+                    );
+                }
+                return null;
+            }
+            return null;
+        } else if (format.equals("float")) {
+            if (arg.compareTo(floatInclusiveMinimum) < 0  || arg.compareTo(floatInclusiveMaximum) > 1 ){
+                throw new RuntimeException(
+                    "Invalid value "+arg+" for format float at "+validationMetadata.pathToItem()
+                );
+            }
+            return null;
+        } else if (format.equals("double")) {
+            if (arg.compareTo(doubleInclusiveMinimum) < 0  || arg.compareTo(doubleInclusiveMaximum) > 1 ){
+                throw new RuntimeException(
+                    "Invalid value "+arg+" for format double at "+validationMetadata.pathToItem()
+                );
+            }
+            return null;
+        }
+        return null;
+    }
+
+    private Void validateStringFormat(String arg, String format, ValidationMetadata validationMetadata) {
+        if (format.equals("uuid")) {
+            // todo
+            return null;
+        } else if (format.equals("number")) {
+            try {
+                new BigDecimal(arg);
+            } catch (NumberFormatException e) {
+                throw new RuntimeException(
+                    "Value cannot be converted to a decimal. Invalid value "+
+                            arg+" for format number at "+validationMetadata.pathToItem()
+                );
+            }
+            return null;
+        } else if (format.equals("date")) {
+            try {
+                new CustomIsoparser().parseIsodate(arg);
+            } catch (DateTimeParseException e) {
+                throw new RuntimeException(
+                        "Value does not conform to the required ISO-8601 date format. "+
+                        "Invalid value "+arg+" for format date at "+validationMetadata.pathToItem()
+                );
+            }
+            return null;
+        } else if (format.equals("date-time")) {
+            try {
+                new CustomIsoparser().parseIsodatetime(arg);
+            } catch (DateTimeParseException e) {
+                throw new RuntimeException(
+                        "Value does not conform to the required ISO-8601 datetime format. "+
+                                "Invalid value "+arg+" for format datetime at "+validationMetadata.pathToItem()
+                );
+            }
+            return null;
+        }
+        return null;
+    }
+
+    @Override
+    public PathToSchemasMap validate(Object arg, Object value, Object extra, Class<SchemaValidator> cls, ValidationMetadata validationMetadata) {
+        String format = (String) value;
+        if (arg instanceof BigDecimal) {
+            validateNumericFormat(
+                (BigDecimal) arg,
+                format,
+                validationMetadata
+            );
+            return null;
+        } else if (arg instanceof String) {
+            validateStringFormat(
+                (String) arg,
+                format,
+                validationMetadata
+            );
+            return null;
+        }
+        return null;
+    }
+}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/TypeValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/TypeValidator.java
@@ -10,7 +10,13 @@ public class TypeValidator implements KeywordValidator {
     @Override
     public PathToSchemasMap validate(Object arg, Object value, Object extra, Class<SchemaValidator> cls, ValidationMetadata validationMetadata) {
         HashSet<Class<?>> types = (HashSet<Class<?>>) value;
-        if (!types.contains(arg.getClass())) {
+        Class<?> argClass;
+        if (arg == null) {
+            argClass = Void.class;
+        } else {
+            argClass = arg.getClass();
+        }
+        if (!types.contains(argClass)) {
             throw new RuntimeException("invalid type");
         }
         return null;

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/AnyTypeSchemaTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/AnyTypeSchemaTest.java
@@ -30,9 +30,15 @@ public class AnyTypeSchemaTest {
     }
 
     @Test
-    public void testValidateInt() {
+    public void testValidateInteger() {
         Integer validatedValue = AnyTypeSchema.validate(1, configuration);
         Assert.assertEquals(validatedValue, Integer.valueOf(1));
+    }
+
+    @Test
+    public void testValidateLong() {
+        Long validatedValue = AnyTypeSchema.validate(1L, configuration);
+        Assert.assertEquals(validatedValue, Long.valueOf(1));
     }
 
     @Test

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/BooleanSchemaTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/BooleanSchemaTest.java
@@ -1,0 +1,29 @@
+package org.openapijsonschematools.schemas;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
+import org.openapijsonschematools.configurations.SchemaConfiguration;
+
+public class BooleanSchemaTest {
+    static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
+
+    @Test
+    public void testValidateTrue() {
+        Boolean validatedValue = BooleanSchema.validate(Boolean.TRUE, configuration);
+        Assert.assertEquals(validatedValue, Boolean.TRUE);
+    }
+
+    @Test
+    public void testValidateFalse() {
+        Boolean validatedValue = BooleanSchema.validate(Boolean.FALSE, configuration);
+        Assert.assertEquals(validatedValue, Boolean.FALSE);
+    }
+
+    @Test
+    public void testExceptionThrownForInvalidType() {
+        Assert.assertThrows(RuntimeException.class, () -> Schema.validate(
+                BooleanSchema.class, (Void) null, configuration
+        ));
+    }
+}

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/NullSchemaTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/NullSchemaTest.java
@@ -1,0 +1,23 @@
+package org.openapijsonschematools.schemas;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
+import org.openapijsonschematools.configurations.SchemaConfiguration;
+
+public class NullSchemaTest {
+    static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
+
+    @Test
+    public void testValidateNull() {
+        Void validatedValue = NullSchema.validate(null, configuration);
+        Assert.assertNull(validatedValue);
+    }
+
+    @Test
+    public void testExceptionThrownForInvalidType() {
+        Assert.assertThrows(RuntimeException.class, () -> Schema.validate(
+                NullSchema.class, Boolean.TRUE, configuration
+        ));
+    }
+}

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/NumberSchemaTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/NumberSchemaTest.java
@@ -1,0 +1,43 @@
+package org.openapijsonschematools.schemas;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
+import org.openapijsonschematools.configurations.SchemaConfiguration;
+
+import java.math.BigDecimal;
+
+public class NumberSchemaTest {
+    static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
+
+    @Test
+    public void testValidateInteger() {
+        BigDecimal validatedValue = NumberSchema.validate(1, configuration);
+        Assert.assertEquals(validatedValue, BigDecimal.valueOf(1));
+    }
+
+    @Test
+    public void testValidateLong() {
+        BigDecimal validatedValue = NumberSchema.validate(1L, configuration);
+        Assert.assertEquals(validatedValue, BigDecimal.valueOf(1L));
+    }
+
+    @Test
+    public void testValidateFloat() {
+        BigDecimal validatedValue = NumberSchema.validate(3.14f, configuration);
+        Assert.assertEquals(validatedValue, BigDecimal.valueOf(3.14f));
+    }
+
+    @Test
+    public void testValidateDouble() {
+        BigDecimal validatedValue = NumberSchema.validate(3.14d, configuration);
+        Assert.assertEquals(validatedValue, BigDecimal.valueOf(3.14d));
+    }
+
+    @Test
+    public void testExceptionThrownForInvalidType() {
+        Assert.assertThrows(RuntimeException.class, () -> Schema.validate(
+                NumberSchema.class, (Void) null, configuration
+        ));
+    }
+}

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/SchemaValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/SchemaValidatorTest.java
@@ -5,7 +5,6 @@ import org.junit.Test;
 import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/FormatValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/FormatValidatorTest.java
@@ -1,0 +1,152 @@
+package org.openapijsonschematools.schemas.validators;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
+import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.schemas.PathToSchemasMap;
+import org.openapijsonschematools.schemas.SchemaValidator;
+import org.openapijsonschematools.schemas.ValidationMetadata;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+
+public class FormatValidatorTest {
+    static final ValidationMetadata validationMetadata = new ValidationMetadata(
+            new ArrayList<>(),
+            new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone()),
+            new PathToSchemasMap(),
+            new LinkedHashSet<>()
+    );
+
+    @Test
+    public void testIntFormatSucceedsWithFloat() {
+        final FormatValidator validator = new FormatValidator();
+        PathToSchemasMap pathToSchemasMap = validator.validate(
+                new BigDecimal("1.0"),
+                "int",
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        );
+        Assert.assertNull(pathToSchemasMap);
+    }
+
+    @Test
+    public void testIntFormatSucceedsWithInt() {
+        final FormatValidator validator = new FormatValidator();
+        PathToSchemasMap pathToSchemasMap = validator.validate(
+                new BigDecimal("1"),
+                "int",
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        );
+        Assert.assertNull(pathToSchemasMap);
+    }
+
+    @Test
+    public void testInt32InclusiveMinSucceeds() {
+        final FormatValidator validator = new FormatValidator();
+        PathToSchemasMap pathToSchemasMap = validator.validate(
+                new BigDecimal(-2147483648),
+                "int32",
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        );
+        Assert.assertNull(pathToSchemasMap);
+    }
+
+    @Test
+    public void testInt32InclusiveMaxSucceeds() {
+        final FormatValidator validator = new FormatValidator();
+        PathToSchemasMap pathToSchemasMap = validator.validate(
+                new BigDecimal(2147483647),
+                "int32",
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        );
+        Assert.assertNull(pathToSchemasMap);
+    }
+
+    @Test
+    public void testInt64InclusiveMinSucceeds() {
+        final FormatValidator validator = new FormatValidator();
+        PathToSchemasMap pathToSchemasMap = validator.validate(
+                new BigDecimal(-9223372036854775808L),
+                "int64",
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        );
+        Assert.assertNull(pathToSchemasMap);
+    }
+
+    @Test
+    public void testInt64InclusiveMaxSucceeds() {
+        final FormatValidator validator = new FormatValidator();
+        PathToSchemasMap pathToSchemasMap = validator.validate(
+                new BigDecimal(9223372036854775807L),
+                "int64",
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        );
+        Assert.assertNull(pathToSchemasMap);
+    }
+
+    @Test
+    public void testFloatInclusiveMinSucceeds() {
+        final FormatValidator validator = new FormatValidator();
+        PathToSchemasMap pathToSchemasMap = validator.validate(
+                new BigDecimal(-3.4028234663852886e+38),
+                "float",
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        );
+        Assert.assertNull(pathToSchemasMap);
+    }
+
+    @Test
+    public void testFloatInclusiveMaxSucceeds() {
+        final FormatValidator validator = new FormatValidator();
+        PathToSchemasMap pathToSchemasMap = validator.validate(
+                new BigDecimal(3.4028234663852886e+38),
+                "float",
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        );
+        Assert.assertNull(pathToSchemasMap);
+    }
+
+    @Test
+    public void testDoubleInclusiveMinSucceeds() {
+        final FormatValidator validator = new FormatValidator();
+        PathToSchemasMap pathToSchemasMap = validator.validate(
+                BigDecimal.valueOf(-1.7976931348623157E+308d),
+                "double",
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        );
+        Assert.assertNull(pathToSchemasMap);
+    }
+
+    @Test
+    public void testDoubleInclusiveMaxSucceeds() {
+        final FormatValidator validator = new FormatValidator();
+        PathToSchemasMap pathToSchemasMap = validator.validate(
+                BigDecimal.valueOf(1.7976931348623157E+308d),
+                "double",
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        );
+        Assert.assertNull(pathToSchemasMap);
+    }
+}

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/FormatValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/FormatValidatorTest.java
@@ -9,6 +9,7 @@ import org.openapijsonschematools.schemas.SchemaValidator;
 import org.openapijsonschematools.schemas.ValidationMetadata;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 
@@ -34,6 +35,18 @@ public class FormatValidatorTest {
     }
 
     @Test
+    public void testIntFormatFailsWithFloat() {
+        final FormatValidator validator = new FormatValidator();
+        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                new BigDecimal("3.14"),
+                "int",
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        ));
+    }
+
+    @Test
     public void testIntFormatSucceedsWithInt() {
         final FormatValidator validator = new FormatValidator();
         PathToSchemasMap pathToSchemasMap = validator.validate(
@@ -44,6 +57,18 @@ public class FormatValidatorTest {
                 validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
+    }
+
+    @Test
+    public void testInt32UnderMinFails() {
+        final FormatValidator validator = new FormatValidator();
+        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                new BigDecimal(-2147483649L),
+                "int32",
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        ));
     }
 
     @Test
@@ -73,6 +98,31 @@ public class FormatValidatorTest {
     }
 
     @Test
+    public void testInt32OverMaxFails() {
+        final FormatValidator validator = new FormatValidator();
+        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                BigDecimal.valueOf(2147483648L),
+                "int32",
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        ));
+    }
+
+    @Test
+    public void testInt64UnderMinFails() {
+        final FormatValidator validator = new FormatValidator();
+
+        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                new BigDecimal(new BigInteger("-9223372036854775809")),
+                "int64",
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        ));
+    }
+
+    @Test
     public void testInt64InclusiveMinSucceeds() {
         final FormatValidator validator = new FormatValidator();
         PathToSchemasMap pathToSchemasMap = validator.validate(
@@ -96,6 +146,31 @@ public class FormatValidatorTest {
                 validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
+    }
+
+    @Test
+    public void testInt64OverMaxFails() {
+        final FormatValidator validator = new FormatValidator();
+
+        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                new BigDecimal(new BigInteger("9223372036854775808")),
+                "int64",
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        ));
+    }
+
+    @Test
+    public void testFloatUnderMinFails() {
+        final FormatValidator validator = new FormatValidator();
+        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                BigDecimal.valueOf(-3.402823466385289e+38),
+                "float",
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        ));
     }
 
     @Test
@@ -125,6 +200,30 @@ public class FormatValidatorTest {
     }
 
     @Test
+    public void testFloatOverMaxFails() {
+        final FormatValidator validator = new FormatValidator();
+        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                BigDecimal.valueOf(3.402823466385289e+38),
+                "float",
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        ));
+    }
+
+    @Test
+    public void testDoubleUnderMinFails() {
+        final FormatValidator validator = new FormatValidator();
+        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                new BigDecimal("-1.7976931348623157082e+308"),
+                "double",
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        ));
+    }
+
+    @Test
     public void testDoubleInclusiveMinSucceeds() {
         final FormatValidator validator = new FormatValidator();
         PathToSchemasMap pathToSchemasMap = validator.validate(
@@ -148,5 +247,17 @@ public class FormatValidatorTest {
                 validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
+    }
+
+    @Test
+    public void testDoubleOverMaxFails() {
+        final FormatValidator validator = new FormatValidator();
+        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                new BigDecimal("1.7976931348623157082e+308"),
+                "double",
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        ));
     }
 }

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -266,6 +266,10 @@ public class JavaClientGenerator extends AbstractJavaGenerator
                 packagePath() + File.separatorChar + "schemas",
                 "AnyTypeSchema.java"));
         supportingFiles.add(new SupportingFile(
+                "src/main/java/org/openapitools/schemas/BooleanSchema.hbs",
+                packagePath() + File.separatorChar + "schemas",
+                "BooleanSchema.java"));
+        supportingFiles.add(new SupportingFile(
                 "src/main/java/org/openapitools/schemas/CustomIsoparser.hbs",
                 packagePath() + File.separatorChar + "schemas",
                 "CustomIsoparser.java"));
@@ -302,6 +306,10 @@ public class JavaClientGenerator extends AbstractJavaGenerator
                 "src/test/java/org/openapitools/schemas/AnyTypeSchemaTest.hbs",
                 testPackagePath() + File.separatorChar + "schemas",
                 "AnyTypeSchemaTest.java"));
+        supportingFiles.add(new SupportingFile(
+                "src/test/java/org/openapitools/schemas/BooleanSchemaTest.hbs",
+                testPackagePath() + File.separatorChar + "schemas",
+                "BooleanSchemaTest.java"));
         supportingFiles.add(new SupportingFile(
                 "src/test/java/org/openapitools/schemas/CustomIsoparserTest.hbs",
                 testPackagePath() + File.separatorChar + "schemas",

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -349,6 +349,10 @@ public class JavaClientGenerator extends AbstractJavaGenerator
                 "src/test/java/org/openapitools/schemas/validators/TypeValidatorTest.hbs",
                 testPackagePath() + File.separatorChar + "schemas" + File.separatorChar + "validators",
                 "TypeValidatorTest.java"));
+        supportingFiles.add(new SupportingFile(
+                "src/test/java/org/openapitools/schemas/validators/FormatValidatorTest.hbs",
+                testPackagePath() + File.separatorChar + "schemas" + File.separatorChar + "validators",
+                "FormatValidatorTest.java"));
 
         // configuration
         supportingFiles.add(new SupportingFile(

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -278,6 +278,10 @@ public class JavaClientGenerator extends AbstractJavaGenerator
                 packagePath() + File.separatorChar + "schemas",
                 "NullSchema.java"));
         supportingFiles.add(new SupportingFile(
+                "src/main/java/org/openapitools/schemas/NumberSchema.hbs",
+                packagePath() + File.separatorChar + "schemas",
+                "NumberSchema.java"));
+        supportingFiles.add(new SupportingFile(
                 "src/main/java/org/openapitools/schemas/PathToSchemasMap.hbs",
                 packagePath() + File.separatorChar + "schemas",
                 "PathToSchemasMap.java"));
@@ -318,6 +322,10 @@ public class JavaClientGenerator extends AbstractJavaGenerator
                 "src/test/java/org/openapitools/schemas/NullSchemaTest.hbs",
                 testPackagePath() + File.separatorChar + "schemas",
                 "NullSchemaTest.java"));
+        supportingFiles.add(new SupportingFile(
+                "src/test/java/org/openapitools/schemas/NumberSchemaTest.hbs",
+                testPackagePath() + File.separatorChar + "schemas",
+                "NumberSchemaTest.java"));
         supportingFiles.add(new SupportingFile(
                 "src/test/java/org/openapitools/schemas/SchemaValidatorTest.hbs",
                 testPackagePath() + File.separatorChar + "schemas",

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -307,6 +307,10 @@ public class JavaClientGenerator extends AbstractJavaGenerator
                 testPackagePath() + File.separatorChar + "schemas",
                 "CustomIsoparserTest.java"));
         supportingFiles.add(new SupportingFile(
+                "src/test/java/org/openapitools/schemas/NullSchemaTest.hbs",
+                testPackagePath() + File.separatorChar + "schemas",
+                "NullSchemaTest.java"));
+        supportingFiles.add(new SupportingFile(
                 "src/test/java/org/openapitools/schemas/SchemaValidatorTest.hbs",
                 testPackagePath() + File.separatorChar + "schemas",
                 "SchemaValidatorTest.java"));

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -274,6 +274,14 @@ public class JavaClientGenerator extends AbstractJavaGenerator
                 packagePath() + File.separatorChar + "schemas",
                 "CustomIsoparser.java"));
         supportingFiles.add(new SupportingFile(
+                "src/main/java/org/openapitools/schemas/DoubleSchema.hbs",
+                packagePath() + File.separatorChar + "schemas",
+                "DoubleSchema.java"));
+        supportingFiles.add(new SupportingFile(
+                "src/main/java/org/openapitools/schemas/FloatSchema.hbs",
+                packagePath() + File.separatorChar + "schemas",
+                "FloatSchema.java"));
+        supportingFiles.add(new SupportingFile(
                 "src/main/java/org/openapitools/schemas/Int32Schema.hbs",
                 packagePath() + File.separatorChar + "schemas",
                 "Int32Schema.java"));

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -278,6 +278,10 @@ public class JavaClientGenerator extends AbstractJavaGenerator
                 packagePath() + File.separatorChar + "schemas",
                 "Int32Schema.java"));
         supportingFiles.add(new SupportingFile(
+                "src/main/java/org/openapitools/schemas/Int64Schema.hbs",
+                packagePath() + File.separatorChar + "schemas",
+                "Int64Schema.java"));
+        supportingFiles.add(new SupportingFile(
                 "src/main/java/org/openapitools/schemas/NullSchema.hbs",
                 packagePath() + File.separatorChar + "schemas",
                 "NullSchema.java"));

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -274,6 +274,10 @@ public class JavaClientGenerator extends AbstractJavaGenerator
                 packagePath() + File.separatorChar + "schemas",
                 "CustomIsoparser.java"));
         supportingFiles.add(new SupportingFile(
+                "src/main/java/org/openapitools/schemas/Int32Schema.hbs",
+                packagePath() + File.separatorChar + "schemas",
+                "Int32Schema.java"));
+        supportingFiles.add(new SupportingFile(
                 "src/main/java/org/openapitools/schemas/NullSchema.hbs",
                 packagePath() + File.separatorChar + "schemas",
                 "NullSchema.java"));

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -270,6 +270,10 @@ public class JavaClientGenerator extends AbstractJavaGenerator
                 packagePath() + File.separatorChar + "schemas",
                 "CustomIsoparser.java"));
         supportingFiles.add(new SupportingFile(
+                "src/main/java/org/openapitools/schemas/NullSchema.hbs",
+                packagePath() + File.separatorChar + "schemas",
+                "NullSchema.java"));
+        supportingFiles.add(new SupportingFile(
                 "src/main/java/org/openapitools/schemas/PathToSchemasMap.hbs",
                 packagePath() + File.separatorChar + "schemas",
                 "PathToSchemasMap.java"));

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -282,6 +282,10 @@ public class JavaClientGenerator extends AbstractJavaGenerator
                 packagePath() + File.separatorChar + "schemas",
                 "Int64Schema.java"));
         supportingFiles.add(new SupportingFile(
+                "src/main/java/org/openapitools/schemas/IntSchema.hbs",
+                packagePath() + File.separatorChar + "schemas",
+                "IntSchema.java"));
+        supportingFiles.add(new SupportingFile(
                 "src/main/java/org/openapitools/schemas/NullSchema.hbs",
                 packagePath() + File.separatorChar + "schemas",
                 "NullSchema.java"));

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -340,6 +340,10 @@ public class JavaClientGenerator extends AbstractJavaGenerator
                 "src/main/java/org/openapitools/schemas/validators/TypeValidator.hbs",
                 packagePath() + File.separatorChar + "schemas" + File.separatorChar + "validators",
                 "TypeValidator.java"));
+        supportingFiles.add(new SupportingFile(
+                "src/main/java/org/openapitools/schemas/validators/FormatValidator.hbs",
+                packagePath() + File.separatorChar + "schemas" + File.separatorChar + "validators",
+                "FormatValidator.java"));
         // tests
         supportingFiles.add(new SupportingFile(
                 "src/test/java/org/openapitools/schemas/validators/TypeValidatorTest.hbs",

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/AnyTypeSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/AnyTypeSchema.hbs
@@ -24,6 +24,10 @@ record AnyTypeSchema() implements Schema {
         return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }
 
+    public static Long validate(Long arg, SchemaConfiguration configuration) {
+        return Schema.validate(AnyTypeSchema.class, arg, configuration);
+    }
+
     public static Float validate(Float arg, SchemaConfiguration configuration) {
         return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/BooleanSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/BooleanSchema.hbs
@@ -1,0 +1,17 @@
+package {{{packageName}}}.schemas;
+
+import {{{packageName}}}.configurations.SchemaConfiguration;
+
+import java.util.LinkedHashSet;
+
+record BooleanSchema(LinkedHashSet<Class<?>> type) implements Schema {
+    public static BooleanSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        type.add(Boolean.class);
+        return new BooleanSchema(type);
+    }
+
+    public static Boolean validate(Boolean arg, SchemaConfiguration configuration) {
+        return Schema.validate(BooleanSchema.class, arg, configuration);
+    }
+}

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/DoubleSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/DoubleSchema.hbs
@@ -1,0 +1,19 @@
+package {{{packageName}}}.schemas;
+
+import {{{packageName}}}.configurations.SchemaConfiguration;
+
+import java.util.LinkedHashSet;
+import java.math.BigDecimal;
+
+record DoubleSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
+    public static DoubleSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        type.add(BigDecimal.class);
+        String format = "float";
+        return new DoubleSchema(type, format);
+    }
+
+    public static Double validate(Double arg, SchemaConfiguration configuration) {
+        return Schema.validate(DoubleSchema.class, arg, configuration);
+    }
+}

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/FloatSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/FloatSchema.hbs
@@ -1,0 +1,19 @@
+package {{{packageName}}}.schemas;
+
+import {{{packageName}}}.configurations.SchemaConfiguration;
+
+import java.util.LinkedHashSet;
+import java.math.BigDecimal;
+
+record FloatSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
+    public static FloatSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        type.add(BigDecimal.class);
+        String format = "float";
+        return new FloatSchema(type, format);
+    }
+
+    public static Float validate(Float arg, SchemaConfiguration configuration) {
+        return Schema.validate(FloatSchema.class, arg, configuration);
+    }
+}

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/Int32Schema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/Int32Schema.hbs
@@ -1,0 +1,23 @@
+package {{{packageName}}}.schemas;
+
+import {{{packageName}}}.configurations.SchemaConfiguration;
+
+import java.util.LinkedHashSet;
+import java.math.BigDecimal;
+
+record Int32Schema(LinkedHashSet<Class<?>> type, String format) implements Schema {
+    public static Int32Schema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        type.add(BigDecimal.class);
+        String format = "int32";
+        return new Int32Schema(type, format);
+    }
+
+    public static Integer validate(Integer arg, SchemaConfiguration configuration) {
+        return Schema.validate(NumberSchema.class, arg, configuration);
+    }
+
+    public static Integer validate(Float arg, SchemaConfiguration configuration) {
+        return Schema.validate(NumberSchema.class, Integer.parseInt(arg.toString()), configuration);
+    }
+}

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/Int32Schema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/Int32Schema.hbs
@@ -14,10 +14,10 @@ record Int32Schema(LinkedHashSet<Class<?>> type, String format) implements Schem
     }
 
     public static Integer validate(Integer arg, SchemaConfiguration configuration) {
-        return Schema.validate(NumberSchema.class, arg, configuration);
+        return Schema.validate(Int32Schema.class, arg, configuration);
     }
 
     public static Integer validate(Float arg, SchemaConfiguration configuration) {
-        return Schema.validate(NumberSchema.class, Integer.parseInt(arg.toString()), configuration);
+        return Schema.validate(Int32Schema.class, Integer.parseInt(arg.toString()), configuration);
     }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/Int64Schema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/Int64Schema.hbs
@@ -1,0 +1,31 @@
+package {{{packageName}}}.schemas;
+
+import {{{packageName}}}.configurations.SchemaConfiguration;
+
+import java.util.LinkedHashSet;
+import java.math.BigDecimal;
+
+record Int64Schema(LinkedHashSet<Class<?>> type, String format) implements Schema {
+    public static Int64Schema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        type.add(BigDecimal.class);
+        String format = "int64";
+        return new Int64Schema(type, format);
+    }
+
+    public static Long validate(Integer arg, SchemaConfiguration configuration) {
+        return Schema.validate(Int64Schema.class, Long.valueOf(arg), configuration);
+    }
+
+    public static Long validate(Float arg, SchemaConfiguration configuration) {
+        return Schema.validate(Int64Schema.class, Long.parseLong(arg.toString()), configuration);
+    }
+
+    public static Long validate(Long arg, SchemaConfiguration configuration) {
+        return Schema.validate(Int64Schema.class, arg, configuration);
+    }
+
+    public static Long validate(Double arg, SchemaConfiguration configuration) {
+        return Schema.validate(Int64Schema.class, Long.parseLong(arg.toString()), configuration);
+    }
+}

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/IntSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/IntSchema.hbs
@@ -1,0 +1,31 @@
+package {{{packageName}}}.schemas;
+
+import {{{packageName}}}.configurations.SchemaConfiguration;
+
+import java.util.LinkedHashSet;
+import java.math.BigDecimal;
+
+record IntSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
+    public static IntSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        type.add(BigDecimal.class);
+        String format = "int";
+        return new IntSchema(type, format);
+    }
+
+    public static Long validate(Integer arg, SchemaConfiguration configuration) {
+        return Schema.validate(IntSchema.class, Long.valueOf(arg), configuration);
+    }
+
+    public static Long validate(Float arg, SchemaConfiguration configuration) {
+        return Schema.validate(IntSchema.class, Long.parseLong(arg.toString()), configuration);
+    }
+
+    public static Long validate(Long arg, SchemaConfiguration configuration) {
+        return Schema.validate(IntSchema.class, arg, configuration);
+    }
+
+    public static Long validate(Double arg, SchemaConfiguration configuration) {
+        return Schema.validate(IntSchema.class, Long.parseLong(arg.toString()), configuration);
+    }
+}

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/NullSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/NullSchema.hbs
@@ -1,0 +1,17 @@
+package {{{packageName}}}.schemas;
+
+import {{{packageName}}}.configurations.SchemaConfiguration;
+
+import java.util.LinkedHashSet;
+
+record NullSchema(LinkedHashSet<Class<?>> type) implements Schema {
+    public static NullSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        type.add(Void.class);
+        return new NullSchema(type);
+    }
+
+    public static Void validate(Void arg, SchemaConfiguration configuration) {
+        return Schema.validate(NullSchema.class, arg, configuration);
+    }
+}

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/NumberSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/NumberSchema.hbs
@@ -1,0 +1,30 @@
+package {{{packageName}}}.schemas;
+
+import {{{packageName}}}.configurations.SchemaConfiguration;
+
+import java.util.LinkedHashSet;
+import java.math.BigDecimal;
+
+record NumberSchema(LinkedHashSet<Class<?>> type) implements Schema {
+    public static NumberSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        type.add(BigDecimal.class);
+        return new NumberSchema(type);
+    }
+
+    public static BigDecimal validate(Integer arg, SchemaConfiguration configuration) {
+        return Schema.validate(NumberSchema.class, BigDecimal.valueOf(arg), configuration);
+    }
+
+    public static BigDecimal validate(Long arg, SchemaConfiguration configuration) {
+        return Schema.validate(NumberSchema.class, BigDecimal.valueOf(arg), configuration);
+    }
+
+    public static BigDecimal validate(Float arg, SchemaConfiguration configuration) {
+        return Schema.validate(NumberSchema.class, BigDecimal.valueOf(arg), configuration);
+    }
+
+    public static BigDecimal validate(Double arg, SchemaConfiguration configuration) {
+        return Schema.validate(NumberSchema.class, BigDecimal.valueOf(arg), configuration);
+    }
+}

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/Schema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/Schema.hbs
@@ -40,6 +40,9 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
       } else if (arg instanceof Boolean) {
          pathToType.put(pathToItem, Boolean.class);
          return arg;
+      } else if (arg instanceof BigDecimal) {
+         pathToType.put(pathToItem, BigDecimal.class);
+         return arg;
       } else if (arg instanceof Integer) {
          pathToType.put(pathToItem, BigDecimal.class);
          return BigDecimal.valueOf((Integer) arg);

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/Schema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/Schema.hbs
@@ -41,17 +41,17 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
          pathToType.put(pathToItem, Boolean.class);
          return arg;
       } else if (arg instanceof Integer) {
-         pathToType.put(pathToItem, Integer.class);
-         return arg;
+         pathToType.put(pathToItem, BigDecimal.class);
+         return BigDecimal.valueOf((Integer) arg);
       } else if (arg instanceof Long) {
-         pathToType.put(pathToItem, Long.class);
-         return arg;
+         pathToType.put(pathToItem, BigDecimal.class);
+         return BigDecimal.valueOf((Long) arg);
       } else if (arg instanceof Float) {
-         pathToType.put(pathToItem, Float.class);
-         return arg;
+         pathToType.put(pathToItem, BigDecimal.class);
+         return BigDecimal.valueOf((Float) arg);
       } else if (arg instanceof Double) {
-         pathToType.put(pathToItem, Double.class);
-         return arg;
+         pathToType.put(pathToItem, BigDecimal.class);
+         return BigDecimal.valueOf((Double) arg);
       } else if (arg instanceof List) {
          pathToType.put(pathToItem, List.class);
          List<Object> argFixed = new ArrayList<>();
@@ -171,19 +171,23 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
    }
 
    static Integer validate(Class<?> cls, Integer arg, SchemaConfiguration configuration) {
-      return (Integer) validateObject(cls, arg, configuration);
+      BigDecimal val = (BigDecimal) validateObject(cls, arg, configuration);
+      return val.intValue();
    }
 
    static Long validate(Class<?> cls, Long arg, SchemaConfiguration configuration) {
-      return (Long) validateObject(cls, arg, configuration);
+      BigDecimal val = (BigDecimal) validateObject(cls, arg, configuration);
+      return val.longValue();
    }
 
    static Float validate(Class<?> cls, Float arg, SchemaConfiguration configuration) {
-      return (Float) validateObject(cls, arg, configuration);
+      BigDecimal val = (BigDecimal) validateObject(cls, arg, configuration);
+      return val.floatValue();
    }
 
    static Double validate(Class<?> cls, Double arg, SchemaConfiguration configuration) {
-      return (Double) validateObject(cls, arg, configuration);
+      BigDecimal val = (BigDecimal) validateObject(cls, arg, configuration);
+      return val.doubleValue();
    }
 
    static String validate(Class<?> cls, String arg, SchemaConfiguration configuration) {

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/Schema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/Schema.hbs
@@ -173,6 +173,10 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
       return (Boolean) validateObject(cls, arg, configuration);
    }
 
+   static BigDecimal validate(Class<?> cls, BigDecimal arg, SchemaConfiguration configuration) {
+      return (BigDecimal) validateObject(cls, arg, configuration);
+   }
+
    static Integer validate(Class<?> cls, Integer arg, SchemaConfiguration configuration) {
       BigDecimal val = (BigDecimal) validateObject(cls, arg, configuration);
       return val.intValue();

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/Schema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/Schema.hbs
@@ -43,14 +43,14 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
       } else if (arg instanceof Integer) {
          pathToType.put(pathToItem, Integer.class);
          return arg;
+      } else if (arg instanceof Long) {
+         pathToType.put(pathToItem, Long.class);
+         return arg;
       } else if (arg instanceof Float) {
          pathToType.put(pathToItem, Float.class);
          return arg;
       } else if (arg instanceof Double) {
          pathToType.put(pathToItem, Double.class);
-         return arg;
-      } else if (arg instanceof BigDecimal) {
-         pathToType.put(pathToItem, BigDecimal.class);
          return arg;
       } else if (arg instanceof List) {
          pathToType.put(pathToItem, List.class);
@@ -172,6 +172,10 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
 
    static Integer validate(Class<?> cls, Integer arg, SchemaConfiguration configuration) {
       return (Integer) validateObject(cls, arg, configuration);
+   }
+
+   static Long validate(Class<?> cls, Long arg, SchemaConfiguration configuration) {
+      return (Long) validateObject(cls, arg, configuration);
    }
 
    static Float validate(Class<?> cls, Float arg, SchemaConfiguration configuration) {

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/SchemaValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/SchemaValidator.hbs
@@ -2,6 +2,7 @@ package {{{packageName}}}.schemas;
 
 import {{{packageName}}}.schemas.validators.KeywordValidator;
 import {{{packageName}}}.schemas.validators.TypeValidator;
+import {{{packageName}}}.schemas.validators.FormatValidator;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.RecordComponent;
@@ -14,6 +15,7 @@ import java.util.Map;
 public interface SchemaValidator {
     HashMap<String, KeywordValidator> keywordToValidator = new HashMap()\{{
         put("type", new TypeValidator());
+        put("format", new FormatValidator());
     }};
 
     static PathToSchemasMap validate(

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/UnsetAnyTypeSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/UnsetAnyTypeSchema.hbs
@@ -24,6 +24,10 @@ record UnsetAnyTypeSchema() implements Schema {
         return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
+    public static Long validate(Long arg, SchemaConfiguration configuration) {
+        return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
+    }
+
     static Float validate(Float arg, SchemaConfiguration configuration) {
         return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/FormatValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/FormatValidator.hbs
@@ -9,32 +9,32 @@ import java.math.BigDecimal;
 import java.time.format.DateTimeParseException;
 
 public class FormatValidator implements KeywordValidator {
-    private static BigDecimal int32InclusiveMinimum = BigDecimal.valueOf(-2147483648);
-    private static BigDecimal int32InclusiveMaximum = BigDecimal.valueOf(2147483647);
-    private static BigDecimal int64InclusiveMinimum = BigDecimal.valueOf(-9223372036854775808L);
-    private static BigDecimal int64InclusiveMaximum = BigDecimal.valueOf(9223372036854775807L);
-    private static BigDecimal floatInclusiveMinimum = BigDecimal.valueOf(-3.4028234663852886e+38);
-    private static BigDecimal floatInclusiveMaximum = BigDecimal.valueOf(3.4028234663852886e+38);
-    private static BigDecimal doubleInclusiveMinimum = BigDecimal.valueOf(-1.7976931348623157E+308d);
-    private static BigDecimal doubleInclusiveMaximum = BigDecimal.valueOf(1.7976931348623157E+308d);
+    private final static BigDecimal int32InclusiveMinimum = BigDecimal.valueOf(-2147483648);
+    private final static BigDecimal int32InclusiveMaximum = BigDecimal.valueOf(2147483647);
+    private final static BigDecimal int64InclusiveMinimum = BigDecimal.valueOf(-9223372036854775808L);
+    private final static BigDecimal int64InclusiveMaximum = BigDecimal.valueOf(9223372036854775807L);
+    private final static BigDecimal floatInclusiveMinimum = BigDecimal.valueOf(-3.4028234663852886e+38);
+    private final static BigDecimal floatInclusiveMaximum = BigDecimal.valueOf(3.4028234663852886e+38);
+    private final static BigDecimal doubleInclusiveMinimum = BigDecimal.valueOf(-1.7976931348623157E+308d);
+    private final static BigDecimal doubleInclusiveMaximum = BigDecimal.valueOf(1.7976931348623157E+308d);
 
     private Void validateNumericFormat(BigDecimal arg, String format, ValidationMetadata validationMetadata) {
         if (format.startsWith("int")) {
             // there is a json schema test where 1.0 validates as an integer
-            if (arg.longValue() != Long.valueOf(arg.toString())) {
+            if (arg.stripTrailingZeros().scale() > 0) {
                 throw new RuntimeException(
                         "Invalid non-integer value " + arg + " for format " + format + " at " + validationMetadata.pathToItem()
                 );
             }
             if (format.equals("int32")) {
-                if (arg.compareTo(int32InclusiveMinimum) < 0  || arg.compareTo(int32InclusiveMaximum) > 1 ){
+                if (arg.compareTo(int32InclusiveMinimum) < 0  || arg.compareTo(int32InclusiveMaximum) > 0 ){
                     throw new RuntimeException(
                         "Invalid value "+arg+" for format int32 at "+validationMetadata.pathToItem()
                     );
                 }
                 return null;
             } else if (format.equals("int64")) {
-                if (arg.compareTo(int64InclusiveMinimum) < 0  || arg.compareTo(int64InclusiveMaximum) > 1 ){
+                if (arg.compareTo(int64InclusiveMinimum) < 0  || arg.compareTo(int64InclusiveMaximum) > 0 ){
                     throw new RuntimeException(
                         "Invalid value "+arg+" for format int64 at "+validationMetadata.pathToItem()
                     );
@@ -43,14 +43,14 @@ public class FormatValidator implements KeywordValidator {
             }
             return null;
         } else if (format.equals("float")) {
-            if (arg.compareTo(floatInclusiveMinimum) < 0  || arg.compareTo(floatInclusiveMaximum) > 1 ){
+            if (arg.compareTo(floatInclusiveMinimum) < 0  || arg.compareTo(floatInclusiveMaximum) > 0 ){
                 throw new RuntimeException(
                     "Invalid value "+arg+" for format float at "+validationMetadata.pathToItem()
                 );
             }
             return null;
         } else if (format.equals("double")) {
-            if (arg.compareTo(doubleInclusiveMinimum) < 0  || arg.compareTo(doubleInclusiveMaximum) > 1 ){
+            if (arg.compareTo(doubleInclusiveMinimum) < 0  || arg.compareTo(doubleInclusiveMaximum) > 0 ){
                 throw new RuntimeException(
                     "Invalid value "+arg+" for format double at "+validationMetadata.pathToItem()
                 );

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/FormatValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/FormatValidator.hbs
@@ -1,0 +1,121 @@
+package {{{packageName}}}.schemas.validators;
+
+import {{{packageName}}}.schemas.CustomIsoparser;
+import {{{packageName}}}.schemas.PathToSchemasMap;
+import {{{packageName}}}.schemas.SchemaValidator;
+import {{{packageName}}}.schemas.ValidationMetadata;
+
+import java.math.BigDecimal;
+import java.time.format.DateTimeParseException;
+
+public class FormatValidator implements KeywordValidator {
+    private static BigDecimal int32InclusiveMinimum = BigDecimal.valueOf(-2147483648);
+    private static BigDecimal int32InclusiveMaximum = BigDecimal.valueOf(2147483647);
+    private static BigDecimal int64InclusiveMinimum = BigDecimal.valueOf(-9223372036854775808L);
+    private static BigDecimal int64InclusiveMaximum = BigDecimal.valueOf(9223372036854775807L);
+    private static BigDecimal floatInclusiveMinimum = BigDecimal.valueOf(-3.4028234663852886e+38);
+    private static BigDecimal floatInclusiveMaximum = BigDecimal.valueOf(3.4028234663852886e+38);
+    private static BigDecimal doubleInclusiveMinimum = BigDecimal.valueOf(-1.7976931348623157E+308d);
+    private static BigDecimal doubleInclusiveMaximum = BigDecimal.valueOf(1.7976931348623157E+308d);
+
+    private Void validateNumericFormat(BigDecimal arg, String format, ValidationMetadata validationMetadata) {
+        if (format.startsWith("int")) {
+            // there is a json schema test where 1.0 validates as an integer
+            if (arg.longValue() != Long.valueOf(arg.toString())) {
+                throw new RuntimeException(
+                        "Invalid non-integer value " + arg + " for format " + format + " at " + validationMetadata.pathToItem()
+                );
+            }
+            if (format.equals("int32")) {
+                if (arg.compareTo(int32InclusiveMinimum) < 0  || arg.compareTo(int32InclusiveMaximum) > 1 ){
+                    throw new RuntimeException(
+                        "Invalid value "+arg+" for format int32 at "+validationMetadata.pathToItem()
+                    );
+                }
+                return null;
+            } else if (format.equals("int64")) {
+                if (arg.compareTo(int64InclusiveMinimum) < 0  || arg.compareTo(int64InclusiveMaximum) > 1 ){
+                    throw new RuntimeException(
+                        "Invalid value "+arg+" for format int64 at "+validationMetadata.pathToItem()
+                    );
+                }
+                return null;
+            }
+            return null;
+        } else if (format.equals("float")) {
+            if (arg.compareTo(floatInclusiveMinimum) < 0  || arg.compareTo(floatInclusiveMaximum) > 1 ){
+                throw new RuntimeException(
+                    "Invalid value "+arg+" for format float at "+validationMetadata.pathToItem()
+                );
+            }
+            return null;
+        } else if (format.equals("double")) {
+            if (arg.compareTo(doubleInclusiveMinimum) < 0  || arg.compareTo(doubleInclusiveMaximum) > 1 ){
+                throw new RuntimeException(
+                    "Invalid value "+arg+" for format double at "+validationMetadata.pathToItem()
+                );
+            }
+            return null;
+        }
+        return null;
+    }
+
+    private Void validateStringFormat(String arg, String format, ValidationMetadata validationMetadata) {
+        if (format.equals("uuid")) {
+            // todo
+            return null;
+        } else if (format.equals("number")) {
+            try {
+                new BigDecimal(arg);
+            } catch (NumberFormatException e) {
+                throw new RuntimeException(
+                    "Value cannot be converted to a decimal. Invalid value "+
+                            arg+" for format number at "+validationMetadata.pathToItem()
+                );
+            }
+            return null;
+        } else if (format.equals("date")) {
+            try {
+                new CustomIsoparser().parseIsodate(arg);
+            } catch (DateTimeParseException e) {
+                throw new RuntimeException(
+                        "Value does not conform to the required ISO-8601 date format. "+
+                        "Invalid value "+arg+" for format date at "+validationMetadata.pathToItem()
+                );
+            }
+            return null;
+        } else if (format.equals("date-time")) {
+            try {
+                new CustomIsoparser().parseIsodatetime(arg);
+            } catch (DateTimeParseException e) {
+                throw new RuntimeException(
+                        "Value does not conform to the required ISO-8601 datetime format. "+
+                                "Invalid value "+arg+" for format datetime at "+validationMetadata.pathToItem()
+                );
+            }
+            return null;
+        }
+        return null;
+    }
+
+    @Override
+    public PathToSchemasMap validate(Object arg, Object value, Object extra, Class<SchemaValidator> cls, ValidationMetadata validationMetadata) {
+        String format = (String) value;
+        if (arg instanceof BigDecimal) {
+            validateNumericFormat(
+                (BigDecimal) arg,
+                format,
+                validationMetadata
+            );
+            return null;
+        } else if (arg instanceof String) {
+            validateStringFormat(
+                (String) arg,
+                format,
+                validationMetadata
+            );
+            return null;
+        }
+        return null;
+    }
+}

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/TypeValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/TypeValidator.hbs
@@ -10,7 +10,13 @@ public class TypeValidator implements KeywordValidator {
     @Override
     public PathToSchemasMap validate(Object arg, Object value, Object extra, Class<SchemaValidator> cls, ValidationMetadata validationMetadata) {
         HashSet<Class<?>> types = (HashSet<Class<?>>) value;
-        if (!types.contains(arg.getClass())) {
+        Class<?> argClass;
+        if (arg == null) {
+            argClass = Void.class;
+        } else {
+            argClass = arg.getClass();
+        }
+        if (!types.contains(argClass)) {
             throw new RuntimeException("invalid type");
         }
         return null;

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/AnyTypeSchemaTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/AnyTypeSchemaTest.hbs
@@ -30,9 +30,15 @@ public class AnyTypeSchemaTest {
     }
 
     @Test
-    public void testValidateInt() {
+    public void testValidateInteger() {
         Integer validatedValue = AnyTypeSchema.validate(1, configuration);
         Assert.assertEquals(validatedValue, Integer.valueOf(1));
+    }
+
+    @Test
+    public void testValidateLong() {
+        Long validatedValue = AnyTypeSchema.validate(1L, configuration);
+        Assert.assertEquals(validatedValue, Long.valueOf(1));
     }
 
     @Test

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/BooleanSchemaTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/BooleanSchemaTest.hbs
@@ -1,0 +1,29 @@
+package {{{packageName}}}.schemas;
+
+import org.junit.Assert;
+import org.junit.Test;
+import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
+import {{{packageName}}}.configurations.SchemaConfiguration;
+
+public class BooleanSchemaTest {
+    static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
+
+    @Test
+    public void testValidateTrue() {
+        Boolean validatedValue = BooleanSchema.validate(Boolean.TRUE, configuration);
+        Assert.assertEquals(validatedValue, Boolean.TRUE);
+    }
+
+    @Test
+    public void testValidateFalse() {
+        Boolean validatedValue = BooleanSchema.validate(Boolean.FALSE, configuration);
+        Assert.assertEquals(validatedValue, Boolean.FALSE);
+    }
+
+    @Test
+    public void testExceptionThrownForInvalidType() {
+        Assert.assertThrows(RuntimeException.class, () -> Schema.validate(
+                BooleanSchema.class, (Void) null, configuration
+        ));
+    }
+}

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/NullSchemaTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/NullSchemaTest.hbs
@@ -1,0 +1,23 @@
+package {{{packageName}}}.schemas;
+
+import org.junit.Assert;
+import org.junit.Test;
+import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
+import {{{packageName}}}.configurations.SchemaConfiguration;
+
+public class NullSchemaTest {
+    static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
+
+    @Test
+    public void testValidateNull() {
+        Void validatedValue = NullSchema.validate(null, configuration);
+        Assert.assertNull(validatedValue);
+    }
+
+    @Test
+    public void testExceptionThrownForInvalidType() {
+        Assert.assertThrows(RuntimeException.class, () -> Schema.validate(
+                NullSchema.class, Boolean.TRUE, configuration
+        ));
+    }
+}

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/NumberSchemaTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/NumberSchemaTest.hbs
@@ -1,0 +1,43 @@
+package {{{packageName}}}.schemas;
+
+import org.junit.Assert;
+import org.junit.Test;
+import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
+import {{{packageName}}}.configurations.SchemaConfiguration;
+
+import java.math.BigDecimal;
+
+public class NumberSchemaTest {
+    static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
+
+    @Test
+    public void testValidateInteger() {
+        BigDecimal validatedValue = NumberSchema.validate(1, configuration);
+        Assert.assertEquals(validatedValue, BigDecimal.valueOf(1));
+    }
+
+    @Test
+    public void testValidateLong() {
+        BigDecimal validatedValue = NumberSchema.validate(1L, configuration);
+        Assert.assertEquals(validatedValue, BigDecimal.valueOf(1L));
+    }
+
+    @Test
+    public void testValidateFloat() {
+        BigDecimal validatedValue = NumberSchema.validate(3.14f, configuration);
+        Assert.assertEquals(validatedValue, BigDecimal.valueOf(3.14f));
+    }
+
+    @Test
+    public void testValidateDouble() {
+        BigDecimal validatedValue = NumberSchema.validate(3.14d, configuration);
+        Assert.assertEquals(validatedValue, BigDecimal.valueOf(3.14d));
+    }
+
+    @Test
+    public void testExceptionThrownForInvalidType() {
+        Assert.assertThrows(RuntimeException.class, () -> Schema.validate(
+                NumberSchema.class, (Void) null, configuration
+        ));
+    }
+}

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/SchemaValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/SchemaValidatorTest.hbs
@@ -5,7 +5,6 @@ import org.junit.Test;
 import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
 import {{{packageName}}}.configurations.SchemaConfiguration;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/FormatValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/FormatValidatorTest.hbs
@@ -1,12 +1,12 @@
-package org.openapijsonschematools.schemas.validators;
+package {{{packageName}}}.schemas.validators;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.configurations.SchemaConfiguration;
-import org.openapijsonschematools.schemas.PathToSchemasMap;
-import org.openapijsonschematools.schemas.SchemaValidator;
-import org.openapijsonschematools.schemas.ValidationMetadata;
+import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
+import {{{packageName}}}.configurations.SchemaConfiguration;
+import {{{packageName}}}.schemas.PathToSchemasMap;
+import {{{packageName}}}.schemas.SchemaValidator;
+import {{{packageName}}}.schemas.ValidationMetadata;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;


### PR DESCRIPTION
- Adds and uses FormatValidator
- Adds these schemas
  - NullSchema
  - BooleanSchema
  - NumberSchema
  - FormatValidator
  - Int64Schema
  - Int32Schema
  - DoubleSchema
  - FloatSchema

Java context for integer and floating pt numeric types
floating:
- 4 bytes - float
- 8 bytes - double

integer:
- 4 bytes - int
- 8 bytes - long

type number - Long + Double (cast Integer and Float into these) or optionally use BigDecimal to ensure that both can be held. Otherwise return type is Object.
type integer - Integer, Long, Float, Double (Long accessor)
type number format int32: Integer, Float [Not long/double] (Integer accessor)
type number format int64: Integer, Float, Long, Double (Long accessor)
type number format float: Float [not Double] (Float accessor)
type number format double: Double (Double accessor)

### Plan
- Store all numeric types as BigDecimal, this ensures that type number can return BigDecimal
- schema validate converts types back to needed Long/Integer/Float/Double to mirror object property access
- The XSchema.validate method and the TypeValidator will validate type
- The FormatValidator will validate bounds

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
