### PR TITLE
Java, add String schema classes

### DIFF
--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -6,6 +6,7 @@ src/main/java/org/openapijsonschematools/schemas/AnyTypeSchema.java
 src/main/java/org/openapijsonschematools/schemas/BooleanSchema.java
 src/main/java/org/openapijsonschematools/schemas/CustomIsoparser.java
 src/main/java/org/openapijsonschematools/schemas/DateSchema.java
+src/main/java/org/openapijsonschematools/schemas/DateTimeSchema.java
 src/main/java/org/openapijsonschematools/schemas/DoubleSchema.java
 src/main/java/org/openapijsonschematools/schemas/FloatSchema.java
 src/main/java/org/openapijsonschematools/schemas/Int32Schema.java

--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -16,6 +16,7 @@ src/main/java/org/openapijsonschematools/schemas/PathToSchemasMap.java
 src/main/java/org/openapijsonschematools/schemas/PathToTypeMap.java
 src/main/java/org/openapijsonschematools/schemas/Schema.java
 src/main/java/org/openapijsonschematools/schemas/SchemaValidator.java
+src/main/java/org/openapijsonschematools/schemas/StringSchema.java
 src/main/java/org/openapijsonschematools/schemas/UnsetAnyTypeSchema.java
 src/main/java/org/openapijsonschematools/schemas/ValidationMetadata.java
 src/main/java/org/openapijsonschematools/schemas/validators/FormatValidator.java

--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -5,6 +5,7 @@ src/main/java/org/openapijsonschematools/configurations/SchemaConfiguration.java
 src/main/java/org/openapijsonschematools/schemas/AnyTypeSchema.java
 src/main/java/org/openapijsonschematools/schemas/BooleanSchema.java
 src/main/java/org/openapijsonschematools/schemas/CustomIsoparser.java
+src/main/java/org/openapijsonschematools/schemas/DateSchema.java
 src/main/java/org/openapijsonschematools/schemas/DoubleSchema.java
 src/main/java/org/openapijsonschematools/schemas/FloatSchema.java
 src/main/java/org/openapijsonschematools/schemas/Int32Schema.java

--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -7,6 +7,7 @@ src/main/java/org/openapijsonschematools/schemas/BooleanSchema.java
 src/main/java/org/openapijsonschematools/schemas/CustomIsoparser.java
 src/main/java/org/openapijsonschematools/schemas/DateSchema.java
 src/main/java/org/openapijsonschematools/schemas/DateTimeSchema.java
