### PR TITLE
Java: changes return types from BigDecimal to Number

### DIFF
--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/DoubleSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/DoubleSchema.java
@@ -3,13 +3,12 @@ package org.openapijsonschematools.schemas;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 
 import java.util.LinkedHashSet;
-import java.math.BigDecimal;
 
 public record DoubleSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
     public static DoubleSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
-        type.add(BigDecimal.class);
-        String format = "float";
+        type.add(Double.class);
+        String format = "double";
         return new DoubleSchema(type, format);
     }
 

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/FloatSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/FloatSchema.java
@@ -3,12 +3,11 @@ package org.openapijsonschematools.schemas;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 
 import java.util.LinkedHashSet;
-import java.math.BigDecimal;
 
 public record FloatSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
     public static FloatSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
-        type.add(BigDecimal.class);
+        type.add(Float.class);
         String format = "float";
         return new FloatSchema(type, format);
     }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Int32Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Int32Schema.java
@@ -3,12 +3,12 @@ package org.openapijsonschematools.schemas;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 
 import java.util.LinkedHashSet;
-import java.math.BigDecimal;
 
 public record Int32Schema(LinkedHashSet<Class<?>> type, String format) implements Schema {
     public static Int32Schema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
-        type.add(BigDecimal.class);
+        type.add(Integer.class);
+        type.add(Float.class);
         String format = "int32";
         return new Int32Schema(type, format);
     }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Int64Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Int64Schema.java
@@ -3,12 +3,14 @@ package org.openapijsonschematools.schemas;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 
 import java.util.LinkedHashSet;
-import java.math.BigDecimal;
 
 public record Int64Schema(LinkedHashSet<Class<?>> type, String format) implements Schema {
     public static Int64Schema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
-        type.add(BigDecimal.class);
+        type.add(Integer.class);
+        type.add(Long.class);
+        type.add(Float.class);
+        type.add(Double.class);
         String format = "int64";
         return new Int64Schema(type, format);
     }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/IntSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/IntSchema.java
@@ -3,12 +3,11 @@ package org.openapijsonschematools.schemas;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 
 import java.util.LinkedHashSet;
-import java.math.BigDecimal;
 
 public record IntSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
     public static IntSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
-        type.add(BigDecimal.class);
+        type.add(Number.class);
         String format = "int";
         return new IntSchema(type, format);
     }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/NumberSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/NumberSchema.java
@@ -3,28 +3,30 @@ package org.openapijsonschematools.schemas;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 
 import java.util.LinkedHashSet;
-import java.math.BigDecimal;
 
 public record NumberSchema(LinkedHashSet<Class<?>> type) implements Schema {
     public static NumberSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
-        type.add(BigDecimal.class);
+        type.add(Integer.class);
+        type.add(Long.class);
+        type.add(Float.class);
+        type.add(Double.class);
         return new NumberSchema(type);
     }
 
