### PR TITLE
Java, adds output class instantiation for Map and List use cases

### DIFF
--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Schema.java
@@ -172,14 +172,10 @@ public interface Schema extends SchemaValidator {
          if (typeToOutputClass == null) {
             return usedArg;
          }
-         Class<?> outputClass = typeToOutputClass.get(argType);
-         if (outputClass == null) {
-            return usedArg;
-         }
          try {
-             return outputClass.getConstructor(Collection.class).newInstance(usedArg);
-         } catch (NoSuchMethodException | InvocationTargetException | InstantiationException | IllegalAccessException e) {
-             throw new RuntimeException(e);
+             return cls.getMethod("getListOutputInstance", FrozenList.class).invoke(usedArg);
+         } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+             return usedArg;
          }
       }
       return null;

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/FormatValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validators/FormatValidator.java
@@ -25,8 +25,13 @@ public class FormatValidator implements KeywordValidator {
             // there is a json schema test where 1.0 validates as an integer
             BigInteger intArg;
             if (arg instanceof Float || arg instanceof Double) {
-                Double doubleArg = (Double) arg;
-                if (Math.floor((Double) arg) != doubleArg) {
+                Double doubleArg;
+                if (arg instanceof Float) {
+                    doubleArg = arg.doubleValue();
+                } else {
+                    doubleArg = (Double) arg;
+                }
+                if (Math.floor(doubleArg) != doubleArg) {
                     throw new RuntimeException(
                             "Invalid non-integer value " + arg + " for format " + format + " at " + validationMetadata.pathToItem()
                     );

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/ArrayTypeSchemaTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/ArrayTypeSchemaTest.java
@@ -28,8 +28,12 @@ record ArrayWithItemsSchema(LinkedHashSet<Class<?>> type, Class<?> items) implem
 }
 
 class ArrayWithOutputClsSchemaList extends FrozenList<String> {
-    public ArrayWithOutputClsSchemaList(Collection<? extends String> m) {
-            super(m);
+    ArrayWithOutputClsSchemaList(FrozenList<? extends String> m) {
+        super(m);
+    }
+
+    public static ArrayWithOutputClsSchemaList of(List<Object> arg, SchemaConfiguration configuration) {
+        return ArrayWithOutputClsSchema.validate(arg, configuration);
     }
 }
 
@@ -43,10 +47,8 @@ record ArrayWithOutputClsSchema(LinkedHashSet<Class<?>> type, Class<?> items) im
         return new ArrayWithOutputClsSchema(type, items);
     }
 
-    public static Map<Class<?>, Class<?>> typeToOutputClass() {
-        Map<Class<?>, Class<?>> typeToOutputClsMap = new HashMap<>();
-        typeToOutputClsMap.put(FrozenList.class, ArrayWithOutputClsSchemaList.class);
-        return typeToOutputClsMap;
+    public static ArrayWithOutputClsSchemaList getListOutputInstance(FrozenList<? extends String> arg) {
+        return new ArrayWithOutputClsSchemaList(arg);
     }
 
     public static ArrayWithOutputClsSchemaList validate(List<Object> arg, SchemaConfiguration configuration) {

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/ArrayTypeSchemaTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/ArrayTypeSchemaTest.java
@@ -6,8 +6,11 @@ import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashSet;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 record ArrayWithItemsSchema(LinkedHashSet<Class<?>> type, Class<?> items) implements Schema {
     public static ArrayWithItemsSchema withDefaults() {
@@ -21,6 +24,33 @@ record ArrayWithItemsSchema(LinkedHashSet<Class<?>> type, Class<?> items) implem
 
     public static FrozenList<Object> validate(List<Object> arg, SchemaConfiguration configuration) {
         return Schema.validate(ArrayWithItemsSchema.class, arg, configuration);
+    }
+}
+
+class ArrayWithOutputClsSchemaList extends FrozenList<String> {
+    public ArrayWithOutputClsSchemaList(Collection<? extends String> m) {
+            super(m);
+    }
+}
+
+record ArrayWithOutputClsSchema(LinkedHashSet<Class<?>> type, Class<?> items) implements Schema {
+    public static ArrayWithOutputClsSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        // can't use ImmutableList because it does not allow null values in entries
+        // can't use Collections.unmodifiableList because Collections.UnmodifiableList is not public + extensible
+        type.add(FrozenList.class);
+        Class<?> items = StringSchema.class;
+        return new ArrayWithOutputClsSchema(type, items);
+    }
+
+    public static Map<Class<?>, Class<?>> typeToOutputClass() {
+        Map<Class<?>, Class<?>> typeToOutputClsMap = new HashMap<>();
+        typeToOutputClsMap.put(FrozenList.class, ArrayWithOutputClsSchemaList.class);
+        return typeToOutputClsMap;
+    }
+
+    public static ArrayWithOutputClsSchemaList validate(List<Object> arg, SchemaConfiguration configuration) {
+        return Schema.validate(ArrayWithOutputClsSchema.class, arg, configuration);
     }
 }
 
@@ -55,6 +85,31 @@ public class ArrayTypeSchemaTest {
         inList.add(1);
         List<Object> finalInList = inList;
         Assert.assertThrows(RuntimeException.class, () -> ArrayWithItemsSchema.validate(
+                finalInList, configuration
+        ));
+    }
+
+    @Test
+    public void testValidateArrayWithOutputClsSchema() {
+        // map with only item works
+        List<Object> inList = new ArrayList<>();
+        inList.add("abc");
+        ArrayWithOutputClsSchemaList validatedValue = ArrayWithOutputClsSchema.validate(inList, configuration);
+        List<Object> outList = new ArrayList<>();
+        outList.add("abc");
+        Assert.assertEquals(validatedValue, outList);
+
+        // map with no items works
+        inList = new ArrayList<>();
+        validatedValue = ArrayWithOutputClsSchema.validate(inList, configuration);
+        outList = new ArrayList<>();
+        Assert.assertEquals(validatedValue, outList);
+
+        // invalid prop type fails
+        inList = new ArrayList<>();
+        inList.add(1);
+        List<Object> finalInList = inList;
+        Assert.assertThrows(RuntimeException.class, () -> ArrayWithOutputClsSchema.validate(
                 finalInList, configuration
         ));
     }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/Schema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/Schema.hbs
@@ -172,14 +172,10 @@ public interface Schema extends SchemaValidator {
          if (typeToOutputClass == null) {
             return usedArg;
          }
-         Class<?> outputClass = typeToOutputClass.get(argType);
-         if (outputClass == null) {
-            return usedArg;
-         }
          try {
-             return outputClass.getConstructor(Collection.class).newInstance(usedArg);
-         } catch (NoSuchMethodException | InvocationTargetException | InstantiationException | IllegalAccessException e) {
-             throw new RuntimeException(e);
+             return cls.getMethod("getListOutputInstance", FrozenList.class).invoke(usedArg);
+         } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+             return usedArg;
          }
       }
       return null;

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/FormatValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validators/FormatValidator.hbs
@@ -25,8 +25,13 @@ public class FormatValidator implements KeywordValidator {
             // there is a json schema test where 1.0 validates as an integer
             BigInteger intArg;
             if (arg instanceof Float || arg instanceof Double) {
-                Double doubleArg = (Double) arg;
-                if (Math.floor((Double) arg) != doubleArg) {
+                Double doubleArg;
+                if (arg instanceof Float) {
+                    doubleArg = arg.doubleValue();
+                } else {
+                    doubleArg = (Double) arg;
+                }
+                if (Math.floor(doubleArg) != doubleArg) {
                     throw new RuntimeException(
                             "Invalid non-integer value " + arg + " for format " + format + " at " + validationMetadata.pathToItem()
                     );

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/ArrayTypeSchemaTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/ArrayTypeSchemaTest.hbs
@@ -28,8 +28,12 @@ record ArrayWithItemsSchema(LinkedHashSet<Class<?>> type, Class<?> items) implem
 }
 
 class ArrayWithOutputClsSchemaList extends FrozenList<String> {
-    public ArrayWithOutputClsSchemaList(Collection<? extends String> m) {
-            super(m);
+    ArrayWithOutputClsSchemaList(FrozenList<? extends String> m) {
+        super(m);
+    }
+
+    public static ArrayWithOutputClsSchemaList of(List<Object> arg, SchemaConfiguration configuration) {
+        return ArrayWithOutputClsSchema.validate(arg, configuration);
     }
 }
 
@@ -43,10 +47,8 @@ record ArrayWithOutputClsSchema(LinkedHashSet<Class<?>> type, Class<?> items) im
         return new ArrayWithOutputClsSchema(type, items);
     }
 
-    public static Map<Class<?>, Class<?>> typeToOutputClass() {
-        Map<Class<?>, Class<?>> typeToOutputClsMap = new HashMap<>();
-        typeToOutputClsMap.put(FrozenList.class, ArrayWithOutputClsSchemaList.class);
-        return typeToOutputClsMap;
+    public static ArrayWithOutputClsSchemaList getListOutputInstance(FrozenList<? extends String> arg) {
+        return new ArrayWithOutputClsSchemaList(arg);
     }
 
     public static ArrayWithOutputClsSchemaList validate(List<Object> arg, SchemaConfiguration configuration) {

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/ArrayTypeSchemaTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/ArrayTypeSchemaTest.hbs
@@ -6,8 +6,11 @@ import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
 import {{{packageName}}}.configurations.SchemaConfiguration;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashSet;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 record ArrayWithItemsSchema(LinkedHashSet<Class<?>> type, Class<?> items) implements Schema {
     public static ArrayWithItemsSchema withDefaults() {
@@ -21,6 +24,33 @@ record ArrayWithItemsSchema(LinkedHashSet<Class<?>> type, Class<?> items) implem
 
     public static FrozenList<Object> validate(List<Object> arg, SchemaConfiguration configuration) {
         return Schema.validate(ArrayWithItemsSchema.class, arg, configuration);
+    }
+}
+
+class ArrayWithOutputClsSchemaList extends FrozenList<String> {
+    public ArrayWithOutputClsSchemaList(Collection<? extends String> m) {
+            super(m);
+    }
+}
+
+record ArrayWithOutputClsSchema(LinkedHashSet<Class<?>> type, Class<?> items) implements Schema {
+    public static ArrayWithOutputClsSchema withDefaults() {
+        LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
+        // can't use ImmutableList because it does not allow null values in entries
+        // can't use Collections.unmodifiableList because Collections.UnmodifiableList is not public + extensible
+        type.add(FrozenList.class);
+        Class<?> items = StringSchema.class;
+        return new ArrayWithOutputClsSchema(type, items);
+    }
+
+    public static Map<Class<?>, Class<?>> typeToOutputClass() {
+        Map<Class<?>, Class<?>> typeToOutputClsMap = new HashMap<>();
+        typeToOutputClsMap.put(FrozenList.class, ArrayWithOutputClsSchemaList.class);
+        return typeToOutputClsMap;
+    }
+
+    public static ArrayWithOutputClsSchemaList validate(List<Object> arg, SchemaConfiguration configuration) {
+        return Schema.validate(ArrayWithOutputClsSchema.class, arg, configuration);
     }
 }
 
@@ -55,6 +85,31 @@ public class ArrayTypeSchemaTest {
         inList.add(1);
         List<Object> finalInList = inList;
         Assert.assertThrows(RuntimeException.class, () -> ArrayWithItemsSchema.validate(
+                finalInList, configuration
+        ));
+    }
+
+    @Test
+    public void testValidateArrayWithOutputClsSchema() {
+        // map with only item works
+        List<Object> inList = new ArrayList<>();
+        inList.add("abc");
+        ArrayWithOutputClsSchemaList validatedValue = ArrayWithOutputClsSchema.validate(inList, configuration);
+        List<Object> outList = new ArrayList<>();
+        outList.add("abc");
+        Assert.assertEquals(validatedValue, outList);
+
+        // map with no items works
+        inList = new ArrayList<>();
+        validatedValue = ArrayWithOutputClsSchema.validate(inList, configuration);
+        outList = new ArrayList<>();
+        Assert.assertEquals(validatedValue, outList);
+
+        // invalid prop type fails
+        inList = new ArrayList<>();
+        inList.add(1);
+        List<Object> finalInList = inList;
+        Assert.assertThrows(RuntimeException.class, () -> ArrayWithOutputClsSchema.validate(
                 finalInList, configuration
         ));
     }


### PR DESCRIPTION
Java, adds output class instantiation for Map and List use cases

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
