### PR TITLE
Java: adds ListSchema

### DIFF
--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -10,10 +10,12 @@ src/main/java/org/openapijsonschematools/schemas/DateTimeSchema.java
 src/main/java/org/openapijsonschematools/schemas/DecimalSchema.java
 src/main/java/org/openapijsonschematools/schemas/DoubleSchema.java
 src/main/java/org/openapijsonschematools/schemas/FloatSchema.java
+src/main/java/org/openapijsonschematools/schemas/FrozenList.java
 src/main/java/org/openapijsonschematools/schemas/FrozenMap.java
 src/main/java/org/openapijsonschematools/schemas/Int32Schema.java
 src/main/java/org/openapijsonschematools/schemas/Int64Schema.java
 src/main/java/org/openapijsonschematools/schemas/IntSchema.java
+src/main/java/org/openapijsonschematools/schemas/ListSchema.java
 src/main/java/org/openapijsonschematools/schemas/MapSchema.java
 src/main/java/org/openapijsonschematools/schemas/NullSchema.java
 src/main/java/org/openapijsonschematools/schemas/NumberSchema.java

--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -45,6 +45,7 @@ src/test/java/org/openapijsonschematools/schemas/ObjectTypeSchemaTest.java
 src/test/java/org/openapijsonschematools/schemas/SchemaValidatorTest.java
 src/test/java/org/openapijsonschematools/schemas/validators/AdditionalPropertiesValidatorTest.java
 src/test/java/org/openapijsonschematools/schemas/validators/FormatValidatorTest.java
+src/test/java/org/openapijsonschematools/schemas/validators/ItemsValidatorTest.java
 src/test/java/org/openapijsonschematools/schemas/validators/PropertiesValidatorTest.java
 src/test/java/org/openapijsonschematools/schemas/validators/RequiredValidatorTest.java
 src/test/java/org/openapijsonschematools/schemas/validators/TypeValidatorTest.java

--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -35,6 +35,7 @@ src/main/java/org/openapijsonschematools/schemas/validators/RequiredValidator.ja
 src/main/java/org/openapijsonschematools/schemas/validators/TypeValidator.java
 src/test/java/org/openapijsonschematools/configurations/JsonSchemaKeywordFlagsTest.java
 src/test/java/org/openapijsonschematools/schemas/AnyTypeSchemaTest.java
+src/test/java/org/openapijsonschematools/schemas/ArrayTypeSchemaTest.java
 src/test/java/org/openapijsonschematools/schemas/BooleanSchemaTest.java
 src/test/java/org/openapijsonschematools/schemas/CustomIsoparserTest.java
 src/test/java/org/openapijsonschematools/schemas/ListSchemaTest.java

--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -28,6 +28,7 @@ src/main/java/org/openapijsonschematools/schemas/UnsetAnyTypeSchema.java
 src/main/java/org/openapijsonschematools/schemas/ValidationMetadata.java
 src/main/java/org/openapijsonschematools/schemas/validators/AdditionalPropertiesValidator.java
 src/main/java/org/openapijsonschematools/schemas/validators/FormatValidator.java
+src/main/java/org/openapijsonschematools/schemas/validators/ItemsValidator.java
 src/main/java/org/openapijsonschematools/schemas/validators/KeywordValidator.java
 src/main/java/org/openapijsonschematools/schemas/validators/PropertiesValidator.java
 src/main/java/org/openapijsonschematools/schemas/validators/RequiredValidator.java

--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -36,6 +36,7 @@ src/test/java/org/openapijsonschematools/configurations/JsonSchemaKeywordFlagsTe
 src/test/java/org/openapijsonschematools/schemas/AnyTypeSchemaTest.java
 src/test/java/org/openapijsonschematools/schemas/BooleanSchemaTest.java
 src/test/java/org/openapijsonschematools/schemas/CustomIsoparserTest.java
+src/test/java/org/openapijsonschematools/schemas/ListSchemaTest.java
 src/test/java/org/openapijsonschematools/schemas/MapSchemaTest.java
 src/test/java/org/openapijsonschematools/schemas/NullSchemaTest.java
 src/test/java/org/openapijsonschematools/schemas/NumberSchemaTest.java

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/AnyTypeSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/AnyTypeSchema.java
@@ -52,7 +52,7 @@ public record AnyTypeSchema() implements Schema {
         return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }
 
