### PR TITLE
Add support for application/x-pem-file MIME type

### DIFF
--- a/samples/client/3_0_3_unit_test/python/src/unit_test_api/api_client.py
+++ b/samples/client/3_0_3_unit_test/python/src/unit_test_api/api_client.py
@@ -907,6 +907,8 @@ class OpenApiResponse(typing.Generic[T], JSONDetector, abc.ABC):
             elif content_type.startswith('multipart/form-data'):
                 body_data = cls.__deserialize_multipart_form_data(response)
                 content_type = 'multipart/form-data'
+            elif content_type == 'application/x-pem-file':
+                body_data = response.data.decode()
             else:
                 raise NotImplementedError('Deserialization of {} has not yet been implemented'.format(content_type))
             body_schema = schemas.get_class(body_schema)
@@ -1258,6 +1260,7 @@ class RequestBody(StyleFormSerializer, JSONDetector):
     content: content_type to MediaType schemas.Schema info
     """
     __json_encoder = JSONEncoder()
+    __plain_txt_content_types = {'text/plain', 'application/x-pem-file'}
     content: typing.Dict[str, typing.Type[MediaType]]
     required: bool = False
 
@@ -1379,7 +1382,7 @@ class RequestBody(StyleFormSerializer, JSONDetector):
             if isinstance(cast_in_data, (schemas.FileIO, bytes)):
                 raise ValueError(f"Invalid input data type. Data must be int/float/str/bool/None/tuple/immutabledict and it was type {type(cast_in_data)}")
             return cls.__serialize_json(cast_in_data)
-        elif content_type == 'text/plain':
+        elif content_type in cls.__plain_txt_content_types:
             if not isinstance(cast_in_data, (int, float, str)):
                 raise ValueError(f"Unable to serialize type {type(cast_in_data)} to text/plain")
             return cls.__serialize_text_plain(cast_in_data)

--- a/samples/client/3_1_0_unit_test/python/src/unit_test_api/api_client.py
+++ b/samples/client/3_1_0_unit_test/python/src/unit_test_api/api_client.py
@@ -907,6 +907,8 @@ class OpenApiResponse(typing.Generic[T], JSONDetector, abc.ABC):
             elif content_type.startswith('multipart/form-data'):
                 body_data = cls.__deserialize_multipart_form_data(response)
                 content_type = 'multipart/form-data'
+            elif content_type == 'application/x-pem-file':
+                body_data = response.data.decode()
             else:
                 raise NotImplementedError('Deserialization of {} has not yet been implemented'.format(content_type))
             body_schema = schemas.get_class(body_schema)
@@ -1258,6 +1260,7 @@ class RequestBody(StyleFormSerializer, JSONDetector):
     content: content_type to MediaType schemas.Schema info
     """
     __json_encoder = JSONEncoder()
+    __plain_txt_content_types = {'text/plain', 'application/x-pem-file'}
     content: typing.Dict[str, typing.Type[MediaType]]
     required: bool = False
 
@@ -1379,7 +1382,7 @@ class RequestBody(StyleFormSerializer, JSONDetector):
             if isinstance(cast_in_data, (schemas.FileIO, bytes)):
                 raise ValueError(f"Invalid input data type. Data must be int/float/str/bool/None/tuple/immutabledict and it was type {type(cast_in_data)}")
             return cls.__serialize_json(cast_in_data)
-        elif content_type == 'text/plain':
+        elif content_type in cls.__plain_txt_content_types:
             if not isinstance(cast_in_data, (int, float, str)):
                 raise ValueError(f"Unable to serialize type {type(cast_in_data)} to text/plain")
             return cls.__serialize_text_plain(cast_in_data)

--- a/samples/client/openapi_features/nonCompliantUseDiscriminatorIfCompositionFails/python/src/this_package/api_client.py
+++ b/samples/client/openapi_features/nonCompliantUseDiscriminatorIfCompositionFails/python/src/this_package/api_client.py
@@ -907,6 +907,8 @@ class OpenApiResponse(typing.Generic[T], JSONDetector, abc.ABC):
             elif content_type.startswith('multipart/form-data'):
                 body_data = cls.__deserialize_multipart_form_data(response)
                 content_type = 'multipart/form-data'
+            elif content_type == 'application/x-pem-file':
+                body_data = response.data.decode()
             else:
                 raise NotImplementedError('Deserialization of {} has not yet been implemented'.format(content_type))
             body_schema = schemas.get_class(body_schema)
@@ -1258,6 +1260,7 @@ class RequestBody(StyleFormSerializer, JSONDetector):
     content: content_type to MediaType schemas.Schema info
     """
     __json_encoder = JSONEncoder()
+    __plain_txt_content_types = {'text/plain', 'application/x-pem-file'}
     content: typing.Dict[str, typing.Type[MediaType]]
     required: bool = False
 
@@ -1379,7 +1382,7 @@ class RequestBody(StyleFormSerializer, JSONDetector):
             if isinstance(cast_in_data, (schemas.FileIO, bytes)):
                 raise ValueError(f"Invalid input data type. Data must be int/float/str/bool/None/tuple/immutabledict and it was type {type(cast_in_data)}")
             return cls.__serialize_json(cast_in_data)
-        elif content_type == 'text/plain':
+        elif content_type in cls.__plain_txt_content_types:
             if not isinstance(cast_in_data, (int, float, str)):
                 raise ValueError(f"Unable to serialize type {type(cast_in_data)} to text/plain")
             return cls.__serialize_text_plain(cast_in_data)

--- a/samples/client/openapi_features/security/python/src/this_package/api_client.py
+++ b/samples/client/openapi_features/security/python/src/this_package/api_client.py
@@ -907,6 +907,8 @@ class OpenApiResponse(typing.Generic[T], JSONDetector, abc.ABC):
             elif content_type.startswith('multipart/form-data'):
                 body_data = cls.__deserialize_multipart_form_data(response)
                 content_type = 'multipart/form-data'
+            elif content_type == 'application/x-pem-file':
+                body_data = response.data.decode()
             else:
                 raise NotImplementedError('Deserialization of {} has not yet been implemented'.format(content_type))
             body_schema = schemas.get_class(body_schema)
@@ -1281,6 +1283,7 @@ class RequestBody(StyleFormSerializer, JSONDetector):
     content: content_type to MediaType schemas.Schema info
     """
     __json_encoder = JSONEncoder()