+src/main/java/org/openapijsonschematools/schemas/DecimalSchema.java
 src/main/java/org/openapijsonschematools/schemas/DoubleSchema.java
 src/main/java/org/openapijsonschematools/schemas/FloatSchema.java
 src/main/java/org/openapijsonschematools/schemas/Int32Schema.java

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/DateSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/DateSchema.java
@@ -1,0 +1,23 @@
+package org.openapijsonschematools.schemas;
+
+import org.openapijsonschematools.configurations.SchemaConfiguration;
+
+import java.util.LinkedHashSet;
+import java.time.LocalDate;
+
+record DateSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
+    public static DateSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        type.add(String.class);
+        String format = "date";
+        return new DateSchema(type, format);
+    }
+
+    public static String validate(String arg, SchemaConfiguration configuration) {
+        return Schema.validate(DateSchema.class, arg, configuration);
+    }
+
+    public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        return Schema.validate(DateSchema.class, arg, configuration);
+    }
+}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/DateTimeSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/DateTimeSchema.java
@@ -1,0 +1,23 @@
+package org.openapijsonschematools.schemas;
+
+import org.openapijsonschematools.configurations.SchemaConfiguration;
+
+import java.util.LinkedHashSet;
+import java.time.ZonedDateTime;
+
+record DateTimeSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
+    public static DateTimeSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        type.add(String.class);
+        String format = "date-time";
+        return new DateTimeSchema(type, format);
+    }
+
+    public static String validate(String arg, SchemaConfiguration configuration) {
+        return Schema.validate(DateTimeSchema.class, arg, configuration);
+    }
+
+    public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        return Schema.validate(DateTimeSchema.class, arg, configuration);
+    }
+}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/DecimalSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/DecimalSchema.java
@@ -1,0 +1,18 @@
+package org.openapijsonschematools.schemas;
+
+import org.openapijsonschematools.configurations.SchemaConfiguration;
+
+import java.util.LinkedHashSet;
+
+record DecimalSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
+    public static DecimalSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        type.add(String.class);
+        String format = "number";
+        return new DecimalSchema(type, format);
+    }
+
+    public static String validate(String arg, SchemaConfiguration configuration) {
+        return Schema.validate(DecimalSchema.class, arg, configuration);
+    }
+}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/StringSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/StringSchema.java
@@ -1,0 +1,27 @@
+package org.openapijsonschematools.schemas;
+
+import org.openapijsonschematools.configurations.SchemaConfiguration;
+
+import java.util.LinkedHashSet;
+import java.time.ZonedDateTime;
+import java.time.LocalDate;
+
+record StringSchema(LinkedHashSet<Class<?>> type) implements Schema {
+    public static StringSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        type.add(String.class);
+        return new StringSchema(type);
+    }
+
+    public static String validate(String arg, SchemaConfiguration configuration) {
+        return Schema.validate(StringSchema.class, arg, configuration);
+    }
+
+    public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        return Schema.validate(StringSchema.class, arg, configuration);
+    }
+
+    public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        return Schema.validate(StringSchema.class, arg, configuration);
+    }
+}

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -318,6 +318,10 @@ public class JavaClientGenerator extends AbstractJavaGenerator
                 packagePath() + File.separatorChar + "schemas",
                 "SchemaValidator.java"));
         supportingFiles.add(new SupportingFile(
+                "src/main/java/org/openapitools/schemas/StringSchema.hbs",
+                packagePath() + File.separatorChar + "schemas",
+                "StringSchema.java"));
+        supportingFiles.add(new SupportingFile(
                 "src/main/java/org/openapitools/schemas/UnsetAnyTypeSchema.hbs",
                 packagePath() + File.separatorChar + "schemas",
                 "UnsetAnyTypeSchema.java"));

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -278,6 +278,10 @@ public class JavaClientGenerator extends AbstractJavaGenerator
                 packagePath() + File.separatorChar + "schemas",
                 "DateSchema.java"));
         supportingFiles.add(new SupportingFile(
+                "src/main/java/org/openapitools/schemas/DateTimeSchema.hbs",
+                packagePath() + File.separatorChar + "schemas",
+                "DateTimeSchema.java"));
+        supportingFiles.add(new SupportingFile(
                 "src/main/java/org/openapitools/schemas/DoubleSchema.hbs",
                 packagePath() + File.separatorChar + "schemas",
                 "DoubleSchema.java"));

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -274,6 +274,10 @@ public class JavaClientGenerator extends AbstractJavaGenerator
                 packagePath() + File.separatorChar + "schemas",
                 "CustomIsoparser.java"));
         supportingFiles.add(new SupportingFile(
+                "src/main/java/org/openapitools/schemas/DateSchema.hbs",
+                packagePath() + File.separatorChar + "schemas",
+                "DateSchema.java"));
+        supportingFiles.add(new SupportingFile(
                 "src/main/java/org/openapitools/schemas/DoubleSchema.hbs",
                 packagePath() + File.separatorChar + "schemas",
                 "DoubleSchema.java"));

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -282,6 +282,10 @@ public class JavaClientGenerator extends AbstractJavaGenerator
                 packagePath() + File.separatorChar + "schemas",
                 "DateTimeSchema.java"));
         supportingFiles.add(new SupportingFile(
+                "src/main/java/org/openapitools/schemas/DecimalSchema.hbs",
+                packagePath() + File.separatorChar + "schemas",
+                "DecimalSchema.java"));
+        supportingFiles.add(new SupportingFile(
                 "src/main/java/org/openapitools/schemas/DoubleSchema.hbs",
                 packagePath() + File.separatorChar + "schemas",
                 "DoubleSchema.java"));

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/DateSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/DateSchema.hbs
@@ -1,0 +1,23 @@
+package {{{packageName}}}.schemas;
+
+import {{{packageName}}}.configurations.SchemaConfiguration;
+
+import java.util.LinkedHashSet;
+import java.time.LocalDate;
+
+record DateSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
+    public static DateSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        type.add(String.class);
+        String format = "date";
+        return new DateSchema(type, format);
+    }
+
+    public static String validate(String arg, SchemaConfiguration configuration) {
+        return Schema.validate(DateSchema.class, arg, configuration);
+    }
+
+    public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        return Schema.validate(DateSchema.class, arg, configuration);
+    }
+}

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/DateTimeSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/DateTimeSchema.hbs
@@ -1,0 +1,23 @@
+package {{{packageName}}}.schemas;
+
+import {{{packageName}}}.configurations.SchemaConfiguration;
+
+import java.util.LinkedHashSet;
+import java.time.ZonedDateTime;
+
+record DateTimeSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
+    public static DateTimeSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        type.add(String.class);
+        String format = "date-time";
+        return new DateTimeSchema(type, format);
+    }
+
+    public static String validate(String arg, SchemaConfiguration configuration) {
+        return Schema.validate(DateTimeSchema.class, arg, configuration);
+    }
+
+    public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        return Schema.validate(DateTimeSchema.class, arg, configuration);
+    }
+}

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/DecimalSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/DecimalSchema.hbs
@@ -1,0 +1,18 @@
+package {{{packageName}}}.schemas;
+
+import {{{packageName}}}.configurations.SchemaConfiguration;
+
+import java.util.LinkedHashSet;
+
+record DecimalSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
+    public static DecimalSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        type.add(String.class);
+        String format = "number";
+        return new DecimalSchema(type, format);
+    }
+
+    public static String validate(String arg, SchemaConfiguration configuration) {
+        return Schema.validate(DecimalSchema.class, arg, configuration);
+    }
+}

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/StringSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/StringSchema.hbs
@@ -1,0 +1,27 @@
+package {{{packageName}}}.schemas;
+
+import {{{packageName}}}.configurations.SchemaConfiguration;
+
+import java.util.LinkedHashSet;
+import java.time.ZonedDateTime;
+import java.time.LocalDate;
+
+record StringSchema(LinkedHashSet<Class<?>> type) implements Schema {
+    public static StringSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        type.add(String.class);
+        return new StringSchema(type);
+    }
+
+    public static String validate(String arg, SchemaConfiguration configuration) {
+        return Schema.validate(StringSchema.class, arg, configuration);
+    }
+
+    public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        return Schema.validate(StringSchema.class, arg, configuration);
+    }
+
+    public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        return Schema.validate(StringSchema.class, arg, configuration);
+    }
+}


### PR DESCRIPTION
Java, add String schema classes
- StringSchema
- DateSchema
- DateTImeSchema
- DecimalSchema

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