-    public static <U extends List> U validate(List<Object> arg, SchemaConfiguration configuration) {
+    public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
         return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/FrozenList.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/FrozenList.java
@@ -1,0 +1,51 @@
+package org.openapijsonschematools.schemas;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class FrozenList<E> extends ArrayList<E> {
+    /*
+    A frozen List
+    Once schema validation has been run, indexed access returns values of the correct type
+    If values were mutable, the types in those methods would not agree with returned values
+     */
+    public FrozenList(Collection<? extends E> m) {
+        super(m);
+    }
+
+    public boolean add(E e) {
+        throw new UnsupportedOperationException();
+    }
+
+    public void add(int index, E element) {
+        throw new UnsupportedOperationException();
+    }
+
+    public E remove(int index) {
+        throw new UnsupportedOperationException();
+    }
+
+    public boolean remove(Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    public void clear() {
+        throw new UnsupportedOperationException();
+    }
+
+    public boolean addAll(Collection<? extends E> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    public boolean addAll(int index, Collection<? extends E> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    public boolean removeAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    public boolean retainAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/ListSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/ListSchema.java
@@ -1,0 +1,18 @@
+package org.openapijsonschematools.schemas;
+
+import org.openapijsonschematools.configurations.SchemaConfiguration;
+
+import java.util.LinkedHashSet;
+import java.util.Map;
+
+public record ListSchema(LinkedHashSet<Class<?>> type) implements Schema {
+    public static MapSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        type.add(FrozenList.class);
+        return new MapSchema(type);
+    }
+
+    public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        return Schema.validate(MapSchema.class, arg, configuration);
+    }
+}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/ListSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/ListSchema.java
@@ -3,16 +3,16 @@ package org.openapijsonschematools.schemas;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 
 import java.util.LinkedHashSet;
-import java.util.Map;
+import java.util.List;
 
 public record ListSchema(LinkedHashSet<Class<?>> type) implements Schema {
-    public static MapSchema withDefaults() {
+    public static ListSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
         type.add(FrozenList.class);
-        return new MapSchema(type);
+        return new ListSchema(type);
     }
 
-    public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) {
-        return Schema.validate(MapSchema.class, arg, configuration);
+    public static FrozenList<Object> validate(List<Object> arg, SchemaConfiguration configuration) {
+        return Schema.validate(ListSchema.class, arg, configuration);
     }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Schema.java
@@ -52,7 +52,7 @@ public interface Schema extends SchemaValidator {
          pathToType.put(pathToItem, Double.class);
          return arg;
       } else if (arg instanceof List) {
-         pathToType.put(pathToItem, List.class);
+         pathToType.put(pathToItem, FrozenList.class);
          List<Object> argFixed = new ArrayList<>();
          int i =0;
          for (Object item: ((List<?>) arg).toArray()) {
@@ -62,7 +62,7 @@ public interface Schema extends SchemaValidator {
             argFixed.add(fixedVal);
             i += 1;
          }
-         return argFixed;
+         return new FrozenList(argFixed);
       } else if (arg instanceof ZonedDateTime) {
          pathToType.put(pathToItem, String.class);
          return arg.toString();
@@ -115,7 +115,7 @@ public interface Schema extends SchemaValidator {
       return new FrozenMap(properties);
    }
 
-   private static List<Object> getItems(Object arg, List<Object> pathToItem, PathToSchemasMap pathToSchemas) {
+   private static FrozenList<Object> getItems(Object arg, List<Object> pathToItem, PathToSchemasMap pathToSchemas) {
       ArrayList<Object> items = new ArrayList<>();
       List<Object> castItems = (List<Object>) arg;
       int i = 0;
@@ -127,7 +127,7 @@ public interface Schema extends SchemaValidator {
          items.add(castItem);
          i += 1;
       }
-      return items;
+      return new FrozenList(items);
    }
 
    private static Map<Class<?>, Class<?>> getTypeToOutputClass(Class<?> cls) {
@@ -201,7 +201,7 @@ public interface Schema extends SchemaValidator {
       return (T) validateObject(cls, arg, configuration);
    }
 
-   static <U extends List> U validate(Class<?> cls, List<Object> arg, SchemaConfiguration configuration) {
+   static <U extends FrozenList> U validate(Class<?> cls, List<Object> arg, SchemaConfiguration configuration) {
       return (U) validateObject(cls, arg, configuration);
    }
 

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/SchemaValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/SchemaValidator.java
@@ -6,6 +6,7 @@ import org.openapijsonschematools.schemas.validators.TypeValidator;
 import org.openapijsonschematools.schemas.validators.FormatValidator;
 import org.openapijsonschematools.schemas.validators.PropertiesValidator;
 import org.openapijsonschematools.schemas.validators.RequiredValidator;
+import org.openapijsonschematools.schemas.validators.ItemsValidator;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.RecordComponent;
@@ -22,6 +23,7 @@ public interface SchemaValidator {
         put("format", new FormatValidator());
         put("properties", new PropertiesValidator());
         put("required", new RequiredValidator());
+        put("items", new ItemsValidator());
     }};
 
     static PathToSchemasMap validate(

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/UnsetAnyTypeSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/UnsetAnyTypeSchema.java
@@ -52,7 +52,7 @@ public record UnsetAnyTypeSchema() implements Schema {
         return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
-    static <U extends List> U validate(List<Object> arg, SchemaConfiguration configuration) {
+    static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
         return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/ItemsValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/ItemsValidator.java
@@ -1,0 +1,42 @@
+package org.openapijsonschematools.schemas.validators;
+
+import org.openapijsonschematools.schemas.PathToSchemasMap;
+import org.openapijsonschematools.schemas.Schema;
+import org.openapijsonschematools.schemas.SchemaValidator;
+import org.openapijsonschematools.schemas.ValidationMetadata;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ItemsValidator implements KeywordValidator {
+    @Override
+    public PathToSchemasMap validate(Object arg, Object value, Object extra, Class<SchemaValidator> cls, ValidationMetadata validationMetadata) {
+        if (!(arg instanceof List)) {
+            return null;
+        }
+        List<Object> castArg = (List<Object>) arg;
+        Class<Schema> itemsSchema = (Class<Schema>) value;
+        PathToSchemasMap pathToSchemas = new PathToSchemasMap();
+        // todo add handling for prefixItems
+        int i = 0;
+        for(Object itemValue: castArg) {
+            List<Object> itemPathToItem = new ArrayList<>(validationMetadata.pathToItem());
+            itemPathToItem.add(i);
+            ValidationMetadata itemValidationMetadata = new ValidationMetadata(
+                    itemPathToItem,
+                    validationMetadata.configuration(),
+                    validationMetadata.validatedPathToSchemas(),
+                    validationMetadata.seenClasses()
+            );
+            if (itemValidationMetadata.validationRanEarlier(itemsSchema)) {
+                // todo add_deeper_validated_schemas
+                i +=1;
+                continue;
+            }
+            PathToSchemasMap otherPathToSchemas = SchemaValidator.validate(itemsSchema, itemValue, itemValidationMetadata);
+            pathToSchemas.update(otherPathToSchemas);
+            i += 1;
+        }
+        return pathToSchemas;
+    }
+}

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/AnyTypeSchemaTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/AnyTypeSchemaTest.java
@@ -85,7 +85,7 @@ public class AnyTypeSchemaTest {
     public void testValidateList() {
         ArrayList<Object> inList = new ArrayList<>();
         inList.add(LocalDate.of(2017, 7, 21));
-        ArrayList<String> validatedValue = AnyTypeSchema.validate(inList, configuration);
+        FrozenList<String> validatedValue = AnyTypeSchema.validate(inList, configuration);
         ArrayList<String> outList = new ArrayList<>();
         outList.add( "2017-07-21");
         Assert.assertEquals(validatedValue, outList);

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/ArrayTypeSchemaTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/ArrayTypeSchemaTest.java
@@ -1,0 +1,61 @@
+package org.openapijsonschematools.schemas;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
+import org.openapijsonschematools.configurations.SchemaConfiguration;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+record ArrayWithItemsSchema(LinkedHashSet<Class<?>> type, Class<?> items) implements Schema {
+    public static ArrayWithItemsSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        // can't use ImmutableList because it does not allow null values in entries
+        // can't use Collections.unmodifiableList because Collections.UnmodifiableList is not public + extensible
+        type.add(FrozenList.class);
+        Class<?> items = StringSchema.class;
+        return new ArrayWithItemsSchema(type, items);
+    }
+
+    public static FrozenList<Object> validate(List<Object> arg, SchemaConfiguration configuration) {
+        return Schema.validate(ArrayWithItemsSchema.class, arg, configuration);
+    }
+}
+
+public class ArrayTypeSchemaTest {
+    static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
+
+    @Test
+    public void testExceptionThrownForInvalidType() {
+        Assert.assertThrows(RuntimeException.class, () -> Schema.validate(
+                ArrayWithItemsSchema.class, (Void) null, configuration
+        ));
+    }
+
+    @Test
+    public void testValidateArrayWithItemsSchema() {
+        // map with only item works
+        List<Object> inList = new ArrayList<>();
+        inList.add("abc");
+        FrozenList<Object> validatedValue = ArrayWithItemsSchema.validate(inList, configuration);
+        List<Object> outList = new ArrayList<>();
+        outList.add("abc");
+        Assert.assertEquals(validatedValue, outList);
+
+        // map with no items works
+        inList = new ArrayList<>();
+        validatedValue = ArrayWithItemsSchema.validate(inList, configuration);
+        outList = new ArrayList<>();
+        Assert.assertEquals(validatedValue, outList);
+
+        // invalid prop type fails
+        inList = new ArrayList<>();
+        inList.add(1);
+        List<Object> finalInList = inList;
+        Assert.assertThrows(RuntimeException.class, () -> ArrayWithItemsSchema.validate(
+                finalInList, configuration
+        ));
+    }
+}

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/ListSchemaTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/ListSchemaTest.java
@@ -1,0 +1,30 @@
+package org.openapijsonschematools.schemas;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
+import org.openapijsonschematools.configurations.SchemaConfiguration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ListSchemaTest {
+    static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
+
+    @Test
+    public void testExceptionThrownForInvalidType() {
+        Assert.assertThrows(RuntimeException.class, () -> Schema.validate(
+                ListSchema.class, (Void) null, configuration
+        ));
+    }
+
+    @Test
+    public void testValidateList() {
+        List<Object> inList = new ArrayList<>();
+        inList.add("today");
+        FrozenList<Object> validatedValue = ListSchema.validate(inList, configuration);
+        ArrayList<String> outList = new ArrayList<>();
+        outList.add("today");
+        Assert.assertEquals(validatedValue, outList);
+    }
+}

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/ItemsValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/ItemsValidatorTest.java
@@ -1,0 +1,95 @@
+package org.openapijsonschematools.schemas.validators;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
+import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.schemas.FrozenList;
+import org.openapijsonschematools.schemas.PathToSchemasMap;
+import org.openapijsonschematools.schemas.SchemaValidator;
+import org.openapijsonschematools.schemas.StringSchema;
+import org.openapijsonschematools.schemas.ValidationMetadata;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+public class ItemsValidatorTest {
+
+    @Test
+    public void testCorrectItemsSucceeds() {
+        List<Object> pathToItem = new ArrayList<>();
+        pathToItem.add("args[0]");
+        ValidationMetadata validationMetadata = new ValidationMetadata(
+                pathToItem,
+                new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone()),
+                new PathToSchemasMap(),
+                new LinkedHashSet<>()
+        );
+        List<Object> mutableList = new ArrayList<>();
+        mutableList.add("a");
+        FrozenList<Object> arg = new FrozenList<>(mutableList);
+        final ItemsValidator validator = new ItemsValidator();
+        PathToSchemasMap pathToSchemas = validator.validate(
+                arg,
+                StringSchema.class,
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        );
+        List<Object> expectedPathToItem = new ArrayList<>();
+        expectedPathToItem.add("args[0]");
+        expectedPathToItem.add(0);
+        LinkedHashMap<Class<?>, Void> expectedClasses = new LinkedHashMap<>();
+        expectedClasses.put(String.class, null);
+        expectedClasses.put(StringSchema.class, null);
+        PathToSchemasMap expectedPathToSchemas = new PathToSchemasMap();
+        expectedPathToSchemas.put(expectedPathToItem, expectedClasses);
+        Assert.assertEquals(pathToSchemas, expectedPathToSchemas);
+    }
+
+    @Test
+    public void testNotApplicableTypeReturnsNull() {
+        List<Object> pathToItem = new ArrayList<>();
+        pathToItem.add("args[0]");
+        ValidationMetadata validationMetadata = new ValidationMetadata(
+                pathToItem,
+                new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone()),
+                new PathToSchemasMap(),
+                new LinkedHashSet<>()
+        );
+        final ItemsValidator validator = new ItemsValidator();
+        PathToSchemasMap pathToSchemas = validator.validate(
+                1,
+                StringSchema.class,
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        );
+        Assert.assertNull(pathToSchemas);
+    }
+
+    @Test
+    public void testIncorrectItemFails() {
+        List<Object> pathToItem = new ArrayList<>();
+        pathToItem.add("args[0]");
+        ValidationMetadata validationMetadata = new ValidationMetadata(
+                pathToItem,
+                new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone()),
+                new PathToSchemasMap(),
+                new LinkedHashSet<>()
+        );
+        List<Object> mutableList = new ArrayList<>();
+        mutableList.add(1);
+        FrozenList<Object> arg = new FrozenList<>(mutableList);
+        final ItemsValidator validator = new ItemsValidator();
+        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                arg,
+                StringSchema.class,
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        ));
+    }
+}

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -295,6 +295,7 @@ public class JavaClientGenerator extends AbstractJavaGenerator
         // tests
         List<String> schemaTestSupportingFiles = new ArrayList<>();
         schemaTestSupportingFiles.add("AnyTypeSchemaTest");
+        schemaTestSupportingFiles.add("ArrayTypeSchemaTest");
         schemaTestSupportingFiles.add("BooleanSchemaTest");
         schemaTestSupportingFiles.add("CustomIsoparserTest");
         schemaTestSupportingFiles.add("ListSchemaTest");

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -314,6 +314,7 @@ public class JavaClientGenerator extends AbstractJavaGenerator
         List<String> keywordValidatorFiles = new ArrayList<>();
         keywordValidatorFiles.add("AdditionalPropertiesValidator");
         keywordValidatorFiles.add("FormatValidator");
+        keywordValidatorFiles.add("ItemsValidator");
         keywordValidatorFiles.add("KeywordValidator");
         keywordValidatorFiles.add("PropertiesValidator");
         keywordValidatorFiles.add("RequiredValidator");

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -297,6 +297,7 @@ public class JavaClientGenerator extends AbstractJavaGenerator
         schemaTestSupportingFiles.add("AnyTypeSchemaTest");
         schemaTestSupportingFiles.add("BooleanSchemaTest");
         schemaTestSupportingFiles.add("CustomIsoparserTest");
+        schemaTestSupportingFiles.add("ListSchemaTest");
         schemaTestSupportingFiles.add("MapSchemaTest");
         schemaTestSupportingFiles.add("NullSchemaTest");
         schemaTestSupportingFiles.add("NumberSchemaTest");

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -270,10 +270,12 @@ public class JavaClientGenerator extends AbstractJavaGenerator
         schemaSupportingFiles.add("DecimalSchema");
         schemaSupportingFiles.add("DoubleSchema");
         schemaSupportingFiles.add("FloatSchema");
+        schemaSupportingFiles.add("FrozenList");
         schemaSupportingFiles.add("FrozenMap");
         schemaSupportingFiles.add("Int32Schema");
         schemaSupportingFiles.add("Int64Schema");
         schemaSupportingFiles.add("IntSchema");
+        schemaSupportingFiles.add("ListSchema");
         schemaSupportingFiles.add("MapSchema");
         schemaSupportingFiles.add("NullSchema");
         schemaSupportingFiles.add("NumberSchema");

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -329,6 +329,7 @@ public class JavaClientGenerator extends AbstractJavaGenerator
         List<String> keywordValidatorTestFiles = new ArrayList<>();
         keywordValidatorTestFiles.add("AdditionalPropertiesValidatorTest");
         keywordValidatorTestFiles.add("FormatValidatorTest");
+        keywordValidatorTestFiles.add("ItemsValidatorTest");
         keywordValidatorTestFiles.add("PropertiesValidatorTest");
         keywordValidatorTestFiles.add("RequiredValidatorTest");
         keywordValidatorTestFiles.add("TypeValidatorTest");

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/AnyTypeSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/AnyTypeSchema.hbs
@@ -52,7 +52,7 @@ public record AnyTypeSchema() implements Schema {
         return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }
 
-    public static <U extends List> U validate(List<Object> arg, SchemaConfiguration configuration) {
+    public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
         return Schema.validate(AnyTypeSchema.class, arg, configuration);
     }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/FrozenList.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/FrozenList.hbs
@@ -1,0 +1,51 @@
+package {{{packageName}}}.schemas;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class FrozenList<E> extends ArrayList<E> {
+    /*
+    A frozen List
+    Once schema validation has been run, indexed access returns values of the correct type
+    If values were mutable, the types in those methods would not agree with returned values
+     */
+    public FrozenList(Collection<? extends E> m) {
+        super(m);
+    }
+
+    public boolean add(E e) {
+        throw new UnsupportedOperationException();
+    }
+
+    public void add(int index, E element) {
+        throw new UnsupportedOperationException();
+    }
+
+    public E remove(int index) {
+        throw new UnsupportedOperationException();
+    }
+
+    public boolean remove(Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    public void clear() {
+        throw new UnsupportedOperationException();
+    }
+
+    public boolean addAll(Collection<? extends E> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    public boolean addAll(int index, Collection<? extends E> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    public boolean removeAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    public boolean retainAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/ListSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/ListSchema.hbs
@@ -1,0 +1,18 @@
+package {{{packageName}}}.schemas;
+
+import {{{packageName}}}.configurations.SchemaConfiguration;
+
+import java.util.LinkedHashSet;
+import java.util.Map;
+
+public record ListSchema(LinkedHashSet<Class<?>> type) implements Schema {
+    public static MapSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        type.add(FrozenList.class);
+        return new MapSchema(type);
+    }
+
+    public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        return Schema.validate(MapSchema.class, arg, configuration);
+    }
+}

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/ListSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/ListSchema.hbs
@@ -3,16 +3,16 @@ package {{{packageName}}}.schemas;
 import {{{packageName}}}.configurations.SchemaConfiguration;
 
 import java.util.LinkedHashSet;
-import java.util.Map;
+import java.util.List;
 
 public record ListSchema(LinkedHashSet<Class<?>> type) implements Schema {
-    public static MapSchema withDefaults() {
+    public static ListSchema withDefaults() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
         type.add(FrozenList.class);
-        return new MapSchema(type);
+        return new ListSchema(type);
     }
 
-    public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) {
-        return Schema.validate(MapSchema.class, arg, configuration);
+    public static FrozenList<Object> validate(List<Object> arg, SchemaConfiguration configuration) {
+        return Schema.validate(ListSchema.class, arg, configuration);
     }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/Schema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/Schema.hbs
@@ -52,7 +52,7 @@ public interface Schema extends SchemaValidator {
          pathToType.put(pathToItem, Double.class);
          return arg;
       } else if (arg instanceof List) {
-         pathToType.put(pathToItem, List.class);
+         pathToType.put(pathToItem, FrozenList.class);
          List<Object> argFixed = new ArrayList<>();
          int i =0;
          for (Object item: ((List<?>) arg).toArray()) {
@@ -62,7 +62,7 @@ public interface Schema extends SchemaValidator {
             argFixed.add(fixedVal);
             i += 1;
          }
-         return argFixed;
+         return new FrozenList(argFixed);
       } else if (arg instanceof ZonedDateTime) {
          pathToType.put(pathToItem, String.class);
          return arg.toString();
@@ -115,7 +115,7 @@ public interface Schema extends SchemaValidator {
       return new FrozenMap(properties);
    }
 
-   private static List<Object> getItems(Object arg, List<Object> pathToItem, PathToSchemasMap pathToSchemas) {
+   private static FrozenList<Object> getItems(Object arg, List<Object> pathToItem, PathToSchemasMap pathToSchemas) {
       ArrayList<Object> items = new ArrayList<>();
       List<Object> castItems = (List<Object>) arg;
       int i = 0;
@@ -127,7 +127,7 @@ public interface Schema extends SchemaValidator {
          items.add(castItem);
          i += 1;
       }
-      return items;
+      return new FrozenList(items);
    }
 
    private static Map<Class<?>, Class<?>> getTypeToOutputClass(Class<?> cls) {
@@ -201,7 +201,7 @@ public interface Schema extends SchemaValidator {
       return (T) validateObject(cls, arg, configuration);
    }
 
-   static <U extends List> U validate(Class<?> cls, List<Object> arg, SchemaConfiguration configuration) {
+   static <U extends FrozenList> U validate(Class<?> cls, List<Object> arg, SchemaConfiguration configuration) {
       return (U) validateObject(cls, arg, configuration);
    }
 

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/SchemaValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/SchemaValidator.hbs
@@ -6,6 +6,7 @@ import {{{packageName}}}.schemas.validators.TypeValidator;
 import {{{packageName}}}.schemas.validators.FormatValidator;
 import {{{packageName}}}.schemas.validators.PropertiesValidator;
 import {{{packageName}}}.schemas.validators.RequiredValidator;
+import {{{packageName}}}.schemas.validators.ItemsValidator;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.RecordComponent;
@@ -22,6 +23,7 @@ public interface SchemaValidator {
         put("format", new FormatValidator());
         put("properties", new PropertiesValidator());
         put("required", new RequiredValidator());
+        put("items", new ItemsValidator());
     }};
 
     static PathToSchemasMap validate(

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/UnsetAnyTypeSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/UnsetAnyTypeSchema.hbs
@@ -52,7 +52,7 @@ public record UnsetAnyTypeSchema() implements Schema {
         return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }
 
-    static <U extends List> U validate(List<Object> arg, SchemaConfiguration configuration) {
+    static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
         return Schema.validate(UnsetAnyTypeSchema.class, arg, configuration);
     }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/ItemsValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/ItemsValidator.hbs
@@ -1,0 +1,42 @@
+package {{{packageName}}}.schemas.validators;
+
+import {{{packageName}}}.schemas.PathToSchemasMap;
+import {{{packageName}}}.schemas.Schema;
+import {{{packageName}}}.schemas.SchemaValidator;
+import {{{packageName}}}.schemas.ValidationMetadata;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ItemsValidator implements KeywordValidator {
+    @Override
+    public PathToSchemasMap validate(Object arg, Object value, Object extra, Class<SchemaValidator> cls, ValidationMetadata validationMetadata) {
+        if (!(arg instanceof List)) {
+            return null;
+        }
+        List<Object> castArg = (List<Object>) arg;
+        Class<Schema> itemsSchema = (Class<Schema>) value;
+        PathToSchemasMap pathToSchemas = new PathToSchemasMap();
+        // todo add handling for prefixItems
+        int i = 0;
+        for(Object itemValue: castArg) {
+            List<Object> itemPathToItem = new ArrayList<>(validationMetadata.pathToItem());
+            itemPathToItem.add(i);
+            ValidationMetadata itemValidationMetadata = new ValidationMetadata(
+                    itemPathToItem,
+                    validationMetadata.configuration(),
+                    validationMetadata.validatedPathToSchemas(),
+                    validationMetadata.seenClasses()
+            );
+            if (itemValidationMetadata.validationRanEarlier(itemsSchema)) {
+                // todo add_deeper_validated_schemas
+                i +=1;
+                continue;
+            }
+            PathToSchemasMap otherPathToSchemas = SchemaValidator.validate(itemsSchema, itemValue, itemValidationMetadata);
+            pathToSchemas.update(otherPathToSchemas);
+            i += 1;
+        }
+        return pathToSchemas;
+    }
+}

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/AnyTypeSchemaTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/AnyTypeSchemaTest.hbs
@@ -85,7 +85,7 @@ public class AnyTypeSchemaTest {
     public void testValidateList() {
         ArrayList<Object> inList = new ArrayList<>();
         inList.add(LocalDate.of(2017, 7, 21));
-        ArrayList<String> validatedValue = AnyTypeSchema.validate(inList, configuration);
+        FrozenList<String> validatedValue = AnyTypeSchema.validate(inList, configuration);
         ArrayList<String> outList = new ArrayList<>();
         outList.add( "2017-07-21");
         Assert.assertEquals(validatedValue, outList);

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/ArrayTypeSchemaTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/ArrayTypeSchemaTest.hbs
@@ -1,0 +1,61 @@
+package {{{packageName}}}.schemas;
+
+import org.junit.Assert;
+import org.junit.Test;
+import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
+import {{{packageName}}}.configurations.SchemaConfiguration;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+record ArrayWithItemsSchema(LinkedHashSet<Class<?>> type, Class<?> items) implements Schema {
+    public static ArrayWithItemsSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        // can't use ImmutableList because it does not allow null values in entries
+        // can't use Collections.unmodifiableList because Collections.UnmodifiableList is not public + extensible
+        type.add(FrozenList.class);
+        Class<?> items = StringSchema.class;
+        return new ArrayWithItemsSchema(type, items);
+    }
+
+    public static FrozenList<Object> validate(List<Object> arg, SchemaConfiguration configuration) {
+        return Schema.validate(ArrayWithItemsSchema.class, arg, configuration);
+    }
+}
+
+public class ArrayTypeSchemaTest {
+    static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
+
+    @Test
+    public void testExceptionThrownForInvalidType() {
+        Assert.assertThrows(RuntimeException.class, () -> Schema.validate(
+                ArrayWithItemsSchema.class, (Void) null, configuration
+        ));
+    }
+
+    @Test
+    public void testValidateArrayWithItemsSchema() {
+        // map with only item works
+        List<Object> inList = new ArrayList<>();
+        inList.add("abc");
+        FrozenList<Object> validatedValue = ArrayWithItemsSchema.validate(inList, configuration);
+        List<Object> outList = new ArrayList<>();
+        outList.add("abc");
+        Assert.assertEquals(validatedValue, outList);
+
+        // map with no items works
+        inList = new ArrayList<>();
+        validatedValue = ArrayWithItemsSchema.validate(inList, configuration);
+        outList = new ArrayList<>();
+        Assert.assertEquals(validatedValue, outList);
+
+        // invalid prop type fails
+        inList = new ArrayList<>();
+        inList.add(1);
+        List<Object> finalInList = inList;
+        Assert.assertThrows(RuntimeException.class, () -> ArrayWithItemsSchema.validate(
+                finalInList, configuration
+        ));
+    }
+}

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/ListSchemaTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/ListSchemaTest.hbs
@@ -1,0 +1,30 @@
+package {{{packageName}}}.schemas;
+
+import org.junit.Assert;
+import org.junit.Test;
+import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
+import {{{packageName}}}.configurations.SchemaConfiguration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ListSchemaTest {
+    static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
+
+    @Test
+    public void testExceptionThrownForInvalidType() {
+        Assert.assertThrows(RuntimeException.class, () -> Schema.validate(
+                ListSchema.class, (Void) null, configuration
+        ));
+    }
+
+    @Test
+    public void testValidateList() {
+        List<Object> inList = new ArrayList<>();
+        inList.add("today");
+        FrozenList<Object> validatedValue = ListSchema.validate(inList, configuration);
+        ArrayList<String> outList = new ArrayList<>();
+        outList.add("today");
+        Assert.assertEquals(validatedValue, outList);
+    }
+}

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/ItemsValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/ItemsValidatorTest.hbs
@@ -1,0 +1,95 @@
+package {{{packageName}}}.schemas.validators;
+
+import org.junit.Assert;
+import org.junit.Test;
+import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
+import {{{packageName}}}.configurations.SchemaConfiguration;
+import {{{packageName}}}.schemas.FrozenList;
+import {{{packageName}}}.schemas.PathToSchemasMap;
+import {{{packageName}}}.schemas.SchemaValidator;
+import {{{packageName}}}.schemas.StringSchema;
+import {{{packageName}}}.schemas.ValidationMetadata;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+public class ItemsValidatorTest {
+
+    @Test
+    public void testCorrectItemsSucceeds() {
+        List<Object> pathToItem = new ArrayList<>();
+        pathToItem.add("args[0]");
+        ValidationMetadata validationMetadata = new ValidationMetadata(
+                pathToItem,
+                new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone()),
+                new PathToSchemasMap(),
+                new LinkedHashSet<>()
+        );
+        List<Object> mutableList = new ArrayList<>();
+        mutableList.add("a");
+        FrozenList<Object> arg = new FrozenList<>(mutableList);
+        final ItemsValidator validator = new ItemsValidator();
+        PathToSchemasMap pathToSchemas = validator.validate(
+                arg,
+                StringSchema.class,
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        );
+        List<Object> expectedPathToItem = new ArrayList<>();
+        expectedPathToItem.add("args[0]");
+        expectedPathToItem.add(0);
+        LinkedHashMap<Class<?>, Void> expectedClasses = new LinkedHashMap<>();
+        expectedClasses.put(String.class, null);
+        expectedClasses.put(StringSchema.class, null);
+        PathToSchemasMap expectedPathToSchemas = new PathToSchemasMap();
+        expectedPathToSchemas.put(expectedPathToItem, expectedClasses);
+        Assert.assertEquals(pathToSchemas, expectedPathToSchemas);
+    }
+
+    @Test
+    public void testNotApplicableTypeReturnsNull() {
+        List<Object> pathToItem = new ArrayList<>();
+        pathToItem.add("args[0]");
+        ValidationMetadata validationMetadata = new ValidationMetadata(
+                pathToItem,
+                new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone()),
+                new PathToSchemasMap(),
+                new LinkedHashSet<>()
+        );
+        final ItemsValidator validator = new ItemsValidator();
+        PathToSchemasMap pathToSchemas = validator.validate(
+                1,
+                StringSchema.class,
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        );
+        Assert.assertNull(pathToSchemas);
+    }
+
+    @Test
+    public void testIncorrectItemFails() {
+        List<Object> pathToItem = new ArrayList<>();
+        pathToItem.add("args[0]");
+        ValidationMetadata validationMetadata = new ValidationMetadata(
+                pathToItem,
+                new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone()),
+                new PathToSchemasMap(),
+                new LinkedHashSet<>()
+        );
+        List<Object> mutableList = new ArrayList<>();
+        mutableList.add(1);
+        FrozenList<Object> arg = new FrozenList<>(mutableList);
+        final ItemsValidator validator = new ItemsValidator();
+        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                arg,
+                StringSchema.class,
+                null,
+                SchemaValidator.class,
+                validationMetadata
+        ));
+    }
+}


### PR DESCRIPTION
- Adds ListSchema + tests
- Adds FrozenList to store payloads validated with ListSchema
- Adds and tests ItemsValidator
- Adds tests of type array schema with items defined in it

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
