### PR TITLE
Java, adds and uses exception types

### DIFF
--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -163,6 +163,7 @@ src/main/java/org/openapijsonschematools/configurations/JsonSchemaKeywordFlags.j
 src/main/java/org/openapijsonschematools/configurations/SchemaConfiguration.java
 src/main/java/org/openapijsonschematools/exceptions/BaseException.java
 src/main/java/org/openapijsonschematools/exceptions/InvalidAdditionalPropertyException.java
+src/main/java/org/openapijsonschematools/exceptions/InvalidTypeException.java
 src/main/java/org/openapijsonschematools/exceptions/UnsetPropertyException.java
 src/main/java/org/openapijsonschematools/exceptions/ValidationException.java
 src/main/java/org/openapijsonschematools/paths/anotherfakedummy/patch/responses/response200/content/applicationjson/Schema.java

--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -161,6 +161,10 @@ src/main/java/org/openapijsonschematools/components/schemas/Whale.java
 src/main/java/org/openapijsonschematools/components/schemas/Zebra.java
 src/main/java/org/openapijsonschematools/configurations/JsonSchemaKeywordFlags.java
 src/main/java/org/openapijsonschematools/configurations/SchemaConfiguration.java
+src/main/java/org/openapijsonschematools/exceptions/BaseException.java
+src/main/java/org/openapijsonschematools/exceptions/InvalidAdditionalPropertyException.java
+src/main/java/org/openapijsonschematools/exceptions/UnsetPropertyException.java
+src/main/java/org/openapijsonschematools/exceptions/ValidationException.java
 src/main/java/org/openapijsonschematools/paths/anotherfakedummy/patch/responses/response200/content/applicationjson/Schema.java
 src/main/java/org/openapijsonschematools/paths/commonparamsubdir/delete/HeaderParameters.java
 src/main/java/org/openapijsonschematools/paths/commonparamsubdir/delete/PathParameters.java

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/requestbodies/userarray/content/applicationjson/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/requestbodies/userarray/content/applicationjson/Schema.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.components.schemas.User;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.ItemsValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -39,7 +40,7 @@ public class Schema {
 
             return new SchemaList(arg);
         }