-    public static BigDecimal validate(Integer arg, SchemaConfiguration configuration) {
-        return Schema.validate(NumberSchema.class, BigDecimal.valueOf(arg), configuration);
+    public static Number validate(Integer arg, SchemaConfiguration configuration) {
+        return Schema.validate(NumberSchema.class, arg, configuration);
     }
 
-    public static BigDecimal validate(Long arg, SchemaConfiguration configuration) {
-        return Schema.validate(NumberSchema.class, BigDecimal.valueOf(arg), configuration);
+    public static Number validate(Long arg, SchemaConfiguration configuration) {
+        return Schema.validate(NumberSchema.class, arg, configuration);
     }
 
-    public static BigDecimal validate(Float arg, SchemaConfiguration configuration) {
-        return Schema.validate(NumberSchema.class, BigDecimal.valueOf(arg), configuration);
+    public static Number validate(Float arg, SchemaConfiguration configuration) {
+        return Schema.validate(NumberSchema.class, arg, configuration);
     }
 
-    public static BigDecimal validate(Double arg, SchemaConfiguration configuration) {
-        return Schema.validate(NumberSchema.class, BigDecimal.valueOf(arg), configuration);
+    public static Number validate(Double arg, SchemaConfiguration configuration) {
+        return Schema.validate(NumberSchema.class, arg, configuration);
     }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Schema.java
@@ -5,11 +5,9 @@ import org.openapijsonschematools.configurations.SchemaConfiguration;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -41,21 +39,18 @@ public interface Schema extends SchemaValidator {
       } else if (arg instanceof Boolean) {
          pathToType.put(pathToItem, Boolean.class);
          return arg;
-      } else if (arg instanceof BigDecimal) {
-         pathToType.put(pathToItem, BigDecimal.class);
-         return arg;
       } else if (arg instanceof Integer) {
-         pathToType.put(pathToItem, BigDecimal.class);
-         return BigDecimal.valueOf((Integer) arg);
+         pathToType.put(pathToItem, Integer.class);
+         return arg;
       } else if (arg instanceof Long) {
-         pathToType.put(pathToItem, BigDecimal.class);
-         return BigDecimal.valueOf((Long) arg);
+         pathToType.put(pathToItem, Long.class);
+         return arg;
       } else if (arg instanceof Float) {
-         pathToType.put(pathToItem, BigDecimal.class);
-         return BigDecimal.valueOf((Float) arg);
+         pathToType.put(pathToItem, Float.class);
+         return arg;
       } else if (arg instanceof Double) {
-         pathToType.put(pathToItem, BigDecimal.class);
-         return BigDecimal.valueOf((Double) arg);
+         pathToType.put(pathToItem, Double.class);
+         return arg;
       } else if (arg instanceof List) {
          pathToType.put(pathToItem, List.class);
          List<Object> argFixed = new ArrayList<>();
@@ -174,28 +169,20 @@ public interface Schema extends SchemaValidator {
       return (Boolean) validateObject(cls, arg, configuration);
    }
 
-   static BigDecimal validate(Class<?> cls, BigDecimal arg, SchemaConfiguration configuration) {
-      return (BigDecimal) validateObject(cls, arg, configuration);
-   }
-
    static Integer validate(Class<?> cls, Integer arg, SchemaConfiguration configuration) {
-      BigDecimal val = (BigDecimal) validateObject(cls, arg, configuration);
-      return val.intValue();
+      return (Integer) validateObject(cls, arg, configuration);
    }
 
    static Long validate(Class<?> cls, Long arg, SchemaConfiguration configuration) {
-      BigDecimal val = (BigDecimal) validateObject(cls, arg, configuration);
-      return val.longValue();
+      return (Long) validateObject(cls, arg, configuration);
    }
 
    static Float validate(Class<?> cls, Float arg, SchemaConfiguration configuration) {
-      BigDecimal val = (BigDecimal) validateObject(cls, arg, configuration);
-      return val.floatValue();
+      return (Float) validateObject(cls, arg, configuration);
    }
 
    static Double validate(Class<?> cls, Double arg, SchemaConfiguration configuration) {
-      BigDecimal val = (BigDecimal) validateObject(cls, arg, configuration);
-      return val.doubleValue();
+      return (Double) validateObject(cls, arg, configuration);
    }
 
    static String validate(Class<?> cls, String arg, SchemaConfiguration configuration) {

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/NumberSchemaTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/NumberSchemaTest.java
@@ -12,26 +12,26 @@ public class NumberSchemaTest {
 
     @Test
     public void testValidateInteger() {
-        BigDecimal validatedValue = NumberSchema.validate(1, configuration);
-        Assert.assertEquals(validatedValue, BigDecimal.valueOf(1));
+        Number validatedValue = NumberSchema.validate(1, configuration);
+        Assert.assertEquals(validatedValue, 1);
     }
 
     @Test
     public void testValidateLong() {
-        BigDecimal validatedValue = NumberSchema.validate(1L, configuration);
-        Assert.assertEquals(validatedValue, BigDecimal.valueOf(1L));
+        Number validatedValue = NumberSchema.validate(1L, configuration);
+        Assert.assertEquals(validatedValue, 1L);
     }
 
     @Test
     public void testValidateFloat() {
-        BigDecimal validatedValue = NumberSchema.validate(3.14f, configuration);
-        Assert.assertEquals(validatedValue, BigDecimal.valueOf(3.14f));
+        Number validatedValue = NumberSchema.validate(3.14f, configuration);
+        Assert.assertEquals(validatedValue, 3.14f);
     }
 
     @Test
     public void testValidateDouble() {
-        BigDecimal validatedValue = NumberSchema.validate(3.14d, configuration);
-        Assert.assertEquals(validatedValue, BigDecimal.valueOf(3.14d));
+        Number validatedValue = NumberSchema.validate(3.14d, configuration);
+        Assert.assertEquals(validatedValue, 3.14d);
     }
 
     @Test

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/DoubleSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/DoubleSchema.hbs
@@ -3,13 +3,12 @@ package {{{packageName}}}.schemas;
 import {{{packageName}}}.configurations.SchemaConfiguration;
 
 import java.util.LinkedHashSet;
-import java.math.BigDecimal;
 
 public record DoubleSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
     public static DoubleSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
-        type.add(BigDecimal.class);
-        String format = "float";
+        type.add(Double.class);
+        String format = "double";
         return new DoubleSchema(type, format);
     }
 

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/FloatSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/FloatSchema.hbs
@@ -3,12 +3,11 @@ package {{{packageName}}}.schemas;
 import {{{packageName}}}.configurations.SchemaConfiguration;
 
 import java.util.LinkedHashSet;
-import java.math.BigDecimal;
 
 public record FloatSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
     public static FloatSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
-        type.add(BigDecimal.class);
+        type.add(Float.class);
         String format = "float";
         return new FloatSchema(type, format);
     }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/Int32Schema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/Int32Schema.hbs
@@ -3,12 +3,12 @@ package {{{packageName}}}.schemas;
 import {{{packageName}}}.configurations.SchemaConfiguration;
 
 import java.util.LinkedHashSet;
-import java.math.BigDecimal;
 
 public record Int32Schema(LinkedHashSet<Class<?>> type, String format) implements Schema {
     public static Int32Schema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
-        type.add(BigDecimal.class);
+        type.add(Integer.class);
+        type.add(Float.class);
         String format = "int32";
         return new Int32Schema(type, format);
     }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/Int64Schema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/Int64Schema.hbs
@@ -3,12 +3,14 @@ package {{{packageName}}}.schemas;
 import {{{packageName}}}.configurations.SchemaConfiguration;
 
 import java.util.LinkedHashSet;
-import java.math.BigDecimal;
 
 public record Int64Schema(LinkedHashSet<Class<?>> type, String format) implements Schema {
     public static Int64Schema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
-        type.add(BigDecimal.class);
+        type.add(Integer.class);
+        type.add(Long.class);
+        type.add(Float.class);
+        type.add(Double.class);
         String format = "int64";
         return new Int64Schema(type, format);
     }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/IntSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/IntSchema.hbs
@@ -3,12 +3,11 @@ package {{{packageName}}}.schemas;
 import {{{packageName}}}.configurations.SchemaConfiguration;
 
 import java.util.LinkedHashSet;
-import java.math.BigDecimal;
 
 public record IntSchema(LinkedHashSet<Class<?>> type, String format) implements Schema {
     public static IntSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
-        type.add(BigDecimal.class);
+        type.add(Number.class);
         String format = "int";
         return new IntSchema(type, format);
     }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/NumberSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/NumberSchema.hbs
@@ -3,28 +3,30 @@ package {{{packageName}}}.schemas;
 import {{{packageName}}}.configurations.SchemaConfiguration;
 
 import java.util.LinkedHashSet;
-import java.math.BigDecimal;
 
 public record NumberSchema(LinkedHashSet<Class<?>> type) implements Schema {
     public static NumberSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
-        type.add(BigDecimal.class);
+        type.add(Integer.class);
+        type.add(Long.class);
+        type.add(Float.class);
+        type.add(Double.class);
         return new NumberSchema(type);
     }
 
-    public static BigDecimal validate(Integer arg, SchemaConfiguration configuration) {
-        return Schema.validate(NumberSchema.class, BigDecimal.valueOf(arg), configuration);
+    public static Number validate(Integer arg, SchemaConfiguration configuration) {
+        return Schema.validate(NumberSchema.class, arg, configuration);
     }
 
-    public static BigDecimal validate(Long arg, SchemaConfiguration configuration) {
-        return Schema.validate(NumberSchema.class, BigDecimal.valueOf(arg), configuration);
+    public static Number validate(Long arg, SchemaConfiguration configuration) {
+        return Schema.validate(NumberSchema.class, arg, configuration);
     }
 
-    public static BigDecimal validate(Float arg, SchemaConfiguration configuration) {
-        return Schema.validate(NumberSchema.class, BigDecimal.valueOf(arg), configuration);
+    public static Number validate(Float arg, SchemaConfiguration configuration) {
+        return Schema.validate(NumberSchema.class, arg, configuration);
     }
 
-    public static BigDecimal validate(Double arg, SchemaConfiguration configuration) {
-        return Schema.validate(NumberSchema.class, BigDecimal.valueOf(arg), configuration);
+    public static Number validate(Double arg, SchemaConfiguration configuration) {
+        return Schema.validate(NumberSchema.class, arg, configuration);
     }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/Schema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/Schema.hbs
@@ -5,11 +5,9 @@ import {{{packageName}}}.configurations.SchemaConfiguration;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -41,21 +39,18 @@ public interface Schema extends SchemaValidator {
       } else if (arg instanceof Boolean) {
          pathToType.put(pathToItem, Boolean.class);
          return arg;
-      } else if (arg instanceof BigDecimal) {
-         pathToType.put(pathToItem, BigDecimal.class);
-         return arg;
       } else if (arg instanceof Integer) {
-         pathToType.put(pathToItem, BigDecimal.class);
-         return BigDecimal.valueOf((Integer) arg);
+         pathToType.put(pathToItem, Integer.class);
+         return arg;
       } else if (arg instanceof Long) {
-         pathToType.put(pathToItem, BigDecimal.class);
-         return BigDecimal.valueOf((Long) arg);
+         pathToType.put(pathToItem, Long.class);
+         return arg;
       } else if (arg instanceof Float) {
-         pathToType.put(pathToItem, BigDecimal.class);
-         return BigDecimal.valueOf((Float) arg);
+         pathToType.put(pathToItem, Float.class);
+         return arg;
       } else if (arg instanceof Double) {
-         pathToType.put(pathToItem, BigDecimal.class);
-         return BigDecimal.valueOf((Double) arg);
+         pathToType.put(pathToItem, Double.class);
+         return arg;
       } else if (arg instanceof List) {
          pathToType.put(pathToItem, List.class);
          List<Object> argFixed = new ArrayList<>();
@@ -174,28 +169,20 @@ public interface Schema extends SchemaValidator {
       return (Boolean) validateObject(cls, arg, configuration);
    }
 
-   static BigDecimal validate(Class<?> cls, BigDecimal arg, SchemaConfiguration configuration) {
-      return (BigDecimal) validateObject(cls, arg, configuration);
-   }
-
    static Integer validate(Class<?> cls, Integer arg, SchemaConfiguration configuration) {
-      BigDecimal val = (BigDecimal) validateObject(cls, arg, configuration);
-      return val.intValue();
+      return (Integer) validateObject(cls, arg, configuration);
    }
 
    static Long validate(Class<?> cls, Long arg, SchemaConfiguration configuration) {
-      BigDecimal val = (BigDecimal) validateObject(cls, arg, configuration);
-      return val.longValue();
+      return (Long) validateObject(cls, arg, configuration);
    }
 
    static Float validate(Class<?> cls, Float arg, SchemaConfiguration configuration) {
-      BigDecimal val = (BigDecimal) validateObject(cls, arg, configuration);
-      return val.floatValue();
+      return (Float) validateObject(cls, arg, configuration);
    }
 
    static Double validate(Class<?> cls, Double arg, SchemaConfiguration configuration) {
-      BigDecimal val = (BigDecimal) validateObject(cls, arg, configuration);
-      return val.doubleValue();
+      return (Double) validateObject(cls, arg, configuration);
    }
 
    static String validate(Class<?> cls, String arg, SchemaConfiguration configuration) {

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/NumberSchemaTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/NumberSchemaTest.hbs
@@ -12,26 +12,26 @@ public class NumberSchemaTest {
 
     @Test
     public void testValidateInteger() {
-        BigDecimal validatedValue = NumberSchema.validate(1, configuration);
-        Assert.assertEquals(validatedValue, BigDecimal.valueOf(1));
+        Number validatedValue = NumberSchema.validate(1, configuration);
+        Assert.assertEquals(validatedValue, 1);
     }
 
     @Test
     public void testValidateLong() {
-        BigDecimal validatedValue = NumberSchema.validate(1L, configuration);
-        Assert.assertEquals(validatedValue, BigDecimal.valueOf(1L));
+        Number validatedValue = NumberSchema.validate(1L, configuration);
+        Assert.assertEquals(validatedValue, 1L);
     }
 
     @Test
     public void testValidateFloat() {
-        BigDecimal validatedValue = NumberSchema.validate(3.14f, configuration);
-        Assert.assertEquals(validatedValue, BigDecimal.valueOf(3.14f));
+        Number validatedValue = NumberSchema.validate(3.14f, configuration);
+        Assert.assertEquals(validatedValue, 3.14f);
     }
 
     @Test
     public void testValidateDouble() {
-        BigDecimal validatedValue = NumberSchema.validate(3.14d, configuration);
-        Assert.assertEquals(validatedValue, BigDecimal.valueOf(3.14d));
+        Number validatedValue = NumberSchema.validate(3.14d, configuration);
+        Assert.assertEquals(validatedValue, 3.14d);
     }
 
     @Test


### PR DESCRIPTION
Java: changes return types from BigDecimal to Number
This improves on the work in: https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/pull/274

type: number with no format will now return Java type Number
Benefit: numbers not converted into BigDecimal instances

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
