### PR TITLE
Java: adds MapSchema

### DIFF
--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -27,6 +27,7 @@ src/main/java/org/openapijsonschematools/schemas/ValidationMetadata.java
 src/main/java/org/openapijsonschematools/schemas/validators/FormatValidator.java
 src/main/java/org/openapijsonschematools/schemas/validators/KeywordValidator.java
 src/main/java/org/openapijsonschematools/schemas/validators/PropertiesValidator.java
+src/main/java/org/openapijsonschematools/schemas/validators/RequiredValidator.java
 src/main/java/org/openapijsonschematools/schemas/validators/TypeValidator.java
 src/test/java/org/openapijsonschematools/configurations/JsonSchemaKeywordFlagsTest.java
 src/test/java/org/openapijsonschematools/schemas/AnyTypeSchemaTest.java
@@ -38,4 +39,5 @@ src/test/java/org/openapijsonschematools/schemas/NumberSchemaTest.java
 src/test/java/org/openapijsonschematools/schemas/SchemaValidatorTest.java
 src/test/java/org/openapijsonschematools/schemas/validators/FormatValidatorTest.java
 src/test/java/org/openapijsonschematools/schemas/validators/PropertiesValidatorTest.java
+src/test/java/org/openapijsonschematools/schemas/validators/RequiredValidatorTest.java
 src/test/java/org/openapijsonschematools/schemas/validators/TypeValidatorTest.java

--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -37,6 +37,7 @@ src/test/java/org/openapijsonschematools/schemas/CustomIsoparserTest.java
 src/test/java/org/openapijsonschematools/schemas/MapSchemaTest.java
 src/test/java/org/openapijsonschematools/schemas/NullSchemaTest.java
 src/test/java/org/openapijsonschematools/schemas/NumberSchemaTest.java
+src/test/java/org/openapijsonschematools/schemas/ObjectTypeSchemaTest.java
 src/test/java/org/openapijsonschematools/schemas/SchemaValidatorTest.java
 src/test/java/org/openapijsonschematools/schemas/validators/AdditionalPropertiesValidatorTest.java
 src/test/java/org/openapijsonschematools/schemas/validators/FormatValidatorTest.java

--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -24,6 +24,7 @@ src/main/java/org/openapijsonschematools/schemas/UnsetAnyTypeSchema.java
 src/main/java/org/openapijsonschematools/schemas/ValidationMetadata.java
 src/main/java/org/openapijsonschematools/schemas/validators/FormatValidator.java
 src/main/java/org/openapijsonschematools/schemas/validators/KeywordValidator.java
+src/main/java/org/openapijsonschematools/schemas/validators/PropertiesValidator.java
 src/main/java/org/openapijsonschematools/schemas/validators/TypeValidator.java
 src/test/java/org/openapijsonschematools/configurations/JsonSchemaKeywordFlagsTest.java
 src/test/java/org/openapijsonschematools/schemas/AnyTypeSchemaTest.java

--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -10,9 +10,11 @@ src/main/java/org/openapijsonschematools/schemas/DateTimeSchema.java
 src/main/java/org/openapijsonschematools/schemas/DecimalSchema.java
 src/main/java/org/openapijsonschematools/schemas/DoubleSchema.java
 src/main/java/org/openapijsonschematools/schemas/FloatSchema.java
+src/main/java/org/openapijsonschematools/schemas/FrozenMap.java
 src/main/java/org/openapijsonschematools/schemas/Int32Schema.java
 src/main/java/org/openapijsonschematools/schemas/Int64Schema.java
 src/main/java/org/openapijsonschematools/schemas/IntSchema.java
+src/main/java/org/openapijsonschematools/schemas/MapSchema.java
 src/main/java/org/openapijsonschematools/schemas/NullSchema.java
 src/main/java/org/openapijsonschematools/schemas/NumberSchema.java
 src/main/java/org/openapijsonschematools/schemas/PathToSchemasMap.java

--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -32,8 +32,10 @@ src/test/java/org/openapijsonschematools/configurations/JsonSchemaKeywordFlagsTe
 src/test/java/org/openapijsonschematools/schemas/AnyTypeSchemaTest.java
 src/test/java/org/openapijsonschematools/schemas/BooleanSchemaTest.java
 src/test/java/org/openapijsonschematools/schemas/CustomIsoparserTest.java
+src/test/java/org/openapijsonschematools/schemas/MapSchemaTest.java
 src/test/java/org/openapijsonschematools/schemas/NullSchemaTest.java
 src/test/java/org/openapijsonschematools/schemas/NumberSchemaTest.java
 src/test/java/org/openapijsonschematools/schemas/SchemaValidatorTest.java
 src/test/java/org/openapijsonschematools/schemas/validators/FormatValidatorTest.java
+src/test/java/org/openapijsonschematools/schemas/validators/PropertiesValidatorTest.java
 src/test/java/org/openapijsonschematools/schemas/validators/TypeValidatorTest.java

--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -24,6 +24,7 @@ src/main/java/org/openapijsonschematools/schemas/SchemaValidator.java
 src/main/java/org/openapijsonschematools/schemas/StringSchema.java
 src/main/java/org/openapijsonschematools/schemas/UnsetAnyTypeSchema.java
 src/main/java/org/openapijsonschematools/schemas/ValidationMetadata.java
+src/main/java/org/openapijsonschematools/schemas/validators/AdditionalPropertiesValidator.java
 src/main/java/org/openapijsonschematools/schemas/validators/FormatValidator.java
 src/main/java/org/openapijsonschematools/schemas/validators/KeywordValidator.java
 src/main/java/org/openapijsonschematools/schemas/validators/PropertiesValidator.java
@@ -37,6 +38,7 @@ src/test/java/org/openapijsonschematools/schemas/MapSchemaTest.java
 src/test/java/org/openapijsonschematools/schemas/NullSchemaTest.java
 src/test/java/org/openapijsonschematools/schemas/NumberSchemaTest.java
 src/test/java/org/openapijsonschematools/schemas/SchemaValidatorTest.java
+src/test/java/org/openapijsonschematools/schemas/validators/AdditionalPropertiesValidatorTest.java
 src/test/java/org/openapijsonschematools/schemas/validators/FormatValidatorTest.java
 src/test/java/org/openapijsonschematools/schemas/validators/PropertiesValidatorTest.java
 src/test/java/org/openapijsonschematools/schemas/validators/RequiredValidatorTest.java

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/AnyTypeSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/AnyTypeSchema.java
@@ -48,11 +48,11 @@ record AnyTypeSchema() implements Schema {
         return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }
 
-    public static <T extends Map> T validate(T arg, SchemaConfiguration configuration) {
+    public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
         return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }
 