-        public static SchemaList validate(List<Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static SchemaList validate(List<Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return JsonSchema.validate(Schema1.class, arg, configuration);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/requestbodies/userarray/content/applicationjson/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/requestbodies/userarray/content/applicationjson/Schema.java
@@ -23,7 +23,7 @@ public class Schema {
 
             super(m);
         }
-        public static SchemaList of(List<Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static SchemaList of(List<Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return Schema1.validate(arg, configuration);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/responses/headerswithnobody/Headers.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/responses/headerswithnobody/Headers.java
@@ -34,7 +34,7 @@ public class Headers {
         public static final Set<String> optionalKeys = Set.of(
             "location"
         );
-        public static HeadersMap of(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static HeadersMap of(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Headers1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/responses/headerswithnobody/Headers.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/responses/headerswithnobody/Headers.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.components.responses.headerswithnobody.headers.location.LocationSchema;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.validation.AdditionalPropertiesValidator;
@@ -58,7 +59,7 @@ public class Headers {
 
             return new HeadersMap(arg);
         }
-        public static HeadersMap validate(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static HeadersMap validate(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Headers1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/responses/successfulxmlandjsonarrayofpet/content/applicationjson/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/responses/successfulxmlandjsonarrayofpet/content/applicationjson/Schema.java
@@ -24,7 +24,7 @@ public class Schema {
 
             super(m);
         }
-        public static SchemaList of(List<Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static SchemaList of(List<Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return Schema1.validate(arg, configuration);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/responses/successfulxmlandjsonarrayofpet/content/applicationjson/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/responses/successfulxmlandjsonarrayofpet/content/applicationjson/Schema.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import org.openapijsonschematools.components.schemas.Pet;
 import org.openapijsonschematools.components.schemas.RefPet;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.ItemsValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -40,7 +41,7 @@ public class Schema {
 
             return new SchemaList(arg);
         }
-        public static SchemaList validate(List<Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static SchemaList validate(List<Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return JsonSchema.validate(Schema1.class, arg, configuration);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/responses/successfulxmlandjsonarrayofpet/content/applicationxml/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/responses/successfulxmlandjsonarrayofpet/content/applicationxml/Schema.java
@@ -23,7 +23,7 @@ public class Schema {
 
             super(m);
         }
-        public static SchemaList of(List<Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static SchemaList of(List<Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return Schema1.validate(arg, configuration);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/responses/successfulxmlandjsonarrayofpet/content/applicationxml/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/responses/successfulxmlandjsonarrayofpet/content/applicationxml/Schema.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.components.schemas.Pet;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.ItemsValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -39,7 +40,7 @@ public class Schema {
 
             return new SchemaList(arg);
         }
-        public static SchemaList validate(List<Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static SchemaList validate(List<Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return JsonSchema.validate(Schema1.class, arg, configuration);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/responses/successinlinecontentandheader/Headers.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/responses/successinlinecontentandheader/Headers.java
@@ -34,7 +34,7 @@ public class Headers {
         public static final Set<String> optionalKeys = Set.of(
             "someHeader"
         );
-        public static HeadersMap of(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static HeadersMap of(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Headers1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/responses/successinlinecontentandheader/Headers.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/responses/successinlinecontentandheader/Headers.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.components.responses.successinlinecontentandheader.headers.someheader.SomeHeaderSchema;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.validation.AdditionalPropertiesValidator;
@@ -58,7 +59,7 @@ public class Headers {
 
             return new HeadersMap(arg);
         }
-        public static HeadersMap validate(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static HeadersMap validate(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Headers1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/responses/successinlinecontentandheader/content/applicationjson/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/responses/successinlinecontentandheader/content/applicationjson/Schema.java
@@ -27,7 +27,7 @@ public class Schema {
         }
         public static final Set<String> requiredKeys = Set.of();
         public static final Set<String> optionalKeys = Set.of();
-        public static SchemaMap of(Map<String, Integer> arg, SchemaConfiguration configuration) {
+        public static SchemaMap of(Map<String, Integer> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/responses/successinlinecontentandheader/content/applicationjson/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/responses/successinlinecontentandheader/content/applicationjson/Schema.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.Int32JsonSchema;
 import org.openapijsonschematools.schemas.validation.AdditionalPropertiesValidator;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
@@ -47,7 +48,7 @@ public class Schema {
 
             return new SchemaMap(arg);
         }
-        public static SchemaMap validate(Map<String, Integer> arg, SchemaConfiguration configuration) {
+        public static SchemaMap validate(Map<String, Integer> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/responses/successwithjsonapiresponse/Headers.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/responses/successwithjsonapiresponse/Headers.java
@@ -7,6 +7,7 @@ import org.openapijsonschematools.components.headers.numberheader.NumberHeaderSc
 import org.openapijsonschematools.components.headers.stringheader.StringHeaderSchema;
 import org.openapijsonschematools.components.schemas.StringWithValidation;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.validation.AdditionalPropertiesValidator;
@@ -90,7 +91,7 @@ public class Headers {
 
             return new HeadersMap(arg);
         }
-        public static HeadersMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static HeadersMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Headers1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/responses/successwithjsonapiresponse/Headers.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/responses/successwithjsonapiresponse/Headers.java
@@ -43,7 +43,7 @@ public class Headers {
         public static final Set<String> optionalKeys = Set.of(
             "numberHeader"
         );
-        public static HeadersMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static HeadersMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Headers1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/AbstractStepMessage.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/AbstractStepMessage.java
@@ -33,7 +33,7 @@ public class AbstractStepMessage {
             "sequenceNumber"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static AbstractStepMessageMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static AbstractStepMessageMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return AbstractStepMessage1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/AbstractStepMessage.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/AbstractStepMessage.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -82,7 +83,7 @@ public class AbstractStepMessage {
 
             return new AbstractStepMessageMap(arg);
         }
-        public static AbstractStepMessageMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static AbstractStepMessageMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(AbstractStepMessage1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/AdditionalPropertiesClass.java
@@ -32,7 +32,7 @@ public class AdditionalPropertiesClass {
         }
         public static final Set<String> requiredKeys = Set.of();
         public static final Set<String> optionalKeys = Set.of();
-        public static MapPropertyMap of(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static MapPropertyMap of(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return MapProperty.validate(arg, configuration);
         }
@@ -71,7 +71,7 @@ public class AdditionalPropertiesClass {
         }
         public static final Set<String> requiredKeys = Set.of();
         public static final Set<String> optionalKeys = Set.of();
-        public static AdditionalPropertiesMap of(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static AdditionalPropertiesMap of(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return AdditionalProperties1.validate(arg, configuration);
         }
@@ -107,7 +107,7 @@ public class AdditionalPropertiesClass {
         }
         public static final Set<String> requiredKeys = Set.of();
         public static final Set<String> optionalKeys = Set.of();
-        public static MapOfMapPropertyMap of(Map<String, Map<String, String>> arg, SchemaConfiguration configuration) {
+        public static MapOfMapPropertyMap of(Map<String, Map<String, String>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return MapOfMapProperty.validate(arg, configuration);
@@ -157,7 +157,7 @@ public class AdditionalPropertiesClass {
         }
         public static final Set<String> requiredKeys = Set.of();
         public static final Set<String> optionalKeys = Set.of();
-        public static MapWithUndeclaredPropertiesAnytype3Map of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static MapWithUndeclaredPropertiesAnytype3Map of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return MapWithUndeclaredPropertiesAnytype3.validate(arg, configuration);
         }
@@ -196,7 +196,7 @@ public class AdditionalPropertiesClass {
         public static final Set<String> requiredKeys = Set.of();
         public static final Set<String> optionalKeys = Set.of();
         // map with no key value pairs
-        public static EmptyMapMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static EmptyMapMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return EmptyMap.validate(arg, configuration);
         }
     }    
@@ -226,7 +226,7 @@ public class AdditionalPropertiesClass {
         }
         public static final Set<String> requiredKeys = Set.of();
         public static final Set<String> optionalKeys = Set.of();
-        public static MapWithUndeclaredPropertiesStringMap of(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static MapWithUndeclaredPropertiesStringMap of(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return MapWithUndeclaredPropertiesString.validate(arg, configuration);
         }
@@ -271,7 +271,7 @@ public class AdditionalPropertiesClass {
             "empty_map",
             "map_with_undeclared_properties_string"
         );
-        public static AdditionalPropertiesClassMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static AdditionalPropertiesClassMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return AdditionalPropertiesClass1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/AdditionalPropertiesClass.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.MapJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
@@ -52,7 +53,7 @@ public class AdditionalPropertiesClass {
 
             return new MapPropertyMap(arg);
         }
-        public static MapPropertyMap validate(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static MapPropertyMap validate(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(MapProperty.class, arg, configuration);
         }
@@ -91,7 +92,7 @@ public class AdditionalPropertiesClass {
 
             return new AdditionalPropertiesMap(arg);
         }
-        public static AdditionalPropertiesMap validate(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static AdditionalPropertiesMap validate(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(AdditionalProperties1.class, arg, configuration);
         }
@@ -128,7 +129,7 @@ public class AdditionalPropertiesClass {
 
             return new MapOfMapPropertyMap(arg);
         }
-        public static MapOfMapPropertyMap validate(Map<String, Map<String, String>> arg, SchemaConfiguration configuration) {
+        public static MapOfMapPropertyMap validate(Map<String, Map<String, String>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return JsonSchema.validate(MapOfMapProperty.class, arg, configuration);
@@ -177,7 +178,7 @@ public class AdditionalPropertiesClass {
 
             return new MapWithUndeclaredPropertiesAnytype3Map(arg);
         }
-        public static MapWithUndeclaredPropertiesAnytype3Map validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static MapWithUndeclaredPropertiesAnytype3Map validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(MapWithUndeclaredPropertiesAnytype3.class, arg, configuration);
         }
@@ -208,7 +209,7 @@ public class AdditionalPropertiesClass {
         protected static EmptyMapMap getMapOutputInstance(FrozenMap<String, Object> arg) {
             return new EmptyMapMap(arg);
         }
-        public static EmptyMapMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static EmptyMapMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(EmptyMap.class, arg, configuration);
         }
     }
@@ -246,7 +247,7 @@ public class AdditionalPropertiesClass {
 
             return new MapWithUndeclaredPropertiesStringMap(arg);
         }
-        public static MapWithUndeclaredPropertiesStringMap validate(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static MapWithUndeclaredPropertiesStringMap validate(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(MapWithUndeclaredPropertiesString.class, arg, configuration);
         }
@@ -369,7 +370,7 @@ public class AdditionalPropertiesClass {
 
             return new AdditionalPropertiesClassMap(arg);
         }
-        public static AdditionalPropertiesClassMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static AdditionalPropertiesClassMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(AdditionalPropertiesClass1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/AdditionalPropertiesSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/AdditionalPropertiesSchema.java
@@ -32,7 +32,7 @@ public class AdditionalPropertiesSchema {
         }
         public static final Set<String> requiredKeys = Set.of();
         public static final Set<String> optionalKeys = Set.of();
-        public static Schema0Map of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static Schema0Map of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema0.validate(arg, configuration);
         }
@@ -118,7 +118,7 @@ public class AdditionalPropertiesSchema {
         }
         public static final Set<String> requiredKeys = Set.of();
         public static final Set<String> optionalKeys = Set.of();
-        public static Schema1Map of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static Schema1Map of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema1.validate(arg, configuration);
         }
@@ -204,7 +204,7 @@ public class AdditionalPropertiesSchema {
         }
         public static final Set<String> requiredKeys = Set.of();
         public static final Set<String> optionalKeys = Set.of();
-        public static Schema2Map of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static Schema2Map of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema2.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/AdditionalPropertiesSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/AdditionalPropertiesSchema.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.validation.AdditionalPropertiesValidator;
 import org.openapijsonschematools.schemas.validation.FrozenList;
@@ -52,7 +53,7 @@ public class AdditionalPropertiesSchema {
 
             return new Schema0Map(arg);
         }
-        public static Schema0Map validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static Schema0Map validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema0.class, arg, configuration);
         }
@@ -60,51 +61,51 @@ public class AdditionalPropertiesSchema {
     
     
     public class AdditionalProperties1 extends JsonSchema {
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AdditionalProperties1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AdditionalProperties1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AdditionalProperties1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AdditionalProperties1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AdditionalProperties1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AdditionalProperties1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AdditionalProperties1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AdditionalProperties1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AdditionalProperties1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AdditionalProperties1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AdditionalProperties1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AdditionalProperties1.class, arg, configuration);
         }
     }    
@@ -138,7 +139,7 @@ public class AdditionalPropertiesSchema {
 
             return new Schema1Map(arg);
         }
-        public static Schema1Map validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static Schema1Map validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
@@ -146,51 +147,51 @@ public class AdditionalPropertiesSchema {
     
     
     public class AdditionalProperties2 extends JsonSchema {
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AdditionalProperties2.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AdditionalProperties2.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AdditionalProperties2.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AdditionalProperties2.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AdditionalProperties2.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AdditionalProperties2.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AdditionalProperties2.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AdditionalProperties2.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AdditionalProperties2.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AdditionalProperties2.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AdditionalProperties2.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AdditionalProperties2.class, arg, configuration);
         }
     }    
@@ -224,7 +225,7 @@ public class AdditionalPropertiesSchema {
 
             return new Schema2Map(arg);
         }
-        public static Schema2Map validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static Schema2Map validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema2.class, arg, configuration);
         }
@@ -241,7 +242,7 @@ public class AdditionalPropertiesSchema {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(FrozenMap.class)))
         ));
-        public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AdditionalPropertiesSchema1.class, arg, configuration);
         }
     }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/AdditionalPropertiesWithArrayOfEnums.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/AdditionalPropertiesWithArrayOfEnums.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.AdditionalPropertiesValidator;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
@@ -39,7 +40,7 @@ public class AdditionalPropertiesWithArrayOfEnums {
 
             return new AdditionalPropertiesList(arg);
         }
-        public static AdditionalPropertiesList validate(List<String> arg, SchemaConfiguration configuration) {
+        public static AdditionalPropertiesList validate(List<String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(AdditionalProperties.class, arg, configuration);
         }
@@ -82,7 +83,7 @@ public class AdditionalPropertiesWithArrayOfEnums {
 
             return new AdditionalPropertiesWithArrayOfEnumsMap(arg);
         }
-        public static AdditionalPropertiesWithArrayOfEnumsMap validate(Map<String, List<String>> arg, SchemaConfiguration configuration) {
+        public static AdditionalPropertiesWithArrayOfEnumsMap validate(Map<String, List<String>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return JsonSchema.validate(AdditionalPropertiesWithArrayOfEnums1.class, arg, configuration);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/AdditionalPropertiesWithArrayOfEnums.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/AdditionalPropertiesWithArrayOfEnums.java
@@ -24,7 +24,7 @@ public class AdditionalPropertiesWithArrayOfEnums {
 
             super(m);
         }
-        public static AdditionalPropertiesList of(List<String> arg, SchemaConfiguration configuration) {
+        public static AdditionalPropertiesList of(List<String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return AdditionalProperties.validate(arg, configuration);
         }
@@ -54,7 +54,7 @@ public class AdditionalPropertiesWithArrayOfEnums {
         }
         public static final Set<String> requiredKeys = Set.of();
         public static final Set<String> optionalKeys = Set.of();
-        public static AdditionalPropertiesWithArrayOfEnumsMap of(Map<String, List<String>> arg, SchemaConfiguration configuration) {
+        public static AdditionalPropertiesWithArrayOfEnumsMap of(Map<String, List<String>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return AdditionalPropertiesWithArrayOfEnums1.validate(arg, configuration);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Address.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Address.java
@@ -27,7 +27,7 @@ public class Address {
         }
         public static final Set<String> requiredKeys = Set.of();
         public static final Set<String> optionalKeys = Set.of();
-        public static AddressMap of(Map<String, Long> arg, SchemaConfiguration configuration) {
+        public static AddressMap of(Map<String, Long> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Address1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Address.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Address.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.IntJsonSchema;
 import org.openapijsonschematools.schemas.validation.AdditionalPropertiesValidator;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
@@ -53,7 +54,7 @@ public class Address {
 
             return new AddressMap(arg);
         }
-        public static AddressMap validate(Map<String, Long> arg, SchemaConfiguration configuration) {
+        public static AddressMap validate(Map<String, Long> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Address1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Animal.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Animal.java
@@ -44,7 +44,7 @@ public class Animal {
         public static final Set<String> optionalKeys = Set.of(
             "color"
         );
-        public static AnimalMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static AnimalMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Animal1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Animal.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Animal.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -26,7 +27,7 @@ public class Animal {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Color.class, arg, configuration);
         }
     }    
@@ -90,7 +91,7 @@ public class Animal {
 
             return new AnimalMap(arg);
         }
-        public static AnimalMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static AnimalMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Animal1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/AnimalFarm.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/AnimalFarm.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.ItemsValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -44,7 +45,7 @@ public class AnimalFarm {
 
             return new AnimalFarmList(arg);
         }
-        public static AnimalFarmList validate(List<Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static AnimalFarmList validate(List<Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return JsonSchema.validate(AnimalFarm1.class, arg, configuration);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/AnimalFarm.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/AnimalFarm.java
@@ -22,7 +22,7 @@ public class AnimalFarm {
 
             super(m);
         }
-        public static AnimalFarmList of(List<Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static AnimalFarmList of(List<Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return AnimalFarm1.validate(arg, configuration);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/AnyTypeAndFormat.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/AnyTypeAndFormat.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FormatValidator;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
@@ -25,51 +26,51 @@ public class AnyTypeAndFormat {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("format", new FormatValidator("uuid"))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(UuidSchema.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(UuidSchema.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(UuidSchema.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(UuidSchema.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(UuidSchema.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(UuidSchema.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(UuidSchema.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(UuidSchema.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(UuidSchema.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(UuidSchema.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(UuidSchema.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(UuidSchema.class, arg, configuration);
         }
     }    
@@ -78,51 +79,51 @@ public class AnyTypeAndFormat {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("format", new FormatValidator("date"))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Date.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Date.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Date.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Date.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Date.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Date.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Date.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Date.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Date.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Date.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Date.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Date.class, arg, configuration);
         }
     }    
@@ -131,51 +132,51 @@ public class AnyTypeAndFormat {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("format", new FormatValidator("date-time"))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Datetime.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Datetime.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Datetime.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Datetime.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Datetime.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Datetime.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Datetime.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Datetime.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Datetime.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Datetime.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Datetime.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Datetime.class, arg, configuration);
         }
     }    
@@ -184,51 +185,51 @@ public class AnyTypeAndFormat {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("format", new FormatValidator("number"))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NumberSchema.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NumberSchema.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NumberSchema.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NumberSchema.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NumberSchema.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NumberSchema.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NumberSchema.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NumberSchema.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NumberSchema.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NumberSchema.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NumberSchema.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NumberSchema.class, arg, configuration);
         }
     }    
@@ -237,51 +238,51 @@ public class AnyTypeAndFormat {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("format", new FormatValidator("binary"))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Binary.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Binary.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Binary.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Binary.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Binary.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Binary.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Binary.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Binary.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Binary.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Binary.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Binary.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Binary.class, arg, configuration);
         }
     }    
@@ -290,51 +291,51 @@ public class AnyTypeAndFormat {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("format", new FormatValidator("int32"))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Int32.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Int32.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Int32.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Int32.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Int32.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Int32.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Int32.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Int32.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Int32.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Int32.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Int32.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Int32.class, arg, configuration);
         }
     }    
@@ -343,51 +344,51 @@ public class AnyTypeAndFormat {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("format", new FormatValidator("int64"))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Int64.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Int64.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Int64.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Int64.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Int64.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Int64.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Int64.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Int64.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Int64.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Int64.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Int64.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Int64.class, arg, configuration);
         }
     }    
@@ -396,51 +397,51 @@ public class AnyTypeAndFormat {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("format", new FormatValidator("double"))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(DoubleSchema.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(DoubleSchema.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(DoubleSchema.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(DoubleSchema.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(DoubleSchema.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(DoubleSchema.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(DoubleSchema.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(DoubleSchema.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(DoubleSchema.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(DoubleSchema.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(DoubleSchema.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(DoubleSchema.class, arg, configuration);
         }
     }    
@@ -449,51 +450,51 @@ public class AnyTypeAndFormat {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("format", new FormatValidator("float"))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(FloatSchema.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(FloatSchema.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(FloatSchema.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(FloatSchema.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(FloatSchema.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(FloatSchema.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(FloatSchema.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(FloatSchema.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(FloatSchema.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(FloatSchema.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(FloatSchema.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(FloatSchema.class, arg, configuration);
         }
     }    
@@ -581,7 +582,7 @@ public class AnyTypeAndFormat {
 
             return new AnyTypeAndFormatMap(arg);
         }
-        public static AnyTypeAndFormatMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static AnyTypeAndFormatMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(AnyTypeAndFormat1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/AnyTypeAndFormat.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/AnyTypeAndFormat.java
@@ -517,7 +517,7 @@ public class AnyTypeAndFormat {
             "double",
             "float"
         );
-        public static AnyTypeAndFormatMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static AnyTypeAndFormatMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return AnyTypeAndFormat1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/AnyTypeNotString.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/AnyTypeNotString.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
@@ -27,51 +28,51 @@ public class AnyTypeNotString {
     
         Do not edit the class manually.
         */
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AnyTypeNotString1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AnyTypeNotString1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AnyTypeNotString1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AnyTypeNotString1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AnyTypeNotString1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AnyTypeNotString1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AnyTypeNotString1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AnyTypeNotString1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AnyTypeNotString1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AnyTypeNotString1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AnyTypeNotString1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AnyTypeNotString1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ApiResponseSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ApiResponseSchema.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.Int32JsonSchema;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
@@ -93,7 +94,7 @@ public class ApiResponseSchema {
 
             return new ApiResponseMap(arg);
         }
-        public static ApiResponseMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ApiResponseMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(ApiResponseSchema1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ApiResponseSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ApiResponseSchema.java
@@ -39,7 +39,7 @@ public class ApiResponseSchema {
             "type",
             "message"
         );
-        public static ApiResponseMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ApiResponseMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return ApiResponseSchema1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Apple.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Apple.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -22,7 +23,7 @@ public class Apple {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Cultivar.class, arg, configuration);
         }
     }    
@@ -33,7 +34,7 @@ public class Apple {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Origin.class, arg, configuration);
         }
     }    
@@ -96,10 +97,10 @@ public class Apple {
                 "cultivar"
             )))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Apple1.class, arg, configuration);
         }
-        public static AppleMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static AppleMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Apple1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Apple.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Apple.java
@@ -51,7 +51,7 @@ public class Apple {
         public static final Set<String> optionalKeys = Set.of(
             "origin"
         );
-        public static AppleMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static AppleMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Apple1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/AppleReq.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/AppleReq.java
@@ -44,7 +44,7 @@ public class AppleReq {
         public static final Set<String> optionalKeys = Set.of(
             "mealy"
         );
-        public static AppleReqMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static AppleReqMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return AppleReq1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/AppleReq.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/AppleReq.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.BooleanJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
@@ -85,7 +86,7 @@ public class AppleReq {
 
             return new AppleReqMap(arg);
         }
-        public static AppleReqMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static AppleReqMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(AppleReq1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ArrayHoldingAnyType.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ArrayHoldingAnyType.java
@@ -26,7 +26,7 @@ public class ArrayHoldingAnyType {
 
             super(m);
         }
-        public static ArrayHoldingAnyTypeList of(List<Object> arg, SchemaConfiguration configuration) {
+        public static ArrayHoldingAnyTypeList of(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return ArrayHoldingAnyType1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ArrayHoldingAnyType.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ArrayHoldingAnyType.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.ItemsValidator;
@@ -47,7 +48,7 @@ public class ArrayHoldingAnyType {
 
             return new ArrayHoldingAnyTypeList(arg);
         }
-        public static ArrayHoldingAnyTypeList validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static ArrayHoldingAnyTypeList validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(ArrayHoldingAnyType1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ArrayOfArrayOfNumberOnly.java
@@ -29,7 +29,7 @@ public class ArrayOfArrayOfNumberOnly {
 
             super(m);
         }
-        public static ItemsList of(List<Number> arg, SchemaConfiguration configuration) {
+        public static ItemsList of(List<Number> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Items.validate(arg, configuration);
         }
@@ -57,7 +57,7 @@ public class ArrayOfArrayOfNumberOnly {
 
             super(m);
         }
-        public static ArrayArrayNumberList of(List<List<Number>> arg, SchemaConfiguration configuration) {
+        public static ArrayArrayNumberList of(List<List<Number>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return ArrayArrayNumber.validate(arg, configuration);
@@ -91,7 +91,7 @@ public class ArrayOfArrayOfNumberOnly {
         public static final Set<String> optionalKeys = Set.of(
             "ArrayArrayNumber"
         );
-        public static ArrayOfArrayOfNumberOnlyMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ArrayOfArrayOfNumberOnlyMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return ArrayOfArrayOfNumberOnly1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ArrayOfArrayOfNumberOnly.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.NumberJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
@@ -44,7 +45,7 @@ public class ArrayOfArrayOfNumberOnly {
 
             return new ItemsList(arg);
         }
-        public static ItemsList validate(List<Number> arg, SchemaConfiguration configuration) {
+        public static ItemsList validate(List<Number> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Items.class, arg, configuration);
         }
@@ -73,7 +74,7 @@ public class ArrayOfArrayOfNumberOnly {
 
             return new ArrayArrayNumberList(arg);
         }
-        public static ArrayArrayNumberList validate(List<List<Number>> arg, SchemaConfiguration configuration) {
+        public static ArrayArrayNumberList validate(List<List<Number>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return JsonSchema.validate(ArrayArrayNumber.class, arg, configuration);
@@ -127,7 +128,7 @@ public class ArrayOfArrayOfNumberOnly {
 
             return new ArrayOfArrayOfNumberOnlyMap(arg);
         }
-        public static ArrayOfArrayOfNumberOnlyMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ArrayOfArrayOfNumberOnlyMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(ArrayOfArrayOfNumberOnly1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ArrayOfEnums.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ArrayOfEnums.java
@@ -22,7 +22,7 @@ public class ArrayOfEnums {
 
             super(m);
         }
-        public static ArrayOfEnumsList of(List<String> arg, SchemaConfiguration configuration) {
+        public static ArrayOfEnumsList of(List<String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return ArrayOfEnums1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ArrayOfEnums.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ArrayOfEnums.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.ItemsValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -43,7 +44,7 @@ public class ArrayOfEnums {
 
             return new ArrayOfEnumsList(arg);
         }
-        public static ArrayOfEnumsList validate(List<String> arg, SchemaConfiguration configuration) {
+        public static ArrayOfEnumsList validate(List<String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(ArrayOfEnums1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ArrayOfNumberOnly.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.NumberJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
@@ -44,7 +45,7 @@ public class ArrayOfNumberOnly {
 
             return new ArrayNumberList(arg);
         }
-        public static ArrayNumberList validate(List<Number> arg, SchemaConfiguration configuration) {
+        public static ArrayNumberList validate(List<Number> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(ArrayNumber.class, arg, configuration);
         }
@@ -97,7 +98,7 @@ public class ArrayOfNumberOnly {
 
             return new ArrayOfNumberOnlyMap(arg);
         }
-        public static ArrayOfNumberOnlyMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ArrayOfNumberOnlyMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(ArrayOfNumberOnly1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ArrayOfNumberOnly.java
@@ -29,7 +29,7 @@ public class ArrayOfNumberOnly {
 
             super(m);
         }
-        public static ArrayNumberList of(List<Number> arg, SchemaConfiguration configuration) {
+        public static ArrayNumberList of(List<Number> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return ArrayNumber.validate(arg, configuration);
         }
@@ -61,7 +61,7 @@ public class ArrayOfNumberOnly {
         public static final Set<String> optionalKeys = Set.of(
             "ArrayNumber"
         );
-        public static ArrayOfNumberOnlyMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ArrayOfNumberOnlyMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return ArrayOfNumberOnly1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ArrayTest.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ArrayTest.java
@@ -30,7 +30,7 @@ public class ArrayTest {
 
             super(m);
         }
-        public static ArrayOfStringList of(List<String> arg, SchemaConfiguration configuration) {
+        public static ArrayOfStringList of(List<String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return ArrayOfString.validate(arg, configuration);
         }
@@ -61,7 +61,7 @@ public class ArrayTest {
 
             super(m);
         }
-        public static ItemsList of(List<Long> arg, SchemaConfiguration configuration) {
+        public static ItemsList of(List<Long> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Items1.validate(arg, configuration);
         }
@@ -89,7 +89,7 @@ public class ArrayTest {
 
             super(m);
         }
-        public static ArrayArrayOfIntegerList of(List<List<Long>> arg, SchemaConfiguration configuration) {
+        public static ArrayArrayOfIntegerList of(List<List<Long>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return ArrayArrayOfInteger.validate(arg, configuration);
@@ -119,7 +119,7 @@ public class ArrayTest {
 
             super(m);
         }
-        public static ItemsList1 of(List<Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static ItemsList1 of(List<Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return Items3.validate(arg, configuration);
@@ -149,7 +149,7 @@ public class ArrayTest {
 
             super(m);
         }
-        public static ArrayArrayOfModelList of(List<List<Map<String, Object>>> arg, SchemaConfiguration configuration) {
+        public static ArrayArrayOfModelList of(List<List<Map<String, Object>>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
 
@@ -187,7 +187,7 @@ public class ArrayTest {
             "array_array_of_integer",
             "array_array_of_model"
         );
-        public static ArrayTestMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ArrayTestMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return ArrayTest1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ArrayTest.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ArrayTest.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.Int64JsonSchema;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenList;
@@ -45,7 +46,7 @@ public class ArrayTest {
 
             return new ArrayOfStringList(arg);
         }
-        public static ArrayOfStringList validate(List<String> arg, SchemaConfiguration configuration) {
+        public static ArrayOfStringList validate(List<String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(ArrayOfString.class, arg, configuration);
         }
@@ -76,7 +77,7 @@ public class ArrayTest {
 
             return new ItemsList(arg);
         }
-        public static ItemsList validate(List<Long> arg, SchemaConfiguration configuration) {
+        public static ItemsList validate(List<Long> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Items1.class, arg, configuration);
         }
@@ -105,7 +106,7 @@ public class ArrayTest {
 
             return new ArrayArrayOfIntegerList(arg);
         }
-        public static ArrayArrayOfIntegerList validate(List<List<Long>> arg, SchemaConfiguration configuration) {
+        public static ArrayArrayOfIntegerList validate(List<List<Long>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return JsonSchema.validate(ArrayArrayOfInteger.class, arg, configuration);
@@ -135,7 +136,7 @@ public class ArrayTest {
 
             return new ItemsList1(arg);
         }
-        public static ItemsList1 validate(List<Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static ItemsList1 validate(List<Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return JsonSchema.validate(Items3.class, arg, configuration);
@@ -166,7 +167,7 @@ public class ArrayTest {
 
             return new ArrayArrayOfModelList(arg);
         }
-        public static ArrayArrayOfModelList validate(List<List<Map<String, Object>>> arg, SchemaConfiguration configuration) {
+        public static ArrayArrayOfModelList validate(List<List<Map<String, Object>>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
 
@@ -241,7 +242,7 @@ public class ArrayTest {
 
             return new ArrayTestMap(arg);
         }
-        public static ArrayTestMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ArrayTestMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(ArrayTest1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ArrayWithValidationsInItems.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ArrayWithValidationsInItems.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FormatValidator;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.ItemsValidator;
@@ -26,19 +27,19 @@ public class ArrayWithValidationsInItems {
             ))),
             new KeywordEntry("format", new FormatValidator("int64"))
         ));
-        public static long validate(int arg, SchemaConfiguration configuration) {
+        public static long validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Items.class, Long.valueOf(arg), configuration);
         }
         
-        public static long validate(float arg, SchemaConfiguration configuration) {
+        public static long validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Items.class, Long.parseLong(String.valueOf(arg)), configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Items.class, arg, configuration);
         }
         
-        public static long validate(double arg, SchemaConfiguration configuration) {
+        public static long validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Items.class, Long.parseLong(String.valueOf(arg)), configuration);
         }
     }    
@@ -71,7 +72,7 @@ public class ArrayWithValidationsInItems {
 
             return new ArrayWithValidationsInItemsList(arg);
         }
-        public static ArrayWithValidationsInItemsList validate(List<Long> arg, SchemaConfiguration configuration) {
+        public static ArrayWithValidationsInItemsList validate(List<Long> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(ArrayWithValidationsInItems1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ArrayWithValidationsInItems.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ArrayWithValidationsInItems.java
@@ -50,7 +50,7 @@ public class ArrayWithValidationsInItems {
 
             super(m);
         }
-        public static ArrayWithValidationsInItemsList of(List<Long> arg, SchemaConfiguration configuration) {
+        public static ArrayWithValidationsInItemsList of(List<Long> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return ArrayWithValidationsInItems1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Banana.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Banana.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.NumberJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -68,7 +69,7 @@ public class Banana {
 
             return new BananaMap(arg);
         }
-        public static BananaMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static BananaMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Banana1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Banana.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Banana.java
@@ -31,7 +31,7 @@ public class Banana {
             "lengthCm"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static BananaMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static BananaMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Banana1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/BananaReq.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/BananaReq.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.BooleanJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
@@ -85,7 +86,7 @@ public class BananaReq {
 
             return new BananaReqMap(arg);
         }
-        public static BananaReqMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static BananaReqMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(BananaReq1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/BananaReq.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/BananaReq.java
@@ -44,7 +44,7 @@ public class BananaReq {
         public static final Set<String> optionalKeys = Set.of(
             "sweet"
         );
-        public static BananaReqMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static BananaReqMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return BananaReq1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Bar.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Bar.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -24,7 +25,7 @@ public class Bar {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Bar1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/BasquePig.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/BasquePig.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -22,7 +23,7 @@ public class BasquePig {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ClassName.class, arg, configuration);
         }
     }    
@@ -75,7 +76,7 @@ public class BasquePig {
 
             return new BasquePigMap(arg);
         }
-        public static BasquePigMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static BasquePigMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(BasquePig1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/BasquePig.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/BasquePig.java
@@ -38,7 +38,7 @@ public class BasquePig {
             "className"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static BasquePigMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static BasquePigMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return BasquePig1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/BooleanEnum.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/BooleanEnum.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -22,7 +23,7 @@ public class BooleanEnum {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(Boolean.class)))
         ));
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(BooleanEnum1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Capitalization.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Capitalization.java
@@ -50,7 +50,7 @@ public class Capitalization {
             "SCA_ETH_Flow_Points",
             "ATT_NAME"
         );
-        public static CapitalizationMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static CapitalizationMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Capitalization1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Capitalization.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Capitalization.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -131,7 +132,7 @@ public class Capitalization {
 
             return new CapitalizationMap(arg);
         }
-        public static CapitalizationMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static CapitalizationMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Capitalization1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Cat.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Cat.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.BooleanJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
@@ -65,7 +66,7 @@ public class Cat {
 
             return new Schema1Map(arg);
         }
-        public static Schema1Map validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static Schema1Map validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
@@ -79,51 +80,51 @@ public class Cat {
     
         Do not edit the class manually.
         */
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Cat1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Cat1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Cat1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Cat1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Cat1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Cat1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Cat1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Cat1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Cat1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Cat1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Cat1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Cat1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Cat.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Cat.java
@@ -35,7 +35,7 @@ public class Cat {
         public static final Set<String> optionalKeys = Set.of(
             "declawed"
         );
-        public static Schema1Map of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static Schema1Map of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Category.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Category.java
@@ -44,7 +44,7 @@ public class Category {
         public static final Set<String> optionalKeys = Set.of(
             "id"
         );
-        public static CategoryMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static CategoryMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Category1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Category.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Category.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.Int64JsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -26,7 +27,7 @@ public class Category {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Name.class, arg, configuration);
         }
     }    
@@ -90,7 +91,7 @@ public class Category {
 
             return new CategoryMap(arg);
         }
-        public static CategoryMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static CategoryMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Category1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ChildCat.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ChildCat.java
@@ -35,7 +35,7 @@ public class ChildCat {
         public static final Set<String> optionalKeys = Set.of(
             "name"
         );
-        public static Schema1Map of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static Schema1Map of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ChildCat.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ChildCat.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
@@ -65,7 +66,7 @@ public class ChildCat {
 
             return new Schema1Map(arg);
         }
-        public static Schema1Map validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static Schema1Map validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
@@ -79,51 +80,51 @@ public class ChildCat {
     
         Do not edit the class manually.
         */
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ChildCat1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ChildCat1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ChildCat1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ChildCat1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ChildCat1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ChildCat1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ChildCat1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ChildCat1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ChildCat1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ChildCat1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ChildCat1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ChildCat1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ClassModel.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ClassModel.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
@@ -59,51 +60,51 @@ public class ClassModel {
                 new PropertyEntry("_class", ClassSchema.class)
             )))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ClassModel1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ClassModel1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ClassModel1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ClassModel1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ClassModel1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ClassModel1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ClassModel1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ClassModel1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ClassModel1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ClassModel1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ClassModel1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ClassModel1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ClassModel.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ClassModel.java
@@ -34,7 +34,7 @@ public class ClassModel {
         public static final Set<String> optionalKeys = Set.of(
             "_class"
         );
-        public static ClassModelMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ClassModelMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return ClassModel1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Client.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Client.java
@@ -30,7 +30,7 @@ public class Client {
         public static final Set<String> optionalKeys = Set.of(
             "client"
         );
-        public static ClientMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ClientMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Client1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Client.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Client.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -66,7 +67,7 @@ public class Client {
 
             return new ClientMap(arg);
         }
-        public static ClientMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ClientMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Client1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ComplexQuadrilateral.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ComplexQuadrilateral.java
@@ -42,7 +42,7 @@ public class ComplexQuadrilateral {
         public static final Set<String> optionalKeys = Set.of(
             "quadrilateralType"
         );
-        public static Schema1Map of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static Schema1Map of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ComplexQuadrilateral.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ComplexQuadrilateral.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -26,7 +27,7 @@ public class ComplexQuadrilateral {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(QuadrilateralType.class, arg, configuration);
         }
     }    
@@ -72,7 +73,7 @@ public class ComplexQuadrilateral {
 
             return new Schema1Map(arg);
         }
-        public static Schema1Map validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static Schema1Map validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
@@ -86,51 +87,51 @@ public class ComplexQuadrilateral {
     
         Do not edit the class manually.
         */
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComplexQuadrilateral1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComplexQuadrilateral1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComplexQuadrilateral1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComplexQuadrilateral1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComplexQuadrilateral1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComplexQuadrilateral1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComplexQuadrilateral1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComplexQuadrilateral1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComplexQuadrilateral1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComplexQuadrilateral1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComplexQuadrilateral1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComplexQuadrilateral1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ComposedAnyOfDifferentTypesNoValidations.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ComposedAnyOfDifferentTypesNoValidations.java
@@ -71,7 +71,7 @@ public class ComposedAnyOfDifferentTypesNoValidations {
 
             super(m);
         }
-        public static Schema9List of(List<Object> arg, SchemaConfiguration configuration) {
+        public static Schema9List of(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema9.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ComposedAnyOfDifferentTypesNoValidations.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ComposedAnyOfDifferentTypesNoValidations.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.BooleanJsonSchema;
 import org.openapijsonschematools.schemas.DateJsonSchema;
@@ -86,7 +87,7 @@ public class ComposedAnyOfDifferentTypesNoValidations {
 
             return new Schema9List(arg);
         }
-        public static Schema9List validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static Schema9List validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema9.class, arg, configuration);
         }
@@ -117,51 +118,51 @@ public class ComposedAnyOfDifferentTypesNoValidations {
     
         Do not edit the class manually.
         */
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComposedAnyOfDifferentTypesNoValidations1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComposedAnyOfDifferentTypesNoValidations1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComposedAnyOfDifferentTypesNoValidations1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComposedAnyOfDifferentTypesNoValidations1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComposedAnyOfDifferentTypesNoValidations1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComposedAnyOfDifferentTypesNoValidations1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComposedAnyOfDifferentTypesNoValidations1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComposedAnyOfDifferentTypesNoValidations1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComposedAnyOfDifferentTypesNoValidations1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComposedAnyOfDifferentTypesNoValidations1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComposedAnyOfDifferentTypesNoValidations1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComposedAnyOfDifferentTypesNoValidations1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ComposedArray.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ComposedArray.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.ItemsValidator;
@@ -47,7 +48,7 @@ public class ComposedArray {
 
             return new ComposedArrayList(arg);
         }
-        public static ComposedArrayList validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static ComposedArrayList validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(ComposedArray1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ComposedArray.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ComposedArray.java
@@ -26,7 +26,7 @@ public class ComposedArray {
 
             super(m);
         }
-        public static ComposedArrayList of(List<Object> arg, SchemaConfiguration configuration) {
+        public static ComposedArrayList of(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return ComposedArray1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ComposedBool.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ComposedBool.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -26,7 +27,7 @@ public class ComposedBool {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(Boolean.class)))
         ));
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComposedBool1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ComposedNone.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ComposedNone.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -26,7 +27,7 @@ public class ComposedNone {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(Void.class)))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComposedNone1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ComposedNumber.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ComposedNumber.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -31,19 +32,19 @@ public class ComposedNumber {
                 Double.class
             )))
         ));
-        public static Number validate(int arg, SchemaConfiguration configuration) {
+        public static Number validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComposedNumber1.class, arg, configuration);
         }
         
-        public static Number validate(long arg, SchemaConfiguration configuration) {
+        public static Number validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComposedNumber1.class, arg, configuration);
         }
         
-        public static Number validate(float arg, SchemaConfiguration configuration) {
+        public static Number validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComposedNumber1.class, arg, configuration);
         }
         
-        public static Number validate(double arg, SchemaConfiguration configuration) {
+        public static Number validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComposedNumber1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ComposedObject.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ComposedObject.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -27,7 +28,7 @@ public class ComposedObject {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(FrozenMap.class)))
         ));
-        public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComposedObject1.class, arg, configuration);
         }
     }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ComposedOneOfDifferentTypes.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ComposedOneOfDifferentTypes.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.DateJsonSchema;
 import org.openapijsonschematools.schemas.NullJsonSchema;
@@ -33,7 +34,7 @@ public class ComposedOneOfDifferentTypes {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(FrozenMap.class)))
         ));
-        public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema4.class, arg, configuration);
         }
     }
@@ -64,7 +65,7 @@ public class ComposedOneOfDifferentTypes {
 
             return new Schema5List(arg);
         }
-        public static Schema5List validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static Schema5List validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema5.class, arg, configuration);
         }
@@ -77,7 +78,7 @@ public class ComposedOneOfDifferentTypes {
             ))),
             new KeywordEntry("format", new FormatValidator("date-time"))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema6.class, arg, configuration);
         }
     }    
@@ -91,51 +92,51 @@ public class ComposedOneOfDifferentTypes {
     
         this is a model that allows payloads of type object or number
         */
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComposedOneOfDifferentTypes1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComposedOneOfDifferentTypes1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComposedOneOfDifferentTypes1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComposedOneOfDifferentTypes1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComposedOneOfDifferentTypes1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComposedOneOfDifferentTypes1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComposedOneOfDifferentTypes1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComposedOneOfDifferentTypes1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComposedOneOfDifferentTypes1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComposedOneOfDifferentTypes1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComposedOneOfDifferentTypes1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComposedOneOfDifferentTypes1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ComposedOneOfDifferentTypes.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ComposedOneOfDifferentTypes.java
@@ -49,7 +49,7 @@ public class ComposedOneOfDifferentTypes {
 
             super(m);
         }
-        public static Schema5List of(List<Object> arg, SchemaConfiguration configuration) {
+        public static Schema5List of(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema5.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ComposedString.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ComposedString.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -28,7 +29,7 @@ public class ComposedString {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ComposedString1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Currency.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Currency.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -24,7 +25,7 @@ public class Currency {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Currency1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/DanishPig.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/DanishPig.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -22,7 +23,7 @@ public class DanishPig {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ClassName.class, arg, configuration);
         }
     }    
@@ -75,7 +76,7 @@ public class DanishPig {
 
             return new DanishPigMap(arg);
         }
-        public static DanishPigMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static DanishPigMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(DanishPig1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/DanishPig.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/DanishPig.java
@@ -38,7 +38,7 @@ public class DanishPig {
             "className"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static DanishPigMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static DanishPigMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return DanishPig1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/DateTimeTest.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/DateTimeTest.java
@@ -4,6 +4,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FormatValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -27,7 +28,7 @@ public class DateTimeTest {
             ))),
             new KeywordEntry("format", new FormatValidator("date-time"))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(DateTimeTest1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/DateTimeWithValidations.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/DateTimeWithValidations.java
@@ -4,6 +4,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FormatValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -27,7 +28,7 @@ public class DateTimeWithValidations {
             ))),
             new KeywordEntry("format", new FormatValidator("date-time"))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(DateTimeWithValidations1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/DateWithValidations.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/DateWithValidations.java
@@ -4,6 +4,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FormatValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -27,7 +28,7 @@ public class DateWithValidations {
             ))),
             new KeywordEntry("format", new FormatValidator("date"))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(DateWithValidations1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Dog.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Dog.java
@@ -35,7 +35,7 @@ public class Dog {
         public static final Set<String> optionalKeys = Set.of(
             "breed"
         );
-        public static Schema1Map of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static Schema1Map of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Dog.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Dog.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
@@ -65,7 +66,7 @@ public class Dog {
 
             return new Schema1Map(arg);
         }
-        public static Schema1Map validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static Schema1Map validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
@@ -79,51 +80,51 @@ public class Dog {
     
         Do not edit the class manually.
         */
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Dog1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Dog1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Dog1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Dog1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Dog1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Dog1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Dog1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Dog1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Dog1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Dog1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Dog1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Dog1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Drawing.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Drawing.java
@@ -26,7 +26,7 @@ public class Drawing {
 
             super(m);
         }
-        public static ShapesList of(List<Object> arg, SchemaConfiguration configuration) {
+        public static ShapesList of(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Shapes.validate(arg, configuration);
         }
@@ -61,7 +61,7 @@ public class Drawing {
             "nullableShape",
             "shapes"
         );
-        public static DrawingMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static DrawingMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Drawing1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Drawing.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Drawing.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.AdditionalPropertiesValidator;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
@@ -41,7 +42,7 @@ public class Drawing {
 
             return new ShapesList(arg);
         }
-        public static ShapesList validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static ShapesList validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Shapes.class, arg, configuration);
         }
@@ -126,7 +127,7 @@ public class Drawing {
 
             return new DrawingMap(arg);
         }
-        public static DrawingMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static DrawingMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Drawing1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/EnumArrays.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/EnumArrays.java
@@ -47,7 +47,7 @@ public class EnumArrays {
 
             super(m);
         }
-        public static ArrayEnumList of(List<String> arg, SchemaConfiguration configuration) {
+        public static ArrayEnumList of(List<String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return ArrayEnum.validate(arg, configuration);
         }
@@ -80,7 +80,7 @@ public class EnumArrays {
             "just_symbol",
             "array_enum"
         );
-        public static EnumArraysMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static EnumArraysMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return EnumArrays1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/EnumArrays.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/EnumArrays.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.ItemsValidator;
@@ -24,7 +25,7 @@ public class EnumArrays {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(JustSymbol.class, arg, configuration);
         }
     }    
@@ -35,7 +36,7 @@ public class EnumArrays {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Items.class, arg, configuration);
         }
     }    
@@ -62,7 +63,7 @@ public class EnumArrays {
 
             return new ArrayEnumList(arg);
         }
-        public static ArrayEnumList validate(List<String> arg, SchemaConfiguration configuration) {
+        public static ArrayEnumList validate(List<String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(ArrayEnum.class, arg, configuration);
         }
@@ -125,7 +126,7 @@ public class EnumArrays {
 
             return new EnumArraysMap(arg);
         }
-        public static EnumArraysMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static EnumArraysMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(EnumArrays1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/EnumClass.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/EnumClass.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -24,7 +25,7 @@ public class EnumClass {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(EnumClass1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/EnumTest.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/EnumTest.java
@@ -101,7 +101,7 @@ public class EnumTest {
             "IntegerEnumWithDefaultValue",
             "IntegerEnumOneValue"
         );
-        public static EnumTestMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static EnumTestMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return EnumTest1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/EnumTest.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/EnumTest.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FormatValidator;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -23,7 +24,7 @@ public class EnumTest {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(EnumString.class, arg, configuration);
         }
     }    
@@ -34,7 +35,7 @@ public class EnumTest {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(EnumStringRequired.class, arg, configuration);
         }
     }    
@@ -49,19 +50,19 @@ public class EnumTest {
             ))),
             new KeywordEntry("format", new FormatValidator("int32"))
         ));
-        public static long validate(int arg, SchemaConfiguration configuration) {
+        public static long validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(EnumInteger.class, Long.valueOf(arg), configuration);
         }
         
-        public static long validate(float arg, SchemaConfiguration configuration) {
+        public static long validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(EnumInteger.class, Long.parseLong(String.valueOf(arg)), configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(EnumInteger.class, arg, configuration);
         }
         
-        public static long validate(double arg, SchemaConfiguration configuration) {
+        public static long validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(EnumInteger.class, Long.parseLong(String.valueOf(arg)), configuration);
         }
     }    
@@ -76,7 +77,7 @@ public class EnumTest {
             ))),
             new KeywordEntry("format", new FormatValidator("double"))
         ));
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(EnumNumber.class, arg, configuration);
         }
     }    
@@ -210,7 +211,7 @@ public class EnumTest {
 
             return new EnumTestMap(arg);
         }
-        public static EnumTestMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static EnumTestMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(EnumTest1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/EquilateralTriangle.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/EquilateralTriangle.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -26,7 +27,7 @@ public class EquilateralTriangle {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(TriangleType.class, arg, configuration);
         }
     }    
@@ -72,7 +73,7 @@ public class EquilateralTriangle {
 
             return new Schema1Map(arg);
         }
-        public static Schema1Map validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static Schema1Map validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
@@ -86,51 +87,51 @@ public class EquilateralTriangle {
     
         Do not edit the class manually.
         */
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(EquilateralTriangle1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(EquilateralTriangle1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(EquilateralTriangle1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(EquilateralTriangle1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(EquilateralTriangle1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(EquilateralTriangle1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(EquilateralTriangle1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(EquilateralTriangle1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(EquilateralTriangle1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(EquilateralTriangle1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(EquilateralTriangle1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(EquilateralTriangle1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/EquilateralTriangle.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/EquilateralTriangle.java
@@ -42,7 +42,7 @@ public class EquilateralTriangle {
         public static final Set<String> optionalKeys = Set.of(
             "triangleType"
         );
-        public static Schema1Map of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static Schema1Map of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/File.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/File.java
@@ -30,7 +30,7 @@ public class File {
         public static final Set<String> optionalKeys = Set.of(
             "sourceURI"
         );
-        public static FileMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static FileMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return File1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/File.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/File.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -68,7 +69,7 @@ public class File {
 
             return new FileMap(arg);
         }
-        public static FileMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static FileMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(File1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/FileSchemaTestClass.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.ItemsValidator;
@@ -41,7 +42,7 @@ public class FileSchemaTestClass {
 
             return new FilesList(arg);
         }
-        public static FilesList validate(List<Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static FilesList validate(List<Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return JsonSchema.validate(Files.class, arg, configuration);
@@ -105,7 +106,7 @@ public class FileSchemaTestClass {
 
             return new FileSchemaTestClassMap(arg);
         }
-        public static FileSchemaTestClassMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static FileSchemaTestClassMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(FileSchemaTestClass1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/FileSchemaTestClass.java
@@ -25,7 +25,7 @@ public class FileSchemaTestClass {
 
             super(m);
         }
-        public static FilesList of(List<Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static FilesList of(List<Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return Files.validate(arg, configuration);
@@ -60,7 +60,7 @@ public class FileSchemaTestClass {
             "file",
             "files"
         );
-        public static FileSchemaTestClassMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static FileSchemaTestClassMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return FileSchemaTestClass1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Foo.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Foo.java
@@ -26,7 +26,7 @@ public class Foo {
         public static final Set<String> optionalKeys = Set.of(
             "bar"
         );
-        public static FooMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static FooMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Foo1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Foo.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Foo.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -62,7 +63,7 @@ public class Foo {
 
             return new FooMap(arg);
         }
-        public static FooMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static FooMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Foo1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/FormatTest.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/FormatTest.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.DateJsonSchema;
 import org.openapijsonschematools.schemas.DateTimeJsonSchema;
 import org.openapijsonschematools.schemas.DoubleJsonSchema;
@@ -39,19 +40,19 @@ public class FormatTest {
                 Double.class
             )))
         ));
-        public static long validate(int arg, SchemaConfiguration configuration) {
+        public static long validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerSchema.class, Long.valueOf(arg), configuration);
         }
         
-        public static long validate(float arg, SchemaConfiguration configuration) {
+        public static long validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerSchema.class, Long.parseLong(String.valueOf(arg)), configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerSchema.class, arg, configuration);
         }
         
-        public static long validate(double arg, SchemaConfiguration configuration) {
+        public static long validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerSchema.class, Long.parseLong(String.valueOf(arg)), configuration);
         }
     }    
@@ -69,19 +70,19 @@ public class FormatTest {
             ))),
             new KeywordEntry("format", new FormatValidator("int32"))
         ));
-        public static long validate(int arg, SchemaConfiguration configuration) {
+        public static long validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Int32withValidations.class, Long.valueOf(arg), configuration);
         }
         
-        public static long validate(float arg, SchemaConfiguration configuration) {
+        public static long validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Int32withValidations.class, Long.parseLong(String.valueOf(arg)), configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Int32withValidations.class, arg, configuration);
         }
         
-        public static long validate(double arg, SchemaConfiguration configuration) {
+        public static long validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Int32withValidations.class, Long.parseLong(String.valueOf(arg)), configuration);
         }
     }    
@@ -98,19 +99,19 @@ public class FormatTest {
                 Double.class
             )))
         ));
-        public static Number validate(int arg, SchemaConfiguration configuration) {
+        public static Number validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NumberSchema.class, arg, configuration);
         }
         
-        public static Number validate(long arg, SchemaConfiguration configuration) {
+        public static Number validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NumberSchema.class, arg, configuration);
         }
         
-        public static Number validate(float arg, SchemaConfiguration configuration) {
+        public static Number validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NumberSchema.class, arg, configuration);
         }
         
-        public static Number validate(double arg, SchemaConfiguration configuration) {
+        public static Number validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NumberSchema.class, arg, configuration);
         }
     }    
@@ -125,7 +126,7 @@ public class FormatTest {
             ))),
             new KeywordEntry("format", new FormatValidator("float"))
         ));
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(FloatSchema.class, arg, configuration);
         }
     }    
@@ -143,7 +144,7 @@ public class FormatTest {
             ))),
             new KeywordEntry("format", new FormatValidator("double"))
         ));
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(DoubleSchema.class, arg, configuration);
         }
     }    
@@ -176,7 +177,7 @@ public class FormatTest {
 
             return new ArrayWithUniqueItemsList(arg);
         }
-        public static ArrayWithUniqueItemsList validate(List<Number> arg, SchemaConfiguration configuration) {
+        public static ArrayWithUniqueItemsList validate(List<Number> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(ArrayWithUniqueItems.class, arg, configuration);
         }
@@ -188,7 +189,7 @@ public class FormatTest {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(StringSchema.class, arg, configuration);
         }
     }    
@@ -220,7 +221,7 @@ public class FormatTest {
             ))),
             new KeywordEntry("format", new FormatValidator("password"))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Password.class, arg, configuration);
         }
     }    
@@ -231,7 +232,7 @@ public class FormatTest {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(PatternWithDigits.class, arg, configuration);
         }
     }    
@@ -242,7 +243,7 @@ public class FormatTest {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(PatternWithDigitsAndDelimiter.class, arg, configuration);
         }
     }    
@@ -444,7 +445,7 @@ public class FormatTest {
 
             return new FormatTestMap(arg);
         }
-        public static FormatTestMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static FormatTestMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(FormatTest1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/FormatTest.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/FormatTest.java
@@ -161,7 +161,7 @@ public class FormatTest {
 
             super(m);
         }
-        public static ArrayWithUniqueItemsList of(List<Number> arg, SchemaConfiguration configuration) {
+        public static ArrayWithUniqueItemsList of(List<Number> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return ArrayWithUniqueItems.validate(arg, configuration);
         }
@@ -282,7 +282,7 @@ public class FormatTest {
             "pattern_with_digits_and_delimiter",
             "noneProp"
         );
-        public static FormatTestMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static FormatTestMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return FormatTest1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/FromSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/FromSchema.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.IntJsonSchema;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
@@ -80,7 +81,7 @@ public class FromSchema {
 
             return new FromSchemaMap(arg);
         }
-        public static FromSchemaMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static FromSchemaMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(FromSchema1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/FromSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/FromSchema.java
@@ -35,7 +35,7 @@ public class FromSchema {
             "data",
             "id"
         );
-        public static FromSchemaMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static FromSchemaMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return FromSchema1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Fruit.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Fruit.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
@@ -65,51 +66,51 @@ public class Fruit {
                 new PropertyEntry("color", Color.class)
             )))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Fruit1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Fruit1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Fruit1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Fruit1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Fruit1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Fruit1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Fruit1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Fruit1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Fruit1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Fruit1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Fruit1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Fruit1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Fruit.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Fruit.java
@@ -34,7 +34,7 @@ public class Fruit {
         public static final Set<String> optionalKeys = Set.of(
             "color"
         );
-        public static FruitMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static FruitMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Fruit1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/FruitReq.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/FruitReq.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.NullJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
@@ -27,51 +28,51 @@ public class FruitReq {
     
         Do not edit the class manually.
         */
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(FruitReq1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(FruitReq1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(FruitReq1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(FruitReq1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(FruitReq1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(FruitReq1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(FruitReq1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(FruitReq1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(FruitReq1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(FruitReq1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(FruitReq1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(FruitReq1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/GmFruit.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/GmFruit.java
@@ -34,7 +34,7 @@ public class GmFruit {
         public static final Set<String> optionalKeys = Set.of(
             "color"
         );
-        public static GmFruitMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static GmFruitMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return GmFruit1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/GmFruit.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/GmFruit.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
@@ -65,51 +66,51 @@ public class GmFruit {
                 new PropertyEntry("color", Color.class)
             )))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(GmFruit1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(GmFruit1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(GmFruit1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(GmFruit1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(GmFruit1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(GmFruit1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(GmFruit1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(GmFruit1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(GmFruit1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(GmFruit1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(GmFruit1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(GmFruit1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/GrandparentAnimal.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/GrandparentAnimal.java
@@ -31,7 +31,7 @@ public class GrandparentAnimal {
             "pet_type"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static GrandparentAnimalMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static GrandparentAnimalMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return GrandparentAnimal1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/GrandparentAnimal.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/GrandparentAnimal.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -68,7 +69,7 @@ public class GrandparentAnimal {
 
             return new GrandparentAnimalMap(arg);
         }
-        public static GrandparentAnimalMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static GrandparentAnimalMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(GrandparentAnimal1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/HasOnlyReadOnly.java
@@ -34,7 +34,7 @@ public class HasOnlyReadOnly {
             "bar",
             "foo"
         );
-        public static HasOnlyReadOnlyMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static HasOnlyReadOnlyMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return HasOnlyReadOnly1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/HasOnlyReadOnly.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -79,7 +80,7 @@ public class HasOnlyReadOnly {
 
             return new HasOnlyReadOnlyMap(arg);
         }
-        public static HasOnlyReadOnlyMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static HasOnlyReadOnlyMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(HasOnlyReadOnly1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/HealthCheckResult.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/HealthCheckResult.java
@@ -41,7 +41,7 @@ public class HealthCheckResult {
         public static final Set<String> optionalKeys = Set.of(
             "NullableMessage"
         );
-        public static HealthCheckResultMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static HealthCheckResultMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return HealthCheckResult1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/HealthCheckResult.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/HealthCheckResult.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -22,10 +23,10 @@ public class HealthCheckResult {
                 String.class
             )))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NullableMessage.class, arg, configuration);
         }
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NullableMessage.class, arg, configuration);
         }
     }    
@@ -79,7 +80,7 @@ public class HealthCheckResult {
 
             return new HealthCheckResultMap(arg);
         }
-        public static HealthCheckResultMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static HealthCheckResultMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(HealthCheckResult1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/IntegerEnum.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/IntegerEnum.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -27,19 +28,19 @@ public class IntegerEnum {
                 Double.class
             )))
         ));
-        public static long validate(int arg, SchemaConfiguration configuration) {
+        public static long validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerEnum1.class, Long.valueOf(arg), configuration);
         }
         
-        public static long validate(float arg, SchemaConfiguration configuration) {
+        public static long validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerEnum1.class, Long.parseLong(String.valueOf(arg)), configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerEnum1.class, arg, configuration);
         }
         
-        public static long validate(double arg, SchemaConfiguration configuration) {
+        public static long validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerEnum1.class, Long.parseLong(String.valueOf(arg)), configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/IntegerEnumBig.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/IntegerEnumBig.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -27,19 +28,19 @@ public class IntegerEnumBig {
                 Double.class
             )))
         ));
-        public static long validate(int arg, SchemaConfiguration configuration) {
+        public static long validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerEnumBig1.class, Long.valueOf(arg), configuration);
         }
         
-        public static long validate(float arg, SchemaConfiguration configuration) {
+        public static long validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerEnumBig1.class, Long.parseLong(String.valueOf(arg)), configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerEnumBig1.class, arg, configuration);
         }
         
-        public static long validate(double arg, SchemaConfiguration configuration) {
+        public static long validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerEnumBig1.class, Long.parseLong(String.valueOf(arg)), configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/IntegerEnumOneValue.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/IntegerEnumOneValue.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -27,19 +28,19 @@ public class IntegerEnumOneValue {
                 Double.class
             )))
         ));
-        public static long validate(int arg, SchemaConfiguration configuration) {
+        public static long validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerEnumOneValue1.class, Long.valueOf(arg), configuration);
         }
         
-        public static long validate(float arg, SchemaConfiguration configuration) {
+        public static long validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerEnumOneValue1.class, Long.parseLong(String.valueOf(arg)), configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerEnumOneValue1.class, arg, configuration);
         }
         
-        public static long validate(double arg, SchemaConfiguration configuration) {
+        public static long validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerEnumOneValue1.class, Long.parseLong(String.valueOf(arg)), configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/IntegerEnumWithDefaultValue.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/IntegerEnumWithDefaultValue.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -27,19 +28,19 @@ public class IntegerEnumWithDefaultValue {
                 Double.class
             )))
         ));
-        public static long validate(int arg, SchemaConfiguration configuration) {
+        public static long validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerEnumWithDefaultValue1.class, Long.valueOf(arg), configuration);
         }
         
-        public static long validate(float arg, SchemaConfiguration configuration) {
+        public static long validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerEnumWithDefaultValue1.class, Long.parseLong(String.valueOf(arg)), configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerEnumWithDefaultValue1.class, arg, configuration);
         }
         
-        public static long validate(double arg, SchemaConfiguration configuration) {
+        public static long validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerEnumWithDefaultValue1.class, Long.parseLong(String.valueOf(arg)), configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/IntegerMax10.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/IntegerMax10.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FormatValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -29,19 +30,19 @@ public class IntegerMax10 {
             ))),
             new KeywordEntry("format", new FormatValidator("int64"))
         ));
-        public static long validate(int arg, SchemaConfiguration configuration) {
+        public static long validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerMax101.class, Long.valueOf(arg), configuration);
         }
         
-        public static long validate(float arg, SchemaConfiguration configuration) {
+        public static long validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerMax101.class, Long.parseLong(String.valueOf(arg)), configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerMax101.class, arg, configuration);
         }
         
-        public static long validate(double arg, SchemaConfiguration configuration) {
+        public static long validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerMax101.class, Long.parseLong(String.valueOf(arg)), configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/IntegerMin15.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/IntegerMin15.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FormatValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -29,19 +30,19 @@ public class IntegerMin15 {
             ))),
             new KeywordEntry("format", new FormatValidator("int64"))
         ));
-        public static long validate(int arg, SchemaConfiguration configuration) {
+        public static long validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerMin151.class, Long.valueOf(arg), configuration);
         }
         
-        public static long validate(float arg, SchemaConfiguration configuration) {
+        public static long validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerMin151.class, Long.parseLong(String.valueOf(arg)), configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerMin151.class, arg, configuration);
         }
         
-        public static long validate(double arg, SchemaConfiguration configuration) {
+        public static long validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerMin151.class, Long.parseLong(String.valueOf(arg)), configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/IsoscelesTriangle.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/IsoscelesTriangle.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -26,7 +27,7 @@ public class IsoscelesTriangle {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(TriangleType.class, arg, configuration);
         }
     }    
@@ -72,7 +73,7 @@ public class IsoscelesTriangle {
 
             return new Schema1Map(arg);
         }
-        public static Schema1Map validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static Schema1Map validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
@@ -86,51 +87,51 @@ public class IsoscelesTriangle {
     
         Do not edit the class manually.
         */
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IsoscelesTriangle1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IsoscelesTriangle1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IsoscelesTriangle1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IsoscelesTriangle1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IsoscelesTriangle1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IsoscelesTriangle1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IsoscelesTriangle1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IsoscelesTriangle1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IsoscelesTriangle1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IsoscelesTriangle1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IsoscelesTriangle1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IsoscelesTriangle1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/IsoscelesTriangle.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/IsoscelesTriangle.java
@@ -42,7 +42,7 @@ public class IsoscelesTriangle {
         public static final Set<String> optionalKeys = Set.of(
             "triangleType"
         );
-        public static Schema1Map of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static Schema1Map of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Items.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Items.java
@@ -27,7 +27,7 @@ public class Items {
 
             super(m);
         }
-        public static ItemsList of(List<Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static ItemsList of(List<Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return Items1.validate(arg, configuration);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Items.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Items.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.MapJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
@@ -51,7 +52,7 @@ public class Items {
 
             return new ItemsList(arg);
         }
-        public static ItemsList validate(List<Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static ItemsList validate(List<Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return JsonSchema.validate(Items1.class, arg, configuration);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/JSONPatchRequest.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/JSONPatchRequest.java
@@ -76,7 +76,7 @@ public class JSONPatchRequest {
 
             super(m);
         }
-        public static JSONPatchRequestList of(List<Object> arg, SchemaConfiguration configuration) {
+        public static JSONPatchRequestList of(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JSONPatchRequest1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/JSONPatchRequest.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/JSONPatchRequest.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.ItemsValidator;
@@ -20,51 +21,51 @@ public class JSONPatchRequest {
     
     
     public class Items extends JsonSchema {
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Items.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Items.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Items.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Items.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Items.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Items.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Items.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Items.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Items.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Items.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Items.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Items.class, arg, configuration);
         }
     }    
@@ -97,7 +98,7 @@ public class JSONPatchRequest {
 
             return new JSONPatchRequestList(arg);
         }
-        public static JSONPatchRequestList validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static JSONPatchRequestList validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(JSONPatchRequest1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/JSONPatchRequestAddReplaceTest.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/JSONPatchRequestAddReplaceTest.java
@@ -54,7 +54,7 @@ public class JSONPatchRequestAddReplaceTest {
             "value"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static JSONPatchRequestAddReplaceTestMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static JSONPatchRequestAddReplaceTestMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JSONPatchRequestAddReplaceTest1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/JSONPatchRequestAddReplaceTest.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/JSONPatchRequestAddReplaceTest.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.StringJsonSchema;
@@ -36,7 +37,7 @@ public class JSONPatchRequestAddReplaceTest {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Op.class, arg, configuration);
         }
     }    
@@ -101,7 +102,7 @@ public class JSONPatchRequestAddReplaceTest {
 
             return new JSONPatchRequestAddReplaceTestMap(arg);
         }
-        public static JSONPatchRequestAddReplaceTestMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static JSONPatchRequestAddReplaceTestMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(JSONPatchRequestAddReplaceTest1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/JSONPatchRequestMoveCopy.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/JSONPatchRequestMoveCopy.java
@@ -54,7 +54,7 @@ public class JSONPatchRequestMoveCopy {
             "path"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static JSONPatchRequestMoveCopyMap of(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static JSONPatchRequestMoveCopyMap of(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JSONPatchRequestMoveCopy1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/JSONPatchRequestMoveCopy.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/JSONPatchRequestMoveCopy.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.StringJsonSchema;
@@ -36,7 +37,7 @@ public class JSONPatchRequestMoveCopy {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Op.class, arg, configuration);
         }
     }    
@@ -100,7 +101,7 @@ public class JSONPatchRequestMoveCopy {
 
             return new JSONPatchRequestMoveCopyMap(arg);
         }
-        public static JSONPatchRequestMoveCopyMap validate(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static JSONPatchRequestMoveCopyMap validate(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(JSONPatchRequestMoveCopy1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/JSONPatchRequestRemove.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/JSONPatchRequestRemove.java
@@ -50,7 +50,7 @@ public class JSONPatchRequestRemove {
             "path"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static JSONPatchRequestRemoveMap of(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static JSONPatchRequestRemoveMap of(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JSONPatchRequestRemove1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/JSONPatchRequestRemove.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/JSONPatchRequestRemove.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.StringJsonSchema;
@@ -33,7 +34,7 @@ public class JSONPatchRequestRemove {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Op.class, arg, configuration);
         }
     }    
@@ -89,7 +90,7 @@ public class JSONPatchRequestRemove {
 
             return new JSONPatchRequestRemoveMap(arg);
         }
-        public static JSONPatchRequestRemoveMap validate(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static JSONPatchRequestRemoveMap validate(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(JSONPatchRequestRemove1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Mammal.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Mammal.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -23,51 +24,51 @@ public class Mammal {
     
         Do not edit the class manually.
         */
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Mammal1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Mammal1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Mammal1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Mammal1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Mammal1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Mammal1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Mammal1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Mammal1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Mammal1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Mammal1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Mammal1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Mammal1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/MapTest.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/MapTest.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.BooleanJsonSchema;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.AdditionalPropertiesValidator;
@@ -50,7 +51,7 @@ public class MapTest {
 
             return new AdditionalPropertiesMap(arg);
         }
-        public static AdditionalPropertiesMap validate(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static AdditionalPropertiesMap validate(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(AdditionalProperties.class, arg, configuration);
         }
@@ -87,7 +88,7 @@ public class MapTest {
 
             return new MapMapOfStringMap(arg);
         }
-        public static MapMapOfStringMap validate(Map<String, Map<String, String>> arg, SchemaConfiguration configuration) {
+        public static MapMapOfStringMap validate(Map<String, Map<String, String>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return JsonSchema.validate(MapMapOfString.class, arg, configuration);
@@ -101,7 +102,7 @@ public class MapTest {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AdditionalProperties2.class, arg, configuration);
         }
     }    
@@ -135,7 +136,7 @@ public class MapTest {
 
             return new MapOfEnumStringMap(arg);
         }
-        public static MapOfEnumStringMap validate(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static MapOfEnumStringMap validate(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(MapOfEnumString.class, arg, configuration);
         }
@@ -174,7 +175,7 @@ public class MapTest {
 
             return new DirectMapMap(arg);
         }
-        public static DirectMapMap validate(Map<String, Boolean> arg, SchemaConfiguration configuration) {
+        public static DirectMapMap validate(Map<String, Boolean> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(DirectMap.class, arg, configuration);
         }
@@ -258,7 +259,7 @@ public class MapTest {
 
             return new MapTestMap(arg);
         }
-        public static MapTestMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static MapTestMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(MapTest1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/MapTest.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/MapTest.java
@@ -30,7 +30,7 @@ public class MapTest {
         }
         public static final Set<String> requiredKeys = Set.of();
         public static final Set<String> optionalKeys = Set.of();
-        public static AdditionalPropertiesMap of(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static AdditionalPropertiesMap of(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return AdditionalProperties.validate(arg, configuration);
         }
@@ -66,7 +66,7 @@ public class MapTest {
         }
         public static final Set<String> requiredKeys = Set.of();
         public static final Set<String> optionalKeys = Set.of();
-        public static MapMapOfStringMap of(Map<String, Map<String, String>> arg, SchemaConfiguration configuration) {
+        public static MapMapOfStringMap of(Map<String, Map<String, String>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return MapMapOfString.validate(arg, configuration);
@@ -115,7 +115,7 @@ public class MapTest {
         }
         public static final Set<String> requiredKeys = Set.of();
         public static final Set<String> optionalKeys = Set.of();
-        public static MapOfEnumStringMap of(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static MapOfEnumStringMap of(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return MapOfEnumString.validate(arg, configuration);
         }
@@ -154,7 +154,7 @@ public class MapTest {
         }
         public static final Set<String> requiredKeys = Set.of();
         public static final Set<String> optionalKeys = Set.of();
-        public static DirectMapMap of(Map<String, Boolean> arg, SchemaConfiguration configuration) {
+        public static DirectMapMap of(Map<String, Boolean> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return DirectMap.validate(arg, configuration);
         }
@@ -195,7 +195,7 @@ public class MapTest {
             "direct_map",
             "indirect_map"
         );
-        public static MapTestMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static MapTestMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return MapTest1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -33,7 +33,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
         }
         public static final Set<String> requiredKeys = Set.of();
         public static final Set<String> optionalKeys = Set.of();
-        public static MapMap of(Map<String, Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static MapMap of(Map<String, Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return MapSchema.validate(arg, configuration);
@@ -75,7 +75,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
             "dateTime",
             "map"
         );
-        public static MixedPropertiesAndAdditionalPropertiesClassMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static MixedPropertiesAndAdditionalPropertiesClassMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return MixedPropertiesAndAdditionalPropertiesClass1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.DateTimeJsonSchema;
 import org.openapijsonschematools.schemas.UuidJsonSchema;
 import org.openapijsonschematools.schemas.validation.AdditionalPropertiesValidator;
@@ -54,7 +55,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
 
             return new MapMap(arg);
         }
-        public static MapMap validate(Map<String, Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static MapMap validate(Map<String, Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return JsonSchema.validate(MapSchema.class, arg, configuration);
@@ -113,7 +114,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
 
             return new MixedPropertiesAndAdditionalPropertiesClassMap(arg);
         }
-        public static MixedPropertiesAndAdditionalPropertiesClassMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static MixedPropertiesAndAdditionalPropertiesClassMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(MixedPropertiesAndAdditionalPropertiesClass1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Money.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Money.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.DecimalJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
@@ -79,7 +80,7 @@ public class Money {
 
             return new MoneyMap(arg);
         }
-        public static MoneyMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static MoneyMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Money1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Money.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Money.java
@@ -39,7 +39,7 @@ public class Money {
             "currency"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static MoneyMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static MoneyMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Money1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/MyObjectDto.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/MyObjectDto.java
@@ -37,7 +37,7 @@ public class MyObjectDto {
         public static final Set<String> optionalKeys = Set.of(
             "id"
         );
-        public static MyObjectDtoMap of(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static MyObjectDtoMap of(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return MyObjectDto1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/MyObjectDto.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/MyObjectDto.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.UuidJsonSchema;
@@ -67,7 +68,7 @@ public class MyObjectDto {
 
             return new MyObjectDtoMap(arg);
         }
-        public static MyObjectDtoMap validate(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static MyObjectDtoMap validate(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(MyObjectDto1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Name.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Name.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.Int32JsonSchema;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenList;
@@ -97,51 +98,51 @@ public class Name {
                 "name"
             )))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Name1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Name1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Name1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Name1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Name1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Name1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Name1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Name1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Name1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Name1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Name1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Name1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Name.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Name.java
@@ -45,7 +45,7 @@ public class Name {
             "snake_case",
             "property"
         );
-        public static NameMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static NameMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Name1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/NoAdditionalProperties.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/NoAdditionalProperties.java
@@ -43,7 +43,7 @@ public class NoAdditionalProperties {
         public static final Set<String> optionalKeys = Set.of(
             "petId"
         );
-        public static NoAdditionalPropertiesMap of(Map<String, Long> arg, SchemaConfiguration configuration) {
+        public static NoAdditionalPropertiesMap of(Map<String, Long> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return NoAdditionalProperties1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/NoAdditionalProperties.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/NoAdditionalProperties.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.Int64JsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
@@ -82,7 +83,7 @@ public class NoAdditionalProperties {
 
             return new NoAdditionalPropertiesMap(arg);
         }
-        public static NoAdditionalPropertiesMap validate(Map<String, Long> arg, SchemaConfiguration configuration) {
+        public static NoAdditionalPropertiesMap validate(Map<String, Long> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(NoAdditionalProperties1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/NullableClass.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/NullableClass.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.MapJsonSchema;
 import org.openapijsonschematools.schemas.validation.AdditionalPropertiesValidator;
 import org.openapijsonschematools.schemas.validation.FormatValidator;
@@ -30,10 +31,10 @@ public class NullableClass {
                 FrozenMap.class
             )))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AdditionalProperties3.class, arg, configuration);
         }
-        public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AdditionalProperties3.class, arg, configuration);
         }
     }    
@@ -48,22 +49,22 @@ public class NullableClass {
                 Double.class
             )))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerProp.class, arg, configuration);
         }
-        public static long validate(int arg, SchemaConfiguration configuration) {
+        public static long validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerProp.class, Long.valueOf(arg), configuration);
         }
         
-        public static long validate(float arg, SchemaConfiguration configuration) {
+        public static long validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerProp.class, Long.parseLong(String.valueOf(arg)), configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerProp.class, arg, configuration);
         }
         
-        public static long validate(double arg, SchemaConfiguration configuration) {
+        public static long validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerProp.class, Long.parseLong(String.valueOf(arg)), configuration);
         }
     }    
@@ -78,22 +79,22 @@ public class NullableClass {
                 Double.class
             )))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NumberProp.class, arg, configuration);
         }
-        public static Number validate(int arg, SchemaConfiguration configuration) {
-            return JsonSchema.validate(NumberProp.class, arg, configuration);
-        }
-        
-        public static Number validate(long arg, SchemaConfiguration configuration) {
+        public static Number validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NumberProp.class, arg, configuration);
         }
         
-        public static Number validate(float arg, SchemaConfiguration configuration) {
+        public static Number validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NumberProp.class, arg, configuration);
         }
         
-        public static Number validate(double arg, SchemaConfiguration configuration) {
+        public static Number validate(float arg, SchemaConfiguration configuration) throws ValidationException {
+            return JsonSchema.validate(NumberProp.class, arg, configuration);
+        }
+        
+        public static Number validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NumberProp.class, arg, configuration);
         }
     }    
@@ -105,10 +106,10 @@ public class NullableClass {
                 Boolean.class
             )))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(BooleanProp.class, arg, configuration);
         }
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(BooleanProp.class, arg, configuration);
         }
     }    
@@ -120,10 +121,10 @@ public class NullableClass {
                 String.class
             )))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(StringProp.class, arg, configuration);
         }
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(StringProp.class, arg, configuration);
         }
     }    
@@ -136,10 +137,10 @@ public class NullableClass {
             ))),
             new KeywordEntry("format", new FormatValidator("date"))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(DateProp.class, arg, configuration);
         }
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(DateProp.class, arg, configuration);
         }
     }    
@@ -152,10 +153,10 @@ public class NullableClass {
             ))),
             new KeywordEntry("format", new FormatValidator("date-time"))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(DatetimeProp.class, arg, configuration);
         }
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(DatetimeProp.class, arg, configuration);
         }
     }    
@@ -185,10 +186,10 @@ public class NullableClass {
             ))),
             new KeywordEntry("items", new ItemsValidator(Items.class))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ArrayNullableProp.class, arg, configuration);
         }
-        public static ArrayNullablePropList validate(List<Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static ArrayNullablePropList validate(List<Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return JsonSchema.validate(ArrayNullableProp.class, arg, configuration);
@@ -202,10 +203,10 @@ public class NullableClass {
                 FrozenMap.class
             )))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Items1.class, arg, configuration);
         }
-        public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Items1.class, arg, configuration);
         }
     }    
@@ -232,10 +233,10 @@ public class NullableClass {
             ))),
             new KeywordEntry("items", new ItemsValidator(Items1.class))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ArrayAndItemsNullableProp.class, arg, configuration);
         }
-        public static ArrayAndItemsNullablePropList validate(List<Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static ArrayAndItemsNullablePropList validate(List<Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return JsonSchema.validate(ArrayAndItemsNullableProp.class, arg, configuration);
@@ -249,10 +250,10 @@ public class NullableClass {
                 FrozenMap.class
             )))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Items2.class, arg, configuration);
         }
-        public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Items2.class, arg, configuration);
         }
     }    
@@ -280,7 +281,7 @@ public class NullableClass {
 
             return new ArrayItemsNullableList(arg);
         }
-        public static ArrayItemsNullableList validate(List<Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static ArrayItemsNullableList validate(List<Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return JsonSchema.validate(ArrayItemsNullable.class, arg, configuration);
@@ -319,10 +320,10 @@ public class NullableClass {
             ))),
             new KeywordEntry("additionalProperties", new AdditionalPropertiesValidator(AdditionalProperties.class))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ObjectNullableProp.class, arg, configuration);
         }
-        public static ObjectNullablePropMap validate(Map<String, Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static ObjectNullablePropMap validate(Map<String, Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return JsonSchema.validate(ObjectNullableProp.class, arg, configuration);
@@ -336,10 +337,10 @@ public class NullableClass {
                 FrozenMap.class
             )))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AdditionalProperties1.class, arg, configuration);
         }
-        public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AdditionalProperties1.class, arg, configuration);
         }
     }    
