### PR TITLE
Java, adjusts schema validator argument order

### DIFF
--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/SchemaValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/SchemaValidator.java
@@ -57,17 +57,17 @@ public interface SchemaValidator {
         Class<SchemaValidator> castSchemaCls = (Class<SchemaValidator>) schemaCls;
         for (Map.Entry<String, Object> entry: fieldsToValues.entrySet()) {
             String jsonKeyword = entry.getKey();
-            Object value = entry.getValue();
+            Object constraint = entry.getValue();
             if (jsonKeyword.equals("additionalProperties") && fieldsToValues.containsKey("properties")) {
                 extra = fieldsToValues.get("properties");
             }
             KeywordValidator validatorClass = keywordToValidator.get(jsonKeyword);
             PathToSchemasMap otherPathToSchemas = validatorClass.validate(
                     arg,
-                    value,
-                    extra,
+                    constraint,
                     castSchemaCls,
-                    validationMetadata
+                    validationMetadata,
+                    extra
             );
             if (otherPathToSchemas == null) {
                 continue;

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/SchemaValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/SchemaValidator.java
@@ -63,9 +63,9 @@ public interface SchemaValidator {
             }
             KeywordValidator validatorClass = keywordToValidator.get(jsonKeyword);
             PathToSchemasMap otherPathToSchemas = validatorClass.validate(
+                    castSchemaCls,
                     arg,
                     constraint,
-                    castSchemaCls,
                     validationMetadata,
                     extra
             );

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/AdditionalPropertiesValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/AdditionalPropertiesValidator.java
@@ -14,12 +14,12 @@ import java.util.Set;
 
 public class AdditionalPropertiesValidator implements KeywordValidator {
     @Override
-    public PathToSchemasMap validate(Object arg, Object value, Object extra, Class<SchemaValidator> cls, ValidationMetadata validationMetadata) {
+    public PathToSchemasMap validate(Object arg, Object constraint, Class<SchemaValidator> cls, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Map)) {
             return null;
         }
         Map<String, Object> castArg = (Map<String, Object>) arg;
-        Class<Schema> addPropSchema = (Class<Schema>) value;
+        Class<Schema> addPropSchema = (Class<Schema>) constraint;
         Map<String, Class<Schema>> properties = (Map<String, Class<Schema>>) extra;
         if (properties == null) {
             properties = new LinkedHashMap<>();

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/AdditionalPropertiesValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/AdditionalPropertiesValidator.java
@@ -14,7 +14,7 @@ import java.util.Set;
 
 public class AdditionalPropertiesValidator implements KeywordValidator {
     @Override
-    public PathToSchemasMap validate(Object arg, Object constraint, Class<SchemaValidator> cls, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(Class<SchemaValidator> cls, Object arg, Object constraint, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Map)) {
             return null;
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/FormatValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/FormatValidator.java
@@ -107,8 +107,8 @@ public class FormatValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Object arg, Object value, Object extra, Class<SchemaValidator> cls, ValidationMetadata validationMetadata) {
-        String format = (String) value;
+    public PathToSchemasMap validate(Object arg, Object constraint, Class<SchemaValidator> cls, ValidationMetadata validationMetadata, Object extra) {
+        String format = (String) constraint;
         if (arg instanceof BigDecimal) {
             validateNumericFormat(
                 (BigDecimal) arg,

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/ItemsValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/ItemsValidator.java
@@ -10,12 +10,12 @@ import java.util.List;
 
 public class ItemsValidator implements KeywordValidator {
     @Override
-    public PathToSchemasMap validate(Object arg, Object value, Object extra, Class<SchemaValidator> cls, ValidationMetadata validationMetadata) {
+    public PathToSchemasMap validate(Object arg, Object constraint, Class<SchemaValidator> cls, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof List)) {
             return null;
         }
         List<Object> castArg = (List<Object>) arg;
-        Class<Schema> itemsSchema = (Class<Schema>) value;
+        Class<Schema> itemsSchema = (Class<Schema>) constraint;
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         // todo add handling for prefixItems
         int i = 0;

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/ItemsValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/ItemsValidator.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 public class ItemsValidator implements KeywordValidator {
     @Override
-    public PathToSchemasMap validate(Object arg, Object constraint, Class<SchemaValidator> cls, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(Class<SchemaValidator> cls, Object arg, Object constraint, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof List)) {
             return null;
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/KeywordValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/KeywordValidator.java
@@ -7,8 +7,8 @@ import org.openapijsonschematools.schemas.ValidationMetadata;
 public interface KeywordValidator {
     PathToSchemasMap validate(
             Object arg,
-            Object value,
-            Object extra,
+            Object constraint,
             Class<SchemaValidator> cls,
-            ValidationMetadata validationMetadata);
+            ValidationMetadata validationMetadata,
+            Object extra);
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/KeywordValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/KeywordValidator.java
@@ -6,9 +6,9 @@ import org.openapijsonschematools.schemas.ValidationMetadata;
 
 public interface KeywordValidator {
     PathToSchemasMap validate(
+            Class<SchemaValidator> cls,
             Object arg,
             Object constraint,
-            Class<SchemaValidator> cls,
             ValidationMetadata validationMetadata,
             Object extra);
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/PropertiesValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/PropertiesValidator.java
@@ -13,7 +13,7 @@ import java.util.Set;
 
 public class PropertiesValidator implements KeywordValidator {
     @Override
-    public PathToSchemasMap validate(Object arg, Object constraint, Class<SchemaValidator> cls, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(Class<SchemaValidator> cls, Object arg, Object constraint, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Map)) {
             return null;
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/PropertiesValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/PropertiesValidator.java
@@ -13,13 +13,13 @@ import java.util.Set;
 
 public class PropertiesValidator implements KeywordValidator {
     @Override
-    public PathToSchemasMap validate(Object arg, Object value, Object extra, Class<SchemaValidator> cls, ValidationMetadata validationMetadata) {
+    public PathToSchemasMap validate(Object arg, Object constraint, Class<SchemaValidator> cls, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Map)) {
             return null;
         }
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         Map<String, Object> castArg = (Map<String, Object>) arg;
-        Map<String, Class<Schema>> properties = (Map<String, Class<Schema>>) value;
+        Map<String, Class<Schema>> properties = (Map<String, Class<Schema>>) constraint;
         Set<String> presentProperties = new LinkedHashSet<>(castArg.keySet());
         presentProperties.retainAll(properties.keySet());
         for(String propName: presentProperties) {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/RequiredValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/RequiredValidator.java
@@ -11,12 +11,12 @@ import java.util.Set;
 
 public class RequiredValidator implements KeywordValidator {
     @Override
-    public PathToSchemasMap validate(Object arg, Object value, Object extra, Class<SchemaValidator> cls, ValidationMetadata validationMetadata) {
+    public PathToSchemasMap validate(Object arg, Object constraint, Class<SchemaValidator> cls, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Map)) {
             return null;
         }
         Map<String, Object> castArg = (Map<String, Object>) arg;
-        Set<String> requiredProperties = (Set<String>) value;
+        Set<String> requiredProperties = (Set<String>) constraint;
         Set<String> missingRequiredProperties = new HashSet<>(requiredProperties);
         missingRequiredProperties.removeAll(castArg.keySet());
         if (!missingRequiredProperties.isEmpty()) {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/RequiredValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/RequiredValidator.java
@@ -11,7 +11,7 @@ import java.util.Set;
 
 public class RequiredValidator implements KeywordValidator {
     @Override
-    public PathToSchemasMap validate(Object arg, Object constraint, Class<SchemaValidator> cls, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(Class<SchemaValidator> cls, Object arg, Object constraint, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Map)) {
             return null;
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/TypeValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/TypeValidator.java
@@ -8,7 +8,7 @@ import java.util.HashSet;
 
 public class TypeValidator implements KeywordValidator {
     @Override
-    public PathToSchemasMap validate(Object arg, Object constraint, Class<SchemaValidator> cls, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(Class<SchemaValidator> cls, Object arg, Object constraint, ValidationMetadata validationMetadata, Object extra) {
         HashSet<Class<?>> types = (HashSet<Class<?>>) constraint;
         Class<?> argClass;
         if (arg == null) {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/TypeValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/TypeValidator.java
@@ -8,8 +8,8 @@ import java.util.HashSet;
 
 public class TypeValidator implements KeywordValidator {
     @Override
-    public PathToSchemasMap validate(Object arg, Object value, Object extra, Class<SchemaValidator> cls, ValidationMetadata validationMetadata) {
-        HashSet<Class<?>> types = (HashSet<Class<?>>) value;
+    public PathToSchemasMap validate(Object arg, Object constraint, Class<SchemaValidator> cls, ValidationMetadata validationMetadata, Object extra) {
+        HashSet<Class<?>> types = (HashSet<Class<?>>) constraint;
         Class<?> argClass;
         if (arg == null) {
             argClass = Void.class;

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/AdditionalPropertiesValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/AdditionalPropertiesValidatorTest.java
@@ -37,9 +37,9 @@ public class AdditionalPropertiesValidatorTest {
         FrozenMap<String, Object> arg = new FrozenMap<>(mutableMap);
         final AdditionalPropertiesValidator validator = new AdditionalPropertiesValidator();
         PathToSchemasMap pathToSchemas = validator.validate(
+                SchemaValidator.class,
                 arg,
                 StringSchema.class,
-                SchemaValidator.class,
                 validationMetadata,
                 properties
         );
@@ -66,9 +66,9 @@ public class AdditionalPropertiesValidatorTest {
         );
         final AdditionalPropertiesValidator validator = new AdditionalPropertiesValidator();
         PathToSchemasMap pathToSchemas = validator.validate(
+                SchemaValidator.class,
                 1,
                 StringSchema.class,
-                SchemaValidator.class,
                 validationMetadata,
                 null
         );
@@ -94,9 +94,9 @@ public class AdditionalPropertiesValidatorTest {
         FrozenMap<String, Object> arg = new FrozenMap<>(mutableMap);
         final AdditionalPropertiesValidator validator = new AdditionalPropertiesValidator();
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                SchemaValidator.class,
                 arg,
                 StringSchema.class,
-                SchemaValidator.class,
                 validationMetadata,
                 properties
         ));

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/AdditionalPropertiesValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/AdditionalPropertiesValidatorTest.java
@@ -39,9 +39,9 @@ public class AdditionalPropertiesValidatorTest {
         PathToSchemasMap pathToSchemas = validator.validate(
                 arg,
                 StringSchema.class,
-                properties,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                properties
         );
         List<Object> expectedPathToItem = new ArrayList<>();
         expectedPathToItem.add("args[0]");
@@ -68,9 +68,9 @@ public class AdditionalPropertiesValidatorTest {
         PathToSchemasMap pathToSchemas = validator.validate(
                 1,
                 StringSchema.class,
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemas);
     }
@@ -96,9 +96,9 @@ public class AdditionalPropertiesValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 arg,
                 StringSchema.class,
-                properties,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                properties
         ));
     }
 }

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/FormatValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/FormatValidatorTest.java
@@ -27,9 +27,9 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 new BigDecimal("1.0"),
                 "int",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -40,9 +40,9 @@ public class FormatValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 new BigDecimal("3.14"),
                 "int",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         ));
     }
 
@@ -52,9 +52,9 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 new BigDecimal("1"),
                 "int",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -65,9 +65,9 @@ public class FormatValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 new BigDecimal(-2147483649L),
                 "int32",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         ));
     }
 
@@ -77,9 +77,9 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 new BigDecimal(-2147483648),
                 "int32",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -90,9 +90,9 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 new BigDecimal(2147483647),
                 "int32",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -103,9 +103,9 @@ public class FormatValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 BigDecimal.valueOf(2147483648L),
                 "int32",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         ));
     }
 
@@ -116,9 +116,9 @@ public class FormatValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 new BigDecimal(new BigInteger("-9223372036854775809")),
                 "int64",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         ));
     }
 
@@ -128,9 +128,9 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 new BigDecimal(-9223372036854775808L),
                 "int64",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -141,9 +141,9 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 new BigDecimal(9223372036854775807L),
                 "int64",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -155,9 +155,9 @@ public class FormatValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 new BigDecimal(new BigInteger("9223372036854775808")),
                 "int64",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         ));
     }
 
@@ -167,9 +167,9 @@ public class FormatValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 BigDecimal.valueOf(-3.402823466385289e+38),
                 "float",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         ));
     }
 
@@ -179,9 +179,9 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 BigDecimal.valueOf(-3.4028234663852886e+38),
                 "float",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -192,9 +192,9 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 new BigDecimal("3.4028234663852886e+38"),
                 "float",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -205,9 +205,9 @@ public class FormatValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 BigDecimal.valueOf(3.402823466385289e+38),
                 "float",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         ));
     }
 
@@ -217,9 +217,9 @@ public class FormatValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 new BigDecimal("-1.7976931348623157082e+308"),
                 "double",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         ));
     }
 
@@ -229,9 +229,9 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 BigDecimal.valueOf(-1.7976931348623157E+308d),
                 "double",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -242,9 +242,9 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 BigDecimal.valueOf(1.7976931348623157E+308d),
                 "double",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -255,9 +255,9 @@ public class FormatValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 new BigDecimal("1.7976931348623157082e+308"),
                 "double",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         ));
     }
 