-    public static <U extends List> U validate(U arg, SchemaConfiguration configuration) {
+    public static <U extends List> U validate(List<Object> arg, SchemaConfiguration configuration) {
         return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/AnyTypeSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/AnyTypeSchema.java
@@ -7,7 +7,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 
-record AnyTypeSchema() implements Schema {
+public record AnyTypeSchema() implements Schema {
     public static AnyTypeSchema withDefaults() {
         return new AnyTypeSchema();
     }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/BooleanSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/BooleanSchema.java
@@ -4,7 +4,7 @@ import org.openapijsonschematools.configurations.SchemaConfiguration;
 
 import java.util.LinkedHashSet;
 
-record BooleanSchema(LinkedHashSet<Class<?>> type) implements Schema {
+public record BooleanSchema(LinkedHashSet<Class<?>> type) implements Schema {
     public static BooleanSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
         type.add(Boolean.class);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/DateSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/DateSchema.java
@@ -5,7 +5,7 @@ import org.openapijsonschematools.configurations.SchemaConfiguration;
 import java.util.LinkedHashSet;
 import java.time.LocalDate;
 
-record DateSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
+public record DateSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
     public static DateSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
         type.add(String.class);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/DateTimeSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/DateTimeSchema.java
@@ -5,7 +5,7 @@ import org.openapijsonschematools.configurations.SchemaConfiguration;
 import java.util.LinkedHashSet;
 import java.time.ZonedDateTime;
 
-record DateTimeSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
+public record DateTimeSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
     public static DateTimeSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
         type.add(String.class);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/DecimalSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/DecimalSchema.java
@@ -4,7 +4,7 @@ import org.openapijsonschematools.configurations.SchemaConfiguration;
 
 import java.util.LinkedHashSet;
 
-record DecimalSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
+public record DecimalSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
     public static DecimalSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
         type.add(String.class);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/DoubleSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/DoubleSchema.java
@@ -5,7 +5,7 @@ import org.openapijsonschematools.configurations.SchemaConfiguration;
 import java.util.LinkedHashSet;
 import java.math.BigDecimal;
 
-record DoubleSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
+public record DoubleSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
     public static DoubleSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
         type.add(BigDecimal.class);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/FloatSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/FloatSchema.java
@@ -5,7 +5,7 @@ import org.openapijsonschematools.configurations.SchemaConfiguration;
 import java.util.LinkedHashSet;
 import java.math.BigDecimal;
 
-record FloatSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
+public record FloatSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
     public static FloatSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
         type.add(BigDecimal.class);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/FrozenMap.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/FrozenMap.java
@@ -1,0 +1,78 @@
+package org.openapijsonschematools.schemas;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+public class FrozenMap<K, V> extends LinkedHashMap<K, V> {
+    /*
+    A frozen Map
+    Once schema validation has been run, written accessor methods return values of the correct type
+    If values were mutable, the types in those methods would not agree with returned values
+     */
+    public FrozenMap(Map<? extends K, ? extends V> m) {
+        super(m);
+    }
+
+    public V put(K key, V value) {
+        throw new UnsupportedOperationException();
+    }
+    public V remove(Object key) {
+        throw new UnsupportedOperationException();
+    }
+    public void putAll(Map<? extends K, ? extends V> m) {
+        throw new UnsupportedOperationException();
+    }
+    public void clear() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void replaceAll(BiFunction<? super K, ? super V, ? extends V> function) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public V putIfAbsent(K key, V value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean remove(Object key, Object value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean replace(K key, V oldValue, V newValue) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public V replace(K key, V value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public V computeIfPresent(K key,
+                              BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public V compute(K key,
+                     BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public V merge(K key, V value,
+                   BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Int32Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Int32Schema.java
@@ -5,7 +5,7 @@ import org.openapijsonschematools.configurations.SchemaConfiguration;
 import java.util.LinkedHashSet;
 import java.math.BigDecimal;
 
-record Int32Schema(LinkedHashSet<Class<?>> type, String format) implements Schema {
+public record Int32Schema(LinkedHashSet<Class<?>> type, String format) implements Schema {
     public static Int32Schema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
         type.add(BigDecimal.class);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Int64Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Int64Schema.java
@@ -5,7 +5,7 @@ import org.openapijsonschematools.configurations.SchemaConfiguration;
 import java.util.LinkedHashSet;
 import java.math.BigDecimal;
 
-record Int64Schema(LinkedHashSet<Class<?>> type, String format) implements Schema {
+public record Int64Schema(LinkedHashSet<Class<?>> type, String format) implements Schema {
     public static Int64Schema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
         type.add(BigDecimal.class);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/IntSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/IntSchema.java
@@ -5,7 +5,7 @@ import org.openapijsonschematools.configurations.SchemaConfiguration;
 import java.util.LinkedHashSet;
 import java.math.BigDecimal;
 
-record IntSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
+public record IntSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
     public static IntSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
         type.add(BigDecimal.class);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/MapSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/MapSchema.java
@@ -1,0 +1,20 @@
+package org.openapijsonschematools.schemas;
+
+import org.openapijsonschematools.configurations.SchemaConfiguration;
+
+import java.util.LinkedHashSet;
+import java.util.Map;
+
+record MapSchema(LinkedHashSet<Class<?>> type) implements Schema {
+    public static MapSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        // can't use ImmutableMap because it does not allow null values in entries
+        // can't use Collections.unmodifiableMap because Collections.UnmodifiableMap is not public + extensible
+        type.add(FrozenMap.class);
+        return new MapSchema(type);
+    }
+
+    public static Map<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        return Schema.validate(MapSchema.class, arg, configuration);
+    }
+}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/MapSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/MapSchema.java
@@ -14,7 +14,7 @@ record MapSchema(LinkedHashSet<Class<?>> type) implements Schema {
         return new MapSchema(type);
     }
 
-    public static Map<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+    public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) {
         return Schema.validate(MapSchema.class, arg, configuration);
     }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/MapSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/MapSchema.java
@@ -5,7 +5,7 @@ import org.openapijsonschematools.configurations.SchemaConfiguration;
 import java.util.LinkedHashSet;
 import java.util.Map;
 
-record MapSchema(LinkedHashSet<Class<?>> type) implements Schema {
+public record MapSchema(LinkedHashSet<Class<?>> type) implements Schema {
     public static MapSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
         // can't use ImmutableMap because it does not allow null values in entries

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/NullSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/NullSchema.java
@@ -4,7 +4,7 @@ import org.openapijsonschematools.configurations.SchemaConfiguration;
 
 import java.util.LinkedHashSet;
 
-record NullSchema(LinkedHashSet<Class<?>> type) implements Schema {
+public record NullSchema(LinkedHashSet<Class<?>> type) implements Schema {
     public static NullSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
         type.add(Void.class);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/NumberSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/NumberSchema.java
@@ -5,7 +5,7 @@ import org.openapijsonschematools.configurations.SchemaConfiguration;
 import java.util.LinkedHashSet;
 import java.math.BigDecimal;
 
-record NumberSchema(LinkedHashSet<Class<?>> type) implements Schema {
+public record NumberSchema(LinkedHashSet<Class<?>> type) implements Schema {
     public static NumberSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
         type.add(BigDecimal.class);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Schema.java
@@ -9,6 +9,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -17,7 +18,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-public interface Schema<T extends Map, U extends List> extends SchemaValidator {
+public interface Schema extends SchemaValidator {
    private static Object castToAllowedTypes(Object arg, List<Object> pathToItem, PathToTypeMap pathToType) {
       if (arg == null) {
          pathToType.put(pathToItem, Void.class);
@@ -36,7 +37,7 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
             Object fixedVal = castToAllowedTypes(val, newPathToItem, pathToType);
             argFixed.put(key, fixedVal);
          }
-         return argFixed;
+         return new FrozenMap(argFixed);
       } else if (arg instanceof Boolean) {
          pathToType.put(pathToItem, Boolean.class);
          return arg;
@@ -116,7 +117,7 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
          Object castValue = getNewInstance(propertyClass, value, propertyPathToItem, pathToSchemas);
          properties.put(propertyName, castValue);
       }
-      return properties;
+      return new FrozenMap(properties);
    }
 
    private static List<Object> getItems(Object arg, List<Object> pathToItem, PathToSchemasMap pathToSchemas) {
@@ -209,11 +210,11 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
       return (String) validateObject(cls, arg, configuration);
    }
 
-   static <T extends Map> T validate(Class<?> cls, T arg, SchemaConfiguration configuration) {
+   static <T extends FrozenMap> T validate(Class<?> cls, Map<String, Object> arg, SchemaConfiguration configuration) {
       return (T) validateObject(cls, arg, configuration);
    }
 
-   static <U extends List> U validate(Class<?> cls, U arg, SchemaConfiguration configuration) {
+   static <U extends List> U validate(Class<?> cls, List<Object> arg, SchemaConfiguration configuration) {
       return (U) validateObject(cls, arg, configuration);
    }
 

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/SchemaValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/SchemaValidator.java
@@ -1,5 +1,6 @@
 package org.openapijsonschematools.schemas;
 
+import org.openapijsonschematools.schemas.validators.AdditionalPropertiesValidator;
 import org.openapijsonschematools.schemas.validators.KeywordValidator;
 import org.openapijsonschematools.schemas.validators.TypeValidator;
 import org.openapijsonschematools.schemas.validators.FormatValidator;
@@ -16,6 +17,7 @@ import java.util.Map;
 
 public interface SchemaValidator {
     HashMap<String, KeywordValidator> keywordToValidator = new HashMap(){{
+        put("additionalProperties", new AdditionalPropertiesValidator());
         put("type", new TypeValidator());
         put("format", new FormatValidator());
         put("properties", new PropertiesValidator());
@@ -48,6 +50,10 @@ public interface SchemaValidator {
                 throw new RuntimeException(e);
             }
         }
+        Object extra = null;
+        if (fieldsToValues.containsKey("additionalProperties") && fieldsToValues.containsKey("properties")) {
+            extra = fieldsToValues.get("properties");
+        }
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         Class<SchemaValidator> castSchemaCls = (Class<SchemaValidator>) schemaCls;
         for (Map.Entry<String, Object> entry: fieldsToValues.entrySet()) {
@@ -57,7 +63,7 @@ public interface SchemaValidator {
             PathToSchemasMap otherPathToSchemas = validatorClass.validate(
                     arg,
                     value,
-                    null,
+                    extra,
                     castSchemaCls,
                     validationMetadata
             );

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/SchemaValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/SchemaValidator.java
@@ -4,6 +4,7 @@ import org.openapijsonschematools.schemas.validators.KeywordValidator;
 import org.openapijsonschematools.schemas.validators.TypeValidator;
 import org.openapijsonschematools.schemas.validators.FormatValidator;
 import org.openapijsonschematools.schemas.validators.PropertiesValidator;
+import org.openapijsonschematools.schemas.validators.RequiredValidator;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.RecordComponent;
@@ -18,6 +19,7 @@ public interface SchemaValidator {
         put("type", new TypeValidator());
         put("format", new FormatValidator());
         put("properties", new PropertiesValidator());
+        put("required", new RequiredValidator());
     }};
 
     static PathToSchemasMap validate(

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/SchemaValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/SchemaValidator.java
@@ -3,6 +3,7 @@ package org.openapijsonschematools.schemas;
 import org.openapijsonschematools.schemas.validators.KeywordValidator;
 import org.openapijsonschematools.schemas.validators.TypeValidator;
 import org.openapijsonschematools.schemas.validators.FormatValidator;
+import org.openapijsonschematools.schemas.validators.PropertiesValidator;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.RecordComponent;
@@ -16,6 +17,7 @@ public interface SchemaValidator {
     HashMap<String, KeywordValidator> keywordToValidator = new HashMap(){{
         put("type", new TypeValidator());
         put("format", new FormatValidator());
+        put("properties", new PropertiesValidator());
     }};
 
     static PathToSchemasMap validate(

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/SchemaValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/SchemaValidator.java
@@ -51,14 +51,14 @@ public interface SchemaValidator {
             }
         }
         Object extra = null;
-        if (fieldsToValues.containsKey("additionalProperties") && fieldsToValues.containsKey("properties")) {
-            extra = fieldsToValues.get("properties");
-        }
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         Class<SchemaValidator> castSchemaCls = (Class<SchemaValidator>) schemaCls;
         for (Map.Entry<String, Object> entry: fieldsToValues.entrySet()) {
             String jsonKeyword = entry.getKey();
             Object value = entry.getValue();
+            if (jsonKeyword.equals("additionalProperties") && fieldsToValues.containsKey("properties")) {
+                extra = fieldsToValues.get("properties");
+            }
             KeywordValidator validatorClass = keywordToValidator.get(jsonKeyword);
             PathToSchemasMap otherPathToSchemas = validatorClass.validate(
                     arg,

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/StringSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/StringSchema.java
@@ -6,7 +6,7 @@ import java.util.LinkedHashSet;
 import java.time.ZonedDateTime;
 import java.time.LocalDate;
 
-record StringSchema(LinkedHashSet<Class<?>> type) implements Schema {
+public record StringSchema(LinkedHashSet<Class<?>> type) implements Schema {
     public static StringSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
         type.add(String.class);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/UnsetAnyTypeSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/UnsetAnyTypeSchema.java
@@ -48,11 +48,11 @@ record UnsetAnyTypeSchema() implements Schema {
         return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
-    static <T extends Map> T validate(T arg, SchemaConfiguration configuration) {
+    static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
         return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
-    static <U extends List> U validate(U arg, SchemaConfiguration configuration) {
+    static <U extends List> U validate(List<Object> arg, SchemaConfiguration configuration) {
         return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/UnsetAnyTypeSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/UnsetAnyTypeSchema.java
@@ -7,7 +7,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 
-record UnsetAnyTypeSchema() implements Schema {
+public record UnsetAnyTypeSchema() implements Schema {
     static UnsetAnyTypeSchema withDefaults() {
         return new UnsetAnyTypeSchema();
     }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/ValidationMetadata.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/ValidationMetadata.java
@@ -12,7 +12,7 @@ public record ValidationMetadata(
         Set<Class<?>> seenClasses
 ) {
 
-    protected boolean validationRanEarlier(Class<?> cls) {
+    public boolean validationRanEarlier(Class<?> cls) {
         Map<Class<?>, Void> validatedSchemas = validatedPathToSchemas.getOrDefault(pathToItem, null);
         if (validatedSchemas != null && validatedSchemas.containsKey(cls)) {
             return true;

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/AdditionalPropertiesValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/AdditionalPropertiesValidator.java
@@ -1,0 +1,50 @@
+package org.openapijsonschematools.schemas.validators;
+
+import org.openapijsonschematools.schemas.PathToSchemasMap;
+import org.openapijsonschematools.schemas.Schema;
+import org.openapijsonschematools.schemas.SchemaValidator;
+import org.openapijsonschematools.schemas.ValidationMetadata;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class AdditionalPropertiesValidator implements KeywordValidator {
+    @Override
+    public PathToSchemasMap validate(Object arg, Object value, Object extra, Class<SchemaValidator> cls, ValidationMetadata validationMetadata) {
+        if (!(arg instanceof Map)) {
+            return null;
+        }
+        Map<String, Object> castArg = (Map<String, Object>) arg;
+        Class<Schema> addPropSchema = (Class<Schema>) value;
+        Map<String, Class<Schema>> properties = (Map<String, Class<Schema>>) extra;
+        if (properties == null) {
+            properties = new LinkedHashMap<>();
+        }
+        Set<String> presentAdditionalProperties = new LinkedHashSet<>(castArg.keySet());
+        presentAdditionalProperties.removeAll(properties.keySet());
+        PathToSchemasMap pathToSchemas = new PathToSchemasMap();
+        // todo add handling for validatedPatternProperties
+        for(String addPropName: presentAdditionalProperties) {
+            Object propValue = castArg.get(addPropName);
+            List<Object> propPathToItem = new ArrayList<>(validationMetadata.pathToItem());
+            propPathToItem.add(addPropName);
+            ValidationMetadata propValidationMetadata = new ValidationMetadata(
+                    propPathToItem,
+                    validationMetadata.configuration(),
+                    validationMetadata.validatedPathToSchemas(),
+                    validationMetadata.seenClasses()
+            );
+            if (propValidationMetadata.validationRanEarlier(addPropSchema)) {
+                // todo add_deeper_validated_schemas
+                continue;
+            }
+            PathToSchemasMap otherPathToSchemas = SchemaValidator.validate(addPropSchema, propValue, propValidationMetadata);
+            pathToSchemas.update(otherPathToSchemas);
+        }
+        return pathToSchemas;
+    }
+}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/PropertiesValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/PropertiesValidator.java
@@ -1,0 +1,44 @@
+package org.openapijsonschematools.schemas.validators;
+
+import org.openapijsonschematools.schemas.PathToSchemasMap;
+import org.openapijsonschematools.schemas.Schema;
+import org.openapijsonschematools.schemas.SchemaValidator;
+import org.openapijsonschematools.schemas.ValidationMetadata;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PropertiesValidator implements KeywordValidator {
+    @Override
+    public PathToSchemasMap validate(Object arg, Object value, Object extra, Class<SchemaValidator> cls, ValidationMetadata validationMetadata) {
+        if (!(arg instanceof Map)) {
+            return null;
+        }
+        PathToSchemasMap pathToSchemas = new PathToSchemasMap();
+        Map<String, Object> castArg = (Map<String, Object>) arg;
+        Map<String, Class<Schema>> properties = (Map<String, Class<Schema>>) value;
+        Set<String> presentProperties = castArg.keySet();
+        presentProperties.retainAll(properties.keySet());
+        for(String propName: presentProperties) {
+            Object propValue = castArg.get(propName);
+            List<Object> propPathToItem = new ArrayList<>(validationMetadata.pathToItem());
+            propPathToItem.add(propName);
+            Class<Schema> propSchema = properties.get(propName);
+            ValidationMetadata propValidationMetadata = new ValidationMetadata(
+                    propPathToItem,
+                    validationMetadata.configuration(),
+                    validationMetadata.validatedPathToSchemas(),
+                    validationMetadata.seenClasses()
+            );
+            if (propValidationMetadata.validationRanEarlier(propSchema)) {
+                // todo add_deeper_validated_schemas
+                continue;
+            }
+            PathToSchemasMap otherPathToSchemas = SchemaValidator.validate(propSchema, propValue, validationMetadata);
+            pathToSchemas.update(otherPathToSchemas);
+        }
+        return pathToSchemas;
+    }
+}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/PropertiesValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/PropertiesValidator.java
@@ -6,6 +6,7 @@ import org.openapijsonschematools.schemas.SchemaValidator;
 import org.openapijsonschematools.schemas.ValidationMetadata;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -19,7 +20,7 @@ public class PropertiesValidator implements KeywordValidator {
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         Map<String, Object> castArg = (Map<String, Object>) arg;
         Map<String, Class<Schema>> properties = (Map<String, Class<Schema>>) value;
-        Set<String> presentProperties = castArg.keySet();
+        Set<String> presentProperties = new LinkedHashSet<>(castArg.keySet());
         presentProperties.retainAll(properties.keySet());
         for(String propName: presentProperties) {
             Object propValue = castArg.get(propName);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/PropertiesValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/PropertiesValidator.java
@@ -36,7 +36,7 @@ public class PropertiesValidator implements KeywordValidator {
                 // todo add_deeper_validated_schemas
                 continue;
             }
-            PathToSchemasMap otherPathToSchemas = SchemaValidator.validate(propSchema, propValue, validationMetadata);
+            PathToSchemasMap otherPathToSchemas = SchemaValidator.validate(propSchema, propValue, propValidationMetadata);
             pathToSchemas.update(otherPathToSchemas);
         }
         return pathToSchemas;

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/RequiredValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/RequiredValidator.java
@@ -1,0 +1,34 @@
+package org.openapijsonschematools.schemas.validators;
+
+import org.openapijsonschematools.schemas.PathToSchemasMap;
+import org.openapijsonschematools.schemas.SchemaValidator;
+import org.openapijsonschematools.schemas.ValidationMetadata;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class RequiredValidator implements KeywordValidator {
+    @Override
+    public PathToSchemasMap validate(Object arg, Object value, Object extra, Class<SchemaValidator> cls, ValidationMetadata validationMetadata) {
+        if (!(arg instanceof Map)) {
+            return null;
+        }
+        Map<String, Object> castArg = (Map<String, Object>) arg;
+        Set<String> requiredProperties = (Set<String>) value;
+        Set<String> missingRequiredProperties = new HashSet<>(requiredProperties);
+        missingRequiredProperties.removeAll(castArg.keySet());
+        if (!missingRequiredProperties.isEmpty()) {
+            List<String> missingReqProps = missingRequiredProperties.stream().sorted().toList();
+            String pluralChar = "";
+            if (missingRequiredProperties.size() > 1) {
+                pluralChar = "s";
+            }
+            throw new RuntimeException(
+                cls+" is missing "+missingRequiredProperties.size()+" required argument"+pluralChar+": "+missingReqProps
+            );
+        }
+        return null;
+    }
+}

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/AnyTypeSchemaTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/AnyTypeSchemaTest.java
@@ -73,9 +73,9 @@ public class AnyTypeSchemaTest {
 
     @Test
     public void testValidateMap() {
-        LinkedHashMap<String, LocalDate> inMap = new LinkedHashMap<>();
+        LinkedHashMap<String, Object> inMap = new LinkedHashMap<>();
         inMap.put("today", LocalDate.of(2017, 7, 21));
-        LinkedHashMap validatedValue = AnyTypeSchema.validate(inMap, configuration);
+        FrozenMap<String, String> validatedValue = AnyTypeSchema.validate(inMap, configuration);
         LinkedHashMap<String, String> outMap = new LinkedHashMap<>();
         outMap.put("today", "2017-07-21");
         Assert.assertEquals(validatedValue, outMap);
@@ -83,9 +83,9 @@ public class AnyTypeSchemaTest {
 
     @Test
     public void testValidateList() {
-        ArrayList<LocalDate> inList = new ArrayList<>();
+        ArrayList<Object> inList = new ArrayList<>();
         inList.add(LocalDate.of(2017, 7, 21));
-        ArrayList validatedValue = AnyTypeSchema.validate(inList, configuration);
+        ArrayList<String> validatedValue = AnyTypeSchema.validate(inList, configuration);
         ArrayList<String> outList = new ArrayList<>();
         outList.add( "2017-07-21");
         Assert.assertEquals(validatedValue, outList);

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/MapSchemaTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/MapSchemaTest.java
@@ -1,0 +1,31 @@
+package org.openapijsonschematools.schemas;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
+import org.openapijsonschematools.configurations.SchemaConfiguration;
+
+import java.time.LocalDate;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class MapSchemaTest {
+    static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
+
+    @Test
+    public void testExceptionThrownForInvalidType() {
+        Assert.assertThrows(RuntimeException.class, () -> Schema.validate(
+                MapSchema.class, (Void) null, configuration
+        ));
+    }
+
+    @Test
+    public void testValidateMap() {
+        Map<String, Object> inMap = new LinkedHashMap<>();
+        inMap.put("today", LocalDate.of(2017, 7, 21));
+        FrozenMap<String, Object> validatedValue = MapSchema.validate(inMap, configuration);
+        LinkedHashMap<String, String> outMap = new LinkedHashMap<>();
+        outMap.put("today", "2017-07-21");
+        Assert.assertEquals(validatedValue, outMap);
+    }
+}

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/ObjectTypeSchemaTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/ObjectTypeSchemaTest.java
@@ -1,0 +1,164 @@
+package org.openapijsonschematools.schemas;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
+import org.openapijsonschematools.configurations.SchemaConfiguration;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+
+record ObjectWithPropsSchema(LinkedHashSet<Class<?>> type, LinkedHashMap<String, Class<?>> properties) implements Schema {
+    public static ObjectWithPropsSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        // can't use ImmutableMap because it does not allow null values in entries
+        // can't use Collections.unmodifiableMap because Collections.UnmodifiableMap is not public + extensible
+        type.add(FrozenMap.class);
+        LinkedHashMap<String, Class<?>> properties = new LinkedHashMap<>();
+        properties.put("someString", StringSchema.class);
+        return new ObjectWithPropsSchema(type, properties);
+    }
+
+    public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        return Schema.validate(ObjectWithPropsSchema.class, arg, configuration);
+    }
+}
+
+record ObjectWithAddpropsSchema(LinkedHashSet<Class<?>> type, Class<?> additionalProperties) implements Schema {
+    public static ObjectWithAddpropsSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        // can't use ImmutableMap because it does not allow null values in entries
+        // can't use Collections.unmodifiableMap because Collections.UnmodifiableMap is not public + extensible
+        type.add(FrozenMap.class);
+        Class<?> additionalProperties = StringSchema.class;
+        return new ObjectWithAddpropsSchema(type, additionalProperties);
+    }
+
+    public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        return Schema.validate(ObjectWithAddpropsSchema.class, arg, configuration);
+    }
+}
+
+record ObjectWithPropsAndAddpropsSchema(LinkedHashSet<Class<?>> type, LinkedHashMap<String, Class<?>> properties, Class<?> additionalProperties) implements Schema {
+    public static ObjectWithPropsAndAddpropsSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        // can't use ImmutableMap because it does not allow null values in entries
+        // can't use Collections.unmodifiableMap because Collections.UnmodifiableMap is not public + extensible
+        type.add(FrozenMap.class);
+        LinkedHashMap<String, Class<?>> properties = new LinkedHashMap<>();
+        properties.put("someString", StringSchema.class);
+        Class<?> additionalProperties = BooleanSchema.class;
+        return new ObjectWithPropsAndAddpropsSchema(type, properties, additionalProperties);
+    }
+
+    public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        return Schema.validate(ObjectWithPropsAndAddpropsSchema.class, arg, configuration);
+    }
+}
+
+public class ObjectTypeSchemaTest {
+    static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
+
+    @Test
+    public void testExceptionThrownForInvalidType() {
+        Assert.assertThrows(RuntimeException.class, () -> Schema.validate(
+                ObjectWithPropsSchema.class, (Void) null, configuration
+        ));
+    }
+
+    @Test
+    public void testValidateObjectWithPropsSchema() {
+        // map with only property works
+        Map<String, Object> inMap = new LinkedHashMap<>();
+        inMap.put("someString", "abc");
+        FrozenMap<String, Object> validatedValue = ObjectWithPropsSchema.validate(inMap, configuration);
+        LinkedHashMap<String, String> outMap = new LinkedHashMap<>();
+        outMap.put("someString", "abc");
+        Assert.assertEquals(validatedValue, outMap);
+
+        // map with additional unvalidated property works
+        inMap = new LinkedHashMap<>();
+        inMap.put("someString", "abc");
+        inMap.put("someOtherString", "def");
+        validatedValue = ObjectWithPropsSchema.validate(inMap, configuration);
+        outMap = new LinkedHashMap<>();
+        outMap.put("someString", "abc");
+        outMap.put("someOtherString", "def");
+        Assert.assertEquals(validatedValue, outMap);
+
+        // invalid prop type fails
+        inMap = new LinkedHashMap<>();
+        inMap.put("someString", 1);
+        Map<String, Object> finalInMap = inMap;
+        Assert.assertThrows(RuntimeException.class, () -> ObjectWithPropsSchema.validate(
+                finalInMap, configuration
+        ));
+    }
+
+    @Test
+    public void testValidateObjectWithAddpropsSchema() {
+        // map with only property works
+        Map<String, Object> inMap = new LinkedHashMap<>();
+        inMap.put("someString", "abc");
+        FrozenMap<String, Object> validatedValue = ObjectWithAddpropsSchema.validate(inMap, configuration);
+        LinkedHashMap<String, String> outMap = new LinkedHashMap<>();
+        outMap.put("someString", "abc");
+        Assert.assertEquals(validatedValue, outMap);
+
+        // map with additional properties works
+        inMap = new LinkedHashMap<>();
+        inMap.put("someString", "abc");
+        inMap.put("someOtherString", "def");
+        validatedValue = ObjectWithAddpropsSchema.validate(inMap, configuration);
+        outMap = new LinkedHashMap<>();
+        outMap.put("someString", "abc");
+        outMap.put("someOtherString", "def");
+        Assert.assertEquals(validatedValue, outMap);
+
+        // invalid addProp type fails
+        inMap = new LinkedHashMap<>();
+        inMap.put("someString", 1);
+        Map<String, Object> finalInMap = inMap;
+        Assert.assertThrows(RuntimeException.class, () -> ObjectWithAddpropsSchema.validate(
+                finalInMap, configuration
+        ));
+    }
+
+    @Test
+    public void testValidateObjectWithPropsAndAddpropsSchema() {
+        // map with only property works
+        Map<String, Object> inMap = new LinkedHashMap<>();
+        inMap.put("someString", "abc");
+        FrozenMap<String, Object> validatedValue = ObjectWithPropsAndAddpropsSchema.validate(inMap, configuration);
+        LinkedHashMap<String, Object> outMap = new LinkedHashMap<>();
+        outMap.put("someString", "abc");
+        Assert.assertEquals(validatedValue, outMap);
+
+        // map with additional properties works
+        inMap = new LinkedHashMap<>();
+        inMap.put("someString", "abc");
+        inMap.put("someAddProp", true);
+        validatedValue = ObjectWithPropsAndAddpropsSchema.validate(inMap, configuration);
+        outMap = new LinkedHashMap<>();
+        outMap.put("someString", "abc");
+        outMap.put("someAddProp", true);
+        Assert.assertEquals(validatedValue, outMap);
+
+        // invalid prop type fails
+        inMap = new LinkedHashMap<>();
+        inMap.put("someString", 1);
+        Map<String, Object> invalidPropMap = inMap;
+        Assert.assertThrows(RuntimeException.class, () -> ObjectWithPropsAndAddpropsSchema.validate(
+                invalidPropMap, configuration
+        ));
+
+        // invalid addProp type fails
+        inMap = new LinkedHashMap<>();
+        inMap.put("someAddProp", 1);
+        Map<String, Object> invalidAddpropMap = inMap;
+        Assert.assertThrows(RuntimeException.class, () -> ObjectWithPropsAndAddpropsSchema.validate(
+                invalidAddpropMap, configuration
+        ));
+    }
+}

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/AdditionalPropertiesValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/AdditionalPropertiesValidatorTest.java
@@ -1,0 +1,104 @@
+package org.openapijsonschematools.schemas.validators;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
+import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.schemas.FrozenMap;
+import org.openapijsonschematools.schemas.PathToSchemasMap;
+import org.openapijsonschematools.schemas.SchemaValidator;
+import org.openapijsonschematools.schemas.StringSchema;
+import org.openapijsonschematools.schemas.ValidationMetadata;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+
+public class AdditionalPropertiesValidatorTest {
+
+    @Test
+    public void testCorrectPropertySucceeds() {
+        Map<String, Class<?>> properties = new LinkedHashMap<>();
+        properties.put("someString", StringSchema.class);
+
+        List<Object> pathToItem = new ArrayList<>();
+        pathToItem.add("args[0]");
+        ValidationMetadata validationMetadata = new ValidationMetadata(
+                pathToItem,
+                new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone()),
+                new PathToSchemasMap(),
+                new LinkedHashSet<>()
+        );
+        LinkedHashMap<String, Object> mutableMap = new LinkedHashMap<>();
+        mutableMap.put("someString", "abc");
+        mutableMap.put("someAddProp", "def");
+        FrozenMap<String, Object> arg = new FrozenMap<>(mutableMap);
+        final AdditionalPropertiesValidator validator = new AdditionalPropertiesValidator();
+        PathToSchemasMap pathToSchemas = validator.validate(
+                arg,
+                StringSchema.class,
+                properties,
+                SchemaValidator.class,
+                validationMetadata
+        );
+        List<Object> expectedPathToItem = new ArrayList<>();
+        expectedPathToItem.add("args[0]");
+        expectedPathToItem.add("someAddProp");
+        LinkedHashMap<Class<?>, Void> expectedClasses = new LinkedHashMap<>();
+        expectedClasses.put(String.class, null);
+        expectedClasses.put(StringSchema.class, null);
+        PathToSchemasMap expectedPathToSchemas = new PathToSchemasMap();
+        expectedPathToSchemas.put(expectedPathToItem, expectedClasses);
+        Assert.assertEquals(pathToSchemas, expectedPathToSchemas);
+    }
+
+    @Test
+    public void testNotApplicableTypeReturnsNull() {
+        List<Object> pathToItem = new ArrayList<>();
+        pathToItem.add("args[0]");
+        ValidationMetadata validationMetadata = new ValidationMetadata(
+                pathToItem,
+                new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone()),
+                new PathToSchemasMap(),
+                new LinkedHashSet<>()
+        );
+        final AdditionalPropertiesValidator validator = new AdditionalPropertiesValidator();
+        PathToSchemasMap pathToSchemas = validator.validate(
+                1,
+                StringSchema.class,
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        );
+        Assert.assertNull(pathToSchemas);
+    }
+
+    @Test
+    public void testIncorrectPropertyValueFails() {
+        Map<String, Class<?>> properties = new LinkedHashMap<>();
+        properties.put("someString", StringSchema.class);
+
+        List<Object> pathToItem = new ArrayList<>();
+        pathToItem.add("args[0]");
+        ValidationMetadata validationMetadata = new ValidationMetadata(
+                pathToItem,
+                new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone()),
+                new PathToSchemasMap(),
+                new LinkedHashSet<>()
+        );
+        LinkedHashMap<String, Object> mutableMap = new LinkedHashMap<>();
+        mutableMap.put("someString", "abc");
+        mutableMap.put("someAddProp", 1);
+        FrozenMap<String, Object> arg = new FrozenMap<>(mutableMap);
+        final AdditionalPropertiesValidator validator = new AdditionalPropertiesValidator();
+        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                arg,
+                StringSchema.class,
+                properties,
+                SchemaValidator.class,
+                validationMetadata
+        ));
+    }
+}

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/PropertiesValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/PropertiesValidatorTest.java
@@ -1,0 +1,105 @@
+package org.openapijsonschematools.schemas.validators;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
+import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.schemas.FrozenMap;
+import org.openapijsonschematools.schemas.PathToSchemasMap;
+import org.openapijsonschematools.schemas.SchemaValidator;
+import org.openapijsonschematools.schemas.StringSchema;
+import org.openapijsonschematools.schemas.ValidationMetadata;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+
+public class PropertiesValidatorTest {
+
+    @Test
+    public void testCorrectPropertySucceeds() {
+        Map<String, Class<?>> properties = new LinkedHashMap<>();
+        properties.put("someString", StringSchema.class);
+
+        final PropertiesValidator validator = new PropertiesValidator();
+        List<Object> pathToItem = new ArrayList<>();
+        pathToItem.add("args[0]");
+        ValidationMetadata validationMetadata = new ValidationMetadata(
+                pathToItem,
+                new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone()),
+                new PathToSchemasMap(),
+                new LinkedHashSet<>()
+        );
+        LinkedHashMap<String, Object> mutableMap = new LinkedHashMap<>();
+        mutableMap.put("someString", "abc");
+        FrozenMap<String, Object> arg = new FrozenMap<>(mutableMap);
+        PathToSchemasMap pathToSchemas = validator.validate(
+                arg,
+                properties,
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        );
+        List<Object> expectedPathToItem = new ArrayList<>();
+        expectedPathToItem.add("args[0]");
+        expectedPathToItem.add("someString");
+        LinkedHashMap<Class<?>, Void> expectedClasses = new LinkedHashMap<>();
+        expectedClasses.put(String.class, null);
+        expectedClasses.put(StringSchema.class, null);
+        PathToSchemasMap expectedPathToSchemas = new PathToSchemasMap();
+        expectedPathToSchemas.put(expectedPathToItem, expectedClasses);
+        Assert.assertEquals(pathToSchemas, expectedPathToSchemas);
+    }
+
+    @Test
+    public void testNotApplicableTypeReturnsNull() {
+        Map<String, Class<?>> properties = new LinkedHashMap<>();
+        properties.put("someString", StringSchema.class);
+
+        final PropertiesValidator validator = new PropertiesValidator();
+        List<Object> pathToItem = new ArrayList<>();
+        pathToItem.add("args[0]");
+        ValidationMetadata validationMetadata = new ValidationMetadata(
+                pathToItem,
+                new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone()),
+                new PathToSchemasMap(),
+                new LinkedHashSet<>()
+        );
+        PathToSchemasMap pathToSchemas = validator.validate(
+                1,
+                properties,
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        );
+        Assert.assertNull(pathToSchemas);
+    }
+
+    @Test
+    public void testIncorrectPropertyValueFails() {
+        Map<String, Class<?>> properties = new LinkedHashMap<>();
+        properties.put("someString", StringSchema.class);
+
+        final PropertiesValidator validator = new PropertiesValidator();
+        List<Object> pathToItem = new ArrayList<>();
+        pathToItem.add("args[0]");
+        ValidationMetadata validationMetadata = new ValidationMetadata(
+                pathToItem,
+                new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone()),
+                new PathToSchemasMap(),
+                new LinkedHashSet<>()
+        );
+        LinkedHashMap<String, Object> mutableMap = new LinkedHashMap<>();
+        mutableMap.put("someString", 1);
+        FrozenMap<String, Object> arg = new FrozenMap<>(mutableMap);
+        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                arg,
+                properties,
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        ));
+    }
+}

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/RequiredValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/RequiredValidatorTest.java
@@ -1,0 +1,98 @@
+package org.openapijsonschematools.schemas.validators;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
+import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.schemas.FrozenMap;
+import org.openapijsonschematools.schemas.PathToSchemasMap;
+import org.openapijsonschematools.schemas.SchemaValidator;
+import org.openapijsonschematools.schemas.StringSchema;
+import org.openapijsonschematools.schemas.ValidationMetadata;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class RequiredValidatorTest {
+
+    @Test
+    public void testCorrectPropertySucceeds() {
+        Set<String> requiredProperties = new LinkedHashSet<>();
+        requiredProperties.add("someString");
+
+        List<Object> pathToItem = new ArrayList<>();
+        pathToItem.add("args[0]");
+        ValidationMetadata validationMetadata = new ValidationMetadata(
+                pathToItem,
+                new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone()),
+                new PathToSchemasMap(),
+                new LinkedHashSet<>()
+        );
+        LinkedHashMap<String, Object> mutableMap = new LinkedHashMap<>();
+        mutableMap.put("someString", "abc");
+        FrozenMap<String, Object> arg = new FrozenMap<>(mutableMap);
+        final RequiredValidator validator = new RequiredValidator();
+        PathToSchemasMap pathToSchemas = validator.validate(
+                arg,
+                requiredProperties,
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        );
+        Assert.assertNull(pathToSchemas);
+    }
+
+    @Test
+    public void testNotApplicableTypeReturnsNull() {
+        Map<String, Class<?>> properties = new LinkedHashMap<>();
+        properties.put("someString", StringSchema.class);
+
+        List<Object> pathToItem = new ArrayList<>();
+        pathToItem.add("args[0]");
+        ValidationMetadata validationMetadata = new ValidationMetadata(
+                pathToItem,
+                new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone()),
+                new PathToSchemasMap(),
+                new LinkedHashSet<>()
+        );
+        final RequiredValidator validator = new RequiredValidator();
+        PathToSchemasMap pathToSchemas = validator.validate(
+                1,
+                properties,
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        );
+        Assert.assertNull(pathToSchemas);
+    }
+
+    @Test
+    public void testIncorrectPropertyFails() {
+        Set<String> requiredProperties = new LinkedHashSet<>();
+        requiredProperties.add("someString");
+
+        List<Object> pathToItem = new ArrayList<>();
+        pathToItem.add("args[0]");
+        ValidationMetadata validationMetadata = new ValidationMetadata(
+                pathToItem,
+                new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone()),
+                new PathToSchemasMap(),
+                new LinkedHashSet<>()
+        );
+        LinkedHashMap<String, Object> mutableMap = new LinkedHashMap<>();
+        mutableMap.put("aDifferentProp", 1);
+        FrozenMap<String, Object> arg = new FrozenMap<>(mutableMap);
+        final RequiredValidator validator = new RequiredValidator();
+        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                arg,
+                requiredProperties,
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        ));
+    }
+}

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -298,6 +298,7 @@ public class JavaClientGenerator extends AbstractJavaGenerator
         schemaTestSupportingFiles.add("MapSchemaTest");
         schemaTestSupportingFiles.add("NullSchemaTest");
         schemaTestSupportingFiles.add("NumberSchemaTest");
+        schemaTestSupportingFiles.add("ObjectTypeSchemaTest");
         schemaTestSupportingFiles.add("SchemaValidatorTest");
         for (String schemaTestSupportingFile: schemaTestSupportingFiles) {
             supportingFiles.add(new SupportingFile(

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -294,6 +294,10 @@ public class JavaClientGenerator extends AbstractJavaGenerator
                 packagePath() + File.separatorChar + "schemas",
                 "FloatSchema.java"));
         supportingFiles.add(new SupportingFile(
+                "src/main/java/org/openapitools/schemas/FrozenMap.hbs",
+                packagePath() + File.separatorChar + "schemas",
+                "FrozenMap.java"));
+        supportingFiles.add(new SupportingFile(
                 "src/main/java/org/openapitools/schemas/Int32Schema.hbs",
                 packagePath() + File.separatorChar + "schemas",
                 "Int32Schema.java"));
@@ -305,6 +309,10 @@ public class JavaClientGenerator extends AbstractJavaGenerator
                 "src/main/java/org/openapitools/schemas/IntSchema.hbs",
                 packagePath() + File.separatorChar + "schemas",
                 "IntSchema.java"));
+        supportingFiles.add(new SupportingFile(
+                "src/main/java/org/openapitools/schemas/MapSchema.hbs",
+                packagePath() + File.separatorChar + "schemas",
+                "MapSchema.java"));
         supportingFiles.add(new SupportingFile(
                 "src/main/java/org/openapitools/schemas/NullSchema.hbs",
                 packagePath() + File.separatorChar + "schemas",

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -308,6 +308,7 @@ public class JavaClientGenerator extends AbstractJavaGenerator
 
         // keyword validators
         List<String> keywordValidatorFiles = new ArrayList<>();
+        keywordValidatorFiles.add("AdditionalPropertiesValidator");
         keywordValidatorFiles.add("FormatValidator");
         keywordValidatorFiles.add("KeywordValidator");
         keywordValidatorFiles.add("PropertiesValidator");
@@ -321,10 +322,11 @@ public class JavaClientGenerator extends AbstractJavaGenerator
         }
         // tests
         List<String> keywordValidatorTestFiles = new ArrayList<>();
-        keywordValidatorTestFiles.add("TypeValidatorTest");
+        keywordValidatorTestFiles.add("AdditionalPropertiesValidatorTest");
+        keywordValidatorTestFiles.add("FormatValidatorTest");
         keywordValidatorTestFiles.add("PropertiesValidatorTest");
         keywordValidatorTestFiles.add("RequiredValidatorTest");
-        keywordValidatorTestFiles.add("FormatValidatorTest");
+        keywordValidatorTestFiles.add("TypeValidatorTest");
         for (String keywordValidatorTestFile: keywordValidatorTestFiles) {
             supportingFiles.add(new SupportingFile(
                     "src/test/java/org/openapitools/schemas/validators/"+keywordValidatorTestFile+".hbs",

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -369,17 +369,21 @@ public class JavaClientGenerator extends AbstractJavaGenerator
 
         // keyword validators
         supportingFiles.add(new SupportingFile(
+                "src/main/java/org/openapitools/schemas/validators/FormatValidator.hbs",
+                packagePath() + File.separatorChar + "schemas" + File.separatorChar + "validators",
+                "FormatValidator.java"));
+        supportingFiles.add(new SupportingFile(
                 "src/main/java/org/openapitools/schemas/validators/KeywordValidator.hbs",
                 packagePath() + File.separatorChar + "schemas" + File.separatorChar + "validators",
                 "KeywordValidator.java"));
         supportingFiles.add(new SupportingFile(
+                "src/main/java/org/openapitools/schemas/validators/PropertiesValidator.hbs",
+                packagePath() + File.separatorChar + "schemas" + File.separatorChar + "validators",
+                "PropertiesValidator.java"));
+        supportingFiles.add(new SupportingFile(
                 "src/main/java/org/openapitools/schemas/validators/TypeValidator.hbs",
                 packagePath() + File.separatorChar + "schemas" + File.separatorChar + "validators",
                 "TypeValidator.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/main/java/org/openapitools/schemas/validators/FormatValidator.hbs",
-                packagePath() + File.separatorChar + "schemas" + File.separatorChar + "validators",
-                "FormatValidator.java"));
         // tests
         supportingFiles.add(new SupportingFile(
                 "src/test/java/org/openapitools/schemas/validators/TypeValidatorTest.hbs",

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -261,146 +261,74 @@ public class JavaClientGenerator extends AbstractJavaGenerator
     public void processOpts() {
         HashMap<String, String> schemaDocs = new HashMap<>();
         additionalProperties.put(CodegenConstants.PACKAGE_NAME, packageName);
-        supportingFiles.add(new SupportingFile(
-                "src/main/java/org/openapitools/schemas/AnyTypeSchema.hbs",
-                packagePath() + File.separatorChar + "schemas",
-                "AnyTypeSchema.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/main/java/org/openapitools/schemas/BooleanSchema.hbs",
-                packagePath() + File.separatorChar + "schemas",
-                "BooleanSchema.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/main/java/org/openapitools/schemas/CustomIsoparser.hbs",
-                packagePath() + File.separatorChar + "schemas",
-                "CustomIsoparser.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/main/java/org/openapitools/schemas/DateSchema.hbs",
-                packagePath() + File.separatorChar + "schemas",
-                "DateSchema.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/main/java/org/openapitools/schemas/DateTimeSchema.hbs",
-                packagePath() + File.separatorChar + "schemas",
-                "DateTimeSchema.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/main/java/org/openapitools/schemas/DecimalSchema.hbs",
-                packagePath() + File.separatorChar + "schemas",
-                "DecimalSchema.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/main/java/org/openapitools/schemas/DoubleSchema.hbs",
-                packagePath() + File.separatorChar + "schemas",
-                "DoubleSchema.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/main/java/org/openapitools/schemas/FloatSchema.hbs",
-                packagePath() + File.separatorChar + "schemas",
-                "FloatSchema.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/main/java/org/openapitools/schemas/FrozenMap.hbs",
-                packagePath() + File.separatorChar + "schemas",
-                "FrozenMap.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/main/java/org/openapitools/schemas/Int32Schema.hbs",
-                packagePath() + File.separatorChar + "schemas",
-                "Int32Schema.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/main/java/org/openapitools/schemas/Int64Schema.hbs",
-                packagePath() + File.separatorChar + "schemas",
-                "Int64Schema.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/main/java/org/openapitools/schemas/IntSchema.hbs",
-                packagePath() + File.separatorChar + "schemas",
-                "IntSchema.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/main/java/org/openapitools/schemas/MapSchema.hbs",
-                packagePath() + File.separatorChar + "schemas",
-                "MapSchema.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/main/java/org/openapitools/schemas/NullSchema.hbs",
-                packagePath() + File.separatorChar + "schemas",
-                "NullSchema.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/main/java/org/openapitools/schemas/NumberSchema.hbs",
-                packagePath() + File.separatorChar + "schemas",
-                "NumberSchema.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/main/java/org/openapitools/schemas/PathToSchemasMap.hbs",
-                packagePath() + File.separatorChar + "schemas",
-                "PathToSchemasMap.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/main/java/org/openapitools/schemas/PathToTypeMap.hbs",
-                packagePath() + File.separatorChar + "schemas",
-                "PathToTypeMap.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/main/java/org/openapitools/schemas/Schema.hbs",
-                packagePath() + File.separatorChar + "schemas",
-                "Schema.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/main/java/org/openapitools/schemas/SchemaValidator.hbs",
-                packagePath() + File.separatorChar + "schemas",
-                "SchemaValidator.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/main/java/org/openapitools/schemas/StringSchema.hbs",
-                packagePath() + File.separatorChar + "schemas",
-                "StringSchema.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/main/java/org/openapitools/schemas/UnsetAnyTypeSchema.hbs",
-                packagePath() + File.separatorChar + "schemas",
-                "UnsetAnyTypeSchema.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/main/java/org/openapitools/schemas/ValidationMetadata.hbs",
-                packagePath() + File.separatorChar + "schemas",
-                "ValidationMetadata.java"));
+        List<String> schemaSupportingFiles = new ArrayList<>();
+        schemaSupportingFiles.add("AnyTypeSchema");
+        schemaSupportingFiles.add("BooleanSchema");
+        schemaSupportingFiles.add("CustomIsoparser");
+        schemaSupportingFiles.add("DateSchema");
+        schemaSupportingFiles.add("DateTimeSchema");
+        schemaSupportingFiles.add("DecimalSchema");
+        schemaSupportingFiles.add("DoubleSchema");
+        schemaSupportingFiles.add("FloatSchema");
+        schemaSupportingFiles.add("FrozenMap");
+        schemaSupportingFiles.add("Int32Schema");
+        schemaSupportingFiles.add("Int64Schema");
+        schemaSupportingFiles.add("IntSchema");
+        schemaSupportingFiles.add("MapSchema");
+        schemaSupportingFiles.add("NullSchema");
+        schemaSupportingFiles.add("NumberSchema");
+        schemaSupportingFiles.add("PathToSchemasMap");
+        schemaSupportingFiles.add("PathToTypeMap");
+        schemaSupportingFiles.add("Schema");
+        schemaSupportingFiles.add("SchemaValidator");
+        schemaSupportingFiles.add("StringSchema");
+        schemaSupportingFiles.add("UnsetAnyTypeSchema");
+        schemaSupportingFiles.add("ValidationMetadata");
+        for (String schemaSupportingFile: schemaSupportingFiles) {
+            supportingFiles.add(new SupportingFile(
+                    "src/main/java/org/openapitools/schemas/"+schemaSupportingFile+".hbs",
+                    packagePath() + File.separatorChar + "schemas",
+                    schemaSupportingFile + ".java"));
+        }
         // tests
-        supportingFiles.add(new SupportingFile(
-                "src/test/java/org/openapitools/schemas/AnyTypeSchemaTest.hbs",
-                testPackagePath() + File.separatorChar + "schemas",
-                "AnyTypeSchemaTest.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/test/java/org/openapitools/schemas/BooleanSchemaTest.hbs",
-                testPackagePath() + File.separatorChar + "schemas",
-                "BooleanSchemaTest.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/test/java/org/openapitools/schemas/CustomIsoparserTest.hbs",
-                testPackagePath() + File.separatorChar + "schemas",
-                "CustomIsoparserTest.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/test/java/org/openapitools/schemas/NullSchemaTest.hbs",
-                testPackagePath() + File.separatorChar + "schemas",
-                "NullSchemaTest.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/test/java/org/openapitools/schemas/NumberSchemaTest.hbs",
-                testPackagePath() + File.separatorChar + "schemas",
-                "NumberSchemaTest.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/test/java/org/openapitools/schemas/SchemaValidatorTest.hbs",
-                testPackagePath() + File.separatorChar + "schemas",
-                "SchemaValidatorTest.java"));
+        List<String> schemaTestSupportingFiles = new ArrayList<>();
+        schemaTestSupportingFiles.add("AnyTypeSchemaTest");
+        schemaTestSupportingFiles.add("BooleanSchemaTest");
+        schemaTestSupportingFiles.add("CustomIsoparserTest");
+        schemaTestSupportingFiles.add("MapSchemaTest");
+        schemaTestSupportingFiles.add("NullSchemaTest");
+        schemaTestSupportingFiles.add("NumberSchemaTest");
+        schemaTestSupportingFiles.add("SchemaValidatorTest");
+        for (String schemaTestSupportingFile: schemaTestSupportingFiles) {
+            supportingFiles.add(new SupportingFile(
+                    "src/test/java/org/openapitools/schemas/"+schemaTestSupportingFile+".hbs",
+                    testPackagePath() + File.separatorChar + "schemas",
+                    schemaTestSupportingFile + ".java"));
+        }
 
         // keyword validators
-        supportingFiles.add(new SupportingFile(
-                "src/main/java/org/openapitools/schemas/validators/FormatValidator.hbs",
-                packagePath() + File.separatorChar + "schemas" + File.separatorChar + "validators",
-                "FormatValidator.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/main/java/org/openapitools/schemas/validators/KeywordValidator.hbs",
-                packagePath() + File.separatorChar + "schemas" + File.separatorChar + "validators",
-                "KeywordValidator.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/main/java/org/openapitools/schemas/validators/PropertiesValidator.hbs",
-                packagePath() + File.separatorChar + "schemas" + File.separatorChar + "validators",
-                "PropertiesValidator.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/main/java/org/openapitools/schemas/validators/TypeValidator.hbs",
-                packagePath() + File.separatorChar + "schemas" + File.separatorChar + "validators",
-                "TypeValidator.java"));
+        List<String> keywordValidatorFiles = new ArrayList<>();
+        keywordValidatorFiles.add("FormatValidator");
+        keywordValidatorFiles.add("KeywordValidator");
+        keywordValidatorFiles.add("PropertiesValidator");
+        keywordValidatorFiles.add("TypeValidator");
+        for (String keywordValidatorFile: keywordValidatorFiles) {
+            supportingFiles.add(new SupportingFile(
+                    "src/main/java/org/openapitools/schemas/validators/"+keywordValidatorFile+".hbs",
+                    packagePath() + File.separatorChar + "schemas" + File.separatorChar + "validators",
+                    keywordValidatorFile + ".java"));
+        }
         // tests
-        supportingFiles.add(new SupportingFile(
-                "src/test/java/org/openapitools/schemas/validators/TypeValidatorTest.hbs",
-                testPackagePath() + File.separatorChar + "schemas" + File.separatorChar + "validators",
-                "TypeValidatorTest.java"));
-        supportingFiles.add(new SupportingFile(
-                "src/test/java/org/openapitools/schemas/validators/FormatValidatorTest.hbs",
-                testPackagePath() + File.separatorChar + "schemas" + File.separatorChar + "validators",
-                "FormatValidatorTest.java"));
+        List<String> keywordValidatorTestFiles = new ArrayList<>();
+        keywordValidatorTestFiles.add("TypeValidatorTest");
+        keywordValidatorTestFiles.add("PropertiesValidatorTest");
+        keywordValidatorTestFiles.add("FormatValidatorTest");
+        for (String keywordValidatorTestFile: keywordValidatorTestFiles) {
+            supportingFiles.add(new SupportingFile(
+                    "src/test/java/org/openapitools/schemas/validators/"+keywordValidatorTestFile+".hbs",
+                    testPackagePath() + File.separatorChar + "schemas" + File.separatorChar + "validators",
+                    keywordValidatorTestFile + ".java"));
+        }
 
         // configuration
         supportingFiles.add(new SupportingFile(

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -311,6 +311,7 @@ public class JavaClientGenerator extends AbstractJavaGenerator
         keywordValidatorFiles.add("FormatValidator");
         keywordValidatorFiles.add("KeywordValidator");
         keywordValidatorFiles.add("PropertiesValidator");
+        keywordValidatorFiles.add("RequiredValidator");
         keywordValidatorFiles.add("TypeValidator");
         for (String keywordValidatorFile: keywordValidatorFiles) {
             supportingFiles.add(new SupportingFile(
@@ -322,6 +323,7 @@ public class JavaClientGenerator extends AbstractJavaGenerator
         List<String> keywordValidatorTestFiles = new ArrayList<>();
         keywordValidatorTestFiles.add("TypeValidatorTest");
         keywordValidatorTestFiles.add("PropertiesValidatorTest");
+        keywordValidatorTestFiles.add("RequiredValidatorTest");
         keywordValidatorTestFiles.add("FormatValidatorTest");
         for (String keywordValidatorTestFile: keywordValidatorTestFiles) {
             supportingFiles.add(new SupportingFile(

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/AnyTypeSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/AnyTypeSchema.hbs
@@ -48,11 +48,11 @@ record AnyTypeSchema() implements Schema {
         return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }
 
-    public static <T extends Map> T validate(T arg, SchemaConfiguration configuration) {
+    public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
         return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }
 
-    public static <U extends List> U validate(U arg, SchemaConfiguration configuration) {
+    public static <U extends List> U validate(List<Object> arg, SchemaConfiguration configuration) {
         return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/AnyTypeSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/AnyTypeSchema.hbs
@@ -7,7 +7,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 
-record AnyTypeSchema() implements Schema {
+public record AnyTypeSchema() implements Schema {
     public static AnyTypeSchema withDefaults() {
         return new AnyTypeSchema();
     }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/BooleanSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/BooleanSchema.hbs
@@ -4,7 +4,7 @@ import {{{packageName}}}.configurations.SchemaConfiguration;
 
 import java.util.LinkedHashSet;
 
-record BooleanSchema(LinkedHashSet<Class<?>> type) implements Schema {
+public record BooleanSchema(LinkedHashSet<Class<?>> type) implements Schema {
     public static BooleanSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
         type.add(Boolean.class);

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/DateSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/DateSchema.hbs
@@ -5,7 +5,7 @@ import {{{packageName}}}.configurations.SchemaConfiguration;
 import java.util.LinkedHashSet;
 import java.time.LocalDate;
 
-record DateSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
+public record DateSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
     public static DateSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
         type.add(String.class);

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/DateTimeSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/DateTimeSchema.hbs
@@ -5,7 +5,7 @@ import {{{packageName}}}.configurations.SchemaConfiguration;
 import java.util.LinkedHashSet;
 import java.time.ZonedDateTime;
 
-record DateTimeSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
+public record DateTimeSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
     public static DateTimeSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
         type.add(String.class);

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/DecimalSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/DecimalSchema.hbs
@@ -4,7 +4,7 @@ import {{{packageName}}}.configurations.SchemaConfiguration;
 
 import java.util.LinkedHashSet;
 
-record DecimalSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
+public record DecimalSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
     public static DecimalSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
         type.add(String.class);

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/DoubleSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/DoubleSchema.hbs
@@ -5,7 +5,7 @@ import {{{packageName}}}.configurations.SchemaConfiguration;
 import java.util.LinkedHashSet;
 import java.math.BigDecimal;
 
-record DoubleSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
+public record DoubleSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
     public static DoubleSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
         type.add(BigDecimal.class);

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/FloatSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/FloatSchema.hbs
@@ -5,7 +5,7 @@ import {{{packageName}}}.configurations.SchemaConfiguration;
 import java.util.LinkedHashSet;
 import java.math.BigDecimal;
 
-record FloatSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
+public record FloatSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
     public static FloatSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
         type.add(BigDecimal.class);

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/FrozenMap.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/FrozenMap.hbs
@@ -1,0 +1,78 @@
+package {{{packageName}}}.schemas;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+public class FrozenMap<K, V> extends LinkedHashMap<K, V> {
+    /*
+    A frozen Map
+    Once schema validation has been run, written accessor methods return values of the correct type
+    If values were mutable, the types in those methods would not agree with returned values
+     */
+    public FrozenMap(Map<? extends K, ? extends V> m) {
+        super(m);
+    }
+
+    public V put(K key, V value) {
+        throw new UnsupportedOperationException();
+    }
+    public V remove(Object key) {
+        throw new UnsupportedOperationException();
+    }
+    public void putAll(Map<? extends K, ? extends V> m) {
+        throw new UnsupportedOperationException();
+    }
+    public void clear() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void replaceAll(BiFunction<? super K, ? super V, ? extends V> function) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public V putIfAbsent(K key, V value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean remove(Object key, Object value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean replace(K key, V oldValue, V newValue) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public V replace(K key, V value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public V computeIfPresent(K key,
+                              BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public V compute(K key,
+                     BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public V merge(K key, V value,
+                   BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/Int32Schema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/Int32Schema.hbs
@@ -5,7 +5,7 @@ import {{{packageName}}}.configurations.SchemaConfiguration;
 import java.util.LinkedHashSet;
 import java.math.BigDecimal;
 
-record Int32Schema(LinkedHashSet<Class<?>> type, String format) implements Schema {
+public record Int32Schema(LinkedHashSet<Class<?>> type, String format) implements Schema {
     public static Int32Schema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
         type.add(BigDecimal.class);

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/Int64Schema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/Int64Schema.hbs
@@ -5,7 +5,7 @@ import {{{packageName}}}.configurations.SchemaConfiguration;
 import java.util.LinkedHashSet;
 import java.math.BigDecimal;
 
-record Int64Schema(LinkedHashSet<Class<?>> type, String format) implements Schema {
+public record Int64Schema(LinkedHashSet<Class<?>> type, String format) implements Schema {
     public static Int64Schema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
         type.add(BigDecimal.class);

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/IntSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/IntSchema.hbs
@@ -5,7 +5,7 @@ import {{{packageName}}}.configurations.SchemaConfiguration;
 import java.util.LinkedHashSet;
 import java.math.BigDecimal;
 
-record IntSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
+public record IntSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
     public static IntSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
         type.add(BigDecimal.class);

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/MapSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/MapSchema.hbs
@@ -1,0 +1,20 @@
+package {{{packageName}}}.schemas;
+
+import {{{packageName}}}.configurations.SchemaConfiguration;
+
+import java.util.LinkedHashSet;
+import java.util.Map;
+
+record MapSchema(LinkedHashSet<Class<?>> type) implements Schema {
+    public static MapSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        // can't use ImmutableMap because it does not allow null values in entries
+        // can't use Collections.unmodifiableMap because Collections.UnmodifiableMap is not public + extensible
+        type.add(FrozenMap.class);
+        return new MapSchema(type);
+    }
+
+    public static Map<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        return Schema.validate(MapSchema.class, arg, configuration);
+    }
+}

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/MapSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/MapSchema.hbs
@@ -14,7 +14,7 @@ record MapSchema(LinkedHashSet<Class<?>> type) implements Schema {
         return new MapSchema(type);
     }
 
-    public static Map<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+    public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) {
         return Schema.validate(MapSchema.class, arg, configuration);
     }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/MapSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/MapSchema.hbs
@@ -5,7 +5,7 @@ import {{{packageName}}}.configurations.SchemaConfiguration;
 import java.util.LinkedHashSet;
 import java.util.Map;
 
-record MapSchema(LinkedHashSet<Class<?>> type) implements Schema {
+public record MapSchema(LinkedHashSet<Class<?>> type) implements Schema {
     public static MapSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
         // can't use ImmutableMap because it does not allow null values in entries

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/NullSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/NullSchema.hbs
@@ -4,7 +4,7 @@ import {{{packageName}}}.configurations.SchemaConfiguration;
 
 import java.util.LinkedHashSet;
 
-record NullSchema(LinkedHashSet<Class<?>> type) implements Schema {
+public record NullSchema(LinkedHashSet<Class<?>> type) implements Schema {
     public static NullSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
         type.add(Void.class);

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/NumberSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/NumberSchema.hbs
@@ -5,7 +5,7 @@ import {{{packageName}}}.configurations.SchemaConfiguration;
 import java.util.LinkedHashSet;
 import java.math.BigDecimal;
 
-record NumberSchema(LinkedHashSet<Class<?>> type) implements Schema {
+public record NumberSchema(LinkedHashSet<Class<?>> type) implements Schema {
     public static NumberSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
         type.add(BigDecimal.class);

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/Schema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/Schema.hbs
@@ -9,6 +9,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -17,7 +18,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-public interface Schema<T extends Map, U extends List> extends SchemaValidator {
+public interface Schema extends SchemaValidator {
    private static Object castToAllowedTypes(Object arg, List<Object> pathToItem, PathToTypeMap pathToType) {
       if (arg == null) {
          pathToType.put(pathToItem, Void.class);
@@ -36,7 +37,7 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
             Object fixedVal = castToAllowedTypes(val, newPathToItem, pathToType);
             argFixed.put(key, fixedVal);
          }
-         return argFixed;
+         return new FrozenMap(argFixed);
       } else if (arg instanceof Boolean) {
          pathToType.put(pathToItem, Boolean.class);
          return arg;
@@ -116,7 +117,7 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
          Object castValue = getNewInstance(propertyClass, value, propertyPathToItem, pathToSchemas);
          properties.put(propertyName, castValue);
       }
-      return properties;
+      return new FrozenMap(properties);
    }
 
    private static List<Object> getItems(Object arg, List<Object> pathToItem, PathToSchemasMap pathToSchemas) {
@@ -209,11 +210,11 @@ public interface Schema<T extends Map, U extends List> extends SchemaValidator {
       return (String) validateObject(cls, arg, configuration);
    }
 
-   static <T extends Map> T validate(Class<?> cls, T arg, SchemaConfiguration configuration) {
+   static <T extends FrozenMap> T validate(Class<?> cls, Map<String, Object> arg, SchemaConfiguration configuration) {
       return (T) validateObject(cls, arg, configuration);
    }
 
-   static <U extends List> U validate(Class<?> cls, U arg, SchemaConfiguration configuration) {
+   static <U extends List> U validate(Class<?> cls, List<Object> arg, SchemaConfiguration configuration) {
       return (U) validateObject(cls, arg, configuration);
    }
 

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/SchemaValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/SchemaValidator.hbs
@@ -3,6 +3,7 @@ package {{{packageName}}}.schemas;
 import {{{packageName}}}.schemas.validators.KeywordValidator;
 import {{{packageName}}}.schemas.validators.TypeValidator;
 import {{{packageName}}}.schemas.validators.FormatValidator;
+import {{{packageName}}}.schemas.validators.PropertiesValidator;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.RecordComponent;
@@ -16,6 +17,7 @@ public interface SchemaValidator {
     HashMap<String, KeywordValidator> keywordToValidator = new HashMap()\{{
         put("type", new TypeValidator());
         put("format", new FormatValidator());
+        put("properties", new PropertiesValidator());
     }};
 
     static PathToSchemasMap validate(

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/SchemaValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/SchemaValidator.hbs
@@ -4,6 +4,7 @@ import {{{packageName}}}.schemas.validators.KeywordValidator;
 import {{{packageName}}}.schemas.validators.TypeValidator;
 import {{{packageName}}}.schemas.validators.FormatValidator;
 import {{{packageName}}}.schemas.validators.PropertiesValidator;
+import {{{packageName}}}.schemas.validators.RequiredValidator;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.RecordComponent;
@@ -18,6 +19,7 @@ public interface SchemaValidator {
         put("type", new TypeValidator());
         put("format", new FormatValidator());
         put("properties", new PropertiesValidator());
+        put("required", new RequiredValidator());
     }};
 
     static PathToSchemasMap validate(

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/SchemaValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/SchemaValidator.hbs
@@ -1,5 +1,6 @@
 package {{{packageName}}}.schemas;
 
+import {{{packageName}}}.schemas.validators.AdditionalPropertiesValidator;
 import {{{packageName}}}.schemas.validators.KeywordValidator;
 import {{{packageName}}}.schemas.validators.TypeValidator;
 import {{{packageName}}}.schemas.validators.FormatValidator;
@@ -16,6 +17,7 @@ import java.util.Map;
 
 public interface SchemaValidator {
     HashMap<String, KeywordValidator> keywordToValidator = new HashMap()\{{
+        put("additionalProperties", new AdditionalPropertiesValidator());
         put("type", new TypeValidator());
         put("format", new FormatValidator());
         put("properties", new PropertiesValidator());
@@ -48,6 +50,10 @@ public interface SchemaValidator {
                 throw new RuntimeException(e);
             }
         }
+        Object extra = null;
+        if (fieldsToValues.containsKey("additionalProperties") && fieldsToValues.containsKey("properties")) {
+            extra = fieldsToValues.get("properties");
+        }
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         Class<SchemaValidator> castSchemaCls = (Class<SchemaValidator>) schemaCls;
         for (Map.Entry<String, Object> entry: fieldsToValues.entrySet()) {
@@ -57,7 +63,7 @@ public interface SchemaValidator {
             PathToSchemasMap otherPathToSchemas = validatorClass.validate(
                     arg,
                     value,
-                    null,
+                    extra,
                     castSchemaCls,
                     validationMetadata
             );

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/SchemaValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/SchemaValidator.hbs
@@ -51,14 +51,14 @@ public interface SchemaValidator {
             }
         }
         Object extra = null;
-        if (fieldsToValues.containsKey("additionalProperties") && fieldsToValues.containsKey("properties")) {
-            extra = fieldsToValues.get("properties");
-        }
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         Class<SchemaValidator> castSchemaCls = (Class<SchemaValidator>) schemaCls;
         for (Map.Entry<String, Object> entry: fieldsToValues.entrySet()) {
             String jsonKeyword = entry.getKey();
             Object value = entry.getValue();
+            if (jsonKeyword.equals("additionalProperties") && fieldsToValues.containsKey("properties")) {
+                extra = fieldsToValues.get("properties");
+            }
             KeywordValidator validatorClass = keywordToValidator.get(jsonKeyword);
             PathToSchemasMap otherPathToSchemas = validatorClass.validate(
                     arg,

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/StringSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/StringSchema.hbs
@@ -6,7 +6,7 @@ import java.util.LinkedHashSet;
 import java.time.ZonedDateTime;
 import java.time.LocalDate;
 
-record StringSchema(LinkedHashSet<Class<?>> type) implements Schema {
+public record StringSchema(LinkedHashSet<Class<?>> type) implements Schema {
     public static StringSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
         type.add(String.class);

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/UnsetAnyTypeSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/UnsetAnyTypeSchema.hbs
@@ -48,11 +48,11 @@ record UnsetAnyTypeSchema() implements Schema {
         return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
-    static <T extends Map> T validate(T arg, SchemaConfiguration configuration) {
+    static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
         return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
-    static <U extends List> U validate(U arg, SchemaConfiguration configuration) {
+    static <U extends List> U validate(List<Object> arg, SchemaConfiguration configuration) {
         return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/UnsetAnyTypeSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/UnsetAnyTypeSchema.hbs
@@ -7,7 +7,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 
-record UnsetAnyTypeSchema() implements Schema {
+public record UnsetAnyTypeSchema() implements Schema {
     static UnsetAnyTypeSchema withDefaults() {
         return new UnsetAnyTypeSchema();
     }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/ValidationMetadata.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/ValidationMetadata.hbs
@@ -12,7 +12,7 @@ public record ValidationMetadata(
         Set<Class<?>> seenClasses
 ) {
 
-    protected boolean validationRanEarlier(Class<?> cls) {
+    public boolean validationRanEarlier(Class<?> cls) {
         Map<Class<?>, Void> validatedSchemas = validatedPathToSchemas.getOrDefault(pathToItem, null);
         if (validatedSchemas != null && validatedSchemas.containsKey(cls)) {
             return true;

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/AdditionalPropertiesValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/AdditionalPropertiesValidator.hbs
@@ -1,0 +1,50 @@
+package {{{packageName}}}.schemas.validators;
+
+import {{{packageName}}}.schemas.PathToSchemasMap;
+import {{{packageName}}}.schemas.Schema;
+import {{{packageName}}}.schemas.SchemaValidator;
+import {{{packageName}}}.schemas.ValidationMetadata;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class AdditionalPropertiesValidator implements KeywordValidator {
+    @Override
+    public PathToSchemasMap validate(Object arg, Object value, Object extra, Class<SchemaValidator> cls, ValidationMetadata validationMetadata) {
+        if (!(arg instanceof Map)) {
+            return null;
+        }
+        Map<String, Object> castArg = (Map<String, Object>) arg;
+        Class<Schema> addPropSchema = (Class<Schema>) value;
+        Map<String, Class<Schema>> properties = (Map<String, Class<Schema>>) extra;
+        if (properties == null) {
+            properties = new LinkedHashMap<>();
+        }
+        Set<String> presentAdditionalProperties = new LinkedHashSet<>(castArg.keySet());
+        presentAdditionalProperties.removeAll(properties.keySet());
+        PathToSchemasMap pathToSchemas = new PathToSchemasMap();
+        // todo add handling for validatedPatternProperties
+        for(String addPropName: presentAdditionalProperties) {
+            Object propValue = castArg.get(addPropName);
+            List<Object> propPathToItem = new ArrayList<>(validationMetadata.pathToItem());
+            propPathToItem.add(addPropName);
+            ValidationMetadata propValidationMetadata = new ValidationMetadata(
+                    propPathToItem,
+                    validationMetadata.configuration(),
+                    validationMetadata.validatedPathToSchemas(),
+                    validationMetadata.seenClasses()
+            );
+            if (propValidationMetadata.validationRanEarlier(addPropSchema)) {
+                // todo add_deeper_validated_schemas
+                continue;
+            }
+            PathToSchemasMap otherPathToSchemas = SchemaValidator.validate(addPropSchema, propValue, propValidationMetadata);
+            pathToSchemas.update(otherPathToSchemas);
+        }
+        return pathToSchemas;
+    }
+}

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/PropertiesValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/PropertiesValidator.hbs
@@ -1,0 +1,44 @@
+package {{{packageName}}}.schemas.validators;
+
+import {{{packageName}}}.schemas.PathToSchemasMap;
+import {{{packageName}}}.schemas.Schema;
+import {{{packageName}}}.schemas.SchemaValidator;
+import {{{packageName}}}.schemas.ValidationMetadata;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PropertiesValidator implements KeywordValidator {
+    @Override
+    public PathToSchemasMap validate(Object arg, Object value, Object extra, Class<SchemaValidator> cls, ValidationMetadata validationMetadata) {
+        if (!(arg instanceof Map)) {
+            return null;
+        }
+        PathToSchemasMap pathToSchemas = new PathToSchemasMap();
+        Map<String, Object> castArg = (Map<String, Object>) arg;
+        Map<String, Class<Schema>> properties = (Map<String, Class<Schema>>) value;
+        Set<String> presentProperties = castArg.keySet();
+        presentProperties.retainAll(properties.keySet());
+        for(String propName: presentProperties) {
+            Object propValue = castArg.get(propName);
+            List<Object> propPathToItem = new ArrayList<>(validationMetadata.pathToItem());
+            propPathToItem.add(propName);
+            Class<Schema> propSchema = properties.get(propName);
+            ValidationMetadata propValidationMetadata = new ValidationMetadata(
+                    propPathToItem,
+                    validationMetadata.configuration(),
+                    validationMetadata.validatedPathToSchemas(),
+                    validationMetadata.seenClasses()
+            );
+            if (propValidationMetadata.validationRanEarlier(propSchema)) {
+                // todo add_deeper_validated_schemas
+                continue;
+            }
+            PathToSchemasMap otherPathToSchemas = SchemaValidator.validate(propSchema, propValue, validationMetadata);
+            pathToSchemas.update(otherPathToSchemas);
+        }
+        return pathToSchemas;
+    }
+}

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/PropertiesValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/PropertiesValidator.hbs
@@ -36,7 +36,7 @@ public class PropertiesValidator implements KeywordValidator {
                 // todo add_deeper_validated_schemas
                 continue;
             }
-            PathToSchemasMap otherPathToSchemas = SchemaValidator.validate(propSchema, propValue, validationMetadata);
+            PathToSchemasMap otherPathToSchemas = SchemaValidator.validate(propSchema, propValue, propValidationMetadata);
             pathToSchemas.update(otherPathToSchemas);
         }
         return pathToSchemas;

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/PropertiesValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/PropertiesValidator.hbs
@@ -6,6 +6,7 @@ import {{{packageName}}}.schemas.SchemaValidator;
 import {{{packageName}}}.schemas.ValidationMetadata;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -19,7 +20,7 @@ public class PropertiesValidator implements KeywordValidator {
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         Map<String, Object> castArg = (Map<String, Object>) arg;
         Map<String, Class<Schema>> properties = (Map<String, Class<Schema>>) value;
-        Set<String> presentProperties = castArg.keySet();
+        Set<String> presentProperties = new LinkedHashSet<>(castArg.keySet());
         presentProperties.retainAll(properties.keySet());
         for(String propName: presentProperties) {
             Object propValue = castArg.get(propName);

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/RequiredValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/RequiredValidator.hbs
@@ -1,0 +1,34 @@
+package org.openapijsonschematools.schemas.validators;
+
+import org.openapijsonschematools.schemas.PathToSchemasMap;
+import org.openapijsonschematools.schemas.SchemaValidator;
+import org.openapijsonschematools.schemas.ValidationMetadata;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class RequiredValidator implements KeywordValidator {
+    @Override
+    public PathToSchemasMap validate(Object arg, Object value, Object extra, Class<SchemaValidator> cls, ValidationMetadata validationMetadata) {
+        if (!(arg instanceof Map)) {
+            return null;
+        }
+        Map<String, Object> castArg = (Map<String, Object>) arg;
+        Set<String> requiredProperties = (Set<String>) value;
+        Set<String> missingRequiredProperties = new HashSet<>(requiredProperties);
+        missingRequiredProperties.removeAll(castArg.keySet());
+        if (!missingRequiredProperties.isEmpty()) {
+            List<String> missingReqProps = missingRequiredProperties.stream().sorted().toList();
+            String pluralChar = "";
+            if (missingRequiredProperties.size() > 1) {
+                pluralChar = "s";
+            }
+            throw new RuntimeException(
+                cls+" is missing "+missingRequiredProperties.size()+" required argument"+pluralChar+": "+missingReqProps
+            );
+        }
+        return null;
+    }
+}

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/AnyTypeSchemaTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/AnyTypeSchemaTest.hbs
@@ -73,9 +73,9 @@ public class AnyTypeSchemaTest {
 
     @Test
     public void testValidateMap() {
-        LinkedHashMap<String, LocalDate> inMap = new LinkedHashMap<>();
+        LinkedHashMap<String, Object> inMap = new LinkedHashMap<>();
         inMap.put("today", LocalDate.of(2017, 7, 21));
-        LinkedHashMap validatedValue = AnyTypeSchema.validate(inMap, configuration);
+        FrozenMap<String, String> validatedValue = AnyTypeSchema.validate(inMap, configuration);
         LinkedHashMap<String, String> outMap = new LinkedHashMap<>();
         outMap.put("today", "2017-07-21");
         Assert.assertEquals(validatedValue, outMap);
@@ -83,9 +83,9 @@ public class AnyTypeSchemaTest {
 
     @Test
     public void testValidateList() {
-        ArrayList<LocalDate> inList = new ArrayList<>();
+        ArrayList<Object> inList = new ArrayList<>();
         inList.add(LocalDate.of(2017, 7, 21));
-        ArrayList validatedValue = AnyTypeSchema.validate(inList, configuration);
+        ArrayList<String> validatedValue = AnyTypeSchema.validate(inList, configuration);
         ArrayList<String> outList = new ArrayList<>();
         outList.add( "2017-07-21");
         Assert.assertEquals(validatedValue, outList);

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/MapSchemaTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/MapSchemaTest.hbs
@@ -1,0 +1,31 @@
+package {{{packageName}}}.schemas;
+
+import org.junit.Assert;
+import org.junit.Test;
+import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
+import {{{packageName}}}.configurations.SchemaConfiguration;
+
+import java.time.LocalDate;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class MapSchemaTest {
+    static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
+
+    @Test
+    public void testExceptionThrownForInvalidType() {
+        Assert.assertThrows(RuntimeException.class, () -> Schema.validate(
+                MapSchema.class, (Void) null, configuration
+        ));
+    }
+
+    @Test
+    public void testValidateMap() {
+        Map<String, Object> inMap = new LinkedHashMap<>();
+        inMap.put("today", LocalDate.of(2017, 7, 21));
+        FrozenMap<String, Object> validatedValue = MapSchema.validate(inMap, configuration);
+        LinkedHashMap<String, String> outMap = new LinkedHashMap<>();
+        outMap.put("today", "2017-07-21");
+        Assert.assertEquals(validatedValue, outMap);
+    }
+}

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/ObjectTypeSchemaTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/ObjectTypeSchemaTest.hbs
@@ -1,0 +1,164 @@
+package {{{packageName}}}.schemas;
+
+import org.junit.Assert;
+import org.junit.Test;
+import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
+import {{{packageName}}}.configurations.SchemaConfiguration;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+
+record ObjectWithPropsSchema(LinkedHashSet<Class<?>> type, LinkedHashMap<String, Class<?>> properties) implements Schema {
+    public static ObjectWithPropsSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        // can't use ImmutableMap because it does not allow null values in entries
+        // can't use Collections.unmodifiableMap because Collections.UnmodifiableMap is not public + extensible
+        type.add(FrozenMap.class);
+        LinkedHashMap<String, Class<?>> properties = new LinkedHashMap<>();
+        properties.put("someString", StringSchema.class);
+        return new ObjectWithPropsSchema(type, properties);
+    }
+
+    public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        return Schema.validate(ObjectWithPropsSchema.class, arg, configuration);
+    }
+}
+
+record ObjectWithAddpropsSchema(LinkedHashSet<Class<?>> type, Class<?> additionalProperties) implements Schema {
+    public static ObjectWithAddpropsSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        // can't use ImmutableMap because it does not allow null values in entries
+        // can't use Collections.unmodifiableMap because Collections.UnmodifiableMap is not public + extensible
+        type.add(FrozenMap.class);
+        Class<?> additionalProperties = StringSchema.class;
+        return new ObjectWithAddpropsSchema(type, additionalProperties);
+    }
+
+    public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        return Schema.validate(ObjectWithAddpropsSchema.class, arg, configuration);
+    }
+}
+
+record ObjectWithPropsAndAddpropsSchema(LinkedHashSet<Class<?>> type, LinkedHashMap<String, Class<?>> properties, Class<?> additionalProperties) implements Schema {
+    public static ObjectWithPropsAndAddpropsSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        // can't use ImmutableMap because it does not allow null values in entries
+        // can't use Collections.unmodifiableMap because Collections.UnmodifiableMap is not public + extensible
+        type.add(FrozenMap.class);
+        LinkedHashMap<String, Class<?>> properties = new LinkedHashMap<>();
+        properties.put("someString", StringSchema.class);
+        Class<?> additionalProperties = BooleanSchema.class;
+        return new ObjectWithPropsAndAddpropsSchema(type, properties, additionalProperties);
+    }
+
+    public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        return Schema.validate(ObjectWithPropsAndAddpropsSchema.class, arg, configuration);
+    }
+}
+
+public class ObjectTypeSchemaTest {
+    static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
+
+    @Test
+    public void testExceptionThrownForInvalidType() {
+        Assert.assertThrows(RuntimeException.class, () -> Schema.validate(
+                ObjectWithPropsSchema.class, (Void) null, configuration
+        ));
+    }
+
+    @Test
+    public void testValidateObjectWithPropsSchema() {
+        // map with only property works
+        Map<String, Object> inMap = new LinkedHashMap<>();
+        inMap.put("someString", "abc");
+        FrozenMap<String, Object> validatedValue = ObjectWithPropsSchema.validate(inMap, configuration);
+        LinkedHashMap<String, String> outMap = new LinkedHashMap<>();
+        outMap.put("someString", "abc");
+        Assert.assertEquals(validatedValue, outMap);
+
+        // map with additional unvalidated property works
+        inMap = new LinkedHashMap<>();
+        inMap.put("someString", "abc");
+        inMap.put("someOtherString", "def");
+        validatedValue = ObjectWithPropsSchema.validate(inMap, configuration);
+        outMap = new LinkedHashMap<>();
+        outMap.put("someString", "abc");
+        outMap.put("someOtherString", "def");
+        Assert.assertEquals(validatedValue, outMap);
+
+        // invalid prop type fails
+        inMap = new LinkedHashMap<>();
+        inMap.put("someString", 1);
+        Map<String, Object> finalInMap = inMap;
+        Assert.assertThrows(RuntimeException.class, () -> ObjectWithPropsSchema.validate(
+                finalInMap, configuration
+        ));
+    }
+
+    @Test
+    public void testValidateObjectWithAddpropsSchema() {
+        // map with only property works
+        Map<String, Object> inMap = new LinkedHashMap<>();
+        inMap.put("someString", "abc");
+        FrozenMap<String, Object> validatedValue = ObjectWithAddpropsSchema.validate(inMap, configuration);
+        LinkedHashMap<String, String> outMap = new LinkedHashMap<>();
+        outMap.put("someString", "abc");
+        Assert.assertEquals(validatedValue, outMap);
+
+        // map with additional properties works
+        inMap = new LinkedHashMap<>();
+        inMap.put("someString", "abc");
+        inMap.put("someOtherString", "def");
+        validatedValue = ObjectWithAddpropsSchema.validate(inMap, configuration);
+        outMap = new LinkedHashMap<>();
+        outMap.put("someString", "abc");
+        outMap.put("someOtherString", "def");
+        Assert.assertEquals(validatedValue, outMap);
+
+        // invalid addProp type fails
+        inMap = new LinkedHashMap<>();
+        inMap.put("someString", 1);
+        Map<String, Object> finalInMap = inMap;
+        Assert.assertThrows(RuntimeException.class, () -> ObjectWithAddpropsSchema.validate(
+                finalInMap, configuration
+        ));
+    }
+
+    @Test
+    public void testValidateObjectWithPropsAndAddpropsSchema() {
+        // map with only property works
+        Map<String, Object> inMap = new LinkedHashMap<>();
+        inMap.put("someString", "abc");
+        FrozenMap<String, Object> validatedValue = ObjectWithPropsAndAddpropsSchema.validate(inMap, configuration);
+        LinkedHashMap<String, Object> outMap = new LinkedHashMap<>();
+        outMap.put("someString", "abc");
+        Assert.assertEquals(validatedValue, outMap);
+
+        // map with additional properties works
+        inMap = new LinkedHashMap<>();
+        inMap.put("someString", "abc");
+        inMap.put("someAddProp", true);
+        validatedValue = ObjectWithPropsAndAddpropsSchema.validate(inMap, configuration);
+        outMap = new LinkedHashMap<>();
+        outMap.put("someString", "abc");
+        outMap.put("someAddProp", true);
+        Assert.assertEquals(validatedValue, outMap);
+
+        // invalid prop type fails
+        inMap = new LinkedHashMap<>();
+        inMap.put("someString", 1);
+        Map<String, Object> invalidPropMap = inMap;
+        Assert.assertThrows(RuntimeException.class, () -> ObjectWithPropsAndAddpropsSchema.validate(
+                invalidPropMap, configuration
+        ));
+
+        // invalid addProp type fails
+        inMap = new LinkedHashMap<>();
+        inMap.put("someAddProp", 1);
+        Map<String, Object> invalidAddpropMap = inMap;
+        Assert.assertThrows(RuntimeException.class, () -> ObjectWithPropsAndAddpropsSchema.validate(
+                invalidAddpropMap, configuration
+        ));
+    }
+}

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/AdditionalPropertiesValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/AdditionalPropertiesValidatorTest.hbs
@@ -1,0 +1,104 @@
+package {{{packageName}}}.schemas.validators;
+
+import org.junit.Assert;
+import org.junit.Test;
+import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
+import {{{packageName}}}.configurations.SchemaConfiguration;
+import {{{packageName}}}.schemas.FrozenMap;
+import {{{packageName}}}.schemas.PathToSchemasMap;
+import {{{packageName}}}.schemas.SchemaValidator;
+import {{{packageName}}}.schemas.StringSchema;
+import {{{packageName}}}.schemas.ValidationMetadata;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+
+public class AdditionalPropertiesValidatorTest {
+
+    @Test
+    public void testCorrectPropertySucceeds() {
+        Map<String, Class<?>> properties = new LinkedHashMap<>();
+        properties.put("someString", StringSchema.class);
+
+        List<Object> pathToItem = new ArrayList<>();
+        pathToItem.add("args[0]");
+        ValidationMetadata validationMetadata = new ValidationMetadata(
+                pathToItem,
+                new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone()),
+                new PathToSchemasMap(),
+                new LinkedHashSet<>()
+        );
+        LinkedHashMap<String, Object> mutableMap = new LinkedHashMap<>();
+        mutableMap.put("someString", "abc");
+        mutableMap.put("someAddProp", "def");
+        FrozenMap<String, Object> arg = new FrozenMap<>(mutableMap);
+        final AdditionalPropertiesValidator validator = new AdditionalPropertiesValidator();
+        PathToSchemasMap pathToSchemas = validator.validate(
+                arg,
+                StringSchema.class,
+                properties,
+                SchemaValidator.class,
+                validationMetadata
+        );
+        List<Object> expectedPathToItem = new ArrayList<>();
+        expectedPathToItem.add("args[0]");
+        expectedPathToItem.add("someAddProp");
+        LinkedHashMap<Class<?>, Void> expectedClasses = new LinkedHashMap<>();
+        expectedClasses.put(String.class, null);
+        expectedClasses.put(StringSchema.class, null);
+        PathToSchemasMap expectedPathToSchemas = new PathToSchemasMap();
+        expectedPathToSchemas.put(expectedPathToItem, expectedClasses);
+        Assert.assertEquals(pathToSchemas, expectedPathToSchemas);
+    }
+
+    @Test
+    public void testNotApplicableTypeReturnsNull() {
+        List<Object> pathToItem = new ArrayList<>();
+        pathToItem.add("args[0]");
+        ValidationMetadata validationMetadata = new ValidationMetadata(
+                pathToItem,
+                new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone()),
+                new PathToSchemasMap(),
+                new LinkedHashSet<>()
+        );
+        final AdditionalPropertiesValidator validator = new AdditionalPropertiesValidator();
+        PathToSchemasMap pathToSchemas = validator.validate(
+                1,
+                StringSchema.class,
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        );
+        Assert.assertNull(pathToSchemas);
+    }
+
+    @Test
+    public void testIncorrectPropertyValueFails() {
+        Map<String, Class<?>> properties = new LinkedHashMap<>();
+        properties.put("someString", StringSchema.class);
+
+        List<Object> pathToItem = new ArrayList<>();
+        pathToItem.add("args[0]");
+        ValidationMetadata validationMetadata = new ValidationMetadata(
+                pathToItem,
+                new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone()),
+                new PathToSchemasMap(),
+                new LinkedHashSet<>()
+        );
+        LinkedHashMap<String, Object> mutableMap = new LinkedHashMap<>();
+        mutableMap.put("someString", "abc");
+        mutableMap.put("someAddProp", 1);
+        FrozenMap<String, Object> arg = new FrozenMap<>(mutableMap);
+        final AdditionalPropertiesValidator validator = new AdditionalPropertiesValidator();
+        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                arg,
+                StringSchema.class,
+                properties,
+                SchemaValidator.class,
+                validationMetadata
+        ));
+    }
+}

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/PropertiesValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/PropertiesValidatorTest.hbs
@@ -1,0 +1,105 @@
+package {{{packageName}}}.schemas.validators;
+
+import org.junit.Assert;
+import org.junit.Test;
+import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
+import {{{packageName}}}.configurations.SchemaConfiguration;
+import {{{packageName}}}.schemas.FrozenMap;
+import {{{packageName}}}.schemas.PathToSchemasMap;
+import {{{packageName}}}.schemas.SchemaValidator;
+import {{{packageName}}}.schemas.StringSchema;
+import {{{packageName}}}.schemas.ValidationMetadata;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+
+public class PropertiesValidatorTest {
+
+    @Test
+    public void testCorrectPropertySucceeds() {
+        Map<String, Class<?>> properties = new LinkedHashMap<>();
+        properties.put("someString", StringSchema.class);
+
+        final PropertiesValidator validator = new PropertiesValidator();
+        List<Object> pathToItem = new ArrayList<>();
+        pathToItem.add("args[0]");
+        ValidationMetadata validationMetadata = new ValidationMetadata(
+                pathToItem,
+                new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone()),
+                new PathToSchemasMap(),
+                new LinkedHashSet<>()
+        );
+        LinkedHashMap<String, Object> mutableMap = new LinkedHashMap<>();
+        mutableMap.put("someString", "abc");
+        FrozenMap<String, Object> arg = new FrozenMap<>(mutableMap);
+        PathToSchemasMap pathToSchemas = validator.validate(
+                arg,
+                properties,
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        );
+        List<Object> expectedPathToItem = new ArrayList<>();
+        expectedPathToItem.add("args[0]");
+        expectedPathToItem.add("someString");
+        LinkedHashMap<Class<?>, Void> expectedClasses = new LinkedHashMap<>();
+        expectedClasses.put(String.class, null);
+        expectedClasses.put(StringSchema.class, null);
+        PathToSchemasMap expectedPathToSchemas = new PathToSchemasMap();
+        expectedPathToSchemas.put(expectedPathToItem, expectedClasses);
+        Assert.assertEquals(pathToSchemas, expectedPathToSchemas);
+    }
+
+    @Test
+    public void testNotApplicableTypeReturnsNull() {
+        Map<String, Class<?>> properties = new LinkedHashMap<>();
+        properties.put("someString", StringSchema.class);
+
+        final PropertiesValidator validator = new PropertiesValidator();
+        List<Object> pathToItem = new ArrayList<>();
+        pathToItem.add("args[0]");
+        ValidationMetadata validationMetadata = new ValidationMetadata(
+                pathToItem,
+                new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone()),
+                new PathToSchemasMap(),
+                new LinkedHashSet<>()
+        );
+        PathToSchemasMap pathToSchemas = validator.validate(
+                1,
+                properties,
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        );
+        Assert.assertNull(pathToSchemas);
+    }
+
+    @Test
+    public void testIncorrectPropertyValueFails() {
+        Map<String, Class<?>> properties = new LinkedHashMap<>();
+        properties.put("someString", StringSchema.class);
+
+        final PropertiesValidator validator = new PropertiesValidator();
+        List<Object> pathToItem = new ArrayList<>();
+        pathToItem.add("args[0]");
+        ValidationMetadata validationMetadata = new ValidationMetadata(
+                pathToItem,
+                new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone()),
+                new PathToSchemasMap(),
+                new LinkedHashSet<>()
+        );
+        LinkedHashMap<String, Object> mutableMap = new LinkedHashMap<>();
+        mutableMap.put("someString", 1);
+        FrozenMap<String, Object> arg = new FrozenMap<>(mutableMap);
+        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                arg,
+                properties,
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        ));
+    }
+}

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/RequiredValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/RequiredValidatorTest.hbs
@@ -1,0 +1,98 @@
+package {{{packageName}}}.schemas.validators;
+
+import org.junit.Assert;
+import org.junit.Test;
+import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
+import {{{packageName}}}.configurations.SchemaConfiguration;
+import {{{packageName}}}.schemas.FrozenMap;
+import {{{packageName}}}.schemas.PathToSchemasMap;
+import {{{packageName}}}.schemas.SchemaValidator;
+import {{{packageName}}}.schemas.StringSchema;
+import {{{packageName}}}.schemas.ValidationMetadata;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class RequiredValidatorTest {
+
+    @Test
+    public void testCorrectPropertySucceeds() {
+        Set<String> requiredProperties = new LinkedHashSet<>();
+        requiredProperties.add("someString");
+
+        List<Object> pathToItem = new ArrayList<>();
+        pathToItem.add("args[0]");
+        ValidationMetadata validationMetadata = new ValidationMetadata(
+                pathToItem,
+                new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone()),
+                new PathToSchemasMap(),
+                new LinkedHashSet<>()
+        );
+        LinkedHashMap<String, Object> mutableMap = new LinkedHashMap<>();
+        mutableMap.put("someString", "abc");
+        FrozenMap<String, Object> arg = new FrozenMap<>(mutableMap);
+        final RequiredValidator validator = new RequiredValidator();
+        PathToSchemasMap pathToSchemas = validator.validate(
+                arg,
+                requiredProperties,
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        );
+        Assert.assertNull(pathToSchemas);
+    }
+
+    @Test
+    public void testNotApplicableTypeReturnsNull() {
+        Map<String, Class<?>> properties = new LinkedHashMap<>();
+        properties.put("someString", StringSchema.class);
+
+        List<Object> pathToItem = new ArrayList<>();
+        pathToItem.add("args[0]");
+        ValidationMetadata validationMetadata = new ValidationMetadata(
+                pathToItem,
+                new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone()),
+                new PathToSchemasMap(),
+                new LinkedHashSet<>()
+        );
+        final RequiredValidator validator = new RequiredValidator();
+        PathToSchemasMap pathToSchemas = validator.validate(
+                1,
+                properties,
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        );
+        Assert.assertNull(pathToSchemas);
+    }
+
+    @Test
+    public void testIncorrectPropertyFails() {
+        Set<String> requiredProperties = new LinkedHashSet<>();
+        requiredProperties.add("someString");
+
+        List<Object> pathToItem = new ArrayList<>();
+        pathToItem.add("args[0]");
+        ValidationMetadata validationMetadata = new ValidationMetadata(
+                pathToItem,
+                new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone()),
+                new PathToSchemasMap(),
+                new LinkedHashSet<>()
+        );
+        LinkedHashMap<String, Object> mutableMap = new LinkedHashMap<>();
+        mutableMap.put("aDifferentProp", 1);
+        FrozenMap<String, Object> arg = new FrozenMap<>(mutableMap);
+        final RequiredValidator validator = new RequiredValidator();
+        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                arg,
+                requiredProperties,
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        ));
+    }
+}


### PR DESCRIPTION
- Adds MapSchema to store type: object schema and a test of it
- Adds PropertiesValidator and tests of it
- Adds RequiredValidator and tests of it
- Adds FrozenMap to store instances of object schema payloads
- Adds test of type object schema with:
  - only properties
  - only additionalProperties
  - properties + additionalProperties

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