@@ -373,10 +374,10 @@ public class NullableClass {
             ))),
             new KeywordEntry("additionalProperties", new AdditionalPropertiesValidator(AdditionalProperties1.class))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ObjectAndItemsNullableProp.class, arg, configuration);
         }
-        public static ObjectAndItemsNullablePropMap validate(Map<String, Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static ObjectAndItemsNullablePropMap validate(Map<String, Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return JsonSchema.validate(ObjectAndItemsNullableProp.class, arg, configuration);
@@ -390,10 +391,10 @@ public class NullableClass {
                 FrozenMap.class
             )))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AdditionalProperties2.class, arg, configuration);
         }
-        public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AdditionalProperties2.class, arg, configuration);
         }
     }    
@@ -428,7 +429,7 @@ public class NullableClass {
 
             return new ObjectItemsNullableMap(arg);
         }
-        public static ObjectItemsNullableMap validate(Map<String, Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static ObjectItemsNullableMap validate(Map<String, Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return JsonSchema.validate(ObjectItemsNullable.class, arg, configuration);
@@ -595,7 +596,7 @@ public class NullableClass {
 
             return new NullableClassMap(arg);
         }
-        public static NullableClassMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static NullableClassMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(NullableClass1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/NullableClass.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/NullableClass.java
@@ -170,7 +170,7 @@ public class NullableClass {
 
             super(m);
         }
-        public static ArrayNullablePropList of(List<Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static ArrayNullablePropList of(List<Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return ArrayNullableProp.validate(arg, configuration);
@@ -217,7 +217,7 @@ public class NullableClass {
 
             super(m);
         }
-        public static ArrayAndItemsNullablePropList of(List<Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static ArrayAndItemsNullablePropList of(List<Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return ArrayAndItemsNullableProp.validate(arg, configuration);
@@ -264,7 +264,7 @@ public class NullableClass {
 
             super(m);
         }
-        public static ArrayItemsNullableList of(List<Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static ArrayItemsNullableList of(List<Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return ArrayItemsNullable.validate(arg, configuration);
@@ -299,7 +299,7 @@ public class NullableClass {
         }
         public static final Set<String> requiredKeys = Set.of();
         public static final Set<String> optionalKeys = Set.of();
-        public static ObjectNullablePropMap of(Map<String, Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static ObjectNullablePropMap of(Map<String, Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return ObjectNullableProp.validate(arg, configuration);
@@ -353,7 +353,7 @@ public class NullableClass {
         }
         public static final Set<String> requiredKeys = Set.of();
         public static final Set<String> optionalKeys = Set.of();
-        public static ObjectAndItemsNullablePropMap of(Map<String, Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static ObjectAndItemsNullablePropMap of(Map<String, Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return ObjectAndItemsNullableProp.validate(arg, configuration);
@@ -407,7 +407,7 @@ public class NullableClass {
         }
         public static final Set<String> requiredKeys = Set.of();
         public static final Set<String> optionalKeys = Set.of();
-        public static ObjectItemsNullableMap of(Map<String, Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static ObjectItemsNullableMap of(Map<String, Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return ObjectItemsNullable.validate(arg, configuration);
@@ -458,7 +458,7 @@ public class NullableClass {
             "object_and_items_nullable_prop",
             "object_items_nullable"
         );
-        public static NullableClassMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static NullableClassMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return NullableClass1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/NullableShape.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/NullableShape.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.NullJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
@@ -29,51 +30,51 @@ public class NullableShape {
     
         The value may be a shape or the 'null' value. For a composed schema to validate a null payload, one of its chosen oneOf schemas must be type null or nullable (introduced in OAS schema >= 3.0)
         */
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NullableShape1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NullableShape1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NullableShape1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NullableShape1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NullableShape1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NullableShape1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NullableShape1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NullableShape1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NullableShape1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NullableShape1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NullableShape1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NullableShape1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/NullableString.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/NullableString.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -25,10 +26,10 @@ public class NullableString {
                 String.class
             )))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NullableString1.class, arg, configuration);
         }
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NullableString1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/NumberOnly.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/NumberOnly.java
@@ -30,7 +30,7 @@ public class NumberOnly {
         public static final Set<String> optionalKeys = Set.of(
             "JustNumber"
         );
-        public static NumberOnlyMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static NumberOnlyMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return NumberOnly1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/NumberOnly.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/NumberOnly.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.NumberJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -66,7 +67,7 @@ public class NumberOnly {
 
             return new NumberOnlyMap(arg);
         }
-        public static NumberOnlyMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static NumberOnlyMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(NumberOnly1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/NumberWithValidations.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/NumberWithValidations.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -27,19 +28,19 @@ public class NumberWithValidations {
                 Double.class
             )))
         ));
-        public static Number validate(int arg, SchemaConfiguration configuration) {
+        public static Number validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NumberWithValidations1.class, arg, configuration);
         }
         
-        public static Number validate(long arg, SchemaConfiguration configuration) {
+        public static Number validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NumberWithValidations1.class, arg, configuration);
         }
         
-        public static Number validate(float arg, SchemaConfiguration configuration) {
+        public static Number validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NumberWithValidations1.class, arg, configuration);
         }
         
-        public static Number validate(double arg, SchemaConfiguration configuration) {
+        public static Number validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NumberWithValidations1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjWithRequiredProps.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjWithRequiredProps.java
@@ -31,7 +31,7 @@ public class ObjWithRequiredProps {
             "a"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static ObjWithRequiredPropsMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ObjWithRequiredPropsMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return ObjWithRequiredProps1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjWithRequiredProps.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjWithRequiredProps.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -68,7 +69,7 @@ public class ObjWithRequiredProps {
 
             return new ObjWithRequiredPropsMap(arg);
         }
-        public static ObjWithRequiredPropsMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ObjWithRequiredPropsMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(ObjWithRequiredProps1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjWithRequiredPropsBase.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjWithRequiredPropsBase.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -68,7 +69,7 @@ public class ObjWithRequiredPropsBase {
 
             return new ObjWithRequiredPropsBaseMap(arg);
         }
-        public static ObjWithRequiredPropsBaseMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ObjWithRequiredPropsBaseMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(ObjWithRequiredPropsBase1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjWithRequiredPropsBase.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjWithRequiredPropsBase.java
@@ -31,7 +31,7 @@ public class ObjWithRequiredPropsBase {
             "b"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static ObjWithRequiredPropsBaseMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ObjWithRequiredPropsBaseMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return ObjWithRequiredPropsBase1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectModelWithArgAndArgsProperties.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectModelWithArgAndArgsProperties.java
@@ -35,7 +35,7 @@ public class ObjectModelWithArgAndArgsProperties {
             "args"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static ObjectModelWithArgAndArgsPropertiesMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ObjectModelWithArgAndArgsPropertiesMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return ObjectModelWithArgAndArgsProperties1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectModelWithArgAndArgsProperties.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectModelWithArgAndArgsProperties.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -80,7 +81,7 @@ public class ObjectModelWithArgAndArgsProperties {
 
             return new ObjectModelWithArgAndArgsPropertiesMap(arg);
         }
-        public static ObjectModelWithArgAndArgsPropertiesMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ObjectModelWithArgAndArgsPropertiesMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(ObjectModelWithArgAndArgsProperties1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectModelWithRefProps.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectModelWithRefProps.java
@@ -28,7 +28,7 @@ public class ObjectModelWithRefProps {
             "myString",
             "myBoolean"
         );
-        public static ObjectModelWithRefPropsMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ObjectModelWithRefPropsMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return ObjectModelWithRefProps1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectModelWithRefProps.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectModelWithRefProps.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -84,7 +85,7 @@ public class ObjectModelWithRefProps {
 
             return new ObjectModelWithRefPropsMap(arg);
         }
-        public static ObjectModelWithRefPropsMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ObjectModelWithRefPropsMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(ObjectModelWithRefProps1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithAllOfWithReqTestPropFromUnsetAddProp.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithAllOfWithReqTestPropFromUnsetAddProp.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
@@ -75,7 +76,7 @@ public class ObjectWithAllOfWithReqTestPropFromUnsetAddProp {
 
             return new Schema1Map(arg);
         }
-        public static Schema1Map validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static Schema1Map validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
@@ -89,51 +90,51 @@ public class ObjectWithAllOfWithReqTestPropFromUnsetAddProp {
     
         Do not edit the class manually.
         */
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ObjectWithAllOfWithReqTestPropFromUnsetAddProp1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ObjectWithAllOfWithReqTestPropFromUnsetAddProp1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ObjectWithAllOfWithReqTestPropFromUnsetAddProp1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ObjectWithAllOfWithReqTestPropFromUnsetAddProp1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ObjectWithAllOfWithReqTestPropFromUnsetAddProp1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ObjectWithAllOfWithReqTestPropFromUnsetAddProp1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ObjectWithAllOfWithReqTestPropFromUnsetAddProp1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ObjectWithAllOfWithReqTestPropFromUnsetAddProp1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ObjectWithAllOfWithReqTestPropFromUnsetAddProp1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ObjectWithAllOfWithReqTestPropFromUnsetAddProp1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ObjectWithAllOfWithReqTestPropFromUnsetAddProp1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ObjectWithAllOfWithReqTestPropFromUnsetAddProp1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithAllOfWithReqTestPropFromUnsetAddProp.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithAllOfWithReqTestPropFromUnsetAddProp.java
@@ -38,7 +38,7 @@ public class ObjectWithAllOfWithReqTestPropFromUnsetAddProp {
         public static final Set<String> optionalKeys = Set.of(
             "name"
         );
-        public static Schema1Map of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static Schema1Map of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithCollidingProperties.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithCollidingProperties.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.MapJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -81,7 +82,7 @@ public class ObjectWithCollidingProperties {
 
             return new ObjectWithCollidingPropertiesMap(arg);
         }
-        public static ObjectWithCollidingPropertiesMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ObjectWithCollidingPropertiesMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(ObjectWithCollidingProperties1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithCollidingProperties.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithCollidingProperties.java
@@ -34,7 +34,7 @@ public class ObjectWithCollidingProperties {
             "someProp",
             "someprop"
         );
-        public static ObjectWithCollidingPropertiesMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ObjectWithCollidingPropertiesMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return ObjectWithCollidingProperties1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithDecimalProperties.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithDecimalProperties.java
@@ -32,7 +32,7 @@ public class ObjectWithDecimalProperties {
             "width",
             "cost"
         );
-        public static ObjectWithDecimalPropertiesMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ObjectWithDecimalPropertiesMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return ObjectWithDecimalProperties1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithDecimalProperties.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithDecimalProperties.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.DecimalJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -86,7 +87,7 @@ public class ObjectWithDecimalProperties {
 
             return new ObjectWithDecimalPropertiesMap(arg);
         }
-        public static ObjectWithDecimalPropertiesMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ObjectWithDecimalPropertiesMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(ObjectWithDecimalProperties1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithDifficultlyNamedProps.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithDifficultlyNamedProps.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.Int64JsonSchema;
 import org.openapijsonschematools.schemas.IntJsonSchema;
 import org.openapijsonschematools.schemas.StringJsonSchema;
@@ -77,7 +78,7 @@ public class ObjectWithDifficultlyNamedProps {
 
             return new ObjectWithDifficultlyNamedPropsMap(arg);
         }
-        public static ObjectWithDifficultlyNamedPropsMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ObjectWithDifficultlyNamedPropsMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(ObjectWithDifficultlyNamedProps1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithDifficultlyNamedProps.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithDifficultlyNamedProps.java
@@ -42,7 +42,7 @@ public class ObjectWithDifficultlyNamedProps {
             "$special[property.name]",
             "123Number"
         );
-        public static ObjectWithDifficultlyNamedPropsMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ObjectWithDifficultlyNamedPropsMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return ObjectWithDifficultlyNamedProps1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithInlineCompositionProperty.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithInlineCompositionProperty.java
@@ -92,7 +92,7 @@ public class ObjectWithInlineCompositionProperty {
         public static final Set<String> optionalKeys = Set.of(
             "someProp"
         );
-        public static ObjectWithInlineCompositionPropertyMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ObjectWithInlineCompositionPropertyMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return ObjectWithInlineCompositionProperty1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithInlineCompositionProperty.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithInlineCompositionProperty.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -26,57 +27,57 @@ public class ObjectWithInlineCompositionProperty {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema0.class, arg, configuration);
         }
     }    
     
     public class SomeProp extends JsonSchema {
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
     }    
@@ -127,7 +128,7 @@ public class ObjectWithInlineCompositionProperty {
 
             return new ObjectWithInlineCompositionPropertyMap(arg);
         }
-        public static ObjectWithInlineCompositionPropertyMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ObjectWithInlineCompositionPropertyMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(ObjectWithInlineCompositionProperty1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithInvalidNamedRefedProperties.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithInvalidNamedRefedProperties.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -67,7 +68,7 @@ public class ObjectWithInvalidNamedRefedProperties {
 
             return new ObjectWithInvalidNamedRefedPropertiesMap(arg);
         }
-        public static ObjectWithInvalidNamedRefedPropertiesMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ObjectWithInvalidNamedRefedPropertiesMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(ObjectWithInvalidNamedRefedProperties1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithInvalidNamedRefedProperties.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithInvalidNamedRefedProperties.java
@@ -28,7 +28,7 @@ public class ObjectWithInvalidNamedRefedProperties {
             "from"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static ObjectWithInvalidNamedRefedPropertiesMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ObjectWithInvalidNamedRefedPropertiesMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return ObjectWithInvalidNamedRefedProperties1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithNonIntersectingValues.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithNonIntersectingValues.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.NumberJsonSchema;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.AdditionalPropertiesValidator;
@@ -73,7 +74,7 @@ public class ObjectWithNonIntersectingValues {
 
             return new ObjectWithNonIntersectingValuesMap(arg);
         }
-        public static ObjectWithNonIntersectingValuesMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ObjectWithNonIntersectingValuesMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(ObjectWithNonIntersectingValues1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithNonIntersectingValues.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithNonIntersectingValues.java
@@ -35,7 +35,7 @@ public class ObjectWithNonIntersectingValues {
         public static final Set<String> optionalKeys = Set.of(
             "a"
         );
-        public static ObjectWithNonIntersectingValuesMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ObjectWithNonIntersectingValuesMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return ObjectWithNonIntersectingValues1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithOnlyOptionalProps.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithOnlyOptionalProps.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NumberJsonSchema;
@@ -82,7 +83,7 @@ public class ObjectWithOnlyOptionalProps {
 
             return new ObjectWithOnlyOptionalPropsMap(arg);
         }
-        public static ObjectWithOnlyOptionalPropsMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ObjectWithOnlyOptionalPropsMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(ObjectWithOnlyOptionalProps1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithOnlyOptionalProps.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithOnlyOptionalProps.java
@@ -42,7 +42,7 @@ public class ObjectWithOnlyOptionalProps {
             "a",
             "b"
         );
-        public static ObjectWithOnlyOptionalPropsMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ObjectWithOnlyOptionalPropsMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return ObjectWithOnlyOptionalProps1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithOptionalTestProp.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithOptionalTestProp.java
@@ -30,7 +30,7 @@ public class ObjectWithOptionalTestProp {
         public static final Set<String> optionalKeys = Set.of(
             "test"
         );
-        public static ObjectWithOptionalTestPropMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ObjectWithOptionalTestPropMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return ObjectWithOptionalTestProp1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithOptionalTestProp.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithOptionalTestProp.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -66,7 +67,7 @@ public class ObjectWithOptionalTestProp {
 
             return new ObjectWithOptionalTestPropMap(arg);
         }
-        public static ObjectWithOptionalTestPropMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ObjectWithOptionalTestPropMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(ObjectWithOptionalTestProp1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithValidations.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ObjectWithValidations.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -23,7 +24,7 @@ public class ObjectWithValidations {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(FrozenMap.class)))
         ));
-        public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ObjectWithValidations1.class, arg, configuration);
         }
     }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Order.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Order.java
@@ -61,7 +61,7 @@ public class Order {
             "status",
             "complete"
         );
-        public static OrderMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static OrderMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Order1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Order.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Order.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.BooleanJsonSchema;
 import org.openapijsonschematools.schemas.DateTimeJsonSchema;
 import org.openapijsonschematools.schemas.Int32JsonSchema;
@@ -37,7 +38,7 @@ public class Order {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Status.class, arg, configuration);
         }
     }    
@@ -142,7 +143,7 @@ public class Order {
 
             return new OrderMap(arg);
         }
-        public static OrderMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static OrderMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Order1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/PaginatedResultMyObjectDto.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/PaginatedResultMyObjectDto.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.IntJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
@@ -53,7 +54,7 @@ public class PaginatedResultMyObjectDto {
 
             return new ResultsList(arg);
         }
-        public static ResultsList validate(List<Map<String, String>> arg, SchemaConfiguration configuration) {
+        public static ResultsList validate(List<Map<String, String>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return JsonSchema.validate(Results.class, arg, configuration);
@@ -112,7 +113,7 @@ public class PaginatedResultMyObjectDto {
 
             return new PaginatedResultMyObjectDtoMap(arg);
         }
-        public static PaginatedResultMyObjectDtoMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static PaginatedResultMyObjectDtoMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(PaginatedResultMyObjectDto1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/PaginatedResultMyObjectDto.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/PaginatedResultMyObjectDto.java
@@ -37,7 +37,7 @@ public class PaginatedResultMyObjectDto {
 
             super(m);
         }
-        public static ResultsList of(List<Map<String, String>> arg, SchemaConfiguration configuration) {
+        public static ResultsList of(List<Map<String, String>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return Results.validate(arg, configuration);
@@ -72,7 +72,7 @@ public class PaginatedResultMyObjectDto {
             "results"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static PaginatedResultMyObjectDtoMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static PaginatedResultMyObjectDtoMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return PaginatedResultMyObjectDto1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ParentPet.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ParentPet.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -23,7 +24,7 @@ public class ParentPet {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(FrozenMap.class)))
         ));
-        public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ParentPet1.class, arg, configuration);
         }
     }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Pet.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Pet.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.Int64JsonSchema;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenList;
@@ -52,7 +53,7 @@ public class Pet {
 
             return new PhotoUrlsList(arg);
         }
-        public static PhotoUrlsList validate(List<String> arg, SchemaConfiguration configuration) {
+        public static PhotoUrlsList validate(List<String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(PhotoUrls.class, arg, configuration);
         }
@@ -64,7 +65,7 @@ public class Pet {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Status.class, arg, configuration);
         }
     }    
@@ -92,7 +93,7 @@ public class Pet {
 
             return new TagsList(arg);
         }
-        public static TagsList validate(List<Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static TagsList validate(List<Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return JsonSchema.validate(Tags.class, arg, configuration);
@@ -199,7 +200,7 @@ public class Pet {
 
             return new PetMap(arg);
         }
-        public static PetMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static PetMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Pet1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Pet.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Pet.java
@@ -37,7 +37,7 @@ public class Pet {
 
             super(m);
         }
-        public static PhotoUrlsList of(List<String> arg, SchemaConfiguration configuration) {
+        public static PhotoUrlsList of(List<String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return PhotoUrls.validate(arg, configuration);
         }
@@ -76,7 +76,7 @@ public class Pet {
 
             super(m);
         }
-        public static TagsList of(List<Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static TagsList of(List<Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return Tags.validate(arg, configuration);
@@ -116,7 +116,7 @@ public class Pet {
             "tags",
             "status"
         );
-        public static PetMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static PetMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Pet1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Pig.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Pig.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -23,51 +24,51 @@ public class Pig {
     
         Do not edit the class manually.
         */
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Pig1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Pig1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Pig1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Pig1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Pig1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Pig1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Pig1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Pig1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Pig1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Pig1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Pig1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Pig1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Player.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Player.java
@@ -31,7 +31,7 @@ public class Player {
             "name",
             "enemyPlayer"
         );
-        public static PlayerMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static PlayerMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Player1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Player.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Player.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -78,7 +79,7 @@ public class Player {
 
             return new PlayerMap(arg);
         }
-        public static PlayerMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static PlayerMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Player1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/PublicKey.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/PublicKey.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -68,7 +69,7 @@ public class PublicKey {
 
             return new PublicKeyMap(arg);
         }
-        public static PublicKeyMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static PublicKeyMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(PublicKey1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/PublicKey.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/PublicKey.java
@@ -30,7 +30,7 @@ public class PublicKey {
         public static final Set<String> optionalKeys = Set.of(
             "key"
         );
-        public static PublicKeyMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static PublicKeyMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return PublicKey1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Quadrilateral.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Quadrilateral.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -23,51 +24,51 @@ public class Quadrilateral {
     
         Do not edit the class manually.
         */
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Quadrilateral1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Quadrilateral1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Quadrilateral1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Quadrilateral1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Quadrilateral1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Quadrilateral1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Quadrilateral1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Quadrilateral1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Quadrilateral1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Quadrilateral1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Quadrilateral1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Quadrilateral1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/QuadrilateralInterface.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/QuadrilateralInterface.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
@@ -28,7 +29,7 @@ public class QuadrilateralInterface {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ShapeType.class, arg, configuration);
         }
     }    
@@ -88,51 +89,51 @@ public class QuadrilateralInterface {
                 "shapeType"
             )))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(QuadrilateralInterface1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(QuadrilateralInterface1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(QuadrilateralInterface1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(QuadrilateralInterface1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(QuadrilateralInterface1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(QuadrilateralInterface1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(QuadrilateralInterface1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(QuadrilateralInterface1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(QuadrilateralInterface1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(QuadrilateralInterface1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(QuadrilateralInterface1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(QuadrilateralInterface1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/QuadrilateralInterface.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/QuadrilateralInterface.java
@@ -48,7 +48,7 @@ public class QuadrilateralInterface {
             "shapeType"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static QuadrilateralInterfaceMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static QuadrilateralInterfaceMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return QuadrilateralInterface1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ReadOnlyFirst.java
@@ -34,7 +34,7 @@ public class ReadOnlyFirst {
             "bar",
             "baz"
         );
-        public static ReadOnlyFirstMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ReadOnlyFirstMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return ReadOnlyFirst1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ReadOnlyFirst.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -79,7 +80,7 @@ public class ReadOnlyFirst {
 
             return new ReadOnlyFirstMap(arg);
         }
-        public static ReadOnlyFirstMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ReadOnlyFirstMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(ReadOnlyFirst1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ReqPropsFromExplicitAddProps.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ReqPropsFromExplicitAddProps.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.AdditionalPropertiesValidator;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
@@ -66,7 +67,7 @@ public class ReqPropsFromExplicitAddProps {
 
             return new ReqPropsFromExplicitAddPropsMap(arg);
         }
-        public static ReqPropsFromExplicitAddPropsMap validate(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static ReqPropsFromExplicitAddPropsMap validate(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(ReqPropsFromExplicitAddProps1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ReqPropsFromExplicitAddProps.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ReqPropsFromExplicitAddProps.java
@@ -31,7 +31,7 @@ public class ReqPropsFromExplicitAddProps {
             "validName"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static ReqPropsFromExplicitAddPropsMap of(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static ReqPropsFromExplicitAddPropsMap of(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return ReqPropsFromExplicitAddProps1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ReqPropsFromTrueAddProps.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ReqPropsFromTrueAddProps.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.validation.AdditionalPropertiesValidator;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
@@ -66,7 +67,7 @@ public class ReqPropsFromTrueAddProps {
 
             return new ReqPropsFromTrueAddPropsMap(arg);
         }
-        public static ReqPropsFromTrueAddPropsMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ReqPropsFromTrueAddPropsMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(ReqPropsFromTrueAddProps1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ReqPropsFromTrueAddProps.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ReqPropsFromTrueAddProps.java
@@ -31,7 +31,7 @@ public class ReqPropsFromTrueAddProps {
             "validName"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static ReqPropsFromTrueAddPropsMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ReqPropsFromTrueAddPropsMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return ReqPropsFromTrueAddProps1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ReqPropsFromUnsetAddProps.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ReqPropsFromUnsetAddProps.java
@@ -26,7 +26,7 @@ public class ReqPropsFromUnsetAddProps {
             "validName"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static ReqPropsFromUnsetAddPropsMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ReqPropsFromUnsetAddPropsMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return ReqPropsFromUnsetAddProps1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ReqPropsFromUnsetAddProps.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ReqPropsFromUnsetAddProps.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -59,7 +60,7 @@ public class ReqPropsFromUnsetAddProps {
 
             return new ReqPropsFromUnsetAddPropsMap(arg);
         }
-        public static ReqPropsFromUnsetAddPropsMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ReqPropsFromUnsetAddPropsMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(ReqPropsFromUnsetAddProps1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ReturnSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ReturnSchema.java
@@ -34,7 +34,7 @@ public class ReturnSchema {
         public static final Set<String> optionalKeys = Set.of(
             "return"
         );
-        public static ReturnMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ReturnMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return ReturnSchema1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ReturnSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ReturnSchema.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.Int32JsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
@@ -59,51 +60,51 @@ public class ReturnSchema {
                 new PropertyEntry("return", ReturnSchema2.class)
             )))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ReturnSchema1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ReturnSchema1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ReturnSchema1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ReturnSchema1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ReturnSchema1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ReturnSchema1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ReturnSchema1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ReturnSchema1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ReturnSchema1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ReturnSchema1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ReturnSchema1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ReturnSchema1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ScaleneTriangle.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ScaleneTriangle.java
@@ -42,7 +42,7 @@ public class ScaleneTriangle {
         public static final Set<String> optionalKeys = Set.of(
             "triangleType"
         );
-        public static Schema1Map of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static Schema1Map of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ScaleneTriangle.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ScaleneTriangle.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -26,7 +27,7 @@ public class ScaleneTriangle {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(TriangleType.class, arg, configuration);
         }
     }    
@@ -72,7 +73,7 @@ public class ScaleneTriangle {
 
             return new Schema1Map(arg);
         }
-        public static Schema1Map validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static Schema1Map validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
@@ -86,51 +87,51 @@ public class ScaleneTriangle {
     
         Do not edit the class manually.
         */
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ScaleneTriangle1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ScaleneTriangle1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ScaleneTriangle1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ScaleneTriangle1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ScaleneTriangle1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ScaleneTriangle1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ScaleneTriangle1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ScaleneTriangle1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ScaleneTriangle1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ScaleneTriangle1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ScaleneTriangle1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ScaleneTriangle1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Schema200Response.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Schema200Response.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.Int32JsonSchema;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenList;
@@ -73,51 +74,51 @@ public class Schema200Response {
                 new PropertyEntry("class", ClassSchema.class)
             )))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema200Response1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema200Response1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema200Response1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema200Response1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema200Response1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema200Response1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema200Response1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema200Response1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema200Response1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema200Response1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema200Response1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema200Response1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Schema200Response.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Schema200Response.java
@@ -39,7 +39,7 @@ public class Schema200Response {
             "name",
             "class"
         );
-        public static Schema200ResponseMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static Schema200ResponseMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema200Response1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/SelfReferencingArrayModel.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/SelfReferencingArrayModel.java
@@ -22,7 +22,7 @@ public class SelfReferencingArrayModel {
 
             super(m);
         }
-        public static SelfReferencingArrayModelList of(List<List> arg, SchemaConfiguration configuration) {
+        public static SelfReferencingArrayModelList of(List<List> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return SelfReferencingArrayModel1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/SelfReferencingArrayModel.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/SelfReferencingArrayModel.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.ItemsValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -43,7 +44,7 @@ public class SelfReferencingArrayModel {
 
             return new SelfReferencingArrayModelList(arg);
         }
-        public static SelfReferencingArrayModelList validate(List<List> arg, SchemaConfiguration configuration) {
+        public static SelfReferencingArrayModelList validate(List<List> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(SelfReferencingArrayModel1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/SelfReferencingObjectModel.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/SelfReferencingObjectModel.java
@@ -27,7 +27,7 @@ public class SelfReferencingObjectModel {
         public static final Set<String> optionalKeys = Set.of(
             "selfRef"
         );
-        public static SelfReferencingObjectModelMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SelfReferencingObjectModelMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return SelfReferencingObjectModel1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/SelfReferencingObjectModel.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/SelfReferencingObjectModel.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.AdditionalPropertiesValidator;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -65,7 +66,7 @@ public class SelfReferencingObjectModel {
 
             return new SelfReferencingObjectModelMap(arg);
         }
-        public static SelfReferencingObjectModelMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SelfReferencingObjectModelMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(SelfReferencingObjectModel1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Shape.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Shape.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -23,51 +24,51 @@ public class Shape {
     
         Do not edit the class manually.
         */
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Shape1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Shape1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Shape1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Shape1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Shape1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Shape1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Shape1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Shape1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Shape1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Shape1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Shape1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Shape1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ShapeOrNull.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ShapeOrNull.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.NullJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
@@ -29,51 +30,51 @@ public class ShapeOrNull {
     
         The value may be a shape or the 'null' value. This is introduced in OAS schema >= 3.1.
         */
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ShapeOrNull1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ShapeOrNull1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ShapeOrNull1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ShapeOrNull1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ShapeOrNull1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ShapeOrNull1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ShapeOrNull1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ShapeOrNull1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ShapeOrNull1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ShapeOrNull1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ShapeOrNull1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ShapeOrNull1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/SimpleQuadrilateral.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/SimpleQuadrilateral.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -26,7 +27,7 @@ public class SimpleQuadrilateral {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(QuadrilateralType.class, arg, configuration);
         }
     }    
@@ -72,7 +73,7 @@ public class SimpleQuadrilateral {
 
             return new Schema1Map(arg);
         }
-        public static Schema1Map validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static Schema1Map validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
@@ -86,51 +87,51 @@ public class SimpleQuadrilateral {
     
         Do not edit the class manually.
         */
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SimpleQuadrilateral1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SimpleQuadrilateral1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SimpleQuadrilateral1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SimpleQuadrilateral1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SimpleQuadrilateral1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SimpleQuadrilateral1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SimpleQuadrilateral1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SimpleQuadrilateral1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SimpleQuadrilateral1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SimpleQuadrilateral1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SimpleQuadrilateral1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SimpleQuadrilateral1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/SimpleQuadrilateral.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/SimpleQuadrilateral.java
@@ -42,7 +42,7 @@ public class SimpleQuadrilateral {
         public static final Set<String> optionalKeys = Set.of(
             "quadrilateralType"
         );
-        public static Schema1Map of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static Schema1Map of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/SomeObject.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/SomeObject.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -23,51 +24,51 @@ public class SomeObject {
     
         Do not edit the class manually.
         */
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeObject1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeObject1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeObject1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeObject1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeObject1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeObject1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeObject1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeObject1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeObject1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeObject1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeObject1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeObject1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/SpecialModelname.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/SpecialModelname.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -68,7 +69,7 @@ public class SpecialModelname {
 
             return new SpecialModelnameMap(arg);
         }
-        public static SpecialModelnameMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SpecialModelnameMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(SpecialModelname1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/SpecialModelname.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/SpecialModelname.java
@@ -30,7 +30,7 @@ public class SpecialModelname {
         public static final Set<String> optionalKeys = Set.of(
             "a"
         );
-        public static SpecialModelnameMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SpecialModelnameMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return SpecialModelname1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/StringBooleanMap.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/StringBooleanMap.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.BooleanJsonSchema;
 import org.openapijsonschematools.schemas.validation.AdditionalPropertiesValidator;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
@@ -53,7 +54,7 @@ public class StringBooleanMap {
 
             return new StringBooleanMapMap(arg);
         }
-        public static StringBooleanMapMap validate(Map<String, Boolean> arg, SchemaConfiguration configuration) {
+        public static StringBooleanMapMap validate(Map<String, Boolean> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(StringBooleanMap1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/StringBooleanMap.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/StringBooleanMap.java
@@ -27,7 +27,7 @@ public class StringBooleanMap {
         }
         public static final Set<String> requiredKeys = Set.of();
         public static final Set<String> optionalKeys = Set.of();
-        public static StringBooleanMapMap of(Map<String, Boolean> arg, SchemaConfiguration configuration) {
+        public static StringBooleanMapMap of(Map<String, Boolean> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return StringBooleanMap1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/StringEnum.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/StringEnum.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -25,10 +26,10 @@ public class StringEnum {
                 String.class
             )))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(StringEnum1.class, arg, configuration);
         }
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(StringEnum1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/StringEnumWithDefaultValue.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/StringEnumWithDefaultValue.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -24,7 +25,7 @@ public class StringEnumWithDefaultValue {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(StringEnumWithDefaultValue1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/StringWithValidation.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/StringWithValidation.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -24,7 +25,7 @@ public class StringWithValidation {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(StringWithValidation1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Tag.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Tag.java
@@ -35,7 +35,7 @@ public class Tag {
             "id",
             "name"
         );
-        public static TagMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static TagMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Tag1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Tag.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Tag.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.Int64JsonSchema;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
@@ -80,7 +81,7 @@ public class Tag {
 
             return new TagMap(arg);
         }
-        public static TagMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static TagMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Tag1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Triangle.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Triangle.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -23,51 +24,51 @@ public class Triangle {
     
         Do not edit the class manually.
         */
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Triangle1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Triangle1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Triangle1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Triangle1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Triangle1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Triangle1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Triangle1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Triangle1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Triangle1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Triangle1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Triangle1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Triangle1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/TriangleInterface.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/TriangleInterface.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
@@ -28,7 +29,7 @@ public class TriangleInterface {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ShapeType.class, arg, configuration);
         }
     }    
@@ -88,51 +89,51 @@ public class TriangleInterface {
                 "triangleType"
             )))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(TriangleInterface1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(TriangleInterface1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(TriangleInterface1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(TriangleInterface1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(TriangleInterface1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(TriangleInterface1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(TriangleInterface1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(TriangleInterface1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(TriangleInterface1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(TriangleInterface1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(TriangleInterface1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(TriangleInterface1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/TriangleInterface.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/TriangleInterface.java
@@ -48,7 +48,7 @@ public class TriangleInterface {
             "triangleType"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static TriangleInterfaceMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static TriangleInterfaceMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return TriangleInterface1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/UUIDString.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/UUIDString.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FormatValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -27,7 +28,7 @@ public class UUIDString {
             ))),
             new KeywordEntry("format", new FormatValidator("uuid"))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(UUIDString1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/User.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/User.java
@@ -150,7 +150,7 @@ public class User {
             "anyTypeExceptNullProp",
             "anyTypePropNullable"
         );
-        public static UserMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static UserMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return User1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/User.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/User.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.Int32JsonSchema;
 import org.openapijsonschematools.schemas.Int64JsonSchema;
@@ -60,10 +61,10 @@ public class User {
                 FrozenMap.class
             )))
         ));
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ObjectWithNoDeclaredPropsNullable.class, arg, configuration);
         }
-        public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ObjectWithNoDeclaredPropsNullable.class, arg, configuration);
         }
     }    
@@ -75,51 +76,51 @@ public class User {
     
     
     public class AnyTypeExceptNullProp extends JsonSchema {
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AnyTypeExceptNullProp.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AnyTypeExceptNullProp.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AnyTypeExceptNullProp.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AnyTypeExceptNullProp.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AnyTypeExceptNullProp.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AnyTypeExceptNullProp.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AnyTypeExceptNullProp.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AnyTypeExceptNullProp.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AnyTypeExceptNullProp.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AnyTypeExceptNullProp.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AnyTypeExceptNullProp.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(AnyTypeExceptNullProp.class, arg, configuration);
         }
     }    
@@ -291,7 +292,7 @@ public class User {
 
             return new UserMap(arg);
         }
-        public static UserMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static UserMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(User1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Whale.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Whale.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.BooleanJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -29,7 +30,7 @@ public class Whale {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ClassName.class, arg, configuration);
         }
     }    
@@ -103,7 +104,7 @@ public class Whale {
 
             return new WhaleMap(arg);
         }
-        public static WhaleMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static WhaleMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Whale1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Whale.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Whale.java
@@ -48,7 +48,7 @@ public class Whale {
             "hasBaleen",
             "hasTeeth"
         );
-        public static WhaleMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static WhaleMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Whale1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Zebra.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Zebra.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.validation.AdditionalPropertiesValidator;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
@@ -27,7 +28,7 @@ public class Zebra {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Type.class, arg, configuration);
         }
     }    
@@ -38,7 +39,7 @@ public class Zebra {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(ClassName.class, arg, configuration);
         }
     }    
@@ -103,7 +104,7 @@ public class Zebra {
 
             return new ZebraMap(arg);
         }
-        public static ZebraMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ZebraMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Zebra1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Zebra.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Zebra.java
@@ -56,7 +56,7 @@ public class Zebra {
         public static final Set<String> optionalKeys = Set.of(
             "type"
         );
-        public static ZebraMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static ZebraMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Zebra1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/exceptions/BaseException.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/exceptions/BaseException.java
@@ -1,0 +1,4 @@
+package org.openapijsonschematools.exceptions;
+
+public class BaseException extends RuntimeException {
+}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/exceptions/InvalidAdditionalPropertyException.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/exceptions/InvalidAdditionalPropertyException.java
@@ -1,4 +1,7 @@
 package org.openapijsonschematools.exceptions;
 
 public class InvalidAdditionalPropertyException extends BaseException {
+    public InvalidAdditionalPropertyException(String s) {
+        super();
+    }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/exceptions/InvalidAdditionalPropertyException.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/exceptions/InvalidAdditionalPropertyException.java
@@ -1,0 +1,4 @@
+package org.openapijsonschematools.exceptions;
+
+public class InvalidAdditionalPropertyException extends BaseException {
+}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/exceptions/InvalidTypeException.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/exceptions/InvalidTypeException.java
@@ -1,0 +1,7 @@
+package org.openapijsonschematools.exceptions;
+
+public class InvalidTypeException extends BaseException {
+    public InvalidTypeException(String s) {
+        super();
+    }
+}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/exceptions/UnsetPropertyException.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/exceptions/UnsetPropertyException.java
@@ -1,0 +1,4 @@
+package org.openapijsonschematools.exceptions;
+
+public class UnsetPropertyException extends BaseException {
+}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/exceptions/UnsetPropertyException.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/exceptions/UnsetPropertyException.java
@@ -1,4 +1,7 @@
 package org.openapijsonschematools.exceptions;
 
 public class UnsetPropertyException extends BaseException {
+    public UnsetPropertyException(String s) {
+        super();
+    }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/exceptions/ValidationException.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/exceptions/ValidationException.java
@@ -1,4 +1,7 @@
 package org.openapijsonschematools.exceptions;
 
 public class ValidationException extends BaseException {
+    public ValidationException(String s) {
+        super();
+    }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/exceptions/ValidationException.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/exceptions/ValidationException.java
@@ -1,0 +1,4 @@
+package org.openapijsonschematools.exceptions;
+
+public class ValidationException extends BaseException {
+}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/commonparamsubdir/delete/HeaderParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/commonparamsubdir/delete/HeaderParameters.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.commonparamsubdir.delete.parameters.parameter0.Schema0;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
@@ -58,7 +59,7 @@ public class HeaderParameters {
 
             return new HeaderParametersMap(arg);
         }
-        public static HeaderParametersMap validate(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static HeaderParametersMap validate(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(HeaderParameters1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/commonparamsubdir/delete/HeaderParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/commonparamsubdir/delete/HeaderParameters.java
@@ -34,7 +34,7 @@ public class HeaderParameters {
         public static final Set<String> optionalKeys = Set.of(
             "someHeader"
         );
-        public static HeaderParametersMap of(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static HeaderParametersMap of(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return HeaderParameters1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/commonparamsubdir/delete/PathParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/commonparamsubdir/delete/PathParameters.java
@@ -35,7 +35,7 @@ public class PathParameters {
             "subDir"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static PathParametersMap of(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static PathParametersMap of(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return PathParameters1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/commonparamsubdir/delete/PathParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/commonparamsubdir/delete/PathParameters.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.commonparamsubdir.delete.parameters.parameter1.Schema1;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
@@ -60,7 +61,7 @@ public class PathParameters {
 
             return new PathParametersMap(arg);
         }
-        public static PathParametersMap validate(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static PathParametersMap validate(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(PathParameters1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/commonparamsubdir/delete/parameters/parameter1/Schema1.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/commonparamsubdir/delete/parameters/parameter1/Schema1.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -18,7 +19,7 @@ public class Schema1 {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema11.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/commonparamsubdir/get/PathParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/commonparamsubdir/get/PathParameters.java
@@ -35,7 +35,7 @@ public class PathParameters {
             "subDir"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static PathParametersMap of(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static PathParametersMap of(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return PathParameters1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/commonparamsubdir/get/PathParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/commonparamsubdir/get/PathParameters.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.commonparamsubdir.parameters.parameter0.PathParamSchema0;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
@@ -60,7 +61,7 @@ public class PathParameters {
 
             return new PathParametersMap(arg);
         }
-        public static PathParametersMap validate(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static PathParametersMap validate(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(PathParameters1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/commonparamsubdir/get/QueryParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/commonparamsubdir/get/QueryParameters.java
@@ -34,7 +34,7 @@ public class QueryParameters {
         public static final Set<String> optionalKeys = Set.of(
             "searchStr"
         );
-        public static QueryParametersMap of(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static QueryParametersMap of(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return QueryParameters1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/commonparamsubdir/get/QueryParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/commonparamsubdir/get/QueryParameters.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.commonparamsubdir.get.parameters.parameter0.Schema0;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
@@ -58,7 +59,7 @@ public class QueryParameters {
 
             return new QueryParametersMap(arg);
         }
-        public static QueryParametersMap validate(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static QueryParametersMap validate(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(QueryParameters1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/commonparamsubdir/parameters/parameter0/PathParamSchema0.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/commonparamsubdir/parameters/parameter0/PathParamSchema0.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -18,7 +19,7 @@ public class PathParamSchema0 {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(PathParamSchema01.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/commonparamsubdir/post/HeaderParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/commonparamsubdir/post/HeaderParameters.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.commonparamsubdir.post.parameters.parameter0.Schema0;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
@@ -58,7 +59,7 @@ public class HeaderParameters {
 
             return new HeaderParametersMap(arg);
         }
-        public static HeaderParametersMap validate(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static HeaderParametersMap validate(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(HeaderParameters1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/commonparamsubdir/post/HeaderParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/commonparamsubdir/post/HeaderParameters.java
@@ -34,7 +34,7 @@ public class HeaderParameters {
         public static final Set<String> optionalKeys = Set.of(
             "someHeader"
         );
-        public static HeaderParametersMap of(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static HeaderParametersMap of(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return HeaderParameters1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/commonparamsubdir/post/PathParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/commonparamsubdir/post/PathParameters.java
@@ -35,7 +35,7 @@ public class PathParameters {
             "subDir"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static PathParametersMap of(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static PathParametersMap of(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return PathParameters1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/commonparamsubdir/post/PathParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/commonparamsubdir/post/PathParameters.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.commonparamsubdir.parameters.parameter0.PathParamSchema0;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
@@ -60,7 +61,7 @@ public class PathParameters {
 
             return new PathParametersMap(arg);
         }
-        public static PathParametersMap validate(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static PathParametersMap validate(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(PathParameters1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/delete/HeaderParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/delete/HeaderParameters.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.fake.delete.parameters.parameter1.Schema1;
 import org.openapijsonschematools.paths.fake.delete.parameters.parameter4.Schema4;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
@@ -73,7 +74,7 @@ public class HeaderParameters {
 
             return new HeaderParametersMap(arg);
         }
-        public static HeaderParametersMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static HeaderParametersMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(HeaderParameters1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/delete/HeaderParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/delete/HeaderParameters.java
@@ -38,7 +38,7 @@ public class HeaderParameters {
         public static final Set<String> optionalKeys = Set.of(
             "boolean_group"
         );
-        public static HeaderParametersMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static HeaderParametersMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return HeaderParameters1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/delete/QueryParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/delete/QueryParameters.java
@@ -42,7 +42,7 @@ public class QueryParameters {
             "int64_group",
             "string_group"
         );
-        public static QueryParametersMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static QueryParametersMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return QueryParameters1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/delete/QueryParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/delete/QueryParameters.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.fake.delete.parameters.parameter0.Schema0;
 import org.openapijsonschematools.paths.fake.delete.parameters.parameter2.Schema2;
 import org.openapijsonschematools.paths.fake.delete.parameters.parameter3.Schema3;
@@ -94,7 +95,7 @@ public class QueryParameters {
 
             return new QueryParametersMap(arg);
         }
-        public static QueryParametersMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static QueryParametersMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(QueryParameters1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/delete/parameters/parameter1/Schema1.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/delete/parameters/parameter1/Schema1.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -18,7 +19,7 @@ public class Schema1 {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema11.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/delete/parameters/parameter4/Schema4.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/delete/parameters/parameter4/Schema4.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -18,7 +19,7 @@ public class Schema4 {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema41.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/HeaderParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/HeaderParameters.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.fake.get.parameters.parameter0.Schema0;
 import org.openapijsonschematools.paths.fake.get.parameters.parameter1.Schema1;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
@@ -70,7 +71,7 @@ public class HeaderParameters {
 
             return new HeaderParametersMap(arg);
         }
-        public static HeaderParametersMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static HeaderParametersMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(HeaderParameters1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/HeaderParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/HeaderParameters.java
@@ -36,7 +36,7 @@ public class HeaderParameters {
             "enum_header_string",
             "enum_header_string_array"
         );
-        public static HeaderParametersMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static HeaderParametersMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return HeaderParameters1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/QueryParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/QueryParameters.java
@@ -40,7 +40,7 @@ public class QueryParameters {
             "enum_query_integer",
             "enum_query_string_array"
         );
-        public static QueryParametersMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static QueryParametersMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return QueryParameters1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/QueryParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/QueryParameters.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.fake.get.parameters.parameter2.Schema2;
 import org.openapijsonschematools.paths.fake.get.parameters.parameter3.Schema3;
 import org.openapijsonschematools.paths.fake.get.parameters.parameter4.Schema4;
@@ -92,7 +93,7 @@ public class QueryParameters {
 
             return new QueryParametersMap(arg);
         }
-        public static QueryParametersMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static QueryParametersMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(QueryParameters1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/parameters/parameter0/Schema0.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/parameters/parameter0/Schema0.java
@@ -33,7 +33,7 @@ public class Schema0 {
 
             super(m);
         }
-        public static SchemaList0 of(List<String> arg, SchemaConfiguration configuration) {
+        public static SchemaList0 of(List<String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema01.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/parameters/parameter0/Schema0.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/parameters/parameter0/Schema0.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.ItemsValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -21,7 +22,7 @@ public class Schema0 {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Items0.class, arg, configuration);
         }
     }    
@@ -48,7 +49,7 @@ public class Schema0 {
 
             return new SchemaList0(arg);
         }
-        public static SchemaList0 validate(List<String> arg, SchemaConfiguration configuration) {
+        public static SchemaList0 validate(List<String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema01.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/parameters/parameter1/Schema1.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/parameters/parameter1/Schema1.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -18,7 +19,7 @@ public class Schema1 {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema11.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/parameters/parameter2/Schema2.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/parameters/parameter2/Schema2.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.ItemsValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -21,7 +22,7 @@ public class Schema2 {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Items2.class, arg, configuration);
         }
     }    
@@ -48,7 +49,7 @@ public class Schema2 {
 
             return new SchemaList2(arg);
         }
-        public static SchemaList2 validate(List<String> arg, SchemaConfiguration configuration) {
+        public static SchemaList2 validate(List<String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema21.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/parameters/parameter2/Schema2.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/parameters/parameter2/Schema2.java
@@ -33,7 +33,7 @@ public class Schema2 {
 
             super(m);
         }
-        public static SchemaList2 of(List<String> arg, SchemaConfiguration configuration) {
+        public static SchemaList2 of(List<String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema21.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/parameters/parameter3/Schema3.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/parameters/parameter3/Schema3.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -18,7 +19,7 @@ public class Schema3 {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema31.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/parameters/parameter4/Schema4.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/parameters/parameter4/Schema4.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FormatValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -23,19 +24,19 @@ public class Schema4 {
             ))),
             new KeywordEntry("format", new FormatValidator("int32"))
         ));
-        public static long validate(int arg, SchemaConfiguration configuration) {
+        public static long validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema41.class, Long.valueOf(arg), configuration);
         }
         
-        public static long validate(float arg, SchemaConfiguration configuration) {
+        public static long validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema41.class, Long.parseLong(String.valueOf(arg)), configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema41.class, arg, configuration);
         }
         
-        public static long validate(double arg, SchemaConfiguration configuration) {
+        public static long validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema41.class, Long.parseLong(String.valueOf(arg)), configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/parameters/parameter5/Schema5.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/parameters/parameter5/Schema5.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FormatValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -23,7 +24,7 @@ public class Schema5 {
             ))),
             new KeywordEntry("format", new FormatValidator("double"))
         ));
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema51.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/requestbody/content/applicationxwwwformurlencoded/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/requestbody/content/applicationxwwwformurlencoded/Schema.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.ItemsValidator;
@@ -24,7 +25,7 @@ public class Schema {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Items.class, arg, configuration);
         }
     }    
@@ -51,7 +52,7 @@ public class Schema {
 
             return new EnumFormStringArrayList(arg);
         }
-        public static EnumFormStringArrayList validate(List<String> arg, SchemaConfiguration configuration) {
+        public static EnumFormStringArrayList validate(List<String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(EnumFormStringArray.class, arg, configuration);
         }
@@ -63,7 +64,7 @@ public class Schema {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(EnumFormString.class, arg, configuration);
         }
     }    
@@ -119,7 +120,7 @@ public class Schema {
 
             return new SchemaMap(arg);
         }
-        public static SchemaMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SchemaMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/requestbody/content/applicationxwwwformurlencoded/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/requestbody/content/applicationxwwwformurlencoded/Schema.java
@@ -36,7 +36,7 @@ public class Schema {
 
             super(m);
         }
-        public static EnumFormStringArrayList of(List<String> arg, SchemaConfiguration configuration) {
+        public static EnumFormStringArrayList of(List<String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return EnumFormStringArray.validate(arg, configuration);
         }
@@ -80,7 +80,7 @@ public class Schema {
             "enum_form_string_array",
             "enum_form_string"
         );
-        public static SchemaMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SchemaMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/post/requestbody/content/applicationxwwwformurlencoded/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/post/requestbody/content/applicationxwwwformurlencoded/Schema.java
@@ -218,7 +218,7 @@ public class Schema {
             "password",
             "callback"
         );
-        public static SchemaMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SchemaMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/post/requestbody/content/applicationxwwwformurlencoded/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/post/requestbody/content/applicationxwwwformurlencoded/Schema.java
@@ -4,6 +4,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.DateJsonSchema;
 import org.openapijsonschematools.schemas.Int64JsonSchema;
 import org.openapijsonschematools.schemas.StringJsonSchema;
@@ -30,19 +31,19 @@ public class Schema {
                 Double.class
             )))
         ));
-        public static long validate(int arg, SchemaConfiguration configuration) {
+        public static long validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerSchema.class, Long.valueOf(arg), configuration);
         }
         
-        public static long validate(float arg, SchemaConfiguration configuration) {
+        public static long validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerSchema.class, Long.parseLong(String.valueOf(arg)), configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerSchema.class, arg, configuration);
         }
         
-        public static long validate(double arg, SchemaConfiguration configuration) {
+        public static long validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(IntegerSchema.class, Long.parseLong(String.valueOf(arg)), configuration);
         }
     }    
@@ -57,19 +58,19 @@ public class Schema {
             ))),
             new KeywordEntry("format", new FormatValidator("int32"))
         ));
-        public static long validate(int arg, SchemaConfiguration configuration) {
+        public static long validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Int32.class, Long.valueOf(arg), configuration);
         }
         
-        public static long validate(float arg, SchemaConfiguration configuration) {
+        public static long validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Int32.class, Long.parseLong(String.valueOf(arg)), configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Int32.class, arg, configuration);
         }
         
-        public static long validate(double arg, SchemaConfiguration configuration) {
+        public static long validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Int32.class, Long.parseLong(String.valueOf(arg)), configuration);
         }
     }    
@@ -86,19 +87,19 @@ public class Schema {
                 Double.class
             )))
         ));
-        public static Number validate(int arg, SchemaConfiguration configuration) {
+        public static Number validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NumberSchema.class, arg, configuration);
         }
         
-        public static Number validate(long arg, SchemaConfiguration configuration) {
+        public static Number validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NumberSchema.class, arg, configuration);
         }
         
-        public static Number validate(float arg, SchemaConfiguration configuration) {
+        public static Number validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NumberSchema.class, arg, configuration);
         }
         
-        public static Number validate(double arg, SchemaConfiguration configuration) {
+        public static Number validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(NumberSchema.class, arg, configuration);
         }
     }    
@@ -113,7 +114,7 @@ public class Schema {
             ))),
             new KeywordEntry("format", new FormatValidator("float"))
         ));
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(FloatSchema.class, arg, configuration);
         }
     }    
@@ -128,7 +129,7 @@ public class Schema {
             ))),
             new KeywordEntry("format", new FormatValidator("double"))
         ));
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(DoubleSchema.class, arg, configuration);
         }
     }    
@@ -139,7 +140,7 @@ public class Schema {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(StringSchema.class, arg, configuration);
         }
     }    
@@ -150,7 +151,7 @@ public class Schema {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(PatternWithoutDelimiter.class, arg, configuration);
         }
     }    
@@ -173,7 +174,7 @@ public class Schema {
             ))),
             new KeywordEntry("format", new FormatValidator("date-time"))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(DateTime.class, arg, configuration);
         }
     }    
@@ -185,7 +186,7 @@ public class Schema {
             ))),
             new KeywordEntry("format", new FormatValidator("password"))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Password.class, arg, configuration);
         }
     }    
@@ -321,7 +322,7 @@ public class Schema {
 
             return new SchemaMap(arg);
         }
-        public static SchemaMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SchemaMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakebodywithqueryparams/put/QueryParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakebodywithqueryparams/put/QueryParameters.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.fakebodywithqueryparams.put.parameters.parameter0.Schema0;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
@@ -60,7 +61,7 @@ public class QueryParameters {
 
             return new QueryParametersMap(arg);
         }
-        public static QueryParametersMap validate(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static QueryParametersMap validate(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(QueryParameters1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakebodywithqueryparams/put/QueryParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakebodywithqueryparams/put/QueryParameters.java
@@ -35,7 +35,7 @@ public class QueryParameters {
             "query"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static QueryParametersMap of(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static QueryParametersMap of(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return QueryParameters1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakecasesensitiveparams/put/QueryParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakecasesensitiveparams/put/QueryParameters.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.fakecasesensitiveparams.put.parameters.parameter0.Schema0;
 import org.openapijsonschematools.paths.fakecasesensitiveparams.put.parameters.parameter1.Schema1;
 import org.openapijsonschematools.paths.fakecasesensitiveparams.put.parameters.parameter2.Schema2;
@@ -81,7 +82,7 @@ public class QueryParameters {
 
             return new QueryParametersMap(arg);
         }
-        public static QueryParametersMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static QueryParametersMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(QueryParameters1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakecasesensitiveparams/put/QueryParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakecasesensitiveparams/put/QueryParameters.java
@@ -39,7 +39,7 @@ public class QueryParameters {
             "some_var"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static QueryParametersMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static QueryParametersMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return QueryParameters1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakedeletecoffeeid/delete/PathParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakedeletecoffeeid/delete/PathParameters.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.fakedeletecoffeeid.delete.parameters.parameter0.Schema0;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
@@ -60,7 +61,7 @@ public class PathParameters {
 
             return new PathParametersMap(arg);
         }
-        public static PathParametersMap validate(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static PathParametersMap validate(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(PathParameters1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakedeletecoffeeid/delete/PathParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakedeletecoffeeid/delete/PathParameters.java
@@ -35,7 +35,7 @@ public class PathParameters {
             "id"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static PathParametersMap of(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static PathParametersMap of(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return PathParameters1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeinlineadditionalproperties/post/requestbody/content/applicationjson/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeinlineadditionalproperties/post/requestbody/content/applicationjson/Schema.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.AdditionalPropertiesValidator;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
@@ -47,7 +48,7 @@ public class Schema {
 
             return new SchemaMap(arg);
         }
-        public static SchemaMap validate(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static SchemaMap validate(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeinlineadditionalproperties/post/requestbody/content/applicationjson/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeinlineadditionalproperties/post/requestbody/content/applicationjson/Schema.java
@@ -27,7 +27,7 @@ public class Schema {
         }
         public static final Set<String> requiredKeys = Set.of();
         public static final Set<String> optionalKeys = Set.of();
-        public static SchemaMap of(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static SchemaMap of(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeinlinecomposition/post/QueryParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeinlinecomposition/post/QueryParameters.java
@@ -36,7 +36,7 @@ public class QueryParameters {
             "compositionAtRoot",
             "compositionInProperty"
         );
-        public static QueryParametersMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static QueryParametersMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return QueryParameters1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeinlinecomposition/post/QueryParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeinlinecomposition/post/QueryParameters.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.fakeinlinecomposition.post.parameters.parameter0.Schema0;
 import org.openapijsonschematools.paths.fakeinlinecomposition.post.parameters.parameter1.Schema1;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
@@ -70,7 +71,7 @@ public class QueryParameters {
 
             return new QueryParametersMap(arg);
         }
-        public static QueryParametersMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static QueryParametersMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(QueryParameters1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeinlinecomposition/post/parameters/parameter0/Schema0.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeinlinecomposition/post/parameters/parameter0/Schema0.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -24,57 +25,57 @@ public class Schema0 {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema00.class, arg, configuration);
         }
     }    
     
     public class Schema01 extends JsonSchema {
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema01.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema01.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema01.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema01.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema01.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema01.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema01.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema01.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema01.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema01.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema01.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema01.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeinlinecomposition/post/parameters/parameter1/Schema1.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeinlinecomposition/post/parameters/parameter1/Schema1.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -26,57 +27,57 @@ public class Schema1 {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema01.class, arg, configuration);
         }
     }    
     
     public class SomeProp1 extends JsonSchema {
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp1.class, arg, configuration);
         }
     }    
@@ -121,7 +122,7 @@ public class Schema1 {
 
             return new SchemaMap1(arg);
         }
-        public static SchemaMap1 validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SchemaMap1 validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema11.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeinlinecomposition/post/parameters/parameter1/Schema1.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeinlinecomposition/post/parameters/parameter1/Schema1.java
@@ -92,7 +92,7 @@ public class Schema1 {
         public static final Set<String> optionalKeys = Set.of(
             "someProp"
         );
-        public static SchemaMap1 of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SchemaMap1 of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema11.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeinlinecomposition/post/requestbody/content/applicationjson/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeinlinecomposition/post/requestbody/content/applicationjson/Schema.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -24,57 +25,57 @@ public class Schema {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema0.class, arg, configuration);
         }
     }    
     
     public class Schema1 extends JsonSchema {
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeinlinecomposition/post/requestbody/content/multipartformdata/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeinlinecomposition/post/requestbody/content/multipartformdata/Schema.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -26,57 +27,57 @@ public class Schema {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema0.class, arg, configuration);
         }
     }    
     
     public class SomeProp extends JsonSchema {
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
     }    
@@ -121,7 +122,7 @@ public class Schema {
 
             return new SchemaMap(arg);
         }
-        public static SchemaMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SchemaMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeinlinecomposition/post/requestbody/content/multipartformdata/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeinlinecomposition/post/requestbody/content/multipartformdata/Schema.java
@@ -92,7 +92,7 @@ public class Schema {
         public static final Set<String> optionalKeys = Set.of(
             "someProp"
         );
-        public static SchemaMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SchemaMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeinlinecomposition/post/responses/response200/content/applicationjson/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeinlinecomposition/post/responses/response200/content/applicationjson/Schema.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -24,57 +25,57 @@ public class Schema {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema0.class, arg, configuration);
         }
     }    
     
     public class Schema1 extends JsonSchema {
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeinlinecomposition/post/responses/response200/content/multipartformdata/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeinlinecomposition/post/responses/response200/content/multipartformdata/Schema.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -26,57 +27,57 @@ public class Schema {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema0.class, arg, configuration);
         }
     }    
     
     public class SomeProp extends JsonSchema {
-        public static Void validate(Void arg, SchemaConfiguration configuration) {
+        public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+        public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static int validate(int arg, SchemaConfiguration configuration) {
+        public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static float validate(float arg, SchemaConfiguration configuration) {
+        public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static double validate(double arg, SchemaConfiguration configuration) {
+        public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+        public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+        public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static String validate(UUID arg, SchemaConfiguration configuration) {
+        public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
         
-        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+        public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(SomeProp.class, arg, configuration);
         }
     }    
@@ -121,7 +122,7 @@ public class Schema {
 
             return new SchemaMap(arg);
         }
-        public static SchemaMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SchemaMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeinlinecomposition/post/responses/response200/content/multipartformdata/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeinlinecomposition/post/responses/response200/content/multipartformdata/Schema.java
@@ -92,7 +92,7 @@ public class Schema {
         public static final Set<String> optionalKeys = Set.of(
             "someProp"
         );
-        public static SchemaMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SchemaMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakejsonformdata/get/requestbody/content/applicationxwwwformurlencoded/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakejsonformdata/get/requestbody/content/applicationxwwwformurlencoded/Schema.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -74,7 +75,7 @@ public class Schema {
 
             return new SchemaMap(arg);
         }
-        public static SchemaMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SchemaMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakejsonformdata/get/requestbody/content/applicationxwwwformurlencoded/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakejsonformdata/get/requestbody/content/applicationxwwwformurlencoded/Schema.java
@@ -35,7 +35,7 @@ public class Schema {
             "param2"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static SchemaMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SchemaMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakemultiplerequestbodycontenttypes/post/requestbody/content/applicationjson/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakemultiplerequestbodycontenttypes/post/requestbody/content/applicationjson/Schema.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -60,7 +61,7 @@ public class Schema {
 
             return new SchemaMap(arg);
         }
-        public static SchemaMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SchemaMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakemultiplerequestbodycontenttypes/post/requestbody/content/applicationjson/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakemultiplerequestbodycontenttypes/post/requestbody/content/applicationjson/Schema.java
@@ -30,7 +30,7 @@ public class Schema {
         public static final Set<String> optionalKeys = Set.of(
             "a"
         );
-        public static SchemaMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SchemaMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakemultiplerequestbodycontenttypes/post/requestbody/content/multipartformdata/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakemultiplerequestbodycontenttypes/post/requestbody/content/multipartformdata/Schema.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -60,7 +61,7 @@ public class Schema {
 
             return new SchemaMap(arg);
         }
-        public static SchemaMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SchemaMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakemultiplerequestbodycontenttypes/post/requestbody/content/multipartformdata/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakemultiplerequestbodycontenttypes/post/requestbody/content/multipartformdata/Schema.java
@@ -30,7 +30,7 @@ public class Schema {
         public static final Set<String> optionalKeys = Set.of(
             "b"
         );
-        public static SchemaMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SchemaMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeobjinquery/get/QueryParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeobjinquery/get/QueryParameters.java
@@ -34,7 +34,7 @@ public class QueryParameters {
         public static final Set<String> optionalKeys = Set.of(
             "mapBean"
         );
-        public static QueryParametersMap of(Map<String, Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static QueryParametersMap of(Map<String, Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return QueryParameters1.validate(arg, configuration);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeobjinquery/get/QueryParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeobjinquery/get/QueryParameters.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.fakeobjinquery.get.parameters.parameter0.Schema0;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
@@ -59,7 +60,7 @@ public class QueryParameters {
 
             return new QueryParametersMap(arg);
         }
-        public static QueryParametersMap validate(Map<String, Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static QueryParametersMap validate(Map<String, Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return JsonSchema.validate(QueryParameters1.class, arg, configuration);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeobjinquery/get/parameters/parameter0/Schema0.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeobjinquery/get/parameters/parameter0/Schema0.java
@@ -30,7 +30,7 @@ public class Schema0 {
         public static final Set<String> optionalKeys = Set.of(
             "keyword"
         );
-        public static SchemaMap0 of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SchemaMap0 of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema01.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeobjinquery/get/parameters/parameter0/Schema0.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeobjinquery/get/parameters/parameter0/Schema0.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -60,7 +61,7 @@ public class Schema0 {
 
             return new SchemaMap0(arg);
         }
-        public static SchemaMap0 validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SchemaMap0 validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema01.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeparametercollisions1ababselfab/post/CookieParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeparametercollisions1ababselfab/post/CookieParameters.java
@@ -42,7 +42,7 @@ public class CookieParameters {
             "A-B",
             "self"
         );
-        public static CookieParametersMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static CookieParametersMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return CookieParameters1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeparametercollisions1ababselfab/post/CookieParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeparametercollisions1ababselfab/post/CookieParameters.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.fakeparametercollisions1ababselfab.post.parameters.parameter14.Schema14;
 import org.openapijsonschematools.paths.fakeparametercollisions1ababselfab.post.parameters.parameter15.Schema15;
 import org.openapijsonschematools.paths.fakeparametercollisions1ababselfab.post.parameters.parameter16.Schema16;
@@ -87,7 +88,7 @@ public class CookieParameters {
 
             return new CookieParametersMap(arg);
         }
-        public static CookieParametersMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static CookieParametersMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(CookieParameters1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeparametercollisions1ababselfab/post/HeaderParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeparametercollisions1ababselfab/post/HeaderParameters.java
@@ -40,7 +40,7 @@ public class HeaderParameters {
             "A-B",
             "self"
         );
-        public static HeaderParametersMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static HeaderParametersMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return HeaderParameters1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeparametercollisions1ababselfab/post/HeaderParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeparametercollisions1ababselfab/post/HeaderParameters.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.fakeparametercollisions1ababselfab.post.parameters.parameter5.Schema5;
 import org.openapijsonschematools.paths.fakeparametercollisions1ababselfab.post.parameters.parameter6.Schema6;
 import org.openapijsonschematools.paths.fakeparametercollisions1ababselfab.post.parameters.parameter7.Schema7;
@@ -76,7 +77,7 @@ public class HeaderParameters {
 
             return new HeaderParametersMap(arg);
         }
-        public static HeaderParametersMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static HeaderParametersMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(HeaderParameters1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeparametercollisions1ababselfab/post/PathParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeparametercollisions1ababselfab/post/PathParameters.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.fakeparametercollisions1ababselfab.post.parameters.parameter10.Schema10;
 import org.openapijsonschematools.paths.fakeparametercollisions1ababselfab.post.parameters.parameter11.Schema11;
 import org.openapijsonschematools.paths.fakeparametercollisions1ababselfab.post.parameters.parameter12.Schema12;
@@ -89,7 +90,7 @@ public class PathParameters {
 
             return new PathParametersMap(arg);
         }
-        public static PathParametersMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static PathParametersMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(PathParameters1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeparametercollisions1ababselfab/post/PathParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeparametercollisions1ababselfab/post/PathParameters.java
@@ -43,7 +43,7 @@ public class PathParameters {
             "self"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static PathParametersMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static PathParametersMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return PathParameters1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeparametercollisions1ababselfab/post/QueryParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeparametercollisions1ababselfab/post/QueryParameters.java
@@ -42,7 +42,7 @@ public class QueryParameters {
             "A-B",
             "self"
         );
-        public static QueryParametersMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static QueryParametersMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return QueryParameters1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeparametercollisions1ababselfab/post/QueryParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeparametercollisions1ababselfab/post/QueryParameters.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.fakeparametercollisions1ababselfab.post.parameters.parameter0.Schema0;
 import org.openapijsonschematools.paths.fakeparametercollisions1ababselfab.post.parameters.parameter1.Schema1;
 import org.openapijsonschematools.paths.fakeparametercollisions1ababselfab.post.parameters.parameter2.Schema2;
@@ -87,7 +88,7 @@ public class QueryParameters {
 
             return new QueryParametersMap(arg);
         }
-        public static QueryParametersMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static QueryParametersMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(QueryParameters1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakepetiduploadimagewithrequiredfile/post/PathParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakepetiduploadimagewithrequiredfile/post/PathParameters.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.fakepetiduploadimagewithrequiredfile.post.parameters.parameter0.Schema0;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
@@ -60,7 +61,7 @@ public class PathParameters {
 
             return new PathParametersMap(arg);
         }
-        public static PathParametersMap validate(Map<String, Long> arg, SchemaConfiguration configuration) {
+        public static PathParametersMap validate(Map<String, Long> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(PathParameters1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakepetiduploadimagewithrequiredfile/post/PathParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakepetiduploadimagewithrequiredfile/post/PathParameters.java
@@ -35,7 +35,7 @@ public class PathParameters {
             "petId"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static PathParametersMap of(Map<String, Long> arg, SchemaConfiguration configuration) {
+        public static PathParametersMap of(Map<String, Long> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return PathParameters1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakepetiduploadimagewithrequiredfile/post/requestbody/content/multipartformdata/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakepetiduploadimagewithrequiredfile/post/requestbody/content/multipartformdata/Schema.java
@@ -38,7 +38,7 @@ public class Schema {
         public static final Set<String> optionalKeys = Set.of(
             "additionalMetadata"
         );
-        public static SchemaMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SchemaMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakepetiduploadimagewithrequiredfile/post/requestbody/content/multipartformdata/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakepetiduploadimagewithrequiredfile/post/requestbody/content/multipartformdata/Schema.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -78,7 +79,7 @@ public class Schema {
 
             return new SchemaMap(arg);
         }
-        public static SchemaMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SchemaMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakequeryparamwithjsoncontenttype/get/QueryParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakequeryparamwithjsoncontenttype/get/QueryParameters.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.fakequeryparamwithjsoncontenttype.get.parameters.parameter0.content.applicationjson.Schema0;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
@@ -60,7 +61,7 @@ public class QueryParameters {
 
             return new QueryParametersMap(arg);
         }
-        public static QueryParametersMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static QueryParametersMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(QueryParameters1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakequeryparamwithjsoncontenttype/get/QueryParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakequeryparamwithjsoncontenttype/get/QueryParameters.java
@@ -35,7 +35,7 @@ public class QueryParameters {
             "someParam"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static QueryParametersMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static QueryParametersMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return QueryParameters1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakerefobjinquery/get/QueryParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakerefobjinquery/get/QueryParameters.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.components.schemas.Foo;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.validation.AdditionalPropertiesValidator;
@@ -59,7 +60,7 @@ public class QueryParameters {
 
             return new QueryParametersMap(arg);
         }
-        public static QueryParametersMap validate(Map<String, Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static QueryParametersMap validate(Map<String, Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return JsonSchema.validate(QueryParameters1.class, arg, configuration);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakerefobjinquery/get/QueryParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakerefobjinquery/get/QueryParameters.java
@@ -34,7 +34,7 @@ public class QueryParameters {
         public static final Set<String> optionalKeys = Set.of(
             "mapBean"
         );
-        public static QueryParametersMap of(Map<String, Map<String, Object>> arg, SchemaConfiguration configuration) {
+        public static QueryParametersMap of(Map<String, Map<String, Object>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return QueryParameters1.validate(arg, configuration);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/faketestqueryparamters/put/QueryParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/faketestqueryparamters/put/QueryParameters.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.components.schemas.StringWithValidation;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.faketestqueryparamters.put.parameters.parameter0.Schema0;
 import org.openapijsonschematools.paths.faketestqueryparamters.put.parameters.parameter1.Schema1;
 import org.openapijsonschematools.paths.faketestqueryparamters.put.parameters.parameter2.Schema2;
@@ -111,7 +112,7 @@ public class QueryParameters {
 
             return new QueryParametersMap(arg);
         }
-        public static QueryParametersMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static QueryParametersMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(QueryParameters1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/faketestqueryparamters/put/QueryParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/faketestqueryparamters/put/QueryParameters.java
@@ -45,7 +45,7 @@ public class QueryParameters {
             "url"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static QueryParametersMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static QueryParametersMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return QueryParameters1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/faketestqueryparamters/put/parameters/parameter0/Schema0.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/faketestqueryparamters/put/parameters/parameter0/Schema0.java
@@ -26,7 +26,7 @@ public class Schema0 {
 
             super(m);
         }
-        public static SchemaList0 of(List<String> arg, SchemaConfiguration configuration) {
+        public static SchemaList0 of(List<String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema01.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/faketestqueryparamters/put/parameters/parameter0/Schema0.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/faketestqueryparamters/put/parameters/parameter0/Schema0.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.ItemsValidator;
@@ -41,7 +42,7 @@ public class Schema0 {
 
             return new SchemaList0(arg);
         }
-        public static SchemaList0 validate(List<String> arg, SchemaConfiguration configuration) {
+        public static SchemaList0 validate(List<String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema01.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/faketestqueryparamters/put/parameters/parameter1/Schema1.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/faketestqueryparamters/put/parameters/parameter1/Schema1.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.ItemsValidator;
@@ -41,7 +42,7 @@ public class Schema1 {
 
             return new SchemaList1(arg);
         }
-        public static SchemaList1 validate(List<String> arg, SchemaConfiguration configuration) {
+        public static SchemaList1 validate(List<String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema11.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/faketestqueryparamters/put/parameters/parameter1/Schema1.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/faketestqueryparamters/put/parameters/parameter1/Schema1.java
@@ -26,7 +26,7 @@ public class Schema1 {
 
             super(m);
         }
-        public static SchemaList1 of(List<String> arg, SchemaConfiguration configuration) {
+        public static SchemaList1 of(List<String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema11.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/faketestqueryparamters/put/parameters/parameter2/Schema2.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/faketestqueryparamters/put/parameters/parameter2/Schema2.java
@@ -26,7 +26,7 @@ public class Schema2 {
 
             super(m);
         }
-        public static SchemaList2 of(List<String> arg, SchemaConfiguration configuration) {
+        public static SchemaList2 of(List<String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema21.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/faketestqueryparamters/put/parameters/parameter2/Schema2.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/faketestqueryparamters/put/parameters/parameter2/Schema2.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.ItemsValidator;
@@ -41,7 +42,7 @@ public class Schema2 {
 
             return new SchemaList2(arg);
         }
-        public static SchemaList2 validate(List<String> arg, SchemaConfiguration configuration) {
+        public static SchemaList2 validate(List<String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema21.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/faketestqueryparamters/put/parameters/parameter3/Schema3.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/faketestqueryparamters/put/parameters/parameter3/Schema3.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.ItemsValidator;
@@ -41,7 +42,7 @@ public class Schema3 {
 
             return new SchemaList3(arg);
         }
-        public static SchemaList3 validate(List<String> arg, SchemaConfiguration configuration) {
+        public static SchemaList3 validate(List<String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema31.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/faketestqueryparamters/put/parameters/parameter3/Schema3.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/faketestqueryparamters/put/parameters/parameter3/Schema3.java
@@ -26,7 +26,7 @@ public class Schema3 {
 
             super(m);
         }
-        public static SchemaList3 of(List<String> arg, SchemaConfiguration configuration) {
+        public static SchemaList3 of(List<String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema31.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/faketestqueryparamters/put/parameters/parameter4/Schema4.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/faketestqueryparamters/put/parameters/parameter4/Schema4.java
@@ -26,7 +26,7 @@ public class Schema4 {
 
             super(m);
         }
-        public static SchemaList4 of(List<String> arg, SchemaConfiguration configuration) {
+        public static SchemaList4 of(List<String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema41.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/faketestqueryparamters/put/parameters/parameter4/Schema4.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/faketestqueryparamters/put/parameters/parameter4/Schema4.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.ItemsValidator;
@@ -41,7 +42,7 @@ public class Schema4 {
 
             return new SchemaList4(arg);
         }
-        public static SchemaList4 validate(List<String> arg, SchemaConfiguration configuration) {
+        public static SchemaList4 validate(List<String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema41.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeuploadfile/post/requestbody/content/multipartformdata/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeuploadfile/post/requestbody/content/multipartformdata/Schema.java
@@ -38,7 +38,7 @@ public class Schema {
         public static final Set<String> optionalKeys = Set.of(
             "additionalMetadata"
         );
-        public static SchemaMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SchemaMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeuploadfile/post/requestbody/content/multipartformdata/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeuploadfile/post/requestbody/content/multipartformdata/Schema.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -78,7 +79,7 @@ public class Schema {
 
             return new SchemaMap(arg);
         }
-        public static SchemaMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SchemaMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeuploadfiles/post/requestbody/content/multipartformdata/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeuploadfiles/post/requestbody/content/multipartformdata/Schema.java
@@ -30,7 +30,7 @@ public class Schema {
 
             super(m);
         }
-        public static FilesList of(List<String> arg, SchemaConfiguration configuration) {
+        public static FilesList of(List<String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Files.validate(arg, configuration);
         }
@@ -62,7 +62,7 @@ public class Schema {
         public static final Set<String> optionalKeys = Set.of(
             "files"
         );
-        public static SchemaMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SchemaMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeuploadfiles/post/requestbody/content/multipartformdata/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fakeuploadfiles/post/requestbody/content/multipartformdata/Schema.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.ItemsValidator;
@@ -45,7 +46,7 @@ public class Schema {
 
             return new FilesList(arg);
         }
-        public static FilesList validate(List<String> arg, SchemaConfiguration configuration) {
+        public static FilesList validate(List<String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Files.class, arg, configuration);
         }
@@ -92,7 +93,7 @@ public class Schema {
 
             return new SchemaMap(arg);
         }
-        public static SchemaMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SchemaMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/foo/get/responses/responsedefault/content/applicationjson/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/foo/get/responses/responsedefault/content/applicationjson/Schema.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.components.schemas.Foo;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -49,7 +50,7 @@ public class Schema {
 
             return new SchemaMap(arg);
         }
-        public static SchemaMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SchemaMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/foo/get/responses/responsedefault/content/applicationjson/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/foo/get/responses/responsedefault/content/applicationjson/Schema.java
@@ -27,7 +27,7 @@ public class Schema {
         public static final Set<String> optionalKeys = Set.of(
             "string"
         );
-        public static SchemaMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SchemaMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petfindbystatus/get/QueryParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petfindbystatus/get/QueryParameters.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.petfindbystatus.get.parameters.parameter0.Schema0;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
@@ -62,7 +63,7 @@ public class QueryParameters {
 
             return new QueryParametersMap(arg);
         }
-        public static QueryParametersMap validate(Map<String, List<String>> arg, SchemaConfiguration configuration) {
+        public static QueryParametersMap validate(Map<String, List<String>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return JsonSchema.validate(QueryParameters1.class, arg, configuration);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petfindbystatus/get/QueryParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petfindbystatus/get/QueryParameters.java
@@ -36,7 +36,7 @@ public class QueryParameters {
             "status"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static QueryParametersMap of(Map<String, List<String>> arg, SchemaConfiguration configuration) {
+        public static QueryParametersMap of(Map<String, List<String>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return QueryParameters1.validate(arg, configuration);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petfindbystatus/get/parameters/parameter0/Schema0.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petfindbystatus/get/parameters/parameter0/Schema0.java
@@ -33,7 +33,7 @@ public class Schema0 {
 
             super(m);
         }
-        public static SchemaList0 of(List<String> arg, SchemaConfiguration configuration) {
+        public static SchemaList0 of(List<String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema01.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petfindbystatus/get/parameters/parameter0/Schema0.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petfindbystatus/get/parameters/parameter0/Schema0.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.ItemsValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -21,7 +22,7 @@ public class Schema0 {
                 String.class
             )))
         ));
-        public static String validate(String arg, SchemaConfiguration configuration) {
+        public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Items0.class, arg, configuration);
         }
     }    
@@ -48,7 +49,7 @@ public class Schema0 {
 
             return new SchemaList0(arg);
         }
-        public static SchemaList0 validate(List<String> arg, SchemaConfiguration configuration) {
+        public static SchemaList0 validate(List<String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema01.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petfindbytags/get/QueryParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petfindbytags/get/QueryParameters.java
@@ -36,7 +36,7 @@ public class QueryParameters {
             "tags"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static QueryParametersMap of(Map<String, List<String>> arg, SchemaConfiguration configuration) {
+        public static QueryParametersMap of(Map<String, List<String>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return QueryParameters1.validate(arg, configuration);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petfindbytags/get/QueryParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petfindbytags/get/QueryParameters.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.petfindbytags.get.parameters.parameter0.Schema0;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
@@ -62,7 +63,7 @@ public class QueryParameters {
 
             return new QueryParametersMap(arg);
         }
-        public static QueryParametersMap validate(Map<String, List<String>> arg, SchemaConfiguration configuration) {
+        public static QueryParametersMap validate(Map<String, List<String>> arg, SchemaConfiguration configuration) throws ValidationException {
 
 
             return JsonSchema.validate(QueryParameters1.class, arg, configuration);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petfindbytags/get/parameters/parameter0/Schema0.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petfindbytags/get/parameters/parameter0/Schema0.java
@@ -26,7 +26,7 @@ public class Schema0 {
 
             super(m);
         }
-        public static SchemaList0 of(List<String> arg, SchemaConfiguration configuration) {
+        public static SchemaList0 of(List<String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema01.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petfindbytags/get/parameters/parameter0/Schema0.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petfindbytags/get/parameters/parameter0/Schema0.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.ItemsValidator;
@@ -41,7 +42,7 @@ public class Schema0 {
 
             return new SchemaList0(arg);
         }
-        public static SchemaList0 validate(List<String> arg, SchemaConfiguration configuration) {
+        public static SchemaList0 validate(List<String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema01.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petpetid/delete/HeaderParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petpetid/delete/HeaderParameters.java
@@ -34,7 +34,7 @@ public class HeaderParameters {
         public static final Set<String> optionalKeys = Set.of(
             "api_key"
         );
-        public static HeaderParametersMap of(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static HeaderParametersMap of(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return HeaderParameters1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petpetid/delete/HeaderParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petpetid/delete/HeaderParameters.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.petpetid.delete.parameters.parameter0.Schema0;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
@@ -58,7 +59,7 @@ public class HeaderParameters {
 
             return new HeaderParametersMap(arg);
         }
-        public static HeaderParametersMap validate(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static HeaderParametersMap validate(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(HeaderParameters1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petpetid/delete/PathParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petpetid/delete/PathParameters.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.petpetid.delete.parameters.parameter1.Schema1;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
@@ -60,7 +61,7 @@ public class PathParameters {
 
             return new PathParametersMap(arg);
         }
-        public static PathParametersMap validate(Map<String, Long> arg, SchemaConfiguration configuration) {
+        public static PathParametersMap validate(Map<String, Long> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(PathParameters1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petpetid/delete/PathParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petpetid/delete/PathParameters.java
@@ -35,7 +35,7 @@ public class PathParameters {
             "petId"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static PathParametersMap of(Map<String, Long> arg, SchemaConfiguration configuration) {
+        public static PathParametersMap of(Map<String, Long> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return PathParameters1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petpetid/get/PathParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petpetid/get/PathParameters.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.petpetid.get.parameters.parameter0.Schema0;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
@@ -60,7 +61,7 @@ public class PathParameters {
 
             return new PathParametersMap(arg);
         }
-        public static PathParametersMap validate(Map<String, Long> arg, SchemaConfiguration configuration) {
+        public static PathParametersMap validate(Map<String, Long> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(PathParameters1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petpetid/get/PathParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petpetid/get/PathParameters.java
@@ -35,7 +35,7 @@ public class PathParameters {
             "petId"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static PathParametersMap of(Map<String, Long> arg, SchemaConfiguration configuration) {
+        public static PathParametersMap of(Map<String, Long> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return PathParameters1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petpetid/post/PathParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petpetid/post/PathParameters.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.petpetid.post.parameters.parameter0.Schema0;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
@@ -60,7 +61,7 @@ public class PathParameters {
 
             return new PathParametersMap(arg);
         }
-        public static PathParametersMap validate(Map<String, Long> arg, SchemaConfiguration configuration) {
+        public static PathParametersMap validate(Map<String, Long> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(PathParameters1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petpetid/post/PathParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petpetid/post/PathParameters.java
@@ -35,7 +35,7 @@ public class PathParameters {
             "petId"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static PathParametersMap of(Map<String, Long> arg, SchemaConfiguration configuration) {
+        public static PathParametersMap of(Map<String, Long> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return PathParameters1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petpetid/post/requestbody/content/applicationxwwwformurlencoded/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petpetid/post/requestbody/content/applicationxwwwformurlencoded/Schema.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -73,7 +74,7 @@ public class Schema {
 
             return new SchemaMap(arg);
         }
-        public static SchemaMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SchemaMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petpetid/post/requestbody/content/applicationxwwwformurlencoded/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petpetid/post/requestbody/content/applicationxwwwformurlencoded/Schema.java
@@ -34,7 +34,7 @@ public class Schema {
             "name",
             "status"
         );
-        public static SchemaMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SchemaMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petpetiduploadimage/post/PathParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petpetiduploadimage/post/PathParameters.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.petpetiduploadimage.post.parameters.parameter0.Schema0;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
@@ -60,7 +61,7 @@ public class PathParameters {
 
             return new PathParametersMap(arg);
         }
-        public static PathParametersMap validate(Map<String, Long> arg, SchemaConfiguration configuration) {
+        public static PathParametersMap validate(Map<String, Long> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(PathParameters1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petpetiduploadimage/post/PathParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petpetiduploadimage/post/PathParameters.java
@@ -35,7 +35,7 @@ public class PathParameters {
             "petId"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static PathParametersMap of(Map<String, Long> arg, SchemaConfiguration configuration) {
+        public static PathParametersMap of(Map<String, Long> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return PathParameters1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petpetiduploadimage/post/requestbody/content/multipartformdata/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petpetiduploadimage/post/requestbody/content/multipartformdata/Schema.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -75,7 +76,7 @@ public class Schema {
 
             return new SchemaMap(arg);
         }
-        public static SchemaMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SchemaMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Schema1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petpetiduploadimage/post/requestbody/content/multipartformdata/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petpetiduploadimage/post/requestbody/content/multipartformdata/Schema.java
@@ -36,7 +36,7 @@ public class Schema {
             "additionalMetadata",
             "file"
         );
-        public static SchemaMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static SchemaMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Schema1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/storeorderorderid/delete/PathParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/storeorderorderid/delete/PathParameters.java
@@ -35,7 +35,7 @@ public class PathParameters {
             "order_id"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static PathParametersMap of(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static PathParametersMap of(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return PathParameters1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/storeorderorderid/delete/PathParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/storeorderorderid/delete/PathParameters.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.storeorderorderid.delete.parameters.parameter0.Schema0;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
@@ -60,7 +61,7 @@ public class PathParameters {
 
             return new PathParametersMap(arg);
         }
-        public static PathParametersMap validate(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static PathParametersMap validate(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(PathParameters1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/storeorderorderid/get/PathParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/storeorderorderid/get/PathParameters.java
@@ -35,7 +35,7 @@ public class PathParameters {
             "order_id"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static PathParametersMap of(Map<String, Long> arg, SchemaConfiguration configuration) {
+        public static PathParametersMap of(Map<String, Long> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return PathParameters1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/storeorderorderid/get/PathParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/storeorderorderid/get/PathParameters.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.storeorderorderid.get.parameters.parameter0.Schema0;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
@@ -60,7 +61,7 @@ public class PathParameters {
 
             return new PathParametersMap(arg);
         }
-        public static PathParametersMap validate(Map<String, Long> arg, SchemaConfiguration configuration) {
+        public static PathParametersMap validate(Map<String, Long> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(PathParameters1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/storeorderorderid/get/parameters/parameter0/Schema0.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/storeorderorderid/get/parameters/parameter0/Schema0.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FormatValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -23,19 +24,19 @@ public class Schema0 {
             ))),
             new KeywordEntry("format", new FormatValidator("int64"))
         ));
-        public static long validate(int arg, SchemaConfiguration configuration) {
+        public static long validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema01.class, Long.valueOf(arg), configuration);
         }
         
-        public static long validate(float arg, SchemaConfiguration configuration) {
+        public static long validate(float arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema01.class, Long.parseLong(String.valueOf(arg)), configuration);
         }
         
-        public static long validate(long arg, SchemaConfiguration configuration) {
+        public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema01.class, arg, configuration);
         }
         
-        public static long validate(double arg, SchemaConfiguration configuration) {
+        public static long validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema01.class, Long.parseLong(String.valueOf(arg)), configuration);
         }
     }}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/userlogin/get/QueryParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/userlogin/get/QueryParameters.java
@@ -37,7 +37,7 @@ public class QueryParameters {
             "username"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static QueryParametersMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static QueryParametersMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return QueryParameters1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/userlogin/get/QueryParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/userlogin/get/QueryParameters.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.userlogin.get.parameters.parameter0.Schema0;
 import org.openapijsonschematools.paths.userlogin.get.parameters.parameter1.Schema1;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
@@ -71,7 +72,7 @@ public class QueryParameters {
 
             return new QueryParametersMap(arg);
         }
-        public static QueryParametersMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static QueryParametersMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(QueryParameters1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/userlogin/get/responses/response200/Headers.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/userlogin/get/responses/response200/Headers.java
@@ -6,6 +6,7 @@ import org.openapijsonschematools.components.headers.int32jsoncontenttypeheader.
 import org.openapijsonschematools.components.headers.numberheader.NumberHeaderSchema;
 import org.openapijsonschematools.components.schemas.StringWithValidation;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.paths.userlogin.get.responses.response200.headers.xexpiresafter.XExpiresAfterSchema;
 import org.openapijsonschematools.paths.userlogin.get.responses.response200.headers.xratelimit.content.applicationjson.XRateLimitSchema;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
@@ -84,7 +85,7 @@ public class Headers {
 
             return new HeadersMap(arg);
         }
-        public static HeadersMap validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static HeadersMap validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(Headers1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/userlogin/get/responses/response200/Headers.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/userlogin/get/responses/response200/Headers.java
@@ -44,7 +44,7 @@ public class Headers {
             "X-Expires-After",
             "numberHeader"
         );
-        public static HeadersMap of(Map<String, Object> arg, SchemaConfiguration configuration) {
+        public static HeadersMap of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return Headers1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/userusername/delete/PathParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/userusername/delete/PathParameters.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.components.parameters.pathusername.Schema;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.validation.AdditionalPropertiesValidator;
@@ -60,7 +61,7 @@ public class PathParameters {
 
             return new PathParametersMap(arg);
         }
-        public static PathParametersMap validate(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static PathParametersMap validate(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(PathParameters1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/userusername/delete/PathParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/userusername/delete/PathParameters.java
@@ -35,7 +35,7 @@ public class PathParameters {
             "username"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static PathParametersMap of(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static PathParametersMap of(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return PathParameters1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/userusername/get/PathParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/userusername/get/PathParameters.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.components.parameters.pathusername.Schema;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.validation.AdditionalPropertiesValidator;
@@ -60,7 +61,7 @@ public class PathParameters {
 
             return new PathParametersMap(arg);
         }
-        public static PathParametersMap validate(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static PathParametersMap validate(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(PathParameters1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/userusername/get/PathParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/userusername/get/PathParameters.java
@@ -35,7 +35,7 @@ public class PathParameters {
             "username"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static PathParametersMap of(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static PathParametersMap of(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return PathParameters1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/userusername/put/PathParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/userusername/put/PathParameters.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.components.parameters.pathusername.Schema;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.validation.AdditionalPropertiesValidator;
@@ -60,7 +61,7 @@ public class PathParameters {
 
             return new PathParametersMap(arg);
         }
-        public static PathParametersMap validate(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static PathParametersMap validate(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return JsonSchema.validate(PathParameters1.class, arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/userusername/put/PathParameters.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/userusername/put/PathParameters.java
@@ -35,7 +35,7 @@ public class PathParameters {
             "username"
         );
         public static final Set<String> optionalKeys = Set.of();
-        public static PathParametersMap of(Map<String, String> arg, SchemaConfiguration configuration) {
+        public static PathParametersMap of(Map<String, String> arg, SchemaConfiguration configuration) throws ValidationException {
 
             return PathParameters1.validate(arg, configuration);
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/AnyTypeJsonSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/AnyTypeJsonSchema.java
@@ -4,6 +4,7 @@ import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
@@ -13,51 +14,51 @@ import java.util.UUID;
 
 
 public class AnyTypeJsonSchema extends JsonSchema {
-    public static Void validate(Void arg, SchemaConfiguration configuration) {
+    public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(AnyTypeJsonSchema.class, arg, configuration);
     }
 
-    public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+    public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(AnyTypeJsonSchema.class, arg, configuration);
     }
 
-    public static int validate(int arg, SchemaConfiguration configuration) {
+    public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(AnyTypeJsonSchema.class, arg, configuration);
     }
 
-    public static long validate(long arg, SchemaConfiguration configuration) {
+    public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(AnyTypeJsonSchema.class, arg, configuration);
     }
 
-    public static float validate(float arg, SchemaConfiguration configuration) {
+    public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(AnyTypeJsonSchema.class, arg, configuration);
     }
 
-    public static double validate(double arg, SchemaConfiguration configuration) {
+    public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(AnyTypeJsonSchema.class, arg, configuration);
     }
 
-    public static String validate(String arg, SchemaConfiguration configuration) {
+    public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(AnyTypeJsonSchema.class, arg, configuration);
     }
 
-    public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+    public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(AnyTypeJsonSchema.class, arg, configuration);
     }
 
-    public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+    public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(AnyTypeJsonSchema.class, arg, configuration);
     }
 
-    public static String validate(UUID arg, SchemaConfiguration configuration) {
+    public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(AnyTypeJsonSchema.class, arg, configuration);
     }
 
-    public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+    public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(AnyTypeJsonSchema.class, arg, configuration);
     }
 
-    public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+    public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(AnyTypeJsonSchema.class, arg, configuration);
     }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/BooleanJsonSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/BooleanJsonSchema.java
@@ -5,6 +5,7 @@ import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
 import org.openapijsonschematools.schemas.validation.TypeValidator;
+import org.openapijsonschematools.exceptions.ValidationException;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -16,7 +17,7 @@ public class BooleanJsonSchema extends JsonSchema {
         new KeywordEntry("type", new TypeValidator(Set.of(Boolean.class)))
     ));
 
-    public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+    public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(BooleanJsonSchema.class, arg, configuration);
     }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/DateJsonSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/DateJsonSchema.java
@@ -6,6 +6,7 @@ import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
 import org.openapijsonschematools.schemas.validation.TypeValidator;
 import org.openapijsonschematools.schemas.validation.FormatValidator;
+import org.openapijsonschematools.exceptions.ValidationException;
 
 import java.time.LocalDate;
 import java.util.LinkedHashMap;
@@ -19,11 +20,11 @@ public class DateJsonSchema extends JsonSchema {
         new KeywordEntry("format", new FormatValidator("date"))
     ));
 
-    public static String validate(String arg, SchemaConfiguration configuration) {
+    public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(DateJsonSchema.class, arg, configuration);
     }
 
-    public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+    public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(DateJsonSchema.class, arg, configuration);
     }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/DateTimeJsonSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/DateTimeJsonSchema.java
@@ -6,6 +6,7 @@ import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
 import org.openapijsonschematools.schemas.validation.TypeValidator;
 import org.openapijsonschematools.schemas.validation.FormatValidator;
+import org.openapijsonschematools.exceptions.ValidationException;
 
 import java.time.ZonedDateTime;
 import java.util.LinkedHashMap;
@@ -19,11 +20,11 @@ public class DateTimeJsonSchema extends JsonSchema {
         new KeywordEntry("format", new FormatValidator("date-time"))
     ));
 
-    public static String validate(String arg, SchemaConfiguration configuration) {
+    public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(DateTimeJsonSchema.class, arg, configuration);
     }
 
-    public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+    public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(DateTimeJsonSchema.class, arg, configuration);
     }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/DecimalJsonSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/DecimalJsonSchema.java
@@ -6,6 +6,7 @@ import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
 import org.openapijsonschematools.schemas.validation.TypeValidator;
 import org.openapijsonschematools.schemas.validation.FormatValidator;
+import org.openapijsonschematools.exceptions.ValidationException;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -18,7 +19,7 @@ public class DecimalJsonSchema extends JsonSchema {
         new KeywordEntry("format", new FormatValidator("number"))
     ));
 
-    public static String validate(String arg, SchemaConfiguration configuration) {
+    public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(DecimalJsonSchema.class, arg, configuration);
     }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/DoubleJsonSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/DoubleJsonSchema.java
@@ -6,6 +6,7 @@ import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
 import org.openapijsonschematools.schemas.validation.TypeValidator;
 import org.openapijsonschematools.schemas.validation.FormatValidator;
+import org.openapijsonschematools.exceptions.ValidationException;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -18,7 +19,7 @@ public class DoubleJsonSchema extends JsonSchema {
         new KeywordEntry("format", new FormatValidator("double"))
     ));
 
-    public static double validate(double arg, SchemaConfiguration configuration) {
+    public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(DoubleJsonSchema.class, arg, configuration);
     }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/FloatJsonSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/FloatJsonSchema.java
@@ -6,6 +6,7 @@ import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
 import org.openapijsonschematools.schemas.validation.TypeValidator;
 import org.openapijsonschematools.schemas.validation.FormatValidator;
+import org.openapijsonschematools.exceptions.ValidationException;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -18,7 +19,7 @@ public class FloatJsonSchema extends JsonSchema {
         new KeywordEntry("format", new FormatValidator("float"))
     ));
 
-    public static float validate(float arg, SchemaConfiguration configuration) {
+    public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(FloatJsonSchema.class, arg, configuration);
     }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Int32JsonSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Int32JsonSchema.java
@@ -6,6 +6,7 @@ import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
 import org.openapijsonschematools.schemas.validation.TypeValidator;
 import org.openapijsonschematools.schemas.validation.FormatValidator;
+import org.openapijsonschematools.exceptions.ValidationException;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -21,11 +22,11 @@ public class Int32JsonSchema extends JsonSchema {
         new KeywordEntry("format", new FormatValidator("int32"))
     ));
 
-    public static int validate(int arg, SchemaConfiguration configuration) {
+    public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(Int32JsonSchema.class, arg, configuration);
     }
 
-    public static int validate(float arg, SchemaConfiguration configuration) {
+    public static int validate(float arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(Int32JsonSchema.class, Integer.parseInt(String.valueOf(arg)), configuration);
     }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Int64JsonSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/Int64JsonSchema.java
@@ -6,6 +6,7 @@ import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
 import org.openapijsonschematools.schemas.validation.TypeValidator;
 import org.openapijsonschematools.schemas.validation.FormatValidator;
+import org.openapijsonschematools.exceptions.ValidationException;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -23,19 +24,19 @@ public class Int64JsonSchema extends JsonSchema {
         new KeywordEntry("format", new FormatValidator("int64"))
     ));
 
-    public static long validate(int arg, SchemaConfiguration configuration) {
+    public static long validate(int arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(Int64JsonSchema.class, Long.valueOf(arg), configuration);
     }
 
-    public static long validate(float arg, SchemaConfiguration configuration) {
+    public static long validate(float arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(Int64JsonSchema.class, Long.parseLong(String.valueOf(arg)), configuration);
     }
 
-    public static long validate(long arg, SchemaConfiguration configuration) {
+    public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(Int64JsonSchema.class, arg, configuration);
     }
 
-    public static long validate(double arg, SchemaConfiguration configuration) {
+    public static long validate(double arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(Int64JsonSchema.class, Long.parseLong(String.valueOf(arg)), configuration);
     }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/IntJsonSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/IntJsonSchema.java
@@ -6,6 +6,7 @@ import org.openapijsonschematools.schemas.validation.KeywordValidator;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.TypeValidator;
 import org.openapijsonschematools.schemas.validation.FormatValidator;
+import org.openapijsonschematools.exceptions.ValidationException;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -18,19 +19,19 @@ public class IntJsonSchema extends JsonSchema {
         new KeywordEntry("format", new FormatValidator("int"))
     ));
 
-    public static long validate(int arg, SchemaConfiguration configuration) {
+    public static long validate(int arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(IntJsonSchema.class, Long.valueOf(arg), configuration);
     }
 
-    public static long validate(float arg, SchemaConfiguration configuration) {
+    public static long validate(float arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(IntJsonSchema.class, Long.parseLong(String.valueOf(arg)), configuration);
     }
 
-    public static long validate(long arg, SchemaConfiguration configuration) {
+    public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(IntJsonSchema.class, arg, configuration);
     }
 
-    public static long validate(double arg, SchemaConfiguration configuration) {
+    public static long validate(double arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(IntJsonSchema.class, Long.parseLong(String.valueOf(arg)), configuration);
     }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/ListJsonSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/ListJsonSchema.java
@@ -6,6 +6,7 @@ import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.TypeValidator;
+import org.openapijsonschematools.exceptions.ValidationException;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -18,7 +19,7 @@ public class ListJsonSchema extends JsonSchema {
         new KeywordEntry("type", new TypeValidator(Set.of(FrozenList.class)))
     ));
 
-    public static FrozenList<Object> validate(List<Object> arg, SchemaConfiguration configuration) {
+    public static FrozenList<Object> validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(ListJsonSchema.class, arg, configuration);
     }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/MapJsonSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/MapJsonSchema.java
@@ -6,6 +6,7 @@ import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.TypeValidator;
+import org.openapijsonschematools.exceptions.ValidationException;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -17,7 +18,7 @@ public class MapJsonSchema extends JsonSchema {
         new KeywordEntry("type", new TypeValidator(Set.of(FrozenMap.class)))
     ));
 
-    public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+    public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(MapJsonSchema.class, arg, configuration);
     }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/NullJsonSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/NullJsonSchema.java
@@ -5,6 +5,7 @@ import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.TypeValidator;
+import org.openapijsonschematools.exceptions.ValidationException;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -16,7 +17,7 @@ public class NullJsonSchema extends JsonSchema {
         new KeywordEntry("type", new TypeValidator(Set.of(Void.class)))
     ));
 
-    public static Void validate(Void arg, SchemaConfiguration configuration) {
+    public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(NullJsonSchema.class, arg, configuration);
     }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/NumberJsonSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/NumberJsonSchema.java
@@ -5,6 +5,7 @@ import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.TypeValidator;
+import org.openapijsonschematools.exceptions.ValidationException;
 
 import java.util.LinkedHashMap;
 import java.util.Set;
@@ -21,19 +22,19 @@ public class NumberJsonSchema extends JsonSchema {
         )))
     ));
 
-    public static Number validate(Integer arg, SchemaConfiguration configuration) {
+    public static Number validate(Integer arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(NumberJsonSchema.class, arg, configuration);
     }
 
-    public static Number validate(Long arg, SchemaConfiguration configuration) {
+    public static Number validate(Long arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(NumberJsonSchema.class, arg, configuration);
     }
 
-    public static Number validate(Float arg, SchemaConfiguration configuration) {
+    public static Number validate(Float arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(NumberJsonSchema.class, arg, configuration);
     }
 
-    public static Number validate(Double arg, SchemaConfiguration configuration) {
+    public static Number validate(Double arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(NumberJsonSchema.class, arg, configuration);
     }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/StringJsonSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/StringJsonSchema.java
@@ -5,6 +5,7 @@ import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.TypeValidator;
+import org.openapijsonschematools.exceptions.ValidationException;
 
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
@@ -18,19 +19,19 @@ public class StringJsonSchema extends JsonSchema {
         new KeywordEntry("type", new TypeValidator(Set.of(String.class)))
     ));
 
-    public static String validate(String arg, SchemaConfiguration configuration) {
+    public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(StringJsonSchema.class, arg, configuration);
     }
 
-    public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+    public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(StringJsonSchema.class, arg, configuration);
     }
 
-    public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+    public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(StringJsonSchema.class, arg, configuration);
     }
 
-    public static String validate(UUID arg, SchemaConfiguration configuration) {
+    public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(StringJsonSchema.class, arg, configuration);
     }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/UuidJsonSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/UuidJsonSchema.java
@@ -2,6 +2,7 @@ package org.openapijsonschematools.schemas;
 
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -14,11 +15,11 @@ public class UuidJsonSchema extends JsonSchema {
     ));
     public static final String format = "uuid";
 
-    public static String validate(String arg, SchemaConfiguration configuration) {
+    public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(UuidJsonSchema.class, arg, configuration);
     }
 
-    public static String validate(UUID arg, SchemaConfiguration configuration) {
+    public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(UuidJsonSchema.class, arg, configuration);
     }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validation/FormatValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validation/FormatValidator.java
@@ -1,5 +1,7 @@
 package org.openapijsonschematools.schemas.validation;
 
+import org.openapijsonschematools.exceptions.ValidationException;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.format.DateTimeParseException;
@@ -38,7 +40,7 @@ public class FormatValidator implements KeywordValidator {
                     doubleArg = (Double) arg;
                 }
                 if (Math.floor(doubleArg) != doubleArg) {
-                    throw new RuntimeException(
+                    throw new ValidationException(
                             "Invalid non-integer value " + arg + " for format " + format + " at " + validationMetadata.pathToItem()
                     );
                 }
@@ -57,14 +59,14 @@ public class FormatValidator implements KeywordValidator {
             }
             if (format.equals("int32")) {
                 if (intArg.compareTo(int32InclusiveMinimum) < 0 || intArg.compareTo(int32InclusiveMaximum) > 0) {
-                    throw new RuntimeException(
+                    throw new ValidationException(
                             "Invalid value " + arg + " for format int32 at " + validationMetadata.pathToItem()
                     );
                 }
                 return null;
             } else if (format.equals("int64")) {
                 if (intArg.compareTo(int64InclusiveMinimum) < 0 || intArg.compareTo(int64InclusiveMaximum) > 0) {
-                    throw new RuntimeException(
+                    throw new ValidationException(
                             "Invalid value " + arg + " for format int64 at " + validationMetadata.pathToItem()
                     );
                 }
@@ -82,14 +84,14 @@ public class FormatValidator implements KeywordValidator {
         }
         if (format.equals("float")) {
             if (decimalArg.compareTo(floatInclusiveMinimum) < 0  || decimalArg.compareTo(floatInclusiveMaximum) > 0 ){
-                throw new RuntimeException(
+                throw new ValidationException(
                     "Invalid value "+arg+" for format float at "+validationMetadata.pathToItem()
                 );
             }
             return null;
         } else if (format.equals("double")) {
             if (decimalArg.compareTo(doubleInclusiveMinimum) < 0  || decimalArg.compareTo(doubleInclusiveMaximum) > 0 ){
-                throw new RuntimeException(
+                throw new ValidationException(
                     "Invalid value "+arg+" for format double at "+validationMetadata.pathToItem()
                 );
             }
@@ -103,7 +105,7 @@ public class FormatValidator implements KeywordValidator {
             try {
                 UUID.fromString(arg);
             } catch (IllegalArgumentException  e) {
-                throw new RuntimeException(
+                throw new ValidationException(
                     "Value cannot be converted to a UUID. Invalid value "+
                             arg+" for format uuid at "+validationMetadata.pathToItem()
                 );
@@ -113,7 +115,7 @@ public class FormatValidator implements KeywordValidator {
             try {
                 new BigDecimal(arg);
             } catch (NumberFormatException e) {
-                throw new RuntimeException(
+                throw new ValidationException(
                     "Value cannot be converted to a decimal. Invalid value "+
                             arg+" for format number at "+validationMetadata.pathToItem()
                 );
@@ -123,7 +125,7 @@ public class FormatValidator implements KeywordValidator {
             try {
                 new CustomIsoparser().parseIsodate(arg);
             } catch (DateTimeParseException e) {
-                throw new RuntimeException(
+                throw new ValidationException(
                         "Value does not conform to the required ISO-8601 date format. "+
                         "Invalid value "+arg+" for format date at "+validationMetadata.pathToItem()
                 );
@@ -133,7 +135,7 @@ public class FormatValidator implements KeywordValidator {
             try {
                 new CustomIsoparser().parseIsodatetime(arg);
             } catch (DateTimeParseException e) {
-                throw new RuntimeException(
+                throw new ValidationException(
                         "Value does not conform to the required ISO-8601 datetime format. "+
                                 "Invalid value "+arg+" for format datetime at "+validationMetadata.pathToItem()
                 );

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validation/FrozenMap.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validation/FrozenMap.java
@@ -1,5 +1,8 @@
 package org.openapijsonschematools.schemas.validation;
 
+import org.openapijsonschematools.exceptions.UnsetPropertyException;
+import org.openapijsonschematools.exceptions.InvalidAdditionalPropertyException;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -16,15 +19,15 @@ public class FrozenMap<K, V> extends LinkedHashMap<K, V> {
         super(m);
     }
 
-    protected void throwIfKeyNotPresent(String key) throws RuntimeException {
+    protected void throwIfKeyNotPresent(String key) throws UnsetPropertyException {
         if (!containsKey(key)) {
-            throw new RuntimeException(key+" is unset");
+            throw new UnsetPropertyException(key+" is unset");
         }
     }
 
     protected void throwIfKeyKnown(String key, Set<String> requiredKeys, Set<String> optionalKeys) throws IllegalArgumentException {
         if (requiredKeys.contains(key) || optionalKeys.contains(key)) {
-            throw new IllegalArgumentException ("The known key " + key + " may not be passed in when getting an additional property");
+            throw new InvalidAdditionalPropertyException ("The known key " + key + " may not be passed in when getting an additional property");
         }
     }
 

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validation/JsonSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validation/JsonSchema.java
@@ -2,15 +2,14 @@ package org.openapijsonschematools.schemas.validation;
 
 import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Field;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
-import java.util.AbstractMap;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -25,7 +24,7 @@ public abstract class JsonSchema {
             Class<? extends JsonSchema> schemaCls,
             Object arg,
             ValidationMetadata validationMetadata
-    ) {
+    ) throws ValidationException {
         LinkedHashSet<String> disabledKeywords = validationMetadata.configuration().disabledKeywordFlags().getKeywords();
         Class<? extends JsonSchema> usedSchemaCls = schemaCls;
         Class<?> superclass = schemaCls.getSuperclass();
@@ -34,11 +33,12 @@ public abstract class JsonSchema {
             usedSchemaCls = (Class<? extends JsonSchema>) superclass;
         }
         LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>();
-       try {
-          Field keywordToValidatorField = usedSchemaCls.getField("keywordToValidator");
-          LinkedHashMap<String, KeywordValidator> entries = (LinkedHashMap<String, KeywordValidator>) keywordToValidatorField.get(null);
-          keywordToValidator.putAll(entries);
-       } catch (NoSuchFieldException | IllegalAccessException ignore) {}
+        try {
+            Field keywordToValidatorField = usedSchemaCls.getField("keywordToValidator");
+            LinkedHashMap<String, KeywordValidator> entries = (LinkedHashMap<String, KeywordValidator>) keywordToValidatorField.get(null);
+            keywordToValidator.putAll(entries);
+            keywordToValidator.keySet().removeAll(disabledKeywords);
+        } catch (NoSuchFieldException | IllegalAccessException ignore) {}
         Object extra = null;
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         for (Map.Entry<String, KeywordValidator> entry: keywordToValidator.entrySet()) {
@@ -210,57 +210,57 @@ public abstract class JsonSchema {
       return arg;
    }
 
-   protected static Void validate(Class<? extends JsonSchema> cls, Void arg, SchemaConfiguration configuration) {
+   protected static Void validate(Class<? extends JsonSchema> cls, Void arg, SchemaConfiguration configuration) throws ValidationException {
       return (Void) validateObject(cls, arg, configuration);
    }
 
-   protected static boolean validate(Class<? extends JsonSchema> cls, boolean arg, SchemaConfiguration configuration) {
+   protected static boolean validate(Class<? extends JsonSchema> cls, boolean arg, SchemaConfiguration configuration) throws ValidationException {
       return (boolean) validateObject(cls, arg, configuration);
    }
 
-   protected static int validate(Class<? extends JsonSchema> cls, int arg, SchemaConfiguration configuration) {
+   protected static int validate(Class<? extends JsonSchema> cls, int arg, SchemaConfiguration configuration) throws ValidationException {
       return (int) validateObject(cls, arg, configuration);
    }
 
-   protected static long validate(Class<? extends JsonSchema> cls, long arg, SchemaConfiguration configuration) {
+   protected static long validate(Class<? extends JsonSchema> cls, long arg, SchemaConfiguration configuration) throws ValidationException {
       return (long) validateObject(cls, arg, configuration);
    }
 
-   protected static float validate(Class<? extends JsonSchema> cls, float arg, SchemaConfiguration configuration) {
+   protected static float validate(Class<? extends JsonSchema> cls, float arg, SchemaConfiguration configuration) throws ValidationException {
       return (float) validateObject(cls, arg, configuration);
    }
 
-   protected static double validate(Class<? extends JsonSchema> cls, double arg, SchemaConfiguration configuration) {
+   protected static double validate(Class<? extends JsonSchema> cls, double arg, SchemaConfiguration configuration) throws ValidationException {
       return (double) validateObject(cls, arg, configuration);
    }
 
-   protected static String validate(Class<? extends JsonSchema> cls, String arg, SchemaConfiguration configuration) {
+   protected static String validate(Class<? extends JsonSchema> cls, String arg, SchemaConfiguration configuration) throws ValidationException {
       return (String) validateObject(cls, arg, configuration);
    }
 
-   protected static String validate(Class<? extends JsonSchema> cls, ZonedDateTime arg, SchemaConfiguration configuration) {
+   protected static String validate(Class<? extends JsonSchema> cls, ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
       return (String) validateObject(cls, arg, configuration);
    }
 
-   protected static String validate(Class<? extends JsonSchema> cls, LocalDate arg, SchemaConfiguration configuration) {
+   protected static String validate(Class<? extends JsonSchema> cls, LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
       return (String) validateObject(cls, arg, configuration);
    }
 
-   protected static String validate(Class<? extends JsonSchema> cls, UUID arg, SchemaConfiguration configuration) {
+   protected static String validate(Class<? extends JsonSchema> cls, UUID arg, SchemaConfiguration configuration) throws ValidationException {
       return (String) validateObject(cls, arg, configuration);
    }
 
-   protected static <T extends FrozenMap> T validate(Class<? extends JsonSchema> cls, Map<String, ?> arg, SchemaConfiguration configuration) {
+   protected static <T extends FrozenMap> T validate(Class<? extends JsonSchema> cls, Map<String, ?> arg, SchemaConfiguration configuration) throws ValidationException {
       return (T) validateObject(cls, arg, configuration);
    }
 
-   protected static <U extends FrozenList> U validate(Class<? extends JsonSchema> cls, List<?> arg, SchemaConfiguration configuration) {
+   protected static <U extends FrozenList> U validate(Class<? extends JsonSchema> cls, List<?> arg, SchemaConfiguration configuration) throws ValidationException {
       return (U) validateObject(cls, arg, configuration);
    }
 
    // todo add bytes and FileIO
 
-   public static Object validateObject(Class<? extends JsonSchema> cls, Object arg, SchemaConfiguration configuration) {
+   public static Object validateObject(Class<? extends JsonSchema> cls, Object arg, SchemaConfiguration configuration) throws ValidationException {
       if (arg instanceof Map || arg instanceof List) {
          // todo don't run validation if the instance is one of the class generic types
       }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validation/JsonSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validation/JsonSchema.java
@@ -3,6 +3,7 @@ package org.openapijsonschematools.schemas.validation;
 import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
+import org.openapijsonschematools.exceptions.InvalidTypeException;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -124,7 +125,7 @@ public abstract class JsonSchema {
          return arg.toString();
       } else {
          Class<?> argClass = arg.getClass();
-         throw new RuntimeException("Invalid type passed in got input="+arg+" type="+argClass);
+         throw new InvalidTypeException("Invalid type passed in for input="+arg+" type="+argClass);
       }
    }
 

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validation/KeywordValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validation/KeywordValidator.java
@@ -1,11 +1,13 @@
 package org.openapijsonschematools.schemas.validation;
 
+import org.openapijsonschematools.exceptions.ValidationException;
+
 public interface KeywordValidator {
     PathToSchemasMap validate(
             Class<? extends JsonSchema> cls,
             Object arg,
             ValidationMetadata validationMetadata,
-            Object extra);
+            Object extra) throws ValidationException;
 
     Object getConstraint();
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validation/RequiredValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validation/RequiredValidator.java
@@ -1,5 +1,7 @@
 package org.openapijsonschematools.schemas.validation;
 
+import org.openapijsonschematools.exceptions.ValidationException;
+
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -31,7 +33,7 @@ public class RequiredValidator implements KeywordValidator {
             if (missingRequiredProperties.size() > 1) {
                 pluralChar = "s";
             }
-            throw new RuntimeException(
+            throw new ValidationException(
                 cls+" is missing "+missingRequiredProperties.size()+" required argument"+pluralChar+": "+missingReqProps
             );
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validation/TypeValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validation/TypeValidator.java
@@ -1,5 +1,7 @@
 package org.openapijsonschematools.schemas.validation;
 
+import org.openapijsonschematools.exceptions.ValidationException;
+
 import java.util.Set;
 
 public class TypeValidator implements KeywordValidator {
@@ -23,7 +25,7 @@ public class TypeValidator implements KeywordValidator {
             argClass = arg.getClass();
         }
         if (!type.contains(argClass)) {
-            throw new RuntimeException("invalid type");
+            throw new ValidationException("invalid type");
         }
         return null;
     }

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/ArrayTypeSchemaTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/ArrayTypeSchemaTest.java
@@ -10,6 +10,7 @@ import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
 import org.openapijsonschematools.schemas.validation.TypeValidator;
+import org.openapijsonschematools.exceptions.ValidationException;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -59,7 +60,7 @@ public class ArrayTypeSchemaTest {
 
     @Test
     public void testExceptionThrownForInvalidType() {
-        Assert.assertThrows(RuntimeException.class, () -> JsonSchema.validateObject(
+        Assert.assertThrows(ValidationException.class, () -> JsonSchema.validateObject(
                 ArrayWithItemsSchema.class, (Void) null, configuration
         ));
     }
@@ -84,7 +85,7 @@ public class ArrayTypeSchemaTest {
         inList = new ArrayList<>();
         inList.add(1);
         List<Object> finalInList = inList;
-        Assert.assertThrows(RuntimeException.class, () -> ArrayWithItemsSchema.validate(
+        Assert.assertThrows(ValidationException.class, () -> ArrayWithItemsSchema.validate(
                 finalInList, configuration
         ));
     }
@@ -109,7 +110,7 @@ public class ArrayTypeSchemaTest {
         inList = new ArrayList<>();
         inList.add(1);
         List<Object> finalInList = inList;
-        Assert.assertThrows(RuntimeException.class, () -> ArrayWithOutputClsSchema.validate(
+        Assert.assertThrows(ValidationException.class, () -> ArrayWithOutputClsSchema.validate(
                 finalInList, configuration
         ));
     }

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/BooleanSchemaTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/BooleanSchemaTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
+import org.openapijsonschematools.exceptions.ValidationException;
 
 public class BooleanSchemaTest {
     static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
@@ -23,7 +24,7 @@ public class BooleanSchemaTest {
 
     @Test
     public void testExceptionThrownForInvalidType() {
-        Assert.assertThrows(RuntimeException.class, () -> JsonSchema.validateObject(
+        Assert.assertThrows(ValidationException.class, () -> JsonSchema.validateObject(
                 BooleanJsonSchema.class, (Void) null, configuration
         ));
     }

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/ListSchemaTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/ListSchemaTest.java
@@ -6,6 +6,7 @@ import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenList;
+import org.openapijsonschematools.exceptions.ValidationException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,7 +16,7 @@ public class ListSchemaTest {
 
     @Test
     public void testExceptionThrownForInvalidType() {
-        Assert.assertThrows(RuntimeException.class, () -> JsonSchema.validateObject(
+        Assert.assertThrows(ValidationException.class, () -> JsonSchema.validateObject(
                 ListJsonSchema.class, (Void) null, configuration
         ));
     }

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/MapSchemaTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/MapSchemaTest.java
@@ -6,6 +6,7 @@ import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
+import org.openapijsonschematools.exceptions.ValidationException;
 
 import java.time.LocalDate;
 import java.util.LinkedHashMap;
@@ -16,7 +17,7 @@ public class MapSchemaTest {
 
     @Test
     public void testExceptionThrownForInvalidType() {
-        Assert.assertThrows(RuntimeException.class, () -> JsonSchema.validateObject(
+        Assert.assertThrows(ValidationException.class, () -> JsonSchema.validateObject(
                 MapJsonSchema.class, (Void) null, configuration
         ));
     }

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/NullSchemaTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/NullSchemaTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
+import org.openapijsonschematools.exceptions.ValidationException;
 
 public class NullSchemaTest {
     static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
@@ -17,7 +18,7 @@ public class NullSchemaTest {
 
     @Test
     public void testExceptionThrownForInvalidType() {
-        Assert.assertThrows(RuntimeException.class, () -> JsonSchema.validateObject(
+        Assert.assertThrows(ValidationException.class, () -> JsonSchema.validateObject(
                 NullJsonSchema.class, Boolean.TRUE, configuration
         ));
     }

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/NumberSchemaTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/NumberSchemaTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
+import org.openapijsonschematools.exceptions.ValidationException;
 
 import java.math.BigDecimal;
 
@@ -37,7 +38,7 @@ public class NumberSchemaTest {
 
     @Test
     public void testExceptionThrownForInvalidType() {
-        Assert.assertThrows(RuntimeException.class, () -> JsonSchema.validateObject(
+        Assert.assertThrows(ValidationException.class, () -> JsonSchema.validateObject(
                 NumberJsonSchema.class, (Void) null, configuration
         ));
     }

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/ObjectTypeSchemaTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/ObjectTypeSchemaTest.java
@@ -12,6 +12,7 @@ import org.openapijsonschematools.schemas.validation.KeywordValidator;
 import org.openapijsonschematools.schemas.validation.PropertiesValidator;
 import org.openapijsonschematools.schemas.validation.PropertyEntry;
 import org.openapijsonschematools.schemas.validation.TypeValidator;
+import org.openapijsonschematools.exceptions.ValidationException;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -89,7 +90,7 @@ public class ObjectTypeSchemaTest {
 
     @Test
     public void testExceptionThrownForInvalidType() {
-        Assert.assertThrows(RuntimeException.class, () -> JsonSchema.validateObject(
+        Assert.assertThrows(ValidationException.class, () -> JsonSchema.validateObject(
                 ObjectWithPropsSchema.class, (Void) null, configuration
         ));
     }
@@ -118,7 +119,7 @@ public class ObjectTypeSchemaTest {
         inMap = new LinkedHashMap<>();
         inMap.put("someString", 1);
         Map<String, Object> finalInMap = inMap;
-        Assert.assertThrows(RuntimeException.class, () -> ObjectWithPropsSchema.validate(
+        Assert.assertThrows(ValidationException.class, () -> ObjectWithPropsSchema.validate(
                 finalInMap, configuration
         ));
     }
@@ -147,7 +148,7 @@ public class ObjectTypeSchemaTest {
         inMap = new LinkedHashMap<>();
         inMap.put("someString", 1);
         Map<String, Object> finalInMap = inMap;
-        Assert.assertThrows(RuntimeException.class, () -> ObjectWithAddpropsSchema.validate(
+        Assert.assertThrows(ValidationException.class, () -> ObjectWithAddpropsSchema.validate(
                 finalInMap, configuration
         ));
     }
@@ -176,7 +177,7 @@ public class ObjectTypeSchemaTest {
         inMap = new LinkedHashMap<>();
         inMap.put("someString", 1);
         Map<String, Object> invalidPropMap = inMap;
-        Assert.assertThrows(RuntimeException.class, () -> ObjectWithPropsAndAddpropsSchema.validate(
+        Assert.assertThrows(ValidationException.class, () -> ObjectWithPropsAndAddpropsSchema.validate(
                 invalidPropMap, configuration
         ));
 
@@ -184,7 +185,7 @@ public class ObjectTypeSchemaTest {
         inMap = new LinkedHashMap<>();
         inMap.put("someAddProp", 1);
         Map<String, Object> invalidAddpropMap = inMap;
-        Assert.assertThrows(RuntimeException.class, () -> ObjectWithPropsAndAddpropsSchema.validate(
+        Assert.assertThrows(ValidationException.class, () -> ObjectWithPropsAndAddpropsSchema.validate(
                 invalidAddpropMap, configuration
         ));
     }
@@ -213,7 +214,7 @@ public class ObjectTypeSchemaTest {
         inMap = new LinkedHashMap<>();
         inMap.put("someString", 1);
         Map<String, Object> finalInMap = inMap;
-        Assert.assertThrows(RuntimeException.class, () -> ObjectWithOutputTypeSchema.validate(
+        Assert.assertThrows(ValidationException.class, () -> ObjectWithOutputTypeSchema.validate(
                 finalInMap, configuration
         ));
 

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/RefBooleanSchemaTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/RefBooleanSchemaTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
+import org.openapijsonschematools.exceptions.ValidationException;
 
 class RefBooleanSchema {
     public class RefBooleanSchema1 extends BooleanJsonSchema{}
@@ -27,7 +28,7 @@ public class RefBooleanSchemaTest {
 
     @Test
     public void testExceptionThrownForInvalidType() {
-        Assert.assertThrows(RuntimeException.class, () -> JsonSchema.validateObject(
+        Assert.assertThrows(ValidationException.class, () -> JsonSchema.validateObject(
                 RefBooleanSchema.RefBooleanSchema1.class, (Void) null, configuration
         ));
     }

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validation/AdditionalPropertiesValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validation/AdditionalPropertiesValidatorTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.schemas.StringJsonSchema;
+import org.openapijsonschematools.exceptions.ValidationException;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -86,7 +87,7 @@ public class AdditionalPropertiesValidatorTest {
         mutableMap.put("someAddProp", 1);
         FrozenMap<String, Object> arg = new FrozenMap<>(mutableMap);
         final AdditionalPropertiesValidator validator = new AdditionalPropertiesValidator(StringJsonSchema.class);
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 arg,
                 validationMetadata,

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validation/FormatValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validation/FormatValidatorTest.java
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -33,7 +34,7 @@ public class FormatValidatorTest {
     @Test
     public void testIntFormatFailsWithFloat() {
         final FormatValidator validator = new FormatValidator("int");
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 3.14f,
                 validationMetadata,
@@ -56,7 +57,7 @@ public class FormatValidatorTest {
     @Test
     public void testInt32UnderMinFails() {
         final FormatValidator validator = new FormatValidator("int32");
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 -2147483649L,
                 validationMetadata,
@@ -91,7 +92,7 @@ public class FormatValidatorTest {
     @Test
     public void testInt32OverMaxFails() {
         final FormatValidator validator = new FormatValidator("int32");
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 2147483648L,
                 validationMetadata,
@@ -103,7 +104,7 @@ public class FormatValidatorTest {
     public void testInt64UnderMinFails() {
         final FormatValidator validator = new FormatValidator("int64");
 
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 new BigInteger("-9223372036854775809"),
                 validationMetadata,
@@ -139,7 +140,7 @@ public class FormatValidatorTest {
     public void testInt64OverMaxFails() {
         final FormatValidator validator = new FormatValidator("int64");
 
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 new BigInteger("9223372036854775808"),
                 validationMetadata,
@@ -150,7 +151,7 @@ public class FormatValidatorTest {
     @Test
     public void testFloatUnderMinFails() {
         final FormatValidator validator = new FormatValidator("float");
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 -3.402823466385289e+38d,
                 validationMetadata,
@@ -185,7 +186,7 @@ public class FormatValidatorTest {
     @Test
     public void testFloatOverMaxFails() {
         final FormatValidator validator = new FormatValidator("float");
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 3.402823466385289e+38d,
                 validationMetadata,
@@ -196,7 +197,7 @@ public class FormatValidatorTest {
     @Test
     public void testDoubleUnderMinFails() {
         final FormatValidator validator = new FormatValidator("double");
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 new BigDecimal("-1.7976931348623157082e+308"),
                 validationMetadata,
@@ -231,7 +232,7 @@ public class FormatValidatorTest {
     @Test
     public void testDoubleOverMaxFails() {
         final FormatValidator validator = new FormatValidator("double");
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 new BigDecimal("1.7976931348623157082e+308"),
                 validationMetadata,
@@ -242,7 +243,7 @@ public class FormatValidatorTest {
     @Test
     public void testInvalidNumberStringFails() {
         final FormatValidator validator = new FormatValidator("number");
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 "abc",
                 validationMetadata,
@@ -277,7 +278,7 @@ public class FormatValidatorTest {
     @Test
     public void testInvalidDateStringFails() {
         final FormatValidator validator = new FormatValidator("date");
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 "abc",
                 validationMetadata,
@@ -300,7 +301,7 @@ public class FormatValidatorTest {
     @Test
     public void testInvalidDateTimeStringFails() {
         final FormatValidator validator = new FormatValidator("date-time");
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 "abc",
                 validationMetadata,

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validation/ItemsValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validation/ItemsValidatorTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.schemas.StringJsonSchema;
+import org.openapijsonschematools.exceptions.ValidationException;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -77,7 +78,7 @@ public class ItemsValidatorTest {
         mutableList.add(1);
         FrozenList<Object> arg = new FrozenList<>(mutableList);
         final ItemsValidator validator = new ItemsValidator(StringJsonSchema.class);
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 arg,
                 validationMetadata,

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validation/PropertiesValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validation/PropertiesValidatorTest.java
@@ -5,6 +5,8 @@ import org.junit.Test;
 import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.schemas.StringJsonSchema;
+import org.openapijsonschematools.exceptions.ValidationException;
+
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -87,7 +89,7 @@ public class PropertiesValidatorTest {
         LinkedHashMap<String, Object> mutableMap = new LinkedHashMap<>();
         mutableMap.put("someString", 1);
         FrozenMap<String, Object> arg = new FrozenMap<>(mutableMap);
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 arg,
                 validationMetadata,

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validation/RequiredValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validation/RequiredValidatorTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.schemas.StringJsonSchema;
+import org.openapijsonschematools.exceptions.ValidationException;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -81,7 +82,7 @@ public class RequiredValidatorTest {
         mutableMap.put("aDifferentProp", 1);
         FrozenMap<String, Object> arg = new FrozenMap<>(mutableMap);
         final RequiredValidator validator = new RequiredValidator(requiredProperties);
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 arg,
                 validationMetadata,

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validation/TypeValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/schemas/validation/TypeValidatorTest.java
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.openapijsonschematools.configurations.JsonSchemaKeywordFlags;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
+import org.openapijsonschematools.exceptions.ValidationException;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -31,7 +32,7 @@ public class TypeValidatorTest {
     }
 
     @Test
-    public void testValidateFailsIntIsNotString() throws RuntimeException {
+    public void testValidateFailsIntIsNotString() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
         type.add(String.class);
         final TypeValidator validator = new TypeValidator(type);
@@ -41,7 +42,7 @@ public class TypeValidatorTest {
                 new PathToSchemasMap(),
                 new LinkedHashSet<>()
         );
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 1,
                 validationMetadata,

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -386,6 +386,7 @@ public class JavaClientGenerator extends AbstractJavaGenerator
         List<String> exceptionClasses = new ArrayList<>();
         exceptionClasses.add("BaseException");
         exceptionClasses.add("InvalidAdditionalPropertyException");
+        exceptionClasses.add("InvalidTypeException");
         exceptionClasses.add("UnsetPropertyException");
         exceptionClasses.add("ValidationException");
         for (String exceptionClass: exceptionClasses) {

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -1428,6 +1428,7 @@ public class JavaClientGenerator extends AbstractJavaGenerator
     private void addCustomSchemaImports(Set<String> imports) {
         imports.add("import "+packageName + ".configurations.SchemaConfiguration;");
         imports.add("import "+packageName + ".schemas.validation.JsonSchema;");
+        imports.add("import "+packageName + ".exceptions.ValidationException;");
     }
 
 

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -382,6 +382,20 @@ public class JavaClientGenerator extends AbstractJavaGenerator
                     keywordValidatorTestFile + ".java"));
         }
 
+        // exceptions
+        List<String> exceptionClasses = new ArrayList<>();
+        exceptionClasses.add("BaseException");
+        exceptionClasses.add("InvalidAdditionalPropertyException");
+        exceptionClasses.add("UnsetPropertyException");
+        exceptionClasses.add("ValidationException");
+        for (String exceptionClass: exceptionClasses) {
+            supportingFiles.add(new SupportingFile(
+                    "src/main/java/org/openapitools/exceptions/"+exceptionClass+".hbs",
+                    packagePath() + File.separatorChar + "exceptions",
+                    exceptionClass + ".java"));
+        }
+
+
         // configuration
         supportingFiles.add(new SupportingFile(
                 "src/main/java/org/openapitools/configurations/JsonSchemaKeywordFlags.hbs",

--- a/src/main/resources/java/src/main/java/org/openapitools/components/schemas/SchemaClass/_validate.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/components/schemas/SchemaClass/_validate.hbs
@@ -1,34 +1,34 @@
 {{#if types}}
     {{#each types}}
         {{#eq this "null"}}
-public static Void validate(Void arg, SchemaConfiguration configuration) {
+public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, arg, configuration);
 }
         {{/eq}}
         {{#eq this "object"}}
             {{#if ../mapOutputJsonPathPiece}}
                 {{#if mapValueSchema}}
-public static {{../mapOutputJsonPathPiece.camelCase}} validate(Map<String, {{#with mapValueSchema}}{{> src/main/java/org/openapitools/components/schemas/types/schema_input_type sourceJsonPath=../jsonPath forceNull=true endChar="> arg, SchemaConfiguration configuration) {" }}{{/with}}
+public static {{../mapOutputJsonPathPiece.camelCase}} validate(Map<String, {{#with mapValueSchema}}{{> src/main/java/org/openapitools/components/schemas/types/schema_input_type sourceJsonPath=../jsonPath forceNull=true endChar="> arg, SchemaConfiguration configuration) throws ValidationException {" }}{{/with}}
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, arg, configuration);
 }
                 {{else}}
-public static {{../mapOutputJsonPathPiece.camelCase}} validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+public static {{../mapOutputJsonPathPiece.camelCase}} validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, arg, configuration);
 }
                 {{/if}}
             {{else}}
-public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, arg, configuration);
 }
             {{/if}}
         {{/eq}}
         {{#eq this "array"}}
             {{#if ../arrayOutputJsonPathPiece}}
-public static {{../arrayOutputJsonPathPiece.camelCase}} validate(List<{{#with items}}{{> src/main/java/org/openapitools/components/schemas/types/schema_input_type sourceJsonPath=../jsonPath forceNull=true endChar="> arg, SchemaConfiguration configuration) {" }}{{/with}}
+public static {{../arrayOutputJsonPathPiece.camelCase}} validate(List<{{#with items}}{{> src/main/java/org/openapitools/components/schemas/types/schema_input_type sourceJsonPath=../jsonPath forceNull=true endChar="> arg, SchemaConfiguration configuration) throws ValidationException {" }}{{/with}}
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, arg, configuration);
 }
             {{else}}
-public static FrozenList<Object> U validate(List<Object> arg, SchemaConfiguration configuration) {
+public static FrozenList<Object> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, arg, configuration);
 }
             {{/if}}
@@ -38,79 +38,79 @@ public static FrozenList<Object> U validate(List<Object> arg, SchemaConfiguratio
 // FileIO,
 // bytes,
             {{else}}
-public static String validate(String arg, SchemaConfiguration configuration) {
+public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, arg, configuration);
 }
             {{/eq}}
         {{/eq}}
         {{#eq this "integer"}}
-public static long validate(int arg, SchemaConfiguration configuration) {
+public static long validate(int arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, Long.valueOf(arg), configuration);
 }
 
-public static long validate(float arg, SchemaConfiguration configuration) {
+public static long validate(float arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, Long.parseLong(String.valueOf(arg)), configuration);
 }
 
-public static long validate(long arg, SchemaConfiguration configuration) {
+public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, arg, configuration);
 }
 
-public static long validate(double arg, SchemaConfiguration configuration) {
+public static long validate(double arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, Long.parseLong(String.valueOf(arg)), configuration);
 }
         {{/eq}}
         {{#eq this "number"}}
             {{#eq ../format null}}
-public static Number validate(int arg, SchemaConfiguration configuration) {
+public static Number validate(int arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, arg, configuration);
 }
 
-public static Number validate(long arg, SchemaConfiguration configuration) {
+public static Number validate(long arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, arg, configuration);
 }
 
-public static Number validate(float arg, SchemaConfiguration configuration) {
+public static Number validate(float arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, arg, configuration);
 }
 
-public static Number validate(double arg, SchemaConfiguration configuration) {
+public static Number validate(double arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, arg, configuration);
 }
             {{else}}
                 {{#eq ../format "int32"}}
-public static int validate(int arg, SchemaConfiguration configuration) {
+public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, arg, configuration);
 }
 
-public static int validate(float arg, SchemaConfiguration configuration) {
+public static int validate(float arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, Integer.parseInt(String.valueOf(arg)), configuration);
 }
                 {{else}}
                     {{#eq ../format "int64"}}
-public static long validate(int arg, SchemaConfiguration configuration) {
+public static long validate(int arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, Long.valueOf(arg), configuration);
 }
 
-public static long validate(float arg, SchemaConfiguration configuration) {
+public static long validate(float arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, Long.parseLong(String.valueOf(arg)), configuration);
 }
 
-public static long validate(long arg, SchemaConfiguration configuration) {
+public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, arg, configuration);
 }
 
-public static long validate(double arg, SchemaConfiguration configuration) {
+public static long validate(double arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, Long.parseLong(String.valueOf(arg)), configuration);
 }
                     {{else}}
                         {{#eq ../format "float"}}
-public static float validate(float arg, SchemaConfiguration configuration) {
+public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, arg, configuration);
 }
                         {{else}}
                             {{#eq ../format "double"}}
-public static double validate(double arg, SchemaConfiguration configuration) {
+public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, arg, configuration);
 }
                             {{/eq}}
@@ -120,57 +120,57 @@ public static double validate(double arg, SchemaConfiguration configuration) {
             {{/eq}}
         {{/eq}}
         {{#eq this "boolean"}}
-public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, arg, configuration);
 }
         {{/eq}}
     {{/each}}
 {{else}}
-public static Void validate(Void arg, SchemaConfiguration configuration) {
+public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, arg, configuration);
 }
 
-public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, arg, configuration);
 }
 
-public static int validate(int arg, SchemaConfiguration configuration) {
+public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, arg, configuration);
 }
 
-public static long validate(long arg, SchemaConfiguration configuration) {
+public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, arg, configuration);
 }
 
-public static float validate(float arg, SchemaConfiguration configuration) {
+public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, arg, configuration);
 }
 
-public static double validate(double arg, SchemaConfiguration configuration) {
+public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, arg, configuration);
 }
 
-public static String validate(String arg, SchemaConfiguration configuration) {
+public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, arg, configuration);
 }
 
-public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, arg, configuration);
 }
 
-public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, arg, configuration);
 }
 
-public static String validate(UUID arg, SchemaConfiguration configuration) {
+public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, arg, configuration);
 }
 
-public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, arg, configuration);
 }
 
-public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
     return JsonSchema.validate({{#if includeContainer}}{{containerJsonPathPiece.camelCase}}.{{/if}}{{jsonPathPiece.camelCase}}.class, arg, configuration);
 }
 {{/if}}

--- a/src/main/resources/java/src/main/java/org/openapitools/components/schemas/_arrayOutputType.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/components/schemas/_arrayOutputType.hbs
@@ -4,7 +4,7 @@ public static class {{arrayOutputJsonPathPiece.camelCase}} extends FrozenList<{{
     {{arrayOutputJsonPathPiece.camelCase}}(FrozenList<{{#with items}}{{> src/main/java/org/openapitools/components/schemas/types/schema_output_type fullRefModule="" forceNull=true endChar="> m) {" }}{{/with}}
         super(m);
     }
-    public static {{arrayOutputJsonPathPiece.camelCase}} of(List<{{#with items}}{{> src/main/java/org/openapitools/components/schemas/types/schema_input_type sourceJsonPath=../jsonPath forceNull=true endChar="> arg, SchemaConfiguration configuration) {" }}{{/with}}
+    public static {{arrayOutputJsonPathPiece.camelCase}} of(List<{{#with items}}{{> src/main/java/org/openapitools/components/schemas/types/schema_input_type sourceJsonPath=../jsonPath forceNull=true endChar="> arg, SchemaConfiguration configuration) throws ValidationException {" }}{{/with}}
         return {{jsonPathPiece.camelCase}}.validate(arg, configuration);
     }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/components/schemas/_objectOutputType.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/components/schemas/_objectOutputType.hbs
@@ -39,11 +39,11 @@ public static class {{mapOutputJsonPathPiece.camelCase}} extends FrozenMap<Strin
         {{/eq}}
     {{/eq}}
         {{#if mapValueSchema}}
-    public static {{mapOutputJsonPathPiece.camelCase}} of(Map<String, {{#with mapValueSchema}}{{> src/main/java/org/openapitools/components/schemas/types/schema_input_type sourceJsonPath=../jsonPath forceNull=true endChar="> arg, SchemaConfiguration configuration) {" }}{{/with}}
+    public static {{mapOutputJsonPathPiece.camelCase}} of(Map<String, {{#with mapValueSchema}}{{> src/main/java/org/openapitools/components/schemas/types/schema_input_type sourceJsonPath=../jsonPath forceNull=true endChar="> arg, SchemaConfiguration configuration) throws ValidationException {" }}{{/with}}
         return {{jsonPathPiece.camelCase}}.validate(arg, configuration);
     }
         {{else}}
-    public static {{mapOutputJsonPathPiece.camelCase}} of(Map<String, Object> arg, SchemaConfiguration configuration) {
+    public static {{mapOutputJsonPathPiece.camelCase}} of(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
         return {{jsonPathPiece.camelCase}}.validate(arg, configuration);
     }
         {{/if}}

--- a/src/main/resources/java/src/main/java/org/openapitools/exceptions/BaseException.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/exceptions/BaseException.hbs
@@ -1,0 +1,4 @@
+package {{{packageName}}}.exceptions;
+
+public class BaseException extends RuntimeException {
+}

--- a/src/main/resources/java/src/main/java/org/openapitools/exceptions/InvalidAdditionalPropertyException.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/exceptions/InvalidAdditionalPropertyException.hbs
@@ -1,0 +1,4 @@
+package {{{packageName}}}.exceptions;
+
+public class InvalidAdditionalPropertyException extends BaseException {
+}

--- a/src/main/resources/java/src/main/java/org/openapitools/exceptions/InvalidAdditionalPropertyException.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/exceptions/InvalidAdditionalPropertyException.hbs
@@ -1,4 +1,7 @@
 package {{{packageName}}}.exceptions;
 
 public class InvalidAdditionalPropertyException extends BaseException {
+    public InvalidAdditionalPropertyException(String s) {
+        super();
+    }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/exceptions/InvalidTypeException.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/exceptions/InvalidTypeException.hbs
@@ -1,0 +1,7 @@
+package {{{packageName}}}.exceptions;
+
+public class InvalidTypeException extends BaseException {
+    public InvalidTypeException(String s) {
+        super();
+    }
+}

--- a/src/main/resources/java/src/main/java/org/openapitools/exceptions/UnsetPropertyException.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/exceptions/UnsetPropertyException.hbs
@@ -1,4 +1,7 @@
 package {{{packageName}}}.exceptions;
 
 public class UnsetPropertyException extends BaseException {
+    public UnsetPropertyException(String s) {
+        super();
+    }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/exceptions/UnsetPropertyException.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/exceptions/UnsetPropertyException.hbs
@@ -1,0 +1,4 @@
+package {{{packageName}}}.exceptions;
+
+public class UnsetPropertyException extends BaseException {
+}

--- a/src/main/resources/java/src/main/java/org/openapitools/exceptions/ValidationException.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/exceptions/ValidationException.hbs
@@ -1,4 +1,7 @@
 package {{{packageName}}}.exceptions;
 
 public class ValidationException extends BaseException {
+    public ValidationException(String s) {
+        super();
+    }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/exceptions/ValidationException.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/exceptions/ValidationException.hbs
@@ -1,0 +1,4 @@
+package {{{packageName}}}.exceptions;
+
+public class ValidationException extends BaseException {
+}

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/AnyTypeJsonSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/AnyTypeJsonSchema.hbs
@@ -4,6 +4,7 @@ import {{{packageName}}}.schemas.validation.JsonSchema;
 import {{{packageName}}}.schemas.validation.FrozenMap;
 import {{{packageName}}}.schemas.validation.FrozenList;
 import {{{packageName}}}.configurations.SchemaConfiguration;
+import {{{packageName}}}.exceptions.ValidationException;
 
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
@@ -13,51 +14,51 @@ import java.util.UUID;
 
 
 public class AnyTypeJsonSchema extends JsonSchema {
-    public static Void validate(Void arg, SchemaConfiguration configuration) {
+    public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(AnyTypeJsonSchema.class, arg, configuration);
     }
 
-    public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+    public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(AnyTypeJsonSchema.class, arg, configuration);
     }
 
-    public static int validate(int arg, SchemaConfiguration configuration) {
+    public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(AnyTypeJsonSchema.class, arg, configuration);
     }
 
-    public static long validate(long arg, SchemaConfiguration configuration) {
+    public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(AnyTypeJsonSchema.class, arg, configuration);
     }
 
-    public static float validate(float arg, SchemaConfiguration configuration) {
+    public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(AnyTypeJsonSchema.class, arg, configuration);
     }
 
-    public static double validate(double arg, SchemaConfiguration configuration) {
+    public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(AnyTypeJsonSchema.class, arg, configuration);
     }
 
-    public static String validate(String arg, SchemaConfiguration configuration) {
+    public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(AnyTypeJsonSchema.class, arg, configuration);
     }
 
-    public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+    public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(AnyTypeJsonSchema.class, arg, configuration);
     }
 
-    public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+    public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(AnyTypeJsonSchema.class, arg, configuration);
     }
 
-    public static String validate(UUID arg, SchemaConfiguration configuration) {
+    public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(AnyTypeJsonSchema.class, arg, configuration);
     }
 
-    public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+    public static <T extends FrozenMap> T validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(AnyTypeJsonSchema.class, arg, configuration);
     }
 
-    public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) {
+    public static <U extends FrozenList> U validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(AnyTypeJsonSchema.class, arg, configuration);
     }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/BooleanJsonSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/BooleanJsonSchema.hbs
@@ -5,6 +5,7 @@ import {{{packageName}}}.configurations.SchemaConfiguration;
 import {{{packageName}}}.schemas.validation.KeywordEntry;
 import {{{packageName}}}.schemas.validation.KeywordValidator;
 import {{{packageName}}}.schemas.validation.TypeValidator;
+import {{{packageName}}}.exceptions.ValidationException;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -16,7 +17,7 @@ public class BooleanJsonSchema extends JsonSchema {
         new KeywordEntry("type", new TypeValidator(Set.of(Boolean.class)))
     ));
 
-    public static boolean validate(boolean arg, SchemaConfiguration configuration) {
+    public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(BooleanJsonSchema.class, arg, configuration);
     }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/DateJsonSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/DateJsonSchema.hbs
@@ -6,6 +6,7 @@ import {{{packageName}}}.schemas.validation.KeywordEntry;
 import {{{packageName}}}.schemas.validation.KeywordValidator;
 import {{{packageName}}}.schemas.validation.TypeValidator;
 import {{{packageName}}}.schemas.validation.FormatValidator;
+import {{{packageName}}}.exceptions.ValidationException;
 
 import java.time.LocalDate;
 import java.util.LinkedHashMap;
@@ -19,11 +20,11 @@ public class DateJsonSchema extends JsonSchema {
         new KeywordEntry("format", new FormatValidator("date"))
     ));
 
-    public static String validate(String arg, SchemaConfiguration configuration) {
+    public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(DateJsonSchema.class, arg, configuration);
     }
 
-    public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+    public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(DateJsonSchema.class, arg, configuration);
     }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/DateTimeJsonSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/DateTimeJsonSchema.hbs
@@ -6,6 +6,7 @@ import {{{packageName}}}.schemas.validation.KeywordEntry;
 import {{{packageName}}}.schemas.validation.KeywordValidator;
 import {{{packageName}}}.schemas.validation.TypeValidator;
 import {{{packageName}}}.schemas.validation.FormatValidator;
+import {{{packageName}}}.exceptions.ValidationException;
 
 import java.time.ZonedDateTime;
 import java.util.LinkedHashMap;
@@ -19,11 +20,11 @@ public class DateTimeJsonSchema extends JsonSchema {
         new KeywordEntry("format", new FormatValidator("date-time"))
     ));
 
-    public static String validate(String arg, SchemaConfiguration configuration) {
+    public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(DateTimeJsonSchema.class, arg, configuration);
     }
 
-    public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+    public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(DateTimeJsonSchema.class, arg, configuration);
     }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/DecimalJsonSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/DecimalJsonSchema.hbs
@@ -6,6 +6,7 @@ import {{{packageName}}}.schemas.validation.KeywordEntry;
 import {{{packageName}}}.schemas.validation.KeywordValidator;
 import {{{packageName}}}.schemas.validation.TypeValidator;
 import {{{packageName}}}.schemas.validation.FormatValidator;
+import {{{packageName}}}.exceptions.ValidationException;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -18,7 +19,7 @@ public class DecimalJsonSchema extends JsonSchema {
         new KeywordEntry("format", new FormatValidator("number"))
     ));
 
-    public static String validate(String arg, SchemaConfiguration configuration) {
+    public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(DecimalJsonSchema.class, arg, configuration);
     }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/DoubleJsonSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/DoubleJsonSchema.hbs
@@ -6,6 +6,7 @@ import {{{packageName}}}.schemas.validation.KeywordEntry;
 import {{{packageName}}}.schemas.validation.KeywordValidator;
 import {{{packageName}}}.schemas.validation.TypeValidator;
 import {{{packageName}}}.schemas.validation.FormatValidator;
+import {{{packageName}}}.exceptions.ValidationException;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -18,7 +19,7 @@ public class DoubleJsonSchema extends JsonSchema {
         new KeywordEntry("format", new FormatValidator("double"))
     ));
 
-    public static double validate(double arg, SchemaConfiguration configuration) {
+    public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(DoubleJsonSchema.class, arg, configuration);
     }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/FloatJsonSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/FloatJsonSchema.hbs
@@ -6,6 +6,7 @@ import {{{packageName}}}.schemas.validation.KeywordEntry;
 import {{{packageName}}}.schemas.validation.KeywordValidator;
 import {{{packageName}}}.schemas.validation.TypeValidator;
 import {{{packageName}}}.schemas.validation.FormatValidator;
+import {{{packageName}}}.exceptions.ValidationException;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -18,7 +19,7 @@ public class FloatJsonSchema extends JsonSchema {
         new KeywordEntry("format", new FormatValidator("float"))
     ));
 
-    public static float validate(float arg, SchemaConfiguration configuration) {
+    public static float validate(float arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(FloatJsonSchema.class, arg, configuration);
     }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/Int32JsonSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/Int32JsonSchema.hbs
@@ -6,6 +6,7 @@ import {{{packageName}}}.schemas.validation.KeywordEntry;
 import {{{packageName}}}.schemas.validation.KeywordValidator;
 import {{{packageName}}}.schemas.validation.TypeValidator;
 import {{{packageName}}}.schemas.validation.FormatValidator;
+import {{{packageName}}}.exceptions.ValidationException;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -21,11 +22,11 @@ public class Int32JsonSchema extends JsonSchema {
         new KeywordEntry("format", new FormatValidator("int32"))
     ));
 
-    public static int validate(int arg, SchemaConfiguration configuration) {
+    public static int validate(int arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(Int32JsonSchema.class, arg, configuration);
     }
 
-    public static int validate(float arg, SchemaConfiguration configuration) {
+    public static int validate(float arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(Int32JsonSchema.class, Integer.parseInt(String.valueOf(arg)), configuration);
     }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/Int64JsonSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/Int64JsonSchema.hbs
@@ -6,6 +6,7 @@ import {{{packageName}}}.schemas.validation.KeywordEntry;
 import {{{packageName}}}.schemas.validation.KeywordValidator;
 import {{{packageName}}}.schemas.validation.TypeValidator;
 import {{{packageName}}}.schemas.validation.FormatValidator;
+import {{{packageName}}}.exceptions.ValidationException;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -23,19 +24,19 @@ public class Int64JsonSchema extends JsonSchema {
         new KeywordEntry("format", new FormatValidator("int64"))
     ));
 
-    public static long validate(int arg, SchemaConfiguration configuration) {
+    public static long validate(int arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(Int64JsonSchema.class, Long.valueOf(arg), configuration);
     }
 
-    public static long validate(float arg, SchemaConfiguration configuration) {
+    public static long validate(float arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(Int64JsonSchema.class, Long.parseLong(String.valueOf(arg)), configuration);
     }
 
-    public static long validate(long arg, SchemaConfiguration configuration) {
+    public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(Int64JsonSchema.class, arg, configuration);
     }
 
-    public static long validate(double arg, SchemaConfiguration configuration) {
+    public static long validate(double arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(Int64JsonSchema.class, Long.parseLong(String.valueOf(arg)), configuration);
     }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/IntJsonSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/IntJsonSchema.hbs
@@ -6,6 +6,7 @@ import {{{packageName}}}.schemas.validation.KeywordValidator;
 import {{{packageName}}}.schemas.validation.KeywordEntry;
 import {{{packageName}}}.schemas.validation.TypeValidator;
 import {{{packageName}}}.schemas.validation.FormatValidator;
+import {{{packageName}}}.exceptions.ValidationException;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -18,19 +19,19 @@ public class IntJsonSchema extends JsonSchema {
         new KeywordEntry("format", new FormatValidator("int"))
     ));
 
-    public static long validate(int arg, SchemaConfiguration configuration) {
+    public static long validate(int arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(IntJsonSchema.class, Long.valueOf(arg), configuration);
     }
 
-    public static long validate(float arg, SchemaConfiguration configuration) {
+    public static long validate(float arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(IntJsonSchema.class, Long.parseLong(String.valueOf(arg)), configuration);
     }
 
-    public static long validate(long arg, SchemaConfiguration configuration) {
+    public static long validate(long arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(IntJsonSchema.class, arg, configuration);
     }
 
-    public static long validate(double arg, SchemaConfiguration configuration) {
+    public static long validate(double arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(IntJsonSchema.class, Long.parseLong(String.valueOf(arg)), configuration);
     }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/ListJsonSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/ListJsonSchema.hbs
@@ -6,6 +6,7 @@ import {{{packageName}}}.configurations.SchemaConfiguration;
 import {{{packageName}}}.schemas.validation.KeywordValidator;
 import {{{packageName}}}.schemas.validation.KeywordEntry;
 import {{{packageName}}}.schemas.validation.TypeValidator;
+import {{{packageName}}}.exceptions.ValidationException;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -18,7 +19,7 @@ public class ListJsonSchema extends JsonSchema {
         new KeywordEntry("type", new TypeValidator(Set.of(FrozenList.class)))
     ));
 
-    public static FrozenList<Object> validate(List<Object> arg, SchemaConfiguration configuration) {
+    public static FrozenList<Object> validate(List<Object> arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(ListJsonSchema.class, arg, configuration);
     }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/MapJsonSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/MapJsonSchema.hbs
@@ -6,6 +6,7 @@ import {{{packageName}}}.configurations.SchemaConfiguration;
 import {{{packageName}}}.schemas.validation.KeywordValidator;
 import {{{packageName}}}.schemas.validation.KeywordEntry;
 import {{{packageName}}}.schemas.validation.TypeValidator;
+import {{{packageName}}}.exceptions.ValidationException;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -17,7 +18,7 @@ public class MapJsonSchema extends JsonSchema {
         new KeywordEntry("type", new TypeValidator(Set.of(FrozenMap.class)))
     ));
 
-    public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) {
+    public static FrozenMap<String, Object> validate(Map<String, Object> arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(MapJsonSchema.class, arg, configuration);
     }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/NullJsonSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/NullJsonSchema.hbs
@@ -5,6 +5,7 @@ import {{{packageName}}}.configurations.SchemaConfiguration;
 import {{{packageName}}}.schemas.validation.KeywordValidator;
 import {{{packageName}}}.schemas.validation.KeywordEntry;
 import {{{packageName}}}.schemas.validation.TypeValidator;
+import {{{packageName}}}.exceptions.ValidationException;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -16,7 +17,7 @@ public class NullJsonSchema extends JsonSchema {
         new KeywordEntry("type", new TypeValidator(Set.of(Void.class)))
     ));
 
-    public static Void validate(Void arg, SchemaConfiguration configuration) {
+    public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(NullJsonSchema.class, arg, configuration);
     }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/NumberJsonSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/NumberJsonSchema.hbs
@@ -5,6 +5,7 @@ import {{{packageName}}}.configurations.SchemaConfiguration;
 import {{{packageName}}}.schemas.validation.KeywordValidator;
 import {{{packageName}}}.schemas.validation.KeywordEntry;
 import {{{packageName}}}.schemas.validation.TypeValidator;
+import {{{packageName}}}.exceptions.ValidationException;
 
 import java.util.LinkedHashMap;
 import java.util.Set;
@@ -21,19 +22,19 @@ public class NumberJsonSchema extends JsonSchema {
         )))
     ));
 
-    public static Number validate(Integer arg, SchemaConfiguration configuration) {
+    public static Number validate(Integer arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(NumberJsonSchema.class, arg, configuration);
     }
 
-    public static Number validate(Long arg, SchemaConfiguration configuration) {
+    public static Number validate(Long arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(NumberJsonSchema.class, arg, configuration);
     }
 
-    public static Number validate(Float arg, SchemaConfiguration configuration) {
+    public static Number validate(Float arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(NumberJsonSchema.class, arg, configuration);
     }
 
-    public static Number validate(Double arg, SchemaConfiguration configuration) {
+    public static Number validate(Double arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(NumberJsonSchema.class, arg, configuration);
     }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/StringJsonSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/StringJsonSchema.hbs
@@ -5,6 +5,7 @@ import {{{packageName}}}.configurations.SchemaConfiguration;
 import {{{packageName}}}.schemas.validation.KeywordValidator;
 import {{{packageName}}}.schemas.validation.KeywordEntry;
 import {{{packageName}}}.schemas.validation.TypeValidator;
+import {{{packageName}}}.exceptions.ValidationException;
 
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
@@ -18,19 +19,19 @@ public class StringJsonSchema extends JsonSchema {
         new KeywordEntry("type", new TypeValidator(Set.of(String.class)))
     ));
 
-    public static String validate(String arg, SchemaConfiguration configuration) {
+    public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(StringJsonSchema.class, arg, configuration);
     }
 
-    public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) {
+    public static String validate(ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(StringJsonSchema.class, arg, configuration);
     }
 
-    public static String validate(LocalDate arg, SchemaConfiguration configuration) {
+    public static String validate(LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(StringJsonSchema.class, arg, configuration);
     }
 
-    public static String validate(UUID arg, SchemaConfiguration configuration) {
+    public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(StringJsonSchema.class, arg, configuration);
     }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/UuidJsonSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/UuidJsonSchema.hbs
@@ -2,6 +2,7 @@ package {{{packageName}}}.schemas;
 
 import {{{packageName}}}.schemas.validation.JsonSchema;
 import {{{packageName}}}.configurations.SchemaConfiguration;
+import {{{packageName}}}.exceptions.ValidationException;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -14,11 +15,11 @@ public class UuidJsonSchema extends JsonSchema {
     ));
     public static final String format = "uuid";
 
-    public static String validate(String arg, SchemaConfiguration configuration) {
+    public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(UuidJsonSchema.class, arg, configuration);
     }
 
-    public static String validate(UUID arg, SchemaConfiguration configuration) {
+    public static String validate(UUID arg, SchemaConfiguration configuration) throws ValidationException {
         return JsonSchema.validate(UuidJsonSchema.class, arg, configuration);
     }
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/FormatValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/FormatValidator.hbs
@@ -1,5 +1,7 @@
 package {{{packageName}}}.schemas.validation;
 
+import {{{packageName}}}.exceptions.ValidationException;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.format.DateTimeParseException;
@@ -38,7 +40,7 @@ public class FormatValidator implements KeywordValidator {
                     doubleArg = (Double) arg;
                 }
                 if (Math.floor(doubleArg) != doubleArg) {
-                    throw new RuntimeException(
+                    throw new ValidationException(
                             "Invalid non-integer value " + arg + " for format " + format + " at " + validationMetadata.pathToItem()
                     );
                 }
@@ -57,14 +59,14 @@ public class FormatValidator implements KeywordValidator {
             }
             if (format.equals("int32")) {
                 if (intArg.compareTo(int32InclusiveMinimum) < 0 || intArg.compareTo(int32InclusiveMaximum) > 0) {
-                    throw new RuntimeException(
+                    throw new ValidationException(
                             "Invalid value " + arg + " for format int32 at " + validationMetadata.pathToItem()
                     );
                 }
                 return null;
             } else if (format.equals("int64")) {
                 if (intArg.compareTo(int64InclusiveMinimum) < 0 || intArg.compareTo(int64InclusiveMaximum) > 0) {
-                    throw new RuntimeException(
+                    throw new ValidationException(
                             "Invalid value " + arg + " for format int64 at " + validationMetadata.pathToItem()
                     );
                 }
@@ -82,14 +84,14 @@ public class FormatValidator implements KeywordValidator {
         }
         if (format.equals("float")) {
             if (decimalArg.compareTo(floatInclusiveMinimum) < 0  || decimalArg.compareTo(floatInclusiveMaximum) > 0 ){
-                throw new RuntimeException(
+                throw new ValidationException(
                     "Invalid value "+arg+" for format float at "+validationMetadata.pathToItem()
                 );
             }
             return null;
         } else if (format.equals("double")) {
             if (decimalArg.compareTo(doubleInclusiveMinimum) < 0  || decimalArg.compareTo(doubleInclusiveMaximum) > 0 ){
-                throw new RuntimeException(
+                throw new ValidationException(
                     "Invalid value "+arg+" for format double at "+validationMetadata.pathToItem()
                 );
             }
@@ -103,7 +105,7 @@ public class FormatValidator implements KeywordValidator {
             try {
                 UUID.fromString(arg);
             } catch (IllegalArgumentException  e) {
-                throw new RuntimeException(
+                throw new ValidationException(
                     "Value cannot be converted to a UUID. Invalid value "+
                             arg+" for format uuid at "+validationMetadata.pathToItem()
                 );
@@ -113,7 +115,7 @@ public class FormatValidator implements KeywordValidator {
             try {
                 new BigDecimal(arg);
             } catch (NumberFormatException e) {
-                throw new RuntimeException(
+                throw new ValidationException(
                     "Value cannot be converted to a decimal. Invalid value "+
                             arg+" for format number at "+validationMetadata.pathToItem()
                 );
@@ -123,7 +125,7 @@ public class FormatValidator implements KeywordValidator {
             try {
                 new CustomIsoparser().parseIsodate(arg);
             } catch (DateTimeParseException e) {
-                throw new RuntimeException(
+                throw new ValidationException(
                         "Value does not conform to the required ISO-8601 date format. "+
                         "Invalid value "+arg+" for format date at "+validationMetadata.pathToItem()
                 );
@@ -133,7 +135,7 @@ public class FormatValidator implements KeywordValidator {
             try {
                 new CustomIsoparser().parseIsodatetime(arg);
             } catch (DateTimeParseException e) {
-                throw new RuntimeException(
+                throw new ValidationException(
                         "Value does not conform to the required ISO-8601 datetime format. "+
                                 "Invalid value "+arg+" for format datetime at "+validationMetadata.pathToItem()
                 );

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/FrozenMap.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/FrozenMap.hbs
@@ -1,5 +1,8 @@
 package {{{packageName}}}.schemas.validation;
 
+import {{{packageName}}}.exceptions.UnsetPropertyException;
+import {{{packageName}}}.exceptions.InvalidAdditionalPropertyException;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -16,15 +19,15 @@ public class FrozenMap<K, V> extends LinkedHashMap<K, V> {
         super(m);
     }
 
-    protected void throwIfKeyNotPresent(String key) throws RuntimeException {
+    protected void throwIfKeyNotPresent(String key) throws UnsetPropertyException {
         if (!containsKey(key)) {
-            throw new RuntimeException(key+" is unset");
+            throw new UnsetPropertyException(key+" is unset");
         }
     }
 
     protected void throwIfKeyKnown(String key, Set<String> requiredKeys, Set<String> optionalKeys) throws IllegalArgumentException {
         if (requiredKeys.contains(key) || optionalKeys.contains(key)) {
-            throw new IllegalArgumentException ("The known key " + key + " may not be passed in when getting an additional property");
+            throw new InvalidAdditionalPropertyException ("The known key " + key + " may not be passed in when getting an additional property");
         }
     }
 

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/JsonSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/JsonSchema.hbs
@@ -2,15 +2,14 @@ package {{{packageName}}}.schemas.validation;
 
 import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
 import {{{packageName}}}.configurations.SchemaConfiguration;
+import {{{packageName}}}.exceptions.ValidationException;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Field;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
-import java.util.AbstractMap;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -25,7 +24,7 @@ public abstract class JsonSchema {
             Class<? extends JsonSchema> schemaCls,
             Object arg,
             ValidationMetadata validationMetadata
-    ) {
+    ) throws ValidationException {
         LinkedHashSet<String> disabledKeywords = validationMetadata.configuration().disabledKeywordFlags().getKeywords();
         Class<? extends JsonSchema> usedSchemaCls = schemaCls;
         Class<?> superclass = schemaCls.getSuperclass();
@@ -34,11 +33,12 @@ public abstract class JsonSchema {
             usedSchemaCls = (Class<? extends JsonSchema>) superclass;
         }
         LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>();
-       try {
-          Field keywordToValidatorField = usedSchemaCls.getField("keywordToValidator");
-          LinkedHashMap<String, KeywordValidator> entries = (LinkedHashMap<String, KeywordValidator>) keywordToValidatorField.get(null);
-          keywordToValidator.putAll(entries);
-       } catch (NoSuchFieldException | IllegalAccessException ignore) {}
+        try {
+            Field keywordToValidatorField = usedSchemaCls.getField("keywordToValidator");
+            LinkedHashMap<String, KeywordValidator> entries = (LinkedHashMap<String, KeywordValidator>) keywordToValidatorField.get(null);
+            keywordToValidator.putAll(entries);
+            keywordToValidator.keySet().removeAll(disabledKeywords);
+        } catch (NoSuchFieldException | IllegalAccessException ignore) {}
         Object extra = null;
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         for (Map.Entry<String, KeywordValidator> entry: keywordToValidator.entrySet()) {
@@ -210,57 +210,57 @@ public abstract class JsonSchema {
       return arg;
    }
 
-   protected static Void validate(Class<? extends JsonSchema> cls, Void arg, SchemaConfiguration configuration) {
+   protected static Void validate(Class<? extends JsonSchema> cls, Void arg, SchemaConfiguration configuration) throws ValidationException {
       return (Void) validateObject(cls, arg, configuration);
    }
 
-   protected static boolean validate(Class<? extends JsonSchema> cls, boolean arg, SchemaConfiguration configuration) {
+   protected static boolean validate(Class<? extends JsonSchema> cls, boolean arg, SchemaConfiguration configuration) throws ValidationException {
       return (boolean) validateObject(cls, arg, configuration);
    }
 
-   protected static int validate(Class<? extends JsonSchema> cls, int arg, SchemaConfiguration configuration) {
+   protected static int validate(Class<? extends JsonSchema> cls, int arg, SchemaConfiguration configuration) throws ValidationException {
       return (int) validateObject(cls, arg, configuration);
    }
 
-   protected static long validate(Class<? extends JsonSchema> cls, long arg, SchemaConfiguration configuration) {
+   protected static long validate(Class<? extends JsonSchema> cls, long arg, SchemaConfiguration configuration) throws ValidationException {
       return (long) validateObject(cls, arg, configuration);
    }
 
-   protected static float validate(Class<? extends JsonSchema> cls, float arg, SchemaConfiguration configuration) {
+   protected static float validate(Class<? extends JsonSchema> cls, float arg, SchemaConfiguration configuration) throws ValidationException {
       return (float) validateObject(cls, arg, configuration);
    }
 
-   protected static double validate(Class<? extends JsonSchema> cls, double arg, SchemaConfiguration configuration) {
+   protected static double validate(Class<? extends JsonSchema> cls, double arg, SchemaConfiguration configuration) throws ValidationException {
       return (double) validateObject(cls, arg, configuration);
    }
 
-   protected static String validate(Class<? extends JsonSchema> cls, String arg, SchemaConfiguration configuration) {
+   protected static String validate(Class<? extends JsonSchema> cls, String arg, SchemaConfiguration configuration) throws ValidationException {
       return (String) validateObject(cls, arg, configuration);
    }
 
-   protected static String validate(Class<? extends JsonSchema> cls, ZonedDateTime arg, SchemaConfiguration configuration) {
+   protected static String validate(Class<? extends JsonSchema> cls, ZonedDateTime arg, SchemaConfiguration configuration) throws ValidationException {
       return (String) validateObject(cls, arg, configuration);
    }
 
-   protected static String validate(Class<? extends JsonSchema> cls, LocalDate arg, SchemaConfiguration configuration) {
+   protected static String validate(Class<? extends JsonSchema> cls, LocalDate arg, SchemaConfiguration configuration) throws ValidationException {
       return (String) validateObject(cls, arg, configuration);
    }
 
-   protected static String validate(Class<? extends JsonSchema> cls, UUID arg, SchemaConfiguration configuration) {
+   protected static String validate(Class<? extends JsonSchema> cls, UUID arg, SchemaConfiguration configuration) throws ValidationException {
       return (String) validateObject(cls, arg, configuration);
    }
 
-   protected static <T extends FrozenMap> T validate(Class<? extends JsonSchema> cls, Map<String, ?> arg, SchemaConfiguration configuration) {
+   protected static <T extends FrozenMap> T validate(Class<? extends JsonSchema> cls, Map<String, ?> arg, SchemaConfiguration configuration) throws ValidationException {
       return (T) validateObject(cls, arg, configuration);
    }
 
-   protected static <U extends FrozenList> U validate(Class<? extends JsonSchema> cls, List<?> arg, SchemaConfiguration configuration) {
+   protected static <U extends FrozenList> U validate(Class<? extends JsonSchema> cls, List<?> arg, SchemaConfiguration configuration) throws ValidationException {
       return (U) validateObject(cls, arg, configuration);
    }
 
    // todo add bytes and FileIO
 
-   public static Object validateObject(Class<? extends JsonSchema> cls, Object arg, SchemaConfiguration configuration) {
+   public static Object validateObject(Class<? extends JsonSchema> cls, Object arg, SchemaConfiguration configuration) throws ValidationException {
       if (arg instanceof Map || arg instanceof List) {
          // todo don't run validation if the instance is one of the class generic types
       }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/JsonSchema.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/JsonSchema.hbs
@@ -3,6 +3,7 @@ package {{{packageName}}}.schemas.validation;
 import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
 import {{{packageName}}}.configurations.SchemaConfiguration;
 import {{{packageName}}}.exceptions.ValidationException;
+import {{{packageName}}}.exceptions.InvalidTypeException;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -124,7 +125,7 @@ public abstract class JsonSchema {
          return arg.toString();
       } else {
          Class<?> argClass = arg.getClass();
-         throw new RuntimeException("Invalid type passed in got input="+arg+" type="+argClass);
+         throw new InvalidTypeException("Invalid type passed in for input="+arg+" type="+argClass);
       }
    }
 

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/KeywordValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/KeywordValidator.hbs
@@ -1,11 +1,13 @@
 package {{{packageName}}}.schemas.validation;
 
+import {{{packageName}}}.exceptions.ValidationException;
+
 public interface KeywordValidator {
     PathToSchemasMap validate(
             Class<? extends JsonSchema> cls,
             Object arg,
             ValidationMetadata validationMetadata,
-            Object extra);
+            Object extra) throws ValidationException;
 
     Object getConstraint();
 }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/RequiredValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/RequiredValidator.hbs
@@ -1,5 +1,7 @@
 package org.openapijsonschematools.schemas.validation;
 
+import {{{packageName}}}.exceptions.ValidationException;
+
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -31,7 +33,7 @@ public class RequiredValidator implements KeywordValidator {
             if (missingRequiredProperties.size() > 1) {
                 pluralChar = "s";
             }
-            throw new RuntimeException(
+            throw new ValidationException(
                 cls+" is missing "+missingRequiredProperties.size()+" required argument"+pluralChar+": "+missingReqProps
             );
         }

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/TypeValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/TypeValidator.hbs
@@ -1,5 +1,7 @@
 package {{{packageName}}}.schemas.validation;
 
+import {{{packageName}}}.exceptions.ValidationException;
+
 import java.util.Set;
 
 public class TypeValidator implements KeywordValidator {
@@ -23,7 +25,7 @@ public class TypeValidator implements KeywordValidator {
             argClass = arg.getClass();
         }
         if (!type.contains(argClass)) {
-            throw new RuntimeException("invalid type");
+            throw new ValidationException("invalid type");
         }
         return null;
     }

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/ArrayTypeSchemaTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/ArrayTypeSchemaTest.hbs
@@ -10,6 +10,7 @@ import {{{packageName}}}.schemas.validation.FrozenList;
 import {{{packageName}}}.schemas.validation.KeywordEntry;
 import {{{packageName}}}.schemas.validation.KeywordValidator;
 import {{{packageName}}}.schemas.validation.TypeValidator;
+import {{{packageName}}}.exceptions.ValidationException;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -59,7 +60,7 @@ public class ArrayTypeSchemaTest {
 
     @Test
     public void testExceptionThrownForInvalidType() {
-        Assert.assertThrows(RuntimeException.class, () -> JsonSchema.validateObject(
+        Assert.assertThrows(ValidationException.class, () -> JsonSchema.validateObject(
                 ArrayWithItemsSchema.class, (Void) null, configuration
         ));
     }
@@ -84,7 +85,7 @@ public class ArrayTypeSchemaTest {
         inList = new ArrayList<>();
         inList.add(1);
         List<Object> finalInList = inList;
-        Assert.assertThrows(RuntimeException.class, () -> ArrayWithItemsSchema.validate(
+        Assert.assertThrows(ValidationException.class, () -> ArrayWithItemsSchema.validate(
                 finalInList, configuration
         ));
     }
@@ -109,7 +110,7 @@ public class ArrayTypeSchemaTest {
         inList = new ArrayList<>();
         inList.add(1);
         List<Object> finalInList = inList;
-        Assert.assertThrows(RuntimeException.class, () -> ArrayWithOutputClsSchema.validate(
+        Assert.assertThrows(ValidationException.class, () -> ArrayWithOutputClsSchema.validate(
                 finalInList, configuration
         ));
     }

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/BooleanSchemaTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/BooleanSchemaTest.hbs
@@ -5,6 +5,7 @@ import org.junit.Test;
 import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
 import {{{packageName}}}.configurations.SchemaConfiguration;
 import {{{packageName}}}.schemas.validation.JsonSchema;
+import {{{packageName}}}.exceptions.ValidationException;
 
 public class BooleanSchemaTest {
     static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
@@ -23,7 +24,7 @@ public class BooleanSchemaTest {
 
     @Test
     public void testExceptionThrownForInvalidType() {
-        Assert.assertThrows(RuntimeException.class, () -> JsonSchema.validateObject(
+        Assert.assertThrows(ValidationException.class, () -> JsonSchema.validateObject(
                 BooleanJsonSchema.class, (Void) null, configuration
         ));
     }

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/ListSchemaTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/ListSchemaTest.hbs
@@ -6,6 +6,7 @@ import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
 import {{{packageName}}}.configurations.SchemaConfiguration;
 import {{{packageName}}}.schemas.validation.JsonSchema;
 import {{{packageName}}}.schemas.validation.FrozenList;
+import {{{packageName}}}.exceptions.ValidationException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,7 +16,7 @@ public class ListSchemaTest {
 
     @Test
     public void testExceptionThrownForInvalidType() {
-        Assert.assertThrows(RuntimeException.class, () -> JsonSchema.validateObject(
+        Assert.assertThrows(ValidationException.class, () -> JsonSchema.validateObject(
                 ListJsonSchema.class, (Void) null, configuration
         ));
     }

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/MapSchemaTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/MapSchemaTest.hbs
@@ -6,6 +6,7 @@ import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
 import {{{packageName}}}.configurations.SchemaConfiguration;
 import {{{packageName}}}.schemas.validation.JsonSchema;
 import {{{packageName}}}.schemas.validation.FrozenMap;
+import {{{packageName}}}.exceptions.ValidationException;
 
 import java.time.LocalDate;
 import java.util.LinkedHashMap;
@@ -16,7 +17,7 @@ public class MapSchemaTest {
 
     @Test
     public void testExceptionThrownForInvalidType() {
-        Assert.assertThrows(RuntimeException.class, () -> JsonSchema.validateObject(
+        Assert.assertThrows(ValidationException.class, () -> JsonSchema.validateObject(
                 MapJsonSchema.class, (Void) null, configuration
         ));
     }

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/NullSchemaTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/NullSchemaTest.hbs
@@ -5,6 +5,7 @@ import org.junit.Test;
 import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
 import {{{packageName}}}.configurations.SchemaConfiguration;
 import {{{packageName}}}.schemas.validation.JsonSchema;
+import {{{packageName}}}.exceptions.ValidationException;
 
 public class NullSchemaTest {
     static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
@@ -17,7 +18,7 @@ public class NullSchemaTest {
 
     @Test
     public void testExceptionThrownForInvalidType() {
-        Assert.assertThrows(RuntimeException.class, () -> JsonSchema.validateObject(
+        Assert.assertThrows(ValidationException.class, () -> JsonSchema.validateObject(
                 NullJsonSchema.class, Boolean.TRUE, configuration
         ));
     }

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/NumberSchemaTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/NumberSchemaTest.hbs
@@ -5,6 +5,7 @@ import org.junit.Test;
 import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
 import {{{packageName}}}.configurations.SchemaConfiguration;
 import {{{packageName}}}.schemas.validation.JsonSchema;
+import {{{packageName}}}.exceptions.ValidationException;
 
 import java.math.BigDecimal;
 
@@ -37,7 +38,7 @@ public class NumberSchemaTest {
 
     @Test
     public void testExceptionThrownForInvalidType() {
-        Assert.assertThrows(RuntimeException.class, () -> JsonSchema.validateObject(
+        Assert.assertThrows(ValidationException.class, () -> JsonSchema.validateObject(
                 NumberJsonSchema.class, (Void) null, configuration
         ));
     }

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/ObjectTypeSchemaTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/ObjectTypeSchemaTest.hbs
@@ -12,6 +12,7 @@ import {{{packageName}}}.schemas.validation.KeywordValidator;
 import {{{packageName}}}.schemas.validation.PropertiesValidator;
 import {{{packageName}}}.schemas.validation.PropertyEntry;
 import {{{packageName}}}.schemas.validation.TypeValidator;
+import {{{packageName}}}.exceptions.ValidationException;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -89,7 +90,7 @@ public class ObjectTypeSchemaTest {
 
     @Test
     public void testExceptionThrownForInvalidType() {
-        Assert.assertThrows(RuntimeException.class, () -> JsonSchema.validateObject(
+        Assert.assertThrows(ValidationException.class, () -> JsonSchema.validateObject(
                 ObjectWithPropsSchema.class, (Void) null, configuration
         ));
     }
@@ -118,7 +119,7 @@ public class ObjectTypeSchemaTest {
         inMap = new LinkedHashMap<>();
         inMap.put("someString", 1);
         Map<String, Object> finalInMap = inMap;
-        Assert.assertThrows(RuntimeException.class, () -> ObjectWithPropsSchema.validate(
+        Assert.assertThrows(ValidationException.class, () -> ObjectWithPropsSchema.validate(
                 finalInMap, configuration
         ));
     }
@@ -147,7 +148,7 @@ public class ObjectTypeSchemaTest {
         inMap = new LinkedHashMap<>();
         inMap.put("someString", 1);
         Map<String, Object> finalInMap = inMap;
-        Assert.assertThrows(RuntimeException.class, () -> ObjectWithAddpropsSchema.validate(
+        Assert.assertThrows(ValidationException.class, () -> ObjectWithAddpropsSchema.validate(
                 finalInMap, configuration
         ));
     }
@@ -176,7 +177,7 @@ public class ObjectTypeSchemaTest {
         inMap = new LinkedHashMap<>();
         inMap.put("someString", 1);
         Map<String, Object> invalidPropMap = inMap;
-        Assert.assertThrows(RuntimeException.class, () -> ObjectWithPropsAndAddpropsSchema.validate(
+        Assert.assertThrows(ValidationException.class, () -> ObjectWithPropsAndAddpropsSchema.validate(
                 invalidPropMap, configuration
         ));
 
@@ -184,7 +185,7 @@ public class ObjectTypeSchemaTest {
         inMap = new LinkedHashMap<>();
         inMap.put("someAddProp", 1);
         Map<String, Object> invalidAddpropMap = inMap;
-        Assert.assertThrows(RuntimeException.class, () -> ObjectWithPropsAndAddpropsSchema.validate(
+        Assert.assertThrows(ValidationException.class, () -> ObjectWithPropsAndAddpropsSchema.validate(
                 invalidAddpropMap, configuration
         ));
     }
@@ -213,7 +214,7 @@ public class ObjectTypeSchemaTest {
         inMap = new LinkedHashMap<>();
         inMap.put("someString", 1);
         Map<String, Object> finalInMap = inMap;
-        Assert.assertThrows(RuntimeException.class, () -> ObjectWithOutputTypeSchema.validate(
+        Assert.assertThrows(ValidationException.class, () -> ObjectWithOutputTypeSchema.validate(
                 finalInMap, configuration
         ));
 

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/RefBooleanSchemaTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/RefBooleanSchemaTest.hbs
@@ -5,6 +5,7 @@ import org.junit.Test;
 import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
 import {{{packageName}}}.configurations.SchemaConfiguration;
 import {{{packageName}}}.schemas.validation.JsonSchema;
+import {{{packageName}}}.exceptions.ValidationException;
 
 class RefBooleanSchema {
     public class RefBooleanSchema1 extends BooleanJsonSchema{}
@@ -27,7 +28,7 @@ public class RefBooleanSchemaTest {
 
     @Test
     public void testExceptionThrownForInvalidType() {
-        Assert.assertThrows(RuntimeException.class, () -> JsonSchema.validateObject(
+        Assert.assertThrows(ValidationException.class, () -> JsonSchema.validateObject(
                 RefBooleanSchema.RefBooleanSchema1.class, (Void) null, configuration
         ));
     }

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/validation/AdditionalPropertiesValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/validation/AdditionalPropertiesValidatorTest.hbs
@@ -5,6 +5,7 @@ import org.junit.Test;
 import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
 import {{{packageName}}}.configurations.SchemaConfiguration;
 import {{{packageName}}}.schemas.StringJsonSchema;
+import {{{packageName}}}.exceptions.ValidationException;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -86,7 +87,7 @@ public class AdditionalPropertiesValidatorTest {
         mutableMap.put("someAddProp", 1);
         FrozenMap<String, Object> arg = new FrozenMap<>(mutableMap);
         final AdditionalPropertiesValidator validator = new AdditionalPropertiesValidator(StringJsonSchema.class);
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 arg,
                 validationMetadata,

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/validation/FormatValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/validation/FormatValidatorTest.hbs
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
 import {{{packageName}}}.configurations.SchemaConfiguration;
+import {{{packageName}}}.exceptions.ValidationException;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -33,7 +34,7 @@ public class FormatValidatorTest {
     @Test
     public void testIntFormatFailsWithFloat() {
         final FormatValidator validator = new FormatValidator("int");
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 3.14f,
                 validationMetadata,
@@ -56,7 +57,7 @@ public class FormatValidatorTest {
     @Test
     public void testInt32UnderMinFails() {
         final FormatValidator validator = new FormatValidator("int32");
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 -2147483649L,
                 validationMetadata,
@@ -91,7 +92,7 @@ public class FormatValidatorTest {
     @Test
     public void testInt32OverMaxFails() {
         final FormatValidator validator = new FormatValidator("int32");
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 2147483648L,
                 validationMetadata,
@@ -103,7 +104,7 @@ public class FormatValidatorTest {
     public void testInt64UnderMinFails() {
         final FormatValidator validator = new FormatValidator("int64");
 
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 new BigInteger("-9223372036854775809"),
                 validationMetadata,
@@ -139,7 +140,7 @@ public class FormatValidatorTest {
     public void testInt64OverMaxFails() {
         final FormatValidator validator = new FormatValidator("int64");
 
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 new BigInteger("9223372036854775808"),
                 validationMetadata,
@@ -150,7 +151,7 @@ public class FormatValidatorTest {
     @Test
     public void testFloatUnderMinFails() {
         final FormatValidator validator = new FormatValidator("float");
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 -3.402823466385289e+38d,
                 validationMetadata,
@@ -185,7 +186,7 @@ public class FormatValidatorTest {
     @Test
     public void testFloatOverMaxFails() {
         final FormatValidator validator = new FormatValidator("float");
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 3.402823466385289e+38d,
                 validationMetadata,
@@ -196,7 +197,7 @@ public class FormatValidatorTest {
     @Test
     public void testDoubleUnderMinFails() {
         final FormatValidator validator = new FormatValidator("double");
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 new BigDecimal("-1.7976931348623157082e+308"),
                 validationMetadata,
@@ -231,7 +232,7 @@ public class FormatValidatorTest {
     @Test
     public void testDoubleOverMaxFails() {
         final FormatValidator validator = new FormatValidator("double");
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 new BigDecimal("1.7976931348623157082e+308"),
                 validationMetadata,
@@ -242,7 +243,7 @@ public class FormatValidatorTest {
     @Test
     public void testInvalidNumberStringFails() {
         final FormatValidator validator = new FormatValidator("number");
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 "abc",
                 validationMetadata,
@@ -277,7 +278,7 @@ public class FormatValidatorTest {
     @Test
     public void testInvalidDateStringFails() {
         final FormatValidator validator = new FormatValidator("date");
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 "abc",
                 validationMetadata,
@@ -300,7 +301,7 @@ public class FormatValidatorTest {
     @Test
     public void testInvalidDateTimeStringFails() {
         final FormatValidator validator = new FormatValidator("date-time");
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 "abc",
                 validationMetadata,

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/validation/ItemsValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/validation/ItemsValidatorTest.hbs
@@ -5,6 +5,7 @@ import org.junit.Test;
 import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
 import {{{packageName}}}.configurations.SchemaConfiguration;
 import {{{packageName}}}.schemas.StringJsonSchema;
+import {{{packageName}}}.exceptions.ValidationException;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -77,7 +78,7 @@ public class ItemsValidatorTest {
         mutableList.add(1);
         FrozenList<Object> arg = new FrozenList<>(mutableList);
         final ItemsValidator validator = new ItemsValidator(StringJsonSchema.class);
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 arg,
                 validationMetadata,

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/validation/PropertiesValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/validation/PropertiesValidatorTest.hbs
@@ -5,6 +5,8 @@ import org.junit.Test;
 import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
 import {{{packageName}}}.configurations.SchemaConfiguration;
 import {{{packageName}}}.schemas.StringJsonSchema;
+import {{{packageName}}}.exceptions.ValidationException;
+
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -87,7 +89,7 @@ public class PropertiesValidatorTest {
         LinkedHashMap<String, Object> mutableMap = new LinkedHashMap<>();
         mutableMap.put("someString", 1);
         FrozenMap<String, Object> arg = new FrozenMap<>(mutableMap);
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 arg,
                 validationMetadata,

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/validation/RequiredValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/validation/RequiredValidatorTest.hbs
@@ -5,6 +5,7 @@ import org.junit.Test;
 import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
 import {{{packageName}}}.configurations.SchemaConfiguration;
 import {{{packageName}}}.schemas.StringJsonSchema;
+import {{{packageName}}}.exceptions.ValidationException;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -81,7 +82,7 @@ public class RequiredValidatorTest {
         mutableMap.put("aDifferentProp", 1);
         FrozenMap<String, Object> arg = new FrozenMap<>(mutableMap);
         final RequiredValidator validator = new RequiredValidator(requiredProperties);
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 arg,
                 validationMetadata,

--- a/src/main/resources/java/src/test/java/org/openapitools/schemas/validation/TypeValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/org/openapitools/schemas/validation/TypeValidatorTest.hbs
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
 import {{{packageName}}}.configurations.SchemaConfiguration;
+import {{{packageName}}}.exceptions.ValidationException;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -31,7 +32,7 @@ public class TypeValidatorTest {
     }
 
     @Test
-    public void testValidateFailsIntIsNotString() throws RuntimeException {
+    public void testValidateFailsIntIsNotString() {
         LinkedHashSet<Class<?>> type = new LinkedHashSet<>();
         type.add(String.class);
         final TypeValidator validator = new TypeValidator(type);
@@ -41,7 +42,7 @@ public class TypeValidatorTest {
                 new PathToSchemasMap(),
                 new LinkedHashSet<>()
         );
-        Assert.assertThrows(RuntimeException.class, () -> validator.validate(
+        Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 JsonSchema.class,
                 1,
                 validationMetadata,


### PR DESCRIPTION
Java, adds and uses exception types
- validate methods now specify that they throw import ValidationException
- tests check for that exception


### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