+    __plain_txt_content_types = {'text/plain', 'application/x-pem-file'}
     content: typing.Dict[str, typing.Type[MediaType]]
     required: bool = False
 
@@ -1402,7 +1405,7 @@ class RequestBody(StyleFormSerializer, JSONDetector):
             if isinstance(cast_in_data, (schemas.FileIO, bytes)):
                 raise ValueError(f"Invalid input data type. Data must be int/float/str/bool/None/tuple/immutabledict and it was type {type(cast_in_data)}")
             return cls.__serialize_json(cast_in_data)
-        elif content_type == 'text/plain':
+        elif content_type in cls.__plain_txt_content_types:
             if not isinstance(cast_in_data, (int, float, str)):
                 raise ValueError(f"Unable to serialize type {type(cast_in_data)} to text/plain")
             return cls.__serialize_text_plain(cast_in_data)

--- a/samples/client/petstore/python/src/petstore_api/api_client.py
+++ b/samples/client/petstore/python/src/petstore_api/api_client.py
@@ -907,6 +907,8 @@ class OpenApiResponse(typing.Generic[T], JSONDetector, abc.ABC):
             elif content_type.startswith('multipart/form-data'):
                 body_data = cls.__deserialize_multipart_form_data(response)
                 content_type = 'multipart/form-data'
+            elif content_type == 'application/x-pem-file':
+                body_data = response.data.decode()
             else:
                 raise NotImplementedError('Deserialization of {} has not yet been implemented'.format(content_type))
             body_schema = schemas.get_class(body_schema)
@@ -1285,6 +1287,7 @@ class RequestBody(StyleFormSerializer, JSONDetector):
     content: content_type to MediaType schemas.Schema info
     """
     __json_encoder = JSONEncoder()
+    __plain_txt_content_types = {'text/plain', 'application/x-pem-file'}
     content: typing.Dict[str, typing.Type[MediaType]]
     required: bool = False
 
@@ -1406,7 +1409,7 @@ class RequestBody(StyleFormSerializer, JSONDetector):
             if isinstance(cast_in_data, (schemas.FileIO, bytes)):
                 raise ValueError(f"Invalid input data type. Data must be int/float/str/bool/None/tuple/immutabledict and it was type {type(cast_in_data)}")
             return cls.__serialize_json(cast_in_data)
-        elif content_type == 'text/plain':
+        elif content_type in cls.__plain_txt_content_types:
             if not isinstance(cast_in_data, (int, float, str)):
                 raise ValueError(f"Unable to serialize type {type(cast_in_data)} to text/plain")
             return cls.__serialize_text_plain(cast_in_data)

--- a/src/main/resources/python/api_client.hbs
+++ b/src/main/resources/python/api_client.hbs
@@ -905,6 +905,8 @@ class OpenApiResponse(typing.Generic[T], JSONDetector, abc.ABC):
             elif content_type.startswith('multipart/form-data'):
                 body_data = cls.__deserialize_multipart_form_data(response)
                 content_type = 'multipart/form-data'
+            elif content_type == 'application/x-pem-file':
+                body_data = response.data.decode()
             else:
                 raise NotImplementedError('Deserialization of {} has not yet been implemented'.format(content_type))
             body_schema = schemas.get_class(body_schema)
@@ -1283,6 +1285,7 @@ class RequestBody(StyleFormSerializer, JSONDetector):
     content: content_type to MediaType schemas.Schema info
     """
     __json_encoder = JSONEncoder()
+    __plain_txt_content_types = {'text/plain', 'application/x-pem-file'}
     content: typing.Dict[str, typing.Type[MediaType]]
     required: bool = False
 
@@ -1404,7 +1407,7 @@ class RequestBody(StyleFormSerializer, JSONDetector):
             if isinstance(cast_in_data, (schemas.FileIO, bytes)):
                 raise ValueError(f"Invalid input data type. Data must be int/float/str/bool/None/tuple/immutabledict and it was type {type(cast_in_data)}")
             return cls.__serialize_json(cast_in_data)
-        elif content_type == 'text/plain':
+        elif content_type in cls.__plain_txt_content_types:
             if not isinstance(cast_in_data, (int, float, str)):
                 raise ValueError(f"Unable to serialize type {type(cast_in_data)} to text/plain")
             return cls.__serialize_text_plain(cast_in_data)


### PR DESCRIPTION
This patch adds support for serializing and deserializing data with the application/x-pem-file MIME type as plain text.

Fixes: https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/issues/244

Minimal example:

```
openapi: 3.0.0
info:
  title: Sample API
  version: 0.1.0
servers:
  - url: http://api.example.com/v1
paths:
  /:
    get:
      summary: dummy
      requestBody:
        content:
          application/x-pem-file:
            schema:
              type: string
      responses:
        '200':
          description: dummy
          content:
            application/x-pem-file:
              schema: 
                type: string
```

Real world example: https://github.com/Nitrokey/nethsm-sdk-py/pull/65

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