@@ -267,9 +267,9 @@ public class FormatValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 "abc",
                 "number",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         ));
     }
 
@@ -279,9 +279,9 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 "3.14",
                 "number",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -292,9 +292,9 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 "1",
                 "number",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -305,9 +305,9 @@ public class FormatValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 "abc",
                 "date",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         ));
     }
 
@@ -317,9 +317,9 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 "2017-01-20",
                 "date",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -330,9 +330,9 @@ public class FormatValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 "abc",
                 "date-time",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         ));
     }
 
@@ -342,9 +342,9 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 "2017-07-21T17:32:28Z",
                 "date-time",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemasMap);
     }

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/FormatValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/FormatValidatorTest.java
@@ -25,9 +25,9 @@ public class FormatValidatorTest {
     public void testIntFormatSucceedsWithFloat() {
         final FormatValidator validator = new FormatValidator();
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                new BigDecimal("1.0"),
-                "int",
                 SchemaValidator.class,
+                1.0f,
+                "int",
                 validationMetadata,
                 null
         );
@@ -38,9 +38,9 @@ public class FormatValidatorTest {
     public void testIntFormatFailsWithFloat() {
         final FormatValidator validator = new FormatValidator();
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
-                new BigDecimal("3.14"),
-                "int",
                 SchemaValidator.class,
+                3.14f,
+                "int",
                 validationMetadata,
                 null
         ));
@@ -50,9 +50,9 @@ public class FormatValidatorTest {
     public void testIntFormatSucceedsWithInt() {
         final FormatValidator validator = new FormatValidator();
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                new BigDecimal("1"),
-                "int",
                 SchemaValidator.class,
+                1,
+                "int",
                 validationMetadata,
                 null
         );
@@ -63,9 +63,9 @@ public class FormatValidatorTest {
     public void testInt32UnderMinFails() {
         final FormatValidator validator = new FormatValidator();
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
-                new BigDecimal(-2147483649L),
-                "int32",
                 SchemaValidator.class,
+                -2147483649L,
+                "int32",
                 validationMetadata,
                 null
         ));
@@ -75,9 +75,9 @@ public class FormatValidatorTest {
     public void testInt32InclusiveMinSucceeds() {
         final FormatValidator validator = new FormatValidator();
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                new BigDecimal(-2147483648),
-                "int32",
                 SchemaValidator.class,
+                -2147483648,
+                "int32",
                 validationMetadata,
                 null
         );
@@ -88,9 +88,9 @@ public class FormatValidatorTest {
     public void testInt32InclusiveMaxSucceeds() {
         final FormatValidator validator = new FormatValidator();
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                new BigDecimal(2147483647),
-                "int32",
                 SchemaValidator.class,
+                2147483647,
+                "int32",
                 validationMetadata,
                 null
         );
@@ -101,9 +101,9 @@ public class FormatValidatorTest {
     public void testInt32OverMaxFails() {
         final FormatValidator validator = new FormatValidator();
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
-                BigDecimal.valueOf(2147483648L),
-                "int32",
                 SchemaValidator.class,
+                2147483648L,
+                "int32",
                 validationMetadata,
                 null
         ));
@@ -114,9 +114,9 @@ public class FormatValidatorTest {
         final FormatValidator validator = new FormatValidator();
 
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
-                new BigDecimal(new BigInteger("-9223372036854775809")),
-                "int64",
                 SchemaValidator.class,
+                new BigInteger("-9223372036854775809"),
+                "int64",
                 validationMetadata,
                 null
         ));
@@ -126,9 +126,9 @@ public class FormatValidatorTest {
     public void testInt64InclusiveMinSucceeds() {
         final FormatValidator validator = new FormatValidator();
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                new BigDecimal(-9223372036854775808L),
-                "int64",
                 SchemaValidator.class,
+                -9223372036854775808L,
+                "int64",
                 validationMetadata,
                 null
         );
@@ -139,9 +139,9 @@ public class FormatValidatorTest {
     public void testInt64InclusiveMaxSucceeds() {
         final FormatValidator validator = new FormatValidator();
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                new BigDecimal(9223372036854775807L),
-                "int64",
                 SchemaValidator.class,
+                9223372036854775807L,
+                "int64",
                 validationMetadata,
                 null
         );
@@ -153,9 +153,9 @@ public class FormatValidatorTest {
         final FormatValidator validator = new FormatValidator();
 
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
-                new BigDecimal(new BigInteger("9223372036854775808")),
-                "int64",
                 SchemaValidator.class,
+                new BigInteger("9223372036854775808"),
+                "int64",
                 validationMetadata,
                 null
         ));
@@ -165,9 +165,9 @@ public class FormatValidatorTest {
     public void testFloatUnderMinFails() {
         final FormatValidator validator = new FormatValidator();
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
-                BigDecimal.valueOf(-3.402823466385289e+38),
-                "float",
                 SchemaValidator.class,
+                -3.402823466385289e+38d,
+                "float",
                 validationMetadata,
                 null
         ));
@@ -177,9 +177,9 @@ public class FormatValidatorTest {
     public void testFloatInclusiveMinSucceeds() {
         final FormatValidator validator = new FormatValidator();
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                BigDecimal.valueOf(-3.4028234663852886e+38),
-                "float",
                 SchemaValidator.class,
+                -3.4028234663852886e+38f,
+                "float",
                 validationMetadata,
                 null
         );
@@ -190,9 +190,9 @@ public class FormatValidatorTest {
     public void testFloatInclusiveMaxSucceeds() {
         final FormatValidator validator = new FormatValidator();
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                new BigDecimal("3.4028234663852886e+38"),
-                "float",
                 SchemaValidator.class,
+                3.4028234663852886e+38f,
+                "float",
                 validationMetadata,
                 null
         );
@@ -203,9 +203,9 @@ public class FormatValidatorTest {
     public void testFloatOverMaxFails() {
         final FormatValidator validator = new FormatValidator();
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
-                BigDecimal.valueOf(3.402823466385289e+38),
-                "float",
                 SchemaValidator.class,
+                3.402823466385289e+38d,
+                "float",
                 validationMetadata,
                 null
         ));
@@ -215,9 +215,9 @@ public class FormatValidatorTest {
     public void testDoubleUnderMinFails() {
         final FormatValidator validator = new FormatValidator();
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                SchemaValidator.class,
                 new BigDecimal("-1.7976931348623157082e+308"),
                 "double",
-                SchemaValidator.class,
                 validationMetadata,
                 null
         ));
@@ -227,9 +227,9 @@ public class FormatValidatorTest {
     public void testDoubleInclusiveMinSucceeds() {
         final FormatValidator validator = new FormatValidator();
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                BigDecimal.valueOf(-1.7976931348623157E+308d),
-                "double",
                 SchemaValidator.class,
+                -1.7976931348623157E+308d,
+                "double",
                 validationMetadata,
                 null
         );
@@ -240,9 +240,9 @@ public class FormatValidatorTest {
     public void testDoubleInclusiveMaxSucceeds() {
         final FormatValidator validator = new FormatValidator();
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                BigDecimal.valueOf(1.7976931348623157E+308d),
-                "double",
                 SchemaValidator.class,
+                1.7976931348623157E+308d,
+                "double",
                 validationMetadata,
                 null
         );
@@ -253,9 +253,9 @@ public class FormatValidatorTest {
     public void testDoubleOverMaxFails() {
         final FormatValidator validator = new FormatValidator();
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                SchemaValidator.class,
                 new BigDecimal("1.7976931348623157082e+308"),
                 "double",
-                SchemaValidator.class,
                 validationMetadata,
                 null
         ));
@@ -265,9 +265,9 @@ public class FormatValidatorTest {
     public void testInvalidNumberStringFails() {
         final FormatValidator validator = new FormatValidator();
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                SchemaValidator.class,
                 "abc",
                 "number",
-                SchemaValidator.class,
                 validationMetadata,
                 null
         ));
@@ -277,9 +277,9 @@ public class FormatValidatorTest {
     public void testValidFloatNumberStringSucceeds() {
         final FormatValidator validator = new FormatValidator();
         PathToSchemasMap pathToSchemasMap = validator.validate(
+                SchemaValidator.class,
                 "3.14",
                 "number",
-                SchemaValidator.class,
                 validationMetadata,
                 null
         );
@@ -290,9 +290,9 @@ public class FormatValidatorTest {
     public void testValidIntNumberStringSucceeds() {
         final FormatValidator validator = new FormatValidator();
         PathToSchemasMap pathToSchemasMap = validator.validate(
+                SchemaValidator.class,
                 "1",
                 "number",
-                SchemaValidator.class,
                 validationMetadata,
                 null
         );
@@ -303,9 +303,9 @@ public class FormatValidatorTest {
     public void testInvalidDateStringFails() {
         final FormatValidator validator = new FormatValidator();
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                SchemaValidator.class,
                 "abc",
                 "date",
-                SchemaValidator.class,
                 validationMetadata,
                 null
         ));
@@ -315,9 +315,9 @@ public class FormatValidatorTest {
     public void testValidDateStringSucceeds() {
         final FormatValidator validator = new FormatValidator();
         PathToSchemasMap pathToSchemasMap = validator.validate(
+                SchemaValidator.class,
                 "2017-01-20",
                 "date",
-                SchemaValidator.class,
                 validationMetadata,
                 null
         );
@@ -328,9 +328,9 @@ public class FormatValidatorTest {
     public void testInvalidDateTimeStringFails() {
         final FormatValidator validator = new FormatValidator();
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                SchemaValidator.class,
                 "abc",
                 "date-time",
-                SchemaValidator.class,
                 validationMetadata,
                 null
         ));
@@ -340,9 +340,9 @@ public class FormatValidatorTest {
     public void testValidDateTimeStringSucceeds() {
         final FormatValidator validator = new FormatValidator();
         PathToSchemasMap pathToSchemasMap = validator.validate(
+                SchemaValidator.class,
                 "2017-07-21T17:32:28Z",
                 "date-time",
-                SchemaValidator.class,
                 validationMetadata,
                 null
         );

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/ItemsValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/ItemsValidatorTest.java
@@ -34,9 +34,9 @@ public class ItemsValidatorTest {
         PathToSchemasMap pathToSchemas = validator.validate(
                 arg,
                 StringSchema.class,
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         List<Object> expectedPathToItem = new ArrayList<>();
         expectedPathToItem.add("args[0]");
@@ -63,9 +63,9 @@ public class ItemsValidatorTest {
         PathToSchemasMap pathToSchemas = validator.validate(
                 1,
                 StringSchema.class,
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemas);
     }
@@ -87,9 +87,9 @@ public class ItemsValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 arg,
                 StringSchema.class,
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         ));
     }
 }

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/ItemsValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/ItemsValidatorTest.java
@@ -32,9 +32,9 @@ public class ItemsValidatorTest {
         FrozenList<Object> arg = new FrozenList<>(mutableList);
         final ItemsValidator validator = new ItemsValidator();
         PathToSchemasMap pathToSchemas = validator.validate(
+                SchemaValidator.class,
                 arg,
                 StringSchema.class,
-                SchemaValidator.class,
                 validationMetadata,
                 null
         );
@@ -61,9 +61,9 @@ public class ItemsValidatorTest {
         );
         final ItemsValidator validator = new ItemsValidator();
         PathToSchemasMap pathToSchemas = validator.validate(
+                SchemaValidator.class,
                 1,
                 StringSchema.class,
-                SchemaValidator.class,
                 validationMetadata,
                 null
         );
@@ -85,9 +85,9 @@ public class ItemsValidatorTest {
         FrozenList<Object> arg = new FrozenList<>(mutableList);
         final ItemsValidator validator = new ItemsValidator();
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                SchemaValidator.class,
                 arg,
                 StringSchema.class,
-                SchemaValidator.class,
                 validationMetadata,
                 null
         ));

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/PropertiesValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/PropertiesValidatorTest.java
@@ -38,9 +38,9 @@ public class PropertiesValidatorTest {
         PathToSchemasMap pathToSchemas = validator.validate(
                 arg,
                 properties,
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         List<Object> expectedPathToItem = new ArrayList<>();
         expectedPathToItem.add("args[0]");
@@ -70,9 +70,9 @@ public class PropertiesValidatorTest {
         PathToSchemasMap pathToSchemas = validator.validate(
                 1,
                 properties,
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemas);
     }
@@ -97,9 +97,9 @@ public class PropertiesValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 arg,
                 properties,
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         ));
     }
 }

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/PropertiesValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/PropertiesValidatorTest.java
@@ -36,9 +36,9 @@ public class PropertiesValidatorTest {
         mutableMap.put("someString", "abc");
         FrozenMap<String, Object> arg = new FrozenMap<>(mutableMap);
         PathToSchemasMap pathToSchemas = validator.validate(
+                SchemaValidator.class,
                 arg,
                 properties,
-                SchemaValidator.class,
                 validationMetadata,
                 null
         );
@@ -68,9 +68,9 @@ public class PropertiesValidatorTest {
                 new LinkedHashSet<>()
         );
         PathToSchemasMap pathToSchemas = validator.validate(
+                SchemaValidator.class,
                 1,
                 properties,
-                SchemaValidator.class,
                 validationMetadata,
                 null
         );
@@ -95,9 +95,9 @@ public class PropertiesValidatorTest {
         mutableMap.put("someString", 1);
         FrozenMap<String, Object> arg = new FrozenMap<>(mutableMap);
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                SchemaValidator.class,
                 arg,
                 properties,
-                SchemaValidator.class,
                 validationMetadata,
                 null
         ));

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/RequiredValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/RequiredValidatorTest.java
@@ -37,9 +37,9 @@ public class RequiredValidatorTest {
         FrozenMap<String, Object> arg = new FrozenMap<>(mutableMap);
         final RequiredValidator validator = new RequiredValidator();
         PathToSchemasMap pathToSchemas = validator.validate(
+                SchemaValidator.class,
                 arg,
                 requiredProperties,
-                SchemaValidator.class,
                 validationMetadata,
                 null
         );
@@ -61,9 +61,9 @@ public class RequiredValidatorTest {
         );
         final RequiredValidator validator = new RequiredValidator();
         PathToSchemasMap pathToSchemas = validator.validate(
+                SchemaValidator.class,
                 1,
                 properties,
-                SchemaValidator.class,
                 validationMetadata,
                 null
         );
@@ -88,9 +88,9 @@ public class RequiredValidatorTest {
         FrozenMap<String, Object> arg = new FrozenMap<>(mutableMap);
         final RequiredValidator validator = new RequiredValidator();
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                SchemaValidator.class,
                 arg,
                 requiredProperties,
-                SchemaValidator.class,
                 validationMetadata,
                 null
         ));

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/RequiredValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/RequiredValidatorTest.java
@@ -39,9 +39,9 @@ public class RequiredValidatorTest {
         PathToSchemasMap pathToSchemas = validator.validate(
                 arg,
                 requiredProperties,
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemas);
     }
@@ -63,9 +63,9 @@ public class RequiredValidatorTest {
         PathToSchemasMap pathToSchemas = validator.validate(
                 1,
                 properties,
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemas);
     }
@@ -90,9 +90,9 @@ public class RequiredValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 arg,
                 requiredProperties,
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         ));
     }
 }

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/TypeValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/TypeValidatorTest.java
@@ -25,9 +25,9 @@ public class TypeValidatorTest {
                 new LinkedHashSet<>()
         );
         PathToSchemasMap pathToSchemasMap = validator.validate(
+                SchemaValidator.class,
                 "hi",
                 value,
-                SchemaValidator.class,
                 validationMetadata,
                 null
         );
@@ -46,9 +46,9 @@ public class TypeValidatorTest {
                 new LinkedHashSet<>()
         );
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                SchemaValidator.class,
                 1,
                 value,
-                SchemaValidator.class,
                 validationMetadata,
                 null
         ));

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/TypeValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validators/TypeValidatorTest.java
@@ -27,9 +27,9 @@ public class TypeValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 "hi",
                 value,
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -48,9 +48,9 @@ public class TypeValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 1,
                 value,
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         ));
     }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/SchemaValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/SchemaValidator.hbs
@@ -57,17 +57,17 @@ public interface SchemaValidator {
         Class<SchemaValidator> castSchemaCls = (Class<SchemaValidator>) schemaCls;
         for (Map.Entry<String, Object> entry: fieldsToValues.entrySet()) {
             String jsonKeyword = entry.getKey();
-            Object value = entry.getValue();
+            Object constraint = entry.getValue();
             if (jsonKeyword.equals("additionalProperties") && fieldsToValues.containsKey("properties")) {
                 extra = fieldsToValues.get("properties");
             }
             KeywordValidator validatorClass = keywordToValidator.get(jsonKeyword);
             PathToSchemasMap otherPathToSchemas = validatorClass.validate(
                     arg,
-                    value,
-                    extra,
+                    constraint,
                     castSchemaCls,
-                    validationMetadata
+                    validationMetadata,
+                    extra
             );
             if (otherPathToSchemas == null) {
                 continue;

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/SchemaValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/SchemaValidator.hbs
@@ -63,9 +63,9 @@ public interface SchemaValidator {
             }
             KeywordValidator validatorClass = keywordToValidator.get(jsonKeyword);
             PathToSchemasMap otherPathToSchemas = validatorClass.validate(
+                    castSchemaCls,
                     arg,
                     constraint,
-                    castSchemaCls,
                     validationMetadata,
                     extra
             );

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/AdditionalPropertiesValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/AdditionalPropertiesValidator.hbs
@@ -14,12 +14,12 @@ import java.util.Set;
 
 public class AdditionalPropertiesValidator implements KeywordValidator {
     @Override
-    public PathToSchemasMap validate(Object arg, Object value, Object extra, Class<SchemaValidator> cls, ValidationMetadata validationMetadata) {
+    public PathToSchemasMap validate(Object arg, Object constraint, Class<SchemaValidator> cls, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Map)) {
             return null;
         }
         Map<String, Object> castArg = (Map<String, Object>) arg;
-        Class<Schema> addPropSchema = (Class<Schema>) value;
+        Class<Schema> addPropSchema = (Class<Schema>) constraint;
         Map<String, Class<Schema>> properties = (Map<String, Class<Schema>>) extra;
         if (properties == null) {
             properties = new LinkedHashMap<>();

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/AdditionalPropertiesValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/AdditionalPropertiesValidator.hbs
@@ -14,7 +14,7 @@ import java.util.Set;
 
 public class AdditionalPropertiesValidator implements KeywordValidator {
     @Override
-    public PathToSchemasMap validate(Object arg, Object constraint, Class<SchemaValidator> cls, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(Class<SchemaValidator> cls, Object arg, Object constraint, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Map)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/FormatValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/FormatValidator.hbs
@@ -107,8 +107,8 @@ public class FormatValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Object arg, Object value, Object extra, Class<SchemaValidator> cls, ValidationMetadata validationMetadata) {
-        String format = (String) value;
+    public PathToSchemasMap validate(Object arg, Object constraint, Class<SchemaValidator> cls, ValidationMetadata validationMetadata, Object extra) {
+        String format = (String) constraint;
         if (arg instanceof BigDecimal) {
             validateNumericFormat(
                 (BigDecimal) arg,

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/FormatValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/FormatValidator.hbs
@@ -6,52 +6,78 @@ import {{{packageName}}}.schemas.SchemaValidator;
 import {{{packageName}}}.schemas.ValidationMetadata;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.time.format.DateTimeParseException;
 import java.util.UUID;
 
 public class FormatValidator implements KeywordValidator {
-    private final static BigDecimal int32InclusiveMinimum = BigDecimal.valueOf(-2147483648);
-    private final static BigDecimal int32InclusiveMaximum = BigDecimal.valueOf(2147483647);
-    private final static BigDecimal int64InclusiveMinimum = BigDecimal.valueOf(-9223372036854775808L);
-    private final static BigDecimal int64InclusiveMaximum = BigDecimal.valueOf(9223372036854775807L);
+    private final static BigInteger int32InclusiveMinimum = BigInteger.valueOf(-2147483648L);
+    private final static BigInteger int32InclusiveMaximum = BigInteger.valueOf(2147483647L);
+    private final static BigInteger int64InclusiveMinimum = BigInteger.valueOf(-9223372036854775808L);
+    private final static BigInteger int64InclusiveMaximum = BigInteger.valueOf(9223372036854775807L);
     private final static BigDecimal floatInclusiveMinimum = BigDecimal.valueOf(-3.4028234663852886e+38);
     private final static BigDecimal floatInclusiveMaximum = BigDecimal.valueOf(3.4028234663852886e+38);
     private final static BigDecimal doubleInclusiveMinimum = BigDecimal.valueOf(-1.7976931348623157E+308d);
     private final static BigDecimal doubleInclusiveMaximum = BigDecimal.valueOf(1.7976931348623157E+308d);
 
-    private Void validateNumericFormat(BigDecimal arg, String format, ValidationMetadata validationMetadata) {
+    private Void validateNumericFormat(Number arg, String format, ValidationMetadata validationMetadata) {
         if (format.startsWith("int")) {
             // there is a json schema test where 1.0 validates as an integer
-            if (arg.stripTrailingZeros().scale() > 0) {
-                throw new RuntimeException(
-                        "Invalid non-integer value " + arg + " for format " + format + " at " + validationMetadata.pathToItem()
-                );
+            BigInteger intArg;
+            if (arg instanceof Float || arg instanceof Double) {
+                Double doubleArg = (Double) arg;
+                if (Math.floor((Double) arg) != doubleArg) {
+                    throw new RuntimeException(
+                            "Invalid non-integer value " + arg + " for format " + format + " at " + validationMetadata.pathToItem()
+                    );
+                }
+                if (arg instanceof Float) {
+                    Integer smallInt = Math.round((Float) arg);
+                    intArg = BigInteger.valueOf(smallInt.longValue());
+                } else {
+                    intArg = BigInteger.valueOf(Math.round((Double) arg));
+                }
+            } else if (arg instanceof Integer) {
+                intArg = BigInteger.valueOf(arg.longValue());
+            } else if (arg instanceof Long) {
+                intArg = BigInteger.valueOf((Long) arg);
+            } else {
+                intArg = (BigInteger) arg;
             }
             if (format.equals("int32")) {
-                if (arg.compareTo(int32InclusiveMinimum) < 0  || arg.compareTo(int32InclusiveMaximum) > 0 ){
+                if (intArg.compareTo(int32InclusiveMinimum) < 0 || intArg.compareTo(int32InclusiveMaximum) > 0) {
                     throw new RuntimeException(
-                        "Invalid value "+arg+" for format int32 at "+validationMetadata.pathToItem()
+                            "Invalid value " + arg + " for format int32 at " + validationMetadata.pathToItem()
                     );
                 }
                 return null;
             } else if (format.equals("int64")) {
-                if (arg.compareTo(int64InclusiveMinimum) < 0  || arg.compareTo(int64InclusiveMaximum) > 0 ){
+                if (intArg.compareTo(int64InclusiveMinimum) < 0 || intArg.compareTo(int64InclusiveMaximum) > 0) {
                     throw new RuntimeException(
-                        "Invalid value "+arg+" for format int64 at "+validationMetadata.pathToItem()
+                            "Invalid value " + arg + " for format int64 at " + validationMetadata.pathToItem()
                     );
                 }
                 return null;
             }
             return null;
-        } else if (format.equals("float")) {
-            if (arg.compareTo(floatInclusiveMinimum) < 0  || arg.compareTo(floatInclusiveMaximum) > 0 ){
+        }
+        BigDecimal decimalArg;
+        if (arg instanceof Float) {
+            decimalArg = new BigDecimal((Float) arg);
+        } else if (arg instanceof Double) {
+            decimalArg = BigDecimal.valueOf((Double) arg);
+        } else {
+            decimalArg = (BigDecimal) arg;
+        }
+        if (format.equals("float")) {
+            if (decimalArg.compareTo(floatInclusiveMinimum) < 0  || decimalArg.compareTo(floatInclusiveMaximum) > 0 ){
                 throw new RuntimeException(
                     "Invalid value "+arg+" for format float at "+validationMetadata.pathToItem()
                 );
             }
             return null;
         } else if (format.equals("double")) {
-            if (arg.compareTo(doubleInclusiveMinimum) < 0  || arg.compareTo(doubleInclusiveMaximum) > 0 ){
+            if (decimalArg.compareTo(doubleInclusiveMinimum) < 0  || decimalArg.compareTo(doubleInclusiveMaximum) > 0 ){
                 throw new RuntimeException(
                     "Invalid value "+arg+" for format double at "+validationMetadata.pathToItem()
                 );
@@ -107,11 +133,11 @@ public class FormatValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Object arg, Object constraint, Class<SchemaValidator> cls, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(Class<SchemaValidator> cls, Object arg, Object constraint, ValidationMetadata validationMetadata, Object extra) {
         String format = (String) constraint;
-        if (arg instanceof BigDecimal) {
+        if (arg instanceof Number) {
             validateNumericFormat(
-                (BigDecimal) arg,
+                (Number) arg,
                 format,
                 validationMetadata
             );

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/ItemsValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/ItemsValidator.hbs
@@ -10,12 +10,12 @@ import java.util.List;
 
 public class ItemsValidator implements KeywordValidator {
     @Override
-    public PathToSchemasMap validate(Object arg, Object value, Object extra, Class<SchemaValidator> cls, ValidationMetadata validationMetadata) {
+    public PathToSchemasMap validate(Object arg, Object constraint, Class<SchemaValidator> cls, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof List)) {
             return null;
         }
         List<Object> castArg = (List<Object>) arg;
-        Class<Schema> itemsSchema = (Class<Schema>) value;
+        Class<Schema> itemsSchema = (Class<Schema>) constraint;
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         // todo add handling for prefixItems
         int i = 0;

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/ItemsValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/ItemsValidator.hbs
@@ -10,7 +10,7 @@ import java.util.List;
 
 public class ItemsValidator implements KeywordValidator {
     @Override
-    public PathToSchemasMap validate(Object arg, Object constraint, Class<SchemaValidator> cls, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(Class<SchemaValidator> cls, Object arg, Object constraint, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof List)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/KeywordValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/KeywordValidator.hbs
@@ -7,8 +7,8 @@ import {{{packageName}}}.schemas.ValidationMetadata;
 public interface KeywordValidator {
     PathToSchemasMap validate(
             Object arg,
-            Object value,
-            Object extra,
+            Object constraint,
             Class<SchemaValidator> cls,
-            ValidationMetadata validationMetadata);
+            ValidationMetadata validationMetadata,
+            Object extra);
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/KeywordValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/KeywordValidator.hbs
@@ -6,9 +6,9 @@ import {{{packageName}}}.schemas.ValidationMetadata;
 
 public interface KeywordValidator {
     PathToSchemasMap validate(
+            Class<SchemaValidator> cls,
             Object arg,
             Object constraint,
-            Class<SchemaValidator> cls,
             ValidationMetadata validationMetadata,
             Object extra);
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/PropertiesValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/PropertiesValidator.hbs
@@ -13,7 +13,7 @@ import java.util.Set;
 
 public class PropertiesValidator implements KeywordValidator {
     @Override
-    public PathToSchemasMap validate(Object arg, Object constraint, Class<SchemaValidator> cls, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(Class<SchemaValidator> cls, Object arg, Object constraint, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Map)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/PropertiesValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/PropertiesValidator.hbs
@@ -13,13 +13,13 @@ import java.util.Set;
 
 public class PropertiesValidator implements KeywordValidator {
     @Override
-    public PathToSchemasMap validate(Object arg, Object value, Object extra, Class<SchemaValidator> cls, ValidationMetadata validationMetadata) {
+    public PathToSchemasMap validate(Object arg, Object constraint, Class<SchemaValidator> cls, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Map)) {
             return null;
         }
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         Map<String, Object> castArg = (Map<String, Object>) arg;
-        Map<String, Class<Schema>> properties = (Map<String, Class<Schema>>) value;
+        Map<String, Class<Schema>> properties = (Map<String, Class<Schema>>) constraint;
         Set<String> presentProperties = new LinkedHashSet<>(castArg.keySet());
         presentProperties.retainAll(properties.keySet());
         for(String propName: presentProperties) {

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/RequiredValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/RequiredValidator.hbs
@@ -11,12 +11,12 @@ import java.util.Set;
 
 public class RequiredValidator implements KeywordValidator {
     @Override
-    public PathToSchemasMap validate(Object arg, Object value, Object extra, Class<SchemaValidator> cls, ValidationMetadata validationMetadata) {
+    public PathToSchemasMap validate(Object arg, Object constraint, Class<SchemaValidator> cls, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Map)) {
             return null;
         }
         Map<String, Object> castArg = (Map<String, Object>) arg;
-        Set<String> requiredProperties = (Set<String>) value;
+        Set<String> requiredProperties = (Set<String>) constraint;
         Set<String> missingRequiredProperties = new HashSet<>(requiredProperties);
         missingRequiredProperties.removeAll(castArg.keySet());
         if (!missingRequiredProperties.isEmpty()) {

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/RequiredValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/RequiredValidator.hbs
@@ -11,7 +11,7 @@ import java.util.Set;
 
 public class RequiredValidator implements KeywordValidator {
     @Override
-    public PathToSchemasMap validate(Object arg, Object constraint, Class<SchemaValidator> cls, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(Class<SchemaValidator> cls, Object arg, Object constraint, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Map)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/TypeValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/TypeValidator.hbs
@@ -8,7 +8,7 @@ import java.util.HashSet;
 
 public class TypeValidator implements KeywordValidator {
     @Override
-    public PathToSchemasMap validate(Object arg, Object constraint, Class<SchemaValidator> cls, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(Class<SchemaValidator> cls, Object arg, Object constraint, ValidationMetadata validationMetadata, Object extra) {
         HashSet<Class<?>> types = (HashSet<Class<?>>) constraint;
         Class<?> argClass;
         if (arg == null) {

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/TypeValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/TypeValidator.hbs
@@ -8,8 +8,8 @@ import java.util.HashSet;
 
 public class TypeValidator implements KeywordValidator {
     @Override
-    public PathToSchemasMap validate(Object arg, Object value, Object extra, Class<SchemaValidator> cls, ValidationMetadata validationMetadata) {
-        HashSet<Class<?>> types = (HashSet<Class<?>>) value;
+    public PathToSchemasMap validate(Object arg, Object constraint, Class<SchemaValidator> cls, ValidationMetadata validationMetadata, Object extra) {
+        HashSet<Class<?>> types = (HashSet<Class<?>>) constraint;
         Class<?> argClass;
         if (arg == null) {
             argClass = Void.class;

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/AdditionalPropertiesValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/AdditionalPropertiesValidatorTest.hbs
@@ -37,9 +37,9 @@ public class AdditionalPropertiesValidatorTest {
         FrozenMap<String, Object> arg = new FrozenMap<>(mutableMap);
         final AdditionalPropertiesValidator validator = new AdditionalPropertiesValidator();
         PathToSchemasMap pathToSchemas = validator.validate(
+                SchemaValidator.class,
                 arg,
                 StringSchema.class,
-                SchemaValidator.class,
                 validationMetadata,
                 properties
         );
@@ -66,9 +66,9 @@ public class AdditionalPropertiesValidatorTest {
         );
         final AdditionalPropertiesValidator validator = new AdditionalPropertiesValidator();
         PathToSchemasMap pathToSchemas = validator.validate(
+                SchemaValidator.class,
                 1,
                 StringSchema.class,
-                SchemaValidator.class,
                 validationMetadata,
                 null
         );
@@ -94,9 +94,9 @@ public class AdditionalPropertiesValidatorTest {
         FrozenMap<String, Object> arg = new FrozenMap<>(mutableMap);
         final AdditionalPropertiesValidator validator = new AdditionalPropertiesValidator();
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                SchemaValidator.class,
                 arg,
                 StringSchema.class,
-                SchemaValidator.class,
                 validationMetadata,
                 properties
         ));

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/AdditionalPropertiesValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/AdditionalPropertiesValidatorTest.hbs
@@ -39,9 +39,9 @@ public class AdditionalPropertiesValidatorTest {
         PathToSchemasMap pathToSchemas = validator.validate(
                 arg,
                 StringSchema.class,
-                properties,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                properties
         );
         List<Object> expectedPathToItem = new ArrayList<>();
         expectedPathToItem.add("args[0]");
@@ -68,9 +68,9 @@ public class AdditionalPropertiesValidatorTest {
         PathToSchemasMap pathToSchemas = validator.validate(
                 1,
                 StringSchema.class,
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemas);
     }
@@ -96,9 +96,9 @@ public class AdditionalPropertiesValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 arg,
                 StringSchema.class,
-                properties,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                properties
         ));
     }
 }

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/FormatValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/FormatValidatorTest.hbs
@@ -27,9 +27,9 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 new BigDecimal("1.0"),
                 "int",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -40,9 +40,9 @@ public class FormatValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 new BigDecimal("3.14"),
                 "int",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         ));
     }
 
@@ -52,9 +52,9 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 new BigDecimal("1"),
                 "int",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -65,9 +65,9 @@ public class FormatValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 new BigDecimal(-2147483649L),
                 "int32",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         ));
     }
 
@@ -77,9 +77,9 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 new BigDecimal(-2147483648),
                 "int32",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -90,9 +90,9 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 new BigDecimal(2147483647),
                 "int32",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -103,9 +103,9 @@ public class FormatValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 BigDecimal.valueOf(2147483648L),
                 "int32",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         ));
     }
 
@@ -116,9 +116,9 @@ public class FormatValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 new BigDecimal(new BigInteger("-9223372036854775809")),
                 "int64",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         ));
     }
 
@@ -128,9 +128,9 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 new BigDecimal(-9223372036854775808L),
                 "int64",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -141,9 +141,9 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 new BigDecimal(9223372036854775807L),
                 "int64",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -155,9 +155,9 @@ public class FormatValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 new BigDecimal(new BigInteger("9223372036854775808")),
                 "int64",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         ));
     }
 
@@ -167,9 +167,9 @@ public class FormatValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 BigDecimal.valueOf(-3.402823466385289e+38),
                 "float",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         ));
     }
 
@@ -179,9 +179,9 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 BigDecimal.valueOf(-3.4028234663852886e+38),
                 "float",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -192,9 +192,9 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 new BigDecimal("3.4028234663852886e+38"),
                 "float",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -205,9 +205,9 @@ public class FormatValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 BigDecimal.valueOf(3.402823466385289e+38),
                 "float",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         ));
     }
 
@@ -217,9 +217,9 @@ public class FormatValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 new BigDecimal("-1.7976931348623157082e+308"),
                 "double",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         ));
     }
 
@@ -229,9 +229,9 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 BigDecimal.valueOf(-1.7976931348623157E+308d),
                 "double",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -242,9 +242,9 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 BigDecimal.valueOf(1.7976931348623157E+308d),
                 "double",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -255,9 +255,9 @@ public class FormatValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 new BigDecimal("1.7976931348623157082e+308"),
                 "double",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         ));
     }
 
@@ -267,9 +267,9 @@ public class FormatValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 "abc",
                 "number",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         ));
     }
 
@@ -279,9 +279,9 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 "3.14",
                 "number",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -292,9 +292,9 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 "1",
                 "number",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -305,9 +305,9 @@ public class FormatValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 "abc",
                 "date",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         ));
     }
 
@@ -317,9 +317,9 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 "2017-01-20",
                 "date",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -330,9 +330,9 @@ public class FormatValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 "abc",
                 "date-time",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         ));
     }
 
@@ -342,9 +342,9 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 "2017-07-21T17:32:28Z",
                 "date-time",
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemasMap);
     }

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/FormatValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/FormatValidatorTest.hbs
@@ -25,9 +25,9 @@ public class FormatValidatorTest {
     public void testIntFormatSucceedsWithFloat() {
         final FormatValidator validator = new FormatValidator();
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                new BigDecimal("1.0"),
-                "int",
                 SchemaValidator.class,
+                1.0f,
+                "int",
                 validationMetadata,
                 null
         );
@@ -38,9 +38,9 @@ public class FormatValidatorTest {
     public void testIntFormatFailsWithFloat() {
         final FormatValidator validator = new FormatValidator();
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
-                new BigDecimal("3.14"),
-                "int",
                 SchemaValidator.class,
+                3.14f,
+                "int",
                 validationMetadata,
                 null
         ));
@@ -50,9 +50,9 @@ public class FormatValidatorTest {
     public void testIntFormatSucceedsWithInt() {
         final FormatValidator validator = new FormatValidator();
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                new BigDecimal("1"),
-                "int",
                 SchemaValidator.class,
+                1,
+                "int",
                 validationMetadata,
                 null
         );
@@ -63,9 +63,9 @@ public class FormatValidatorTest {
     public void testInt32UnderMinFails() {
         final FormatValidator validator = new FormatValidator();
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
-                new BigDecimal(-2147483649L),
-                "int32",
                 SchemaValidator.class,
+                -2147483649L,
+                "int32",
                 validationMetadata,
                 null
         ));
@@ -75,9 +75,9 @@ public class FormatValidatorTest {
     public void testInt32InclusiveMinSucceeds() {
         final FormatValidator validator = new FormatValidator();
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                new BigDecimal(-2147483648),
-                "int32",
                 SchemaValidator.class,
+                -2147483648,
+                "int32",
                 validationMetadata,
                 null
         );
@@ -88,9 +88,9 @@ public class FormatValidatorTest {
     public void testInt32InclusiveMaxSucceeds() {
         final FormatValidator validator = new FormatValidator();
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                new BigDecimal(2147483647),
-                "int32",
                 SchemaValidator.class,
+                2147483647,
+                "int32",
                 validationMetadata,
                 null
         );
@@ -101,9 +101,9 @@ public class FormatValidatorTest {
     public void testInt32OverMaxFails() {
         final FormatValidator validator = new FormatValidator();
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
-                BigDecimal.valueOf(2147483648L),
-                "int32",
                 SchemaValidator.class,
+                2147483648L,
+                "int32",
                 validationMetadata,
                 null
         ));
@@ -114,9 +114,9 @@ public class FormatValidatorTest {
         final FormatValidator validator = new FormatValidator();
 
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
-                new BigDecimal(new BigInteger("-9223372036854775809")),
-                "int64",
                 SchemaValidator.class,
+                new BigInteger("-9223372036854775809"),
+                "int64",
                 validationMetadata,
                 null
         ));
@@ -126,9 +126,9 @@ public class FormatValidatorTest {
     public void testInt64InclusiveMinSucceeds() {
         final FormatValidator validator = new FormatValidator();
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                new BigDecimal(-9223372036854775808L),
-                "int64",
                 SchemaValidator.class,
+                -9223372036854775808L,
+                "int64",
                 validationMetadata,
                 null
         );
@@ -139,9 +139,9 @@ public class FormatValidatorTest {
     public void testInt64InclusiveMaxSucceeds() {
         final FormatValidator validator = new FormatValidator();
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                new BigDecimal(9223372036854775807L),
-                "int64",
                 SchemaValidator.class,
+                9223372036854775807L,
+                "int64",
                 validationMetadata,
                 null
         );
@@ -153,9 +153,9 @@ public class FormatValidatorTest {
         final FormatValidator validator = new FormatValidator();
 
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
-                new BigDecimal(new BigInteger("9223372036854775808")),
-                "int64",
                 SchemaValidator.class,
+                new BigInteger("9223372036854775808"),
+                "int64",
                 validationMetadata,
                 null
         ));
@@ -165,9 +165,9 @@ public class FormatValidatorTest {
     public void testFloatUnderMinFails() {
         final FormatValidator validator = new FormatValidator();
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
-                BigDecimal.valueOf(-3.402823466385289e+38),
-                "float",
                 SchemaValidator.class,
+                -3.402823466385289e+38d,
+                "float",
                 validationMetadata,
                 null
         ));
@@ -177,9 +177,9 @@ public class FormatValidatorTest {
     public void testFloatInclusiveMinSucceeds() {
         final FormatValidator validator = new FormatValidator();
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                BigDecimal.valueOf(-3.4028234663852886e+38),
-                "float",
                 SchemaValidator.class,
+                -3.4028234663852886e+38f,
+                "float",
                 validationMetadata,
                 null
         );
@@ -190,9 +190,9 @@ public class FormatValidatorTest {
     public void testFloatInclusiveMaxSucceeds() {
         final FormatValidator validator = new FormatValidator();
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                new BigDecimal("3.4028234663852886e+38"),
-                "float",
                 SchemaValidator.class,
+                3.4028234663852886e+38f,
+                "float",
                 validationMetadata,
                 null
         );
@@ -203,9 +203,9 @@ public class FormatValidatorTest {
     public void testFloatOverMaxFails() {
         final FormatValidator validator = new FormatValidator();
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
-                BigDecimal.valueOf(3.402823466385289e+38),
-                "float",
                 SchemaValidator.class,
+                3.402823466385289e+38d,
+                "float",
                 validationMetadata,
                 null
         ));
@@ -215,9 +215,9 @@ public class FormatValidatorTest {
     public void testDoubleUnderMinFails() {
         final FormatValidator validator = new FormatValidator();
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                SchemaValidator.class,
                 new BigDecimal("-1.7976931348623157082e+308"),
                 "double",
-                SchemaValidator.class,
                 validationMetadata,
                 null
         ));
@@ -227,9 +227,9 @@ public class FormatValidatorTest {
     public void testDoubleInclusiveMinSucceeds() {
         final FormatValidator validator = new FormatValidator();
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                BigDecimal.valueOf(-1.7976931348623157E+308d),
-                "double",
                 SchemaValidator.class,
+                -1.7976931348623157E+308d,
+                "double",
                 validationMetadata,
                 null
         );
@@ -240,9 +240,9 @@ public class FormatValidatorTest {
     public void testDoubleInclusiveMaxSucceeds() {
         final FormatValidator validator = new FormatValidator();
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                BigDecimal.valueOf(1.7976931348623157E+308d),
-                "double",
                 SchemaValidator.class,
+                1.7976931348623157E+308d,
+                "double",
                 validationMetadata,
                 null
         );
@@ -253,9 +253,9 @@ public class FormatValidatorTest {
     public void testDoubleOverMaxFails() {
         final FormatValidator validator = new FormatValidator();
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                SchemaValidator.class,
                 new BigDecimal("1.7976931348623157082e+308"),
                 "double",
-                SchemaValidator.class,
                 validationMetadata,
                 null
         ));
@@ -265,9 +265,9 @@ public class FormatValidatorTest {
     public void testInvalidNumberStringFails() {
         final FormatValidator validator = new FormatValidator();
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                SchemaValidator.class,
                 "abc",
                 "number",
-                SchemaValidator.class,
                 validationMetadata,
                 null
         ));
@@ -277,9 +277,9 @@ public class FormatValidatorTest {
     public void testValidFloatNumberStringSucceeds() {
         final FormatValidator validator = new FormatValidator();
         PathToSchemasMap pathToSchemasMap = validator.validate(
+                SchemaValidator.class,
                 "3.14",
                 "number",
-                SchemaValidator.class,
                 validationMetadata,
                 null
         );
@@ -290,9 +290,9 @@ public class FormatValidatorTest {
     public void testValidIntNumberStringSucceeds() {
         final FormatValidator validator = new FormatValidator();
         PathToSchemasMap pathToSchemasMap = validator.validate(
+                SchemaValidator.class,
                 "1",
                 "number",
-                SchemaValidator.class,
                 validationMetadata,
                 null
         );
@@ -303,9 +303,9 @@ public class FormatValidatorTest {
     public void testInvalidDateStringFails() {
         final FormatValidator validator = new FormatValidator();
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                SchemaValidator.class,
                 "abc",
                 "date",
-                SchemaValidator.class,
                 validationMetadata,
                 null
         ));
@@ -315,9 +315,9 @@ public class FormatValidatorTest {
     public void testValidDateStringSucceeds() {
         final FormatValidator validator = new FormatValidator();
         PathToSchemasMap pathToSchemasMap = validator.validate(
+                SchemaValidator.class,
                 "2017-01-20",
                 "date",
-                SchemaValidator.class,
                 validationMetadata,
                 null
         );
@@ -328,9 +328,9 @@ public class FormatValidatorTest {
     public void testInvalidDateTimeStringFails() {
         final FormatValidator validator = new FormatValidator();
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                SchemaValidator.class,
                 "abc",
                 "date-time",
-                SchemaValidator.class,
                 validationMetadata,
                 null
         ));
@@ -340,9 +340,9 @@ public class FormatValidatorTest {
     public void testValidDateTimeStringSucceeds() {
         final FormatValidator validator = new FormatValidator();
         PathToSchemasMap pathToSchemasMap = validator.validate(
+                SchemaValidator.class,
                 "2017-07-21T17:32:28Z",
                 "date-time",
-                SchemaValidator.class,
                 validationMetadata,
                 null
         );

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/ItemsValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/ItemsValidatorTest.hbs
@@ -34,9 +34,9 @@ public class ItemsValidatorTest {
         PathToSchemasMap pathToSchemas = validator.validate(
                 arg,
                 StringSchema.class,
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         List<Object> expectedPathToItem = new ArrayList<>();
         expectedPathToItem.add("args[0]");
@@ -63,9 +63,9 @@ public class ItemsValidatorTest {
         PathToSchemasMap pathToSchemas = validator.validate(
                 1,
                 StringSchema.class,
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemas);
     }
@@ -87,9 +87,9 @@ public class ItemsValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 arg,
                 StringSchema.class,
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         ));
     }
 }

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/ItemsValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/ItemsValidatorTest.hbs
@@ -32,9 +32,9 @@ public class ItemsValidatorTest {
         FrozenList<Object> arg = new FrozenList<>(mutableList);
         final ItemsValidator validator = new ItemsValidator();
         PathToSchemasMap pathToSchemas = validator.validate(
+                SchemaValidator.class,
                 arg,
                 StringSchema.class,
-                SchemaValidator.class,
                 validationMetadata,
                 null
         );
@@ -61,9 +61,9 @@ public class ItemsValidatorTest {
         );
         final ItemsValidator validator = new ItemsValidator();
         PathToSchemasMap pathToSchemas = validator.validate(
+                SchemaValidator.class,
                 1,
                 StringSchema.class,
-                SchemaValidator.class,
                 validationMetadata,
                 null
         );
@@ -85,9 +85,9 @@ public class ItemsValidatorTest {
         FrozenList<Object> arg = new FrozenList<>(mutableList);
         final ItemsValidator validator = new ItemsValidator();
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                SchemaValidator.class,
                 arg,
                 StringSchema.class,
-                SchemaValidator.class,
                 validationMetadata,
                 null
         ));

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/PropertiesValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/PropertiesValidatorTest.hbs
@@ -38,9 +38,9 @@ public class PropertiesValidatorTest {
         PathToSchemasMap pathToSchemas = validator.validate(
                 arg,
                 properties,
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         List<Object> expectedPathToItem = new ArrayList<>();
         expectedPathToItem.add("args[0]");
@@ -70,9 +70,9 @@ public class PropertiesValidatorTest {
         PathToSchemasMap pathToSchemas = validator.validate(
                 1,
                 properties,
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemas);
     }
@@ -97,9 +97,9 @@ public class PropertiesValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 arg,
                 properties,
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         ));
     }
 }

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/PropertiesValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/PropertiesValidatorTest.hbs
@@ -36,9 +36,9 @@ public class PropertiesValidatorTest {
         mutableMap.put("someString", "abc");
         FrozenMap<String, Object> arg = new FrozenMap<>(mutableMap);
         PathToSchemasMap pathToSchemas = validator.validate(
+                SchemaValidator.class,
                 arg,
                 properties,
-                SchemaValidator.class,
                 validationMetadata,
                 null
         );
@@ -68,9 +68,9 @@ public class PropertiesValidatorTest {
                 new LinkedHashSet<>()
         );
         PathToSchemasMap pathToSchemas = validator.validate(
+                SchemaValidator.class,
                 1,
                 properties,
-                SchemaValidator.class,
                 validationMetadata,
                 null
         );
@@ -95,9 +95,9 @@ public class PropertiesValidatorTest {
         mutableMap.put("someString", 1);
         FrozenMap<String, Object> arg = new FrozenMap<>(mutableMap);
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                SchemaValidator.class,
                 arg,
                 properties,
-                SchemaValidator.class,
                 validationMetadata,
                 null
         ));

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/RequiredValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/RequiredValidatorTest.hbs
@@ -37,9 +37,9 @@ public class RequiredValidatorTest {
         FrozenMap<String, Object> arg = new FrozenMap<>(mutableMap);
         final RequiredValidator validator = new RequiredValidator();
         PathToSchemasMap pathToSchemas = validator.validate(
+                SchemaValidator.class,
                 arg,
                 requiredProperties,
-                SchemaValidator.class,
                 validationMetadata,
                 null
         );
@@ -61,9 +61,9 @@ public class RequiredValidatorTest {
         );
         final RequiredValidator validator = new RequiredValidator();
         PathToSchemasMap pathToSchemas = validator.validate(
+                SchemaValidator.class,
                 1,
                 properties,
-                SchemaValidator.class,
                 validationMetadata,
                 null
         );
@@ -88,9 +88,9 @@ public class RequiredValidatorTest {
         FrozenMap<String, Object> arg = new FrozenMap<>(mutableMap);
         final RequiredValidator validator = new RequiredValidator();
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                SchemaValidator.class,
                 arg,
                 requiredProperties,
-                SchemaValidator.class,
                 validationMetadata,
                 null
         ));

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/RequiredValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/RequiredValidatorTest.hbs
@@ -39,9 +39,9 @@ public class RequiredValidatorTest {
         PathToSchemasMap pathToSchemas = validator.validate(
                 arg,
                 requiredProperties,
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemas);
     }
@@ -63,9 +63,9 @@ public class RequiredValidatorTest {
         PathToSchemasMap pathToSchemas = validator.validate(
                 1,
                 properties,
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemas);
     }
@@ -90,9 +90,9 @@ public class RequiredValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 arg,
                 requiredProperties,
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         ));
     }
 }

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/TypeValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/TypeValidatorTest.hbs
@@ -25,9 +25,9 @@ public class TypeValidatorTest {
                 new LinkedHashSet<>()
         );
         PathToSchemasMap pathToSchemasMap = validator.validate(
+                SchemaValidator.class,
                 "hi",
                 value,
-                SchemaValidator.class,
                 validationMetadata,
                 null
         );
@@ -46,9 +46,9 @@ public class TypeValidatorTest {
                 new LinkedHashSet<>()
         );
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+                SchemaValidator.class,
                 1,
                 value,
-                SchemaValidator.class,
                 validationMetadata,
                 null
         ));

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/TypeValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/validators/TypeValidatorTest.hbs
@@ -27,9 +27,9 @@ public class TypeValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 "hi",
                 value,
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -48,9 +48,9 @@ public class TypeValidatorTest {
         Assert.assertThrows(RuntimeException.class, () -> validator.validate(
                 1,
                 value,
-                null,
                 SchemaValidator.class,
-                validationMetadata
+                validationMetadata,
+                null
         ));
     }
 }


### PR DESCRIPTION
Java, adjusts schema validator argument order
Also fixes format numeric input, makes it a Number

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
