### PR TITLE
Java, adds more openapi v3.0.3 validators

### DIFF
--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -666,6 +666,7 @@ src/main/java/org/openapijsonschematools/schemas/validation/AdditionalProperties
 src/main/java/org/openapijsonschematools/schemas/validation/AllOfValidator.java
 src/main/java/org/openapijsonschematools/schemas/validation/AnyOfValidator.java
 src/main/java/org/openapijsonschematools/schemas/validation/CustomIsoparser.java
+src/main/java/org/openapijsonschematools/schemas/validation/EnumValidator.java
 src/main/java/org/openapijsonschematools/schemas/validation/ExclusiveMaximumValidator.java
 src/main/java/org/openapijsonschematools/schemas/validation/ExclusiveMinimumValidator.java
 src/main/java/org/openapijsonschematools/schemas/validation/FakeValidator.java

--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -691,6 +691,7 @@ src/main/java/org/openapijsonschematools/schemas/validation/PropertiesValidator.
 src/main/java/org/openapijsonschematools/schemas/validation/PropertyEntry.java
 src/main/java/org/openapijsonschematools/schemas/validation/RequiredValidator.java
 src/main/java/org/openapijsonschematools/schemas/validation/TypeValidator.java
+src/main/java/org/openapijsonschematools/schemas/validation/UniqueItemsValidator.java
 src/main/java/org/openapijsonschematools/schemas/validation/UnsetAnyTypeJsonSchema.java
 src/main/java/org/openapijsonschematools/schemas/validation/ValidationMetadata.java
 src/test/java/org/openapijsonschematools/configurations/JsonSchemaKeywordFlagsTest.java

--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -688,6 +688,7 @@ src/main/java/org/openapijsonschematools/schemas/validation/MinimumValidator.jav
 src/main/java/org/openapijsonschematools/schemas/validation/MultipleOfValidator.java
 src/main/java/org/openapijsonschematools/schemas/validation/OneOfValidator.java
 src/main/java/org/openapijsonschematools/schemas/validation/PathToSchemasMap.java
+src/main/java/org/openapijsonschematools/schemas/validation/PatternValidator.java
 src/main/java/org/openapijsonschematools/schemas/validation/PropertiesValidator.java
 src/main/java/org/openapijsonschematools/schemas/validation/PropertyEntry.java
 src/main/java/org/openapijsonschematools/schemas/validation/RequiredValidator.java

--- a/samples/client/petstore/java/docs/components/schemas/Apple.md
+++ b/samples/client/petstore/java/docs/components/schemas/Apple.md
@@ -60,7 +60,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("pattern", new PatternValidator(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"/^[A-Z\\s]*$/i"<br>&nbsp;&nbsp;&nbsp;&nbsp;)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
@@ -75,7 +75,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("pattern", new PatternValidator(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"/^[a-zA-Z\\s]*$/"<br>&nbsp;&nbsp;&nbsp;&nbsp;)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/BasquePig.md
+++ b/samples/client/petstore/java/docs/components/schemas/BasquePig.md
@@ -56,7 +56,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"BasquePig"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/BooleanEnum.md
+++ b/samples/client/petstore/java/docs/components/schemas/BooleanEnum.md
@@ -17,7 +17,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(Boolean.class)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(Boolean.class))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;true<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/BooleanEnum.md
+++ b/samples/client/petstore/java/docs/components/schemas/BooleanEnum.md
@@ -17,7 +17,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(Boolean.class))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;true<br>)))<br>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(Boolean.class))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;true)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/ComplexQuadrilateral.md
+++ b/samples/client/petstore/java/docs/components/schemas/ComplexQuadrilateral.md
@@ -80,7 +80,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"ComplexQuadrilateral"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/ComposedOneOfDifferentTypes.md
+++ b/samples/client/petstore/java/docs/components/schemas/ComposedOneOfDifferentTypes.md
@@ -50,7 +50,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("format", new FormatValidator("date-time"))<br>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("format", new FormatValidator("date-time")),<br>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("pattern", new PatternValidator(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"/^2020.*/"<br>&nbsp;&nbsp;&nbsp;&nbsp;)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/Currency.md
+++ b/samples/client/petstore/java/docs/components/schemas/Currency.md
@@ -17,7 +17,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"eur",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"usd"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/DanishPig.md
+++ b/samples/client/petstore/java/docs/components/schemas/DanishPig.md
@@ -56,7 +56,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"DanishPig"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/DateTimeWithValidations.md
+++ b/samples/client/petstore/java/docs/components/schemas/DateTimeWithValidations.md
@@ -17,7 +17,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("format", new FormatValidator("date-time"))<br>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("format", new FormatValidator("date-time")),<br>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("pattern", new PatternValidator(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"/^2020.*/"<br>&nbsp;&nbsp;&nbsp;&nbsp;)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/DateWithValidations.md
+++ b/samples/client/petstore/java/docs/components/schemas/DateWithValidations.md
@@ -17,7 +17,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("format", new FormatValidator("date"))<br>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("format", new FormatValidator("date")),<br>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("pattern", new PatternValidator(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"/^2020.*/"<br>&nbsp;&nbsp;&nbsp;&nbsp;)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/EnumArrays.md
+++ b/samples/client/petstore/java/docs/components/schemas/EnumArrays.md
@@ -95,7 +95,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"fish",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"crab"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
@@ -110,7 +110,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;">=",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"$"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/EnumClass.md
+++ b/samples/client/petstore/java/docs/components/schemas/EnumClass.md
@@ -17,7 +17,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"_abc",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"-efg",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"(xyz)",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"COUNT_1M",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"COUNT_50M"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/EnumTest.md
+++ b/samples/client/petstore/java/docs/components/schemas/EnumTest.md
@@ -75,7 +75,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Integer.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Long.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Float.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Double.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("format", new FormatValidator("double"))<br>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Integer.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Long.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Float.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Double.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("format", new FormatValidator("double")),<br>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1.1,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-1.2<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
@@ -90,7 +90,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Integer.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Long.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Float.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Double.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("format", new FormatValidator("int32"))<br>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Integer.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Long.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Float.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Double.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("format", new FormatValidator("int32")),<br>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-1<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
@@ -105,7 +105,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"UPPER",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"lower",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;""<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
@@ -120,7 +120,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"UPPER",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"lower",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;""<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/EnumTest.md
+++ b/samples/client/petstore/java/docs/components/schemas/EnumTest.md
@@ -75,7 +75,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Integer.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Long.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Float.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Double.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("format", new FormatValidator("double")),<br>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1.1,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-1.2<br>)))<br>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Integer.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Long.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Float.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Double.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("format", new FormatValidator("double")),<br>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1.1,&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-1.2)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
@@ -90,7 +90,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Integer.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Long.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Float.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Double.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("format", new FormatValidator("int32")),<br>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-1<br>)))<br>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Integer.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Long.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Float.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Double.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("format", new FormatValidator("int32")),<br>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1,&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-1)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/EquilateralTriangle.md
+++ b/samples/client/petstore/java/docs/components/schemas/EquilateralTriangle.md
@@ -80,7 +80,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"EquilateralTriangle"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/FormatTest.md
+++ b/samples/client/petstore/java/docs/components/schemas/FormatTest.md
@@ -240,7 +240,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(FrozenList.class))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("items", new ItemsValidator([Items.class](#items)))<br>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(FrozenList.class))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("items", new ItemsValidator([Items.class](#items))),<br>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("uniqueItems", new UniqueItemsValidator(true))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/FormatTest.md
+++ b/samples/client/petstore/java/docs/components/schemas/FormatTest.md
@@ -125,7 +125,7 @@ A string starting with &#x27;image_&#x27; (case insensitive) and one to three di
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("pattern", new PatternValidator(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"/^image_\\d{1,3}$/i"<br>&nbsp;&nbsp;&nbsp;&nbsp;)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
@@ -143,7 +143,7 @@ A string that is a 10 digit number. Can have leading zeros.
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("pattern", new PatternValidator(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"/^\\d{10}$/"<br>&nbsp;&nbsp;&nbsp;&nbsp;)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
@@ -225,7 +225,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("pattern", new PatternValidator(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"/[a-z]/i"<br>&nbsp;&nbsp;&nbsp;&nbsp;)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/IntegerEnum.md
+++ b/samples/client/petstore/java/docs/components/schemas/IntegerEnum.md
@@ -17,7 +17,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Integer.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Long.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Float.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Double.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2<br>)))<br>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Integer.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Long.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Float.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Double.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0,&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1,&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/IntegerEnum.md
+++ b/samples/client/petstore/java/docs/components/schemas/IntegerEnum.md
@@ -17,7 +17,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Integer.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Long.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Float.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Double.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Integer.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Long.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Float.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Double.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/IntegerEnumBig.md
+++ b/samples/client/petstore/java/docs/components/schemas/IntegerEnumBig.md
@@ -17,7 +17,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Integer.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Long.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Float.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Double.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;10,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;11,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;12<br>)))<br>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Integer.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Long.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Float.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Double.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;10,&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;11,&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;12)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/IntegerEnumBig.md
+++ b/samples/client/petstore/java/docs/components/schemas/IntegerEnumBig.md
@@ -17,7 +17,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Integer.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Long.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Float.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Double.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Integer.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Long.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Float.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Double.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;10,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;11,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;12<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/IntegerEnumOneValue.md
+++ b/samples/client/petstore/java/docs/components/schemas/IntegerEnumOneValue.md
@@ -17,7 +17,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Integer.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Long.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Float.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Double.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0<br>)))<br>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Integer.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Long.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Float.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Double.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/IntegerEnumOneValue.md
+++ b/samples/client/petstore/java/docs/components/schemas/IntegerEnumOneValue.md
@@ -17,7 +17,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Integer.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Long.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Float.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Double.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Integer.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Long.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Float.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Double.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/IntegerEnumWithDefaultValue.md
+++ b/samples/client/petstore/java/docs/components/schemas/IntegerEnumWithDefaultValue.md
@@ -17,7 +17,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Integer.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Long.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Float.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Double.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2<br>)))<br>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Integer.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Long.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Float.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Double.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0,&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1,&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/IntegerEnumWithDefaultValue.md
+++ b/samples/client/petstore/java/docs/components/schemas/IntegerEnumWithDefaultValue.md
@@ -17,7 +17,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Integer.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Long.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Float.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Double.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Integer.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Long.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Float.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Double.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/IsoscelesTriangle.md
+++ b/samples/client/petstore/java/docs/components/schemas/IsoscelesTriangle.md
@@ -80,7 +80,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"IsoscelesTriangle"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/JSONPatchRequestAddReplaceTest.md
+++ b/samples/client/petstore/java/docs/components/schemas/JSONPatchRequestAddReplaceTest.md
@@ -64,7 +64,7 @@ The operation to perform.
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"add",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"replace",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"test"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/JSONPatchRequestMoveCopy.md
+++ b/samples/client/petstore/java/docs/components/schemas/JSONPatchRequestMoveCopy.md
@@ -64,7 +64,7 @@ The operation to perform.
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"move",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"copy"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/JSONPatchRequestRemove.md
+++ b/samples/client/petstore/java/docs/components/schemas/JSONPatchRequestRemove.md
@@ -61,7 +61,7 @@ The operation to perform.
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"remove"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/MapTest.md
+++ b/samples/client/petstore/java/docs/components/schemas/MapTest.md
@@ -152,7 +152,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"UPPER",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"lower"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/Order.md
+++ b/samples/client/petstore/java/docs/components/schemas/Order.md
@@ -84,7 +84,7 @@ Order Status
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"placed",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"approved",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"delivered"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/Pet.md
+++ b/samples/client/petstore/java/docs/components/schemas/Pet.md
@@ -113,7 +113,7 @@ pet status in the store
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"available",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"pending",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"sold"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/QuadrilateralInterface.md
+++ b/samples/client/petstore/java/docs/components/schemas/QuadrilateralInterface.md
@@ -77,7 +77,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"Quadrilateral"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/ScaleneTriangle.md
+++ b/samples/client/petstore/java/docs/components/schemas/ScaleneTriangle.md
@@ -80,7 +80,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"ScaleneTriangle"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/SimpleQuadrilateral.md
+++ b/samples/client/petstore/java/docs/components/schemas/SimpleQuadrilateral.md
@@ -80,7 +80,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"SimpleQuadrilateral"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/StringEnum.md
+++ b/samples/client/petstore/java/docs/components/schemas/StringEnum.md
@@ -17,7 +17,9 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Void.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Void.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"placed",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"approved",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"delivered",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"single quoted",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"multiple
+lines",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"double quote 
+ with newline",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/StringEnum.md
+++ b/samples/client/petstore/java/docs/components/schemas/StringEnum.md
@@ -17,9 +17,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Void.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"placed",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"approved",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"delivered",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"single quoted",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"multiple
-lines",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"double quote 
- with newline",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>)))<br>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Void.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"placed",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"approved",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"delivered",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"single quoted",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"multiple\nlines",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"double quote \n with newline",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;null)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/StringEnumWithDefaultValue.md
+++ b/samples/client/petstore/java/docs/components/schemas/StringEnumWithDefaultValue.md
@@ -17,7 +17,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"placed",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"approved",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"delivered"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/TriangleInterface.md
+++ b/samples/client/petstore/java/docs/components/schemas/TriangleInterface.md
@@ -77,7 +77,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"Triangle"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/Whale.md
+++ b/samples/client/petstore/java/docs/components/schemas/Whale.md
@@ -62,7 +62,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"whale"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/schemas/Zebra.md
+++ b/samples/client/petstore/java/docs/components/schemas/Zebra.md
@@ -60,7 +60,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"zebra"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
@@ -75,7 +75,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"plains",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"mountain",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"grevys"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/paths/commonparamsubdir/delete/parameters/parameter1/Schema1.md
+++ b/samples/client/petstore/java/docs/paths/commonparamsubdir/delete/parameters/parameter1/Schema1.md
@@ -17,7 +17,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"c",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"d"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/paths/commonparamsubdir/parameters/parameter0/PathParamSchema0.md
+++ b/samples/client/petstore/java/docs/paths/commonparamsubdir/parameters/parameter0/PathParamSchema0.md
@@ -17,7 +17,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"a",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"b"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/paths/fake/delete/parameters/parameter1/Schema1.md
+++ b/samples/client/petstore/java/docs/paths/fake/delete/parameters/parameter1/Schema1.md
@@ -17,7 +17,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"true",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"false"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/paths/fake/delete/parameters/parameter4/Schema4.md
+++ b/samples/client/petstore/java/docs/paths/fake/delete/parameters/parameter4/Schema4.md
@@ -17,7 +17,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"true",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"false"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter0/Schema0.md
+++ b/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter0/Schema0.md
@@ -53,7 +53,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;">",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"$"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter1/Schema1.md
+++ b/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter1/Schema1.md
@@ -17,7 +17,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"_abc",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"-efg",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"(xyz)"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter2/Schema2.md
+++ b/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter2/Schema2.md
@@ -53,7 +53,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;">",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"$"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter3/Schema3.md
+++ b/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter3/Schema3.md
@@ -17,7 +17,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"_abc",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"-efg",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"(xyz)"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter4/Schema4.md
+++ b/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter4/Schema4.md
@@ -17,7 +17,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Integer.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Long.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Float.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Double.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("format", new FormatValidator("int32")),<br>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-2<br>)))<br>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Integer.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Long.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Float.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Double.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("format", new FormatValidator("int32")),<br>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1,&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-2)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter4/Schema4.md
+++ b/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter4/Schema4.md
@@ -17,7 +17,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Integer.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Long.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Float.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Double.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("format", new FormatValidator("int32"))<br>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Integer.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Long.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Float.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Double.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("format", new FormatValidator("int32")),<br>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-2<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter5/Schema5.md
+++ b/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter5/Schema5.md
@@ -17,7 +17,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Integer.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Long.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Float.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Double.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("format", new FormatValidator("double")),<br>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1.1,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-1.2<br>)))<br>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Integer.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Long.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Float.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Double.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("format", new FormatValidator("double")),<br>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1.1,&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-1.2)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter5/Schema5.md
+++ b/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter5/Schema5.md
@@ -17,7 +17,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Integer.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Long.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Float.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Double.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("format", new FormatValidator("double"))<br>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Integer.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Long.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Float.class,<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Double.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("format", new FormatValidator("double")),<br>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1.1,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-1.2<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/paths/fake/get/requestbody/content/applicationxwwwformurlencoded/Schema.md
+++ b/samples/client/petstore/java/docs/paths/fake/get/requestbody/content/applicationxwwwformurlencoded/Schema.md
@@ -64,7 +64,7 @@ Form parameter enum test (string)
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"_abc",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"-efg",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"(xyz)"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
@@ -116,7 +116,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;">",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"$"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/paths/fake/post/requestbody/content/applicationxwwwformurlencoded/Schema.md
+++ b/samples/client/petstore/java/docs/paths/fake/post/requestbody/content/applicationxwwwformurlencoded/Schema.md
@@ -173,7 +173,7 @@ None
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("pattern", new PatternValidator(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"/^[A-Z].*/"<br>&nbsp;&nbsp;&nbsp;&nbsp;)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
@@ -191,7 +191,7 @@ None
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("pattern", new PatternValidator(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"/[a-z]/i"<br>&nbsp;&nbsp;&nbsp;&nbsp;)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/paths/petfindbystatus/get/parameters/parameter0/Schema0.md
+++ b/samples/client/petstore/java/docs/paths/petfindbystatus/get/parameters/parameter0/Schema0.md
@@ -53,7 +53,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;)))<br/>)); |
+| static LinkedHashMap<String, KeywordValidator> |keywordToValidator<br/>new LinkedHashMap<>(Map.ofEntries(<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("type", new TypeValidator(Set.of(<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String.class<br/>&nbsp;&nbsp;&nbsp;&nbsp;))),<br/>&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"available",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"pending",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"sold"<br>)))<br>)); |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Apple.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Apple.java
@@ -2,12 +2,14 @@ package org.openapijsonschematools.components.schemas;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
+import org.openapijsonschematools.schemas.validation.PatternValidator;
 import org.openapijsonschematools.schemas.validation.PropertiesValidator;
 import org.openapijsonschematools.schemas.validation.PropertyEntry;
 import org.openapijsonschematools.schemas.validation.RequiredValidator;
@@ -21,6 +23,9 @@ public class Apple {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("pattern", new PatternValidator(Pattern.compile(
+                "/^[a-zA-Z\\s]*$/"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
@@ -32,6 +37,9 @@ public class Apple {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("pattern", new PatternValidator(Pattern.compile(
+                "/^[A-Z\\s]*$/i"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/BasquePig.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/BasquePig.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -21,6 +22,9 @@ public class BasquePig {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "BasquePig"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/BooleanEnum.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/BooleanEnum.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -21,7 +22,10 @@ public class BooleanEnum {
         Do not edit the class manually.
         */
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
-            new KeywordEntry("type", new TypeValidator(Set.of(Boolean.class)))
+            new KeywordEntry("type", new TypeValidator(Set.of(Boolean.class))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                true
+            )))
         ));
         public static boolean validate(boolean arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(BooleanEnum1.class, arg, configuration);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ComplexQuadrilateral.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ComplexQuadrilateral.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.AllOfValidator;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -26,6 +27,9 @@ public class ComplexQuadrilateral {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "ComplexQuadrilateral"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ComposedOneOfDifferentTypes.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ComposedOneOfDifferentTypes.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.regex.Pattern;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
@@ -23,6 +24,7 @@ import org.openapijsonschematools.schemas.validation.MaxPropertiesValidator;
 import org.openapijsonschematools.schemas.validation.MinItemsValidator;
 import org.openapijsonschematools.schemas.validation.MinPropertiesValidator;
 import org.openapijsonschematools.schemas.validation.OneOfValidator;
+import org.openapijsonschematools.schemas.validation.PatternValidator;
 import org.openapijsonschematools.schemas.validation.TypeValidator;
 
 public class ComposedOneOfDifferentTypes {
@@ -80,7 +82,10 @@ public class ComposedOneOfDifferentTypes {
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
             ))),
-            new KeywordEntry("format", new FormatValidator("date-time"))
+            new KeywordEntry("format", new FormatValidator("date-time")),
+            new KeywordEntry("pattern", new PatternValidator(Pattern.compile(
+                "/^2020.*/"
+            )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema6.class, arg, configuration);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Currency.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Currency.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -23,6 +24,10 @@ public class Currency {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "eur",
+                "usd"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/DanishPig.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/DanishPig.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -21,6 +22,9 @@ public class DanishPig {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "DanishPig"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/DateTimeWithValidations.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/DateTimeWithValidations.java
@@ -3,12 +3,14 @@ import java.time.ZonedDateTime;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FormatValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
+import org.openapijsonschematools.schemas.validation.PatternValidator;
 import org.openapijsonschematools.schemas.validation.TypeValidator;
 
 public class DateTimeWithValidations {
@@ -26,7 +28,10 @@ public class DateTimeWithValidations {
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
             ))),
-            new KeywordEntry("format", new FormatValidator("date-time"))
+            new KeywordEntry("format", new FormatValidator("date-time")),
+            new KeywordEntry("pattern", new PatternValidator(Pattern.compile(
+                "/^2020.*/"
+            )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(DateTimeWithValidations1.class, arg, configuration);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/DateWithValidations.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/DateWithValidations.java
@@ -3,12 +3,14 @@ import java.time.LocalDate;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.FormatValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
+import org.openapijsonschematools.schemas.validation.PatternValidator;
 import org.openapijsonschematools.schemas.validation.TypeValidator;
 
 public class DateWithValidations {
@@ -26,7 +28,10 @@ public class DateWithValidations {
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
             ))),
-            new KeywordEntry("format", new FormatValidator("date"))
+            new KeywordEntry("format", new FormatValidator("date")),
+            new KeywordEntry("pattern", new PatternValidator(Pattern.compile(
+                "/^2020.*/"
+            )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(DateWithValidations1.class, arg, configuration);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/EnumArrays.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/EnumArrays.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.ItemsValidator;
@@ -23,6 +24,10 @@ public class EnumArrays {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                ">=",
+                "$"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
@@ -34,6 +39,10 @@ public class EnumArrays {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "fish",
+                "crab"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/EnumClass.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/EnumClass.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -23,6 +24,13 @@ public class EnumClass {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "_abc",
+                "-efg",
+                "(xyz)",
+                "COUNT_1M",
+                "COUNT_50M"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/EnumTest.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/EnumTest.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.FormatValidator;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -22,6 +23,11 @@ public class EnumTest {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "UPPER",
+                "lower",
+                ""
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
@@ -33,6 +39,11 @@ public class EnumTest {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "UPPER",
+                "lower",
+                ""
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
@@ -48,7 +59,11 @@ public class EnumTest {
                 Float.class,
                 Double.class
             ))),
-            new KeywordEntry("format", new FormatValidator("int32"))
+            new KeywordEntry("format", new FormatValidator("int32")),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                1,
+                -1
+            )))
         ));
         public static long validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(EnumInteger.class, Long.valueOf(arg), configuration);
@@ -75,7 +90,11 @@ public class EnumTest {
                 Float.class,
                 Double.class
             ))),
-            new KeywordEntry("format", new FormatValidator("double"))
+            new KeywordEntry("format", new FormatValidator("double")),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                1.1,
+                -1.2
+            )))
         ));
         public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(EnumNumber.class, arg, configuration);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/EquilateralTriangle.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/EquilateralTriangle.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.AllOfValidator;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -26,6 +27,9 @@ public class EquilateralTriangle {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "EquilateralTriangle"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/FormatTest.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/FormatTest.java
@@ -31,6 +31,7 @@ import org.openapijsonschematools.schemas.validation.PropertiesValidator;
 import org.openapijsonschematools.schemas.validation.PropertyEntry;
 import org.openapijsonschematools.schemas.validation.RequiredValidator;
 import org.openapijsonschematools.schemas.validation.TypeValidator;
+import org.openapijsonschematools.schemas.validation.UniqueItemsValidator;
 
 public class FormatTest {
     // nest classes so all schemas and input/output classes can be public
@@ -185,7 +186,8 @@ public class FormatTest {
     public static class ArrayWithUniqueItems extends JsonSchema {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(FrozenList.class))),
-            new KeywordEntry("items", new ItemsValidator(Items.class))
+            new KeywordEntry("items", new ItemsValidator(Items.class)),
+            new KeywordEntry("uniqueItems", new UniqueItemsValidator(true))
         ));
         protected static ArrayWithUniqueItemsList getListOutputInstance(FrozenList<Number> arg) {
             return new ArrayWithUniqueItemsList(arg);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/FormatTest.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/FormatTest.java
@@ -3,6 +3,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.DateJsonSchema;
@@ -27,6 +28,7 @@ import org.openapijsonschematools.schemas.validation.MaximumValidator;
 import org.openapijsonschematools.schemas.validation.MinLengthValidator;
 import org.openapijsonschematools.schemas.validation.MinimumValidator;
 import org.openapijsonschematools.schemas.validation.MultipleOfValidator;
+import org.openapijsonschematools.schemas.validation.PatternValidator;
 import org.openapijsonschematools.schemas.validation.PropertiesValidator;
 import org.openapijsonschematools.schemas.validation.PropertyEntry;
 import org.openapijsonschematools.schemas.validation.RequiredValidator;
@@ -201,6 +203,9 @@ public class FormatTest {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("pattern", new PatternValidator(Pattern.compile(
+                "/[a-z]/i"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
@@ -246,6 +251,9 @@ public class FormatTest {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("pattern", new PatternValidator(Pattern.compile(
+                "/^\\d{10}$/"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
@@ -257,6 +265,9 @@ public class FormatTest {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("pattern", new PatternValidator(Pattern.compile(
+                "/^image_\\d{1,3}$/i"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/IntegerEnum.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/IntegerEnum.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -26,6 +27,11 @@ public class IntegerEnum {
                 Long.class,
                 Float.class,
                 Double.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                0,
+                1,
+                2
             )))
         ));
         public static long validate(int arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/IntegerEnumBig.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/IntegerEnumBig.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -26,6 +27,11 @@ public class IntegerEnumBig {
                 Long.class,
                 Float.class,
                 Double.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                10,
+                11,
+                12
             )))
         ));
         public static long validate(int arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/IntegerEnumOneValue.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/IntegerEnumOneValue.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -26,6 +27,9 @@ public class IntegerEnumOneValue {
                 Long.class,
                 Float.class,
                 Double.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                0
             )))
         ));
         public static long validate(int arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/IntegerEnumWithDefaultValue.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/IntegerEnumWithDefaultValue.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -26,6 +27,11 @@ public class IntegerEnumWithDefaultValue {
                 Long.class,
                 Float.class,
                 Double.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                0,
+                1,
+                2
             )))
         ));
         public static long validate(int arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/IsoscelesTriangle.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/IsoscelesTriangle.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.AllOfValidator;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -26,6 +27,9 @@ public class IsoscelesTriangle {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "IsoscelesTriangle"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/JSONPatchRequestAddReplaceTest.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/JSONPatchRequestAddReplaceTest.java
@@ -8,6 +8,7 @@ import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.AdditionalPropertiesValidator;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -35,6 +36,11 @@ public class JSONPatchRequestAddReplaceTest {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "add",
+                "replace",
+                "test"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/JSONPatchRequestMoveCopy.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/JSONPatchRequestMoveCopy.java
@@ -8,6 +8,7 @@ import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.AdditionalPropertiesValidator;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -35,6 +36,10 @@ public class JSONPatchRequestMoveCopy {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "move",
+                "copy"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/JSONPatchRequestRemove.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/JSONPatchRequestRemove.java
@@ -8,6 +8,7 @@ import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.NotAnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.AdditionalPropertiesValidator;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -32,6 +33,9 @@ public class JSONPatchRequestRemove {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "remove"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/MapTest.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/MapTest.java
@@ -7,6 +7,7 @@ import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.BooleanJsonSchema;
 import org.openapijsonschematools.schemas.StringJsonSchema;
 import org.openapijsonschematools.schemas.validation.AdditionalPropertiesValidator;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -88,6 +89,10 @@ public class MapTest {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "UPPER",
+                "lower"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Order.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Order.java
@@ -8,6 +8,7 @@ import org.openapijsonschematools.schemas.BooleanJsonSchema;
 import org.openapijsonschematools.schemas.DateTimeJsonSchema;
 import org.openapijsonschematools.schemas.Int32JsonSchema;
 import org.openapijsonschematools.schemas.Int64JsonSchema;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -36,6 +37,11 @@ public class Order {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "placed",
+                "approved",
+                "delivered"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Pet.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Pet.java
@@ -7,6 +7,7 @@ import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.Int64JsonSchema;
 import org.openapijsonschematools.schemas.StringJsonSchema;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.ItemsValidator;
@@ -58,6 +59,11 @@ public class Pet {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "available",
+                "pending",
+                "sold"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/QuadrilateralInterface.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/QuadrilateralInterface.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -27,6 +28,9 @@ public class QuadrilateralInterface {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "Quadrilateral"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ScaleneTriangle.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/ScaleneTriangle.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.AllOfValidator;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -26,6 +27,9 @@ public class ScaleneTriangle {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "ScaleneTriangle"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/SimpleQuadrilateral.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/SimpleQuadrilateral.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.validation.AllOfValidator;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -26,6 +27,9 @@ public class SimpleQuadrilateral {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "SimpleQuadrilateral"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/StringEnum.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/StringEnum.java
@@ -31,11 +31,9 @@ public class StringEnum {
                 "approved",
                 "delivered",
                 "single quoted",
-                "multiple
-lines",
-                "double quote 
- with newline",
-                
+                "multiple\nlines",
+                "double quote \n with newline",
+                null
             )))
         ));
         public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/StringEnum.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/StringEnum.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -24,6 +25,17 @@ public class StringEnum {
             new KeywordEntry("type", new TypeValidator(Set.of(
                 Void.class,
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "placed",
+                "approved",
+                "delivered",
+                "single quoted",
+                "multiple
+lines",
+                "double quote 
+ with newline",
+                
             )))
         ));
         public static Void validate(Void arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/StringEnumWithDefaultValue.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/StringEnumWithDefaultValue.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -23,6 +24,11 @@ public class StringEnumWithDefaultValue {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "placed",
+                "approved",
+                "delivered"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/TriangleInterface.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/TriangleInterface.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.StringJsonSchema;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -27,6 +28,9 @@ public class TriangleInterface {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "Triangle"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Whale.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Whale.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.BooleanJsonSchema;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -28,6 +29,9 @@ public class Whale {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "whale"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Zebra.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/components/schemas/Zebra.java
@@ -6,6 +6,7 @@ import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.AnyTypeJsonSchema;
 import org.openapijsonschematools.schemas.validation.AdditionalPropertiesValidator;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -26,6 +27,11 @@ public class Zebra {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "plains",
+                "mountain",
+                "grevys"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
@@ -37,6 +43,9 @@ public class Zebra {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "zebra"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/commonparamsubdir/delete/parameters/parameter1/Schema1.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/commonparamsubdir/delete/parameters/parameter1/Schema1.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -17,6 +18,10 @@ public class Schema1 {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "c",
+                "d"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/commonparamsubdir/parameters/parameter0/PathParamSchema0.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/commonparamsubdir/parameters/parameter0/PathParamSchema0.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -17,6 +18,10 @@ public class PathParamSchema0 {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "a",
+                "b"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/delete/parameters/parameter1/Schema1.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/delete/parameters/parameter1/Schema1.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -17,6 +18,10 @@ public class Schema1 {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "true",
+                "false"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/delete/parameters/parameter4/Schema4.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/delete/parameters/parameter4/Schema4.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -17,6 +18,10 @@ public class Schema4 {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "true",
+                "false"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/parameters/parameter0/Schema0.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/parameters/parameter0/Schema0.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.ItemsValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -20,6 +21,10 @@ public class Schema0 {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                ">",
+                "$"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/parameters/parameter1/Schema1.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/parameters/parameter1/Schema1.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -17,6 +18,11 @@ public class Schema1 {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "_abc",
+                "-efg",
+                "(xyz)"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/parameters/parameter2/Schema2.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/parameters/parameter2/Schema2.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.ItemsValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -20,6 +21,10 @@ public class Schema2 {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                ">",
+                "$"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/parameters/parameter3/Schema3.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/parameters/parameter3/Schema3.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
 import org.openapijsonschematools.schemas.validation.KeywordValidator;
@@ -17,6 +18,11 @@ public class Schema3 {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "_abc",
+                "-efg",
+                "(xyz)"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/parameters/parameter4/Schema4.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/parameters/parameter4/Schema4.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.FormatValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -22,7 +23,11 @@ public class Schema4 {
                 Float.class,
                 Double.class
             ))),
-            new KeywordEntry("format", new FormatValidator("int32"))
+            new KeywordEntry("format", new FormatValidator("int32")),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                1,
+                -2
+            )))
         ));
         public static long validate(int arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema41.class, Long.valueOf(arg), configuration);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/parameters/parameter5/Schema5.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/parameters/parameter5/Schema5.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.FormatValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
 import org.openapijsonschematools.schemas.validation.KeywordEntry;
@@ -22,7 +23,11 @@ public class Schema5 {
                 Float.class,
                 Double.class
             ))),
-            new KeywordEntry("format", new FormatValidator("double"))
+            new KeywordEntry("format", new FormatValidator("double")),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                1.1,
+                -1.2
+            )))
         ));
         public static double validate(double arg, SchemaConfiguration configuration) throws ValidationException {
             return JsonSchema.validate(Schema51.class, arg, configuration);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/requestbody/content/applicationxwwwformurlencoded/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/get/requestbody/content/applicationxwwwformurlencoded/Schema.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.FrozenMap;
 import org.openapijsonschematools.schemas.validation.ItemsValidator;
@@ -23,6 +24,10 @@ public class Schema {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                ">",
+                "$"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
@@ -57,6 +62,11 @@ public class Schema {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "_abc",
+                "-efg",
+                "(xyz)"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/post/requestbody/content/applicationxwwwformurlencoded/Schema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/fake/post/requestbody/content/applicationxwwwformurlencoded/Schema.java
@@ -3,6 +3,7 @@ import java.time.ZonedDateTime;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
 import org.openapijsonschematools.schemas.DateJsonSchema;
@@ -17,6 +18,7 @@ import org.openapijsonschematools.schemas.validation.MaxLengthValidator;
 import org.openapijsonschematools.schemas.validation.MaximumValidator;
 import org.openapijsonschematools.schemas.validation.MinLengthValidator;
 import org.openapijsonschematools.schemas.validation.MinimumValidator;
+import org.openapijsonschematools.schemas.validation.PatternValidator;
 import org.openapijsonschematools.schemas.validation.PropertiesValidator;
 import org.openapijsonschematools.schemas.validation.PropertyEntry;
 import org.openapijsonschematools.schemas.validation.RequiredValidator;
@@ -151,6 +153,9 @@ public class Schema {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("pattern", new PatternValidator(Pattern.compile(
+                "/[a-z]/i"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {
@@ -162,6 +167,9 @@ public class Schema {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("pattern", new PatternValidator(Pattern.compile(
+                "/^[A-Z].*/"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petfindbystatus/get/parameters/parameter0/Schema0.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/paths/petfindbystatus/get/parameters/parameter0/Schema0.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openapijsonschematools.configurations.SchemaConfiguration;
 import org.openapijsonschematools.exceptions.ValidationException;
+import org.openapijsonschematools.schemas.validation.EnumValidator;
 import org.openapijsonschematools.schemas.validation.FrozenList;
 import org.openapijsonschematools.schemas.validation.ItemsValidator;
 import org.openapijsonschematools.schemas.validation.JsonSchema;
@@ -20,6 +21,11 @@ public class Schema0 {
         public static final LinkedHashMap<String, KeywordValidator> keywordToValidator = new LinkedHashMap<>(Map.ofEntries(
             new KeywordEntry("type", new TypeValidator(Set.of(
                 String.class
+            ))),
+            new KeywordEntry("enum", new EnumValidator(Set.of(
+                "available",
+                "pending",
+                "sold"
             )))
         ));
         public static String validate(String arg, SchemaConfiguration configuration) throws ValidationException {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validation/EnumValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validation/EnumValidator.java
@@ -1,0 +1,29 @@
+package org.openapijsonschematools.schemas.validation;
+
+import org.openapijsonschematools.exceptions.ValidationException;
+
+import java.util.Set;
+
+public class EnumValidator implements KeywordValidator {
+    public final Set<Object> enumValues;
+
+    public EnumValidator(Set<Object> enumValues) {
+        this.enumValues = enumValues;
+    }
+
+    @Override
+    public Object getConstraint() {
+        return enumValues;
+    }
+
+    @Override
+    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+        if (enumValues.isEmpty()) {
+            throw new ValidationException("No value can match enum because enum is empty");
+        }
+        if (!enumValues.contains(arg)) {
+            throw new ValidationException("Invalid value "+arg+" was not one of the allowed enum "+enumValues);
+        }
+        return null;
+    }
+}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validation/OneOfValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validation/OneOfValidator.java
@@ -25,7 +25,7 @@ public class OneOfValidator implements KeywordValidator {
             if (oneOfClass == cls) {
                 /*
                 optimistically assume that cls schema will pass validation
-                do not invoke _validate on it because that is recursive
+                do not invoke validate on it because that is recursive
                 */
                 validatedOneOfClasses.add(oneOfClass);
                 continue;
@@ -38,12 +38,12 @@ public class OneOfValidator implements KeywordValidator {
                 // silence exceptions because the code needs to accumulate validatedOneOfClasses
             }
         }
-        if (validatedAnyOfClasses.isEmpty()) {
+        if (validatedOneOfClasses.isEmpty()) {
             throw new ValidationException("Invalid inputs given to generate an instance of "+cls+". None "+
                     "of the oneOf schemas matched the input data."
             );
         }
-        if (validatedAnyOfClasses.size() > 1) {
+        if (validatedOneOfClasses.size() > 1) {
             throw new ValidationException("Invalid inputs given to generate an instance of "+cls+". Multiple "+
                     "oneOf schemas validated the data, but a max of one is allowed."
             );

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validation/PatternValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validation/PatternValidator.java
@@ -1,0 +1,29 @@
+package org.openapijsonschematools.schemas.validation;
+
+import org.openapijsonschematools.exceptions.ValidationException;
+
+import java.util.regex.Pattern;
+
+public class PatternValidator implements KeywordValidator {
+    public final Pattern pattern;
+
+    public PatternValidator(Pattern pattern) {
+        this.pattern = pattern;
+    }
+
+    @Override
+    public Object getConstraint() {
+        return pattern;
+    }
+
+    @Override
+    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+        if (!(arg instanceof String)) {
+            return null;
+        }
+        if (!pattern.matcher((String) arg).find()) {
+            throw new ValidationException("Invalid value "+arg+" did not find a match for pattern "+pattern);
+        }
+        return null;
+    }
+}

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validation/UniqueItemsValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validation/UniqueItemsValidator.java
@@ -15,7 +15,7 @@ public class UniqueItemsValidator implements KeywordValidator {
 
     @Override
     public Object getConstraint() {
-        return true;
+        return uniqueItems;
     }
 
     @Override

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validation/UniqueItemsValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/schemas/validation/UniqueItemsValidator.java
@@ -1,0 +1,39 @@
+package org.openapijsonschematools.schemas.validation;
+
+import org.openapijsonschematools.exceptions.ValidationException;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class UniqueItemsValidator implements KeywordValidator {
+    public final boolean uniqueItems;
+
+    public UniqueItemsValidator(boolean uniqueItems) {
+        this.uniqueItems = uniqueItems;
+    }
+
+    @Override
+    public Object getConstraint() {
+        return true;
+    }
+
+    @Override
+    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+        if (!(arg instanceof List)) {
+            return null;
+        }
+        if (!uniqueItems) {
+            return null;
+        }
+        Set<Object> seenItems = new HashSet<>();
+        for (Object item: (List<?>) arg) {
+            int startingSeenItemsSize = seenItems.size();
+            seenItems.add(item);
+            if (seenItems.size() == startingSeenItemsSize) {
+                throw new ValidationException("Invalid list value, list contains duplicate items when uniqueItems is true");
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -962,6 +962,40 @@ public class JavaClientGenerator extends AbstractJavaGenerator
         return getSchemaCamelCaseName(name, sourceJsonPath, true);
     }
 
+    protected String handleSpecialCharacters(String value) {
+        // handles escape characters and the like
+        String stringValue = value;
+        String backslash = "\\";
+        if (stringValue.contains(backslash)) {
+            stringValue = stringValue.replace(backslash, "\\\\");
+        }
+        String nullChar = "\0";
+        if (stringValue.contains(nullChar)) {
+            stringValue = stringValue.replace(nullChar, "\\x00");
+        }
+        String doubleQuoteChar = "\"";
+        if (stringValue.contains(doubleQuoteChar)) {
+            stringValue = stringValue.replace(doubleQuoteChar, "\\\"");
+        }
+        String lineSep = System.lineSeparator();
+        if (stringValue.contains(lineSep)) {
+            stringValue = stringValue.replace(lineSep, "\\n");
+        }
+        String carriageReturn = "\r";
+        if (stringValue.contains(carriageReturn)) {
+            stringValue = stringValue.replace(carriageReturn, "\\r");
+        }
+        String tab = "\t";
+        if (stringValue.contains(tab)) {
+            stringValue = stringValue.replace(tab, "\\t");
+        }
+        String formFeed = "\f";
+        if (stringValue.contains(formFeed)) {
+            stringValue = stringValue.replace(formFeed, "\\f");
+        }
+        return stringValue;
+    }
+
     private String getSchemaCamelCaseName(String name, @NotNull String sourceJsonPath, boolean useCache) {
         String usedKey = handleSpecialCharacters(name);
         usedKey = sanitizeName(usedKey, "[^a-zA-Z0-9_]+");

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -191,7 +191,7 @@ public class JavaClientGenerator extends AbstractJavaGenerator
                         // SchemaFeature.DependentSchemas,
                         // SchemaFeature.Discriminator,
                         // SchemaFeature.Else,
-                        // SchemaFeature.Enum,
+                        SchemaFeature.Enum,
                         SchemaFeature.ExclusiveMaximum,
                         SchemaFeature.ExclusiveMinimum,
                         SchemaFeature.Format,
@@ -384,6 +384,7 @@ public class JavaClientGenerator extends AbstractJavaGenerator
         keywordValidatorFiles.add("AllOfValidator");
         keywordValidatorFiles.add("AnyOfValidator");
         keywordValidatorFiles.add("CustomIsoparser");
+        keywordValidatorFiles.add("EnumValidator");
         keywordValidatorFiles.add("ExclusiveMaximumValidator");
         keywordValidatorFiles.add("ExclusiveMinimumValidator");
         keywordValidatorFiles.add("FakeValidator");
@@ -1303,6 +1304,7 @@ public class JavaClientGenerator extends AbstractJavaGenerator
                         addAllOfValidator(schema, imports);
                         addAnyOfValidator(schema, imports);
                         addOneOfValidator(schema, imports);
+                        addEnumValidator(schema, imports);
                     }
                 } else if (schema.types.contains("null")) {
                     if (schema.isSimpleNull()) {
@@ -1318,6 +1320,7 @@ public class JavaClientGenerator extends AbstractJavaGenerator
                         addAllOfValidator(schema, imports);
                         addAnyOfValidator(schema, imports);
                         addOneOfValidator(schema, imports);
+                        addEnumValidator(schema, imports);
                     }
                 } else if (schema.types.contains("integer")) {
                     if (schema.isSimpleInteger()) {
@@ -1488,9 +1491,17 @@ public class JavaClientGenerator extends AbstractJavaGenerator
                 addAllOfValidator(schema, imports);
                 addAnyOfValidator(schema, imports);
                 addOneOfValidator(schema, imports);
+                addEnumValidator(schema, imports);
             }
         }
         return imports;
+    }
+
+    private void addEnumValidator(CodegenSchema schema, Set<String> imports) {
+        if (schema.enumInfo != null) {
+            imports.add("import "+packageName + ".schemas.validation.EnumValidator;");
+            imports.add("import java.util.Set;");
+        }
     }
 
     private void addUniqueItemsValidator(CodegenSchema schema, Set<String> imports) {
@@ -1662,6 +1673,7 @@ public class JavaClientGenerator extends AbstractJavaGenerator
         addAllOfValidator(schema, imports);
         addAnyOfValidator(schema, imports);
         addOneOfValidator(schema, imports);
+        addEnumValidator(schema, imports);
     }
 
     private void addStringSchemaImports(Set<String> imports, CodegenSchema schema) {
@@ -1680,6 +1692,7 @@ public class JavaClientGenerator extends AbstractJavaGenerator
         addAllOfValidator(schema, imports);
         addAnyOfValidator(schema, imports);
         addOneOfValidator(schema, imports);
+        addEnumValidator(schema, imports);
     }
 
 

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -409,6 +409,7 @@ public class JavaClientGenerator extends AbstractJavaGenerator
         keywordValidatorFiles.add("PropertyEntry");
         keywordValidatorFiles.add("RequiredValidator");
         keywordValidatorFiles.add("TypeValidator");
+        keywordValidatorFiles.add("UniqueItemsValidator");
         keywordValidatorFiles.add("UnsetAnyTypeJsonSchema");
         keywordValidatorFiles.add("ValidationMetadata");
         for (String keywordValidatorFile: keywordValidatorFiles) {
@@ -1483,12 +1484,19 @@ public class JavaClientGenerator extends AbstractJavaGenerator
                 addMaximumValidator(schema, imports);
                 addMinimumValidator(schema, imports);
                 addMultipleOfValidator(schema, imports);
+                addUniqueItemsValidator(schema, imports);
                 addAllOfValidator(schema, imports);
                 addAnyOfValidator(schema, imports);
                 addOneOfValidator(schema, imports);
             }
         }
         return imports;
+    }
+
+    private void addUniqueItemsValidator(CodegenSchema schema, Set<String> imports) {
+        if (schema.uniqueItems != null) {
+            imports.add("import "+packageName + ".schemas.validation.UniqueItemsValidator;");
+        }
     }
 
     private void addPropertiesValidator(CodegenSchema schema, Set<String> imports) {
@@ -1638,6 +1646,7 @@ public class JavaClientGenerator extends AbstractJavaGenerator
         addItemsValidator(schema, imports);
         addMaxItemsValidator(schema, imports);
         addMinItemsValidator(schema, imports);
+        addUniqueItemsValidator(schema, imports);
         addAllOfValidator(schema, imports);
         addAnyOfValidator(schema, imports);
         addOneOfValidator(schema, imports);

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -406,6 +406,7 @@ public class JavaClientGenerator extends AbstractJavaGenerator
         keywordValidatorFiles.add("MultipleOfValidator");
         keywordValidatorFiles.add("OneOfValidator");
         keywordValidatorFiles.add("PathToSchemasMap");
+        keywordValidatorFiles.add("PatternValidator");
         keywordValidatorFiles.add("PropertiesValidator");
         keywordValidatorFiles.add("PropertyEntry");
         keywordValidatorFiles.add("RequiredValidator");
@@ -1526,9 +1527,17 @@ public class JavaClientGenerator extends AbstractJavaGenerator
                 addAnyOfValidator(schema, imports);
                 addOneOfValidator(schema, imports);
                 addEnumValidator(schema, imports);
+                addPatternValidator(schema, imports);
             }
         }
         return imports;
+    }
+
+    private void addPatternValidator(CodegenSchema schema, Set<String> imports) {
+        if (schema.patternInfo != null) {
+            imports.add("import "+packageName + ".schemas.validation.PatternValidator;");
+            imports.add("import java.util.regex.Pattern;");
+        }
     }
 
     private void addEnumValidator(CodegenSchema schema, Set<String> imports) {
@@ -1727,6 +1736,7 @@ public class JavaClientGenerator extends AbstractJavaGenerator
         addAnyOfValidator(schema, imports);
         addOneOfValidator(schema, imports);
         addEnumValidator(schema, imports);
+        addPatternValidator(schema, imports);
     }
 
 

--- a/src/main/java/org/openapijsonschematools/codegen/generators/openapimodels/CodegenSchema.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/openapimodels/CodegenSchema.java
@@ -197,6 +197,9 @@ public class CodegenSchema {
         if (uniqueItems != null) {
             keywords.add("uniqueItems");
         }
+        if (enumInfo != null) {
+            keywords.add("enum");
+        }
         return keywords;
     }
 

--- a/src/main/java/org/openapijsonschematools/codegen/generators/openapimodels/CodegenSchema.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/openapimodels/CodegenSchema.java
@@ -200,6 +200,9 @@ public class CodegenSchema {
         if (enumInfo != null) {
             keywords.add("enum");
         }
+        if (patternInfo != null) {
+            keywords.add("pattern");
+        }
         return keywords;
     }
 

--- a/src/main/java/org/openapijsonschematools/codegen/generators/openapimodels/CodegenSchema.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/openapimodels/CodegenSchema.java
@@ -194,6 +194,9 @@ public class CodegenSchema {
         if (oneOf != null) {
             keywords.add("oneOf");
         }
+        if (uniqueItems != null) {
+            keywords.add("uniqueItems");
+        }
         return keywords;
     }
 

--- a/src/main/resources/java/src/main/java/org/openapitools/components/schemas/SchemaClass/_Schema_anytypeOrMultitype.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/components/schemas/SchemaClass/_Schema_anytypeOrMultitype.hbs
@@ -83,6 +83,9 @@ public static class {{jsonPathPiece.camelCase}} extends JsonSchema {
         {{#eq this "enum"}}
         {{> src/main/java/org/openapitools/components/schemas/SchemaClass/_enum }}
         {{/eq}}
+        {{#eq this "pattern"}}
+        {{> src/main/java/org/openapitools/components/schemas/SchemaClass/_pattern }}
+        {{/eq}}
         {{#if @last}}
     ));
         {{/if}}
@@ -98,9 +101,6 @@ public static class {{jsonPathPiece.camelCase}} extends JsonSchema {
 {{/if}}
 {{#if hasDiscriminatorWithNonEmptyMapping}}
     {{!> components/schemas/schema_cls/_discriminator }}
-{{/if}}
-{{#if patternInfo}}
-    {{!> components/schemas/schema_cls/_pattern }}
 {{/if}}
 {{#if not}}
     {{!> components/schemas/schema_cls/_not }}

--- a/src/main/resources/java/src/main/java/org/openapitools/components/schemas/SchemaClass/_Schema_anytypeOrMultitype.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/components/schemas/SchemaClass/_Schema_anytypeOrMultitype.hbs
@@ -80,13 +80,13 @@ public static class {{jsonPathPiece.camelCase}} extends JsonSchema {
         {{#eq this "uniqueItems"}}
         {{> src/main/java/org/openapitools/components/schemas/SchemaClass/_uniqueItems }}
         {{/eq}}
+        {{#eq this "enum"}}
+        {{> src/main/java/org/openapitools/components/schemas/SchemaClass/_enum }}
+        {{/eq}}
         {{#if @last}}
     ));
         {{/if}}
     {{/each}}
-{{#if enumInfo}}
-    {{!> components/schemas/schema_cls/_enum }}
-{{/if}}
 {{#if constInfo}}
     {{!> components/schemas/schema_cls/_const }}
 {{/if}}

--- a/src/main/resources/java/src/main/java/org/openapitools/components/schemas/SchemaClass/_Schema_anytypeOrMultitype.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/components/schemas/SchemaClass/_Schema_anytypeOrMultitype.hbs
@@ -77,6 +77,9 @@ public static class {{jsonPathPiece.camelCase}} extends JsonSchema {
         {{#eq this "oneOf"}}
         {{> src/main/java/org/openapitools/components/schemas/SchemaClass/_oneOf }}
         {{/eq}}
+        {{#eq this "uniqueItems"}}
+        {{> src/main/java/org/openapitools/components/schemas/SchemaClass/_uniqueItems }}
+        {{/eq}}
         {{#if @last}}
     ));
         {{/if}}
@@ -95,9 +98,6 @@ public static class {{jsonPathPiece.camelCase}} extends JsonSchema {
 {{/if}}
 {{#if hasDiscriminatorWithNonEmptyMapping}}
     {{!> components/schemas/schema_cls/_discriminator }}
-{{/if}}
-{{#if uniqueItems}}
-    {{!> components/schemas/schema_cls/_unique_items }}
 {{/if}}
 {{#if patternInfo}}
     {{!> components/schemas/schema_cls/_pattern }}

--- a/src/main/resources/java/src/main/java/org/openapitools/components/schemas/SchemaClass/_Schema_boolean.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/components/schemas/SchemaClass/_Schema_boolean.hbs
@@ -29,13 +29,13 @@ public static class {{jsonPathPiece.camelCase}} extends JsonSchema {
         {{#eq this "oneOf"}}
         {{> src/main/java/org/openapitools/components/schemas/SchemaClass/_oneOf }}
         {{/eq}}
+        {{#eq this "enum"}}
+        {{> src/main/java/org/openapitools/components/schemas/SchemaClass/_enum }}
+        {{/eq}}
         {{#if @last}}
     ));
         {{/if}}
     {{/each}}
-{{#if enumInfo}}
-    {{!> components/schemas/schema_cls/_enum }}
-{{/if}}
 {{#if constInfo}}
     {{!> components/schemas/schema_cls/_const }}
 {{/if}}

--- a/src/main/resources/java/src/main/java/org/openapitools/components/schemas/SchemaClass/_Schema_list.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/components/schemas/SchemaClass/_Schema_list.hbs
@@ -38,13 +38,13 @@ public static class {{jsonPathPiece.camelCase}} extends JsonSchema {
         {{#eq this "oneOf"}}
         {{> src/main/java/org/openapitools/components/schemas/SchemaClass/_oneOf }}
         {{/eq}}
+        {{#eq this "uniqueItems"}}
+        {{> src/main/java/org/openapitools/components/schemas/SchemaClass/_uniqueItems }}
+        {{/eq}}
         {{#if @last}}
     ));
         {{/if}}
     {{/each}}
-    {{#if uniqueItems}}
-    {{!> components/schemas/schema_cls/_unique_items }}
-    {{/if}}
     {{#if prefixItems}}
     {{!> components/schemas/schema_cls/_prefix_items }}
     {{/if}}

--- a/src/main/resources/java/src/main/java/org/openapitools/components/schemas/SchemaClass/_Schema_null.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/components/schemas/SchemaClass/_Schema_null.hbs
@@ -29,13 +29,13 @@ public static class {{jsonPathPiece.camelCase}} extends JsonSchema {
         {{#eq this "oneOf"}}
         {{> src/main/java/org/openapitools/components/schemas/SchemaClass/_oneOf }}
         {{/eq}}
+        {{#eq this "enum"}}
+        {{> src/main/java/org/openapitools/components/schemas/SchemaClass/_enum }}
+        {{/eq}}
         {{#if @last}}
     ));
         {{/if}}
     {{/each}}
-{{#if enumInfo}}
-    {{!> components/schemas/schema_cls/_enum }}
-{{/if}}
 {{#if constInfo}}
     {{!> components/schemas/schema_cls/_const }}
 {{/if}}

--- a/src/main/resources/java/src/main/java/org/openapitools/components/schemas/SchemaClass/_Schema_number.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/components/schemas/SchemaClass/_Schema_number.hbs
@@ -47,13 +47,13 @@ public static class {{jsonPathPiece.camelCase}} extends JsonSchema {
         {{#eq this "oneOf"}}
         {{> src/main/java/org/openapitools/components/schemas/SchemaClass/_oneOf }}
         {{/eq}}
+        {{#eq this "enum"}}
+        {{> src/main/java/org/openapitools/components/schemas/SchemaClass/_enum }}
+        {{/eq}}
         {{#if @last}}
     ));
         {{/if}}
     {{/each}}
-{{#if enumInfo}}
-    {{!> components/schemas/schema_cls/_enum }}
-{{/if}}
 {{#if constInfo}}
     {{!> components/schemas/schema_cls/_const }}
 {{/if}}

--- a/src/main/resources/java/src/main/java/org/openapitools/components/schemas/SchemaClass/_Schema_string.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/components/schemas/SchemaClass/_Schema_string.hbs
@@ -38,6 +38,9 @@ public static class {{jsonPathPiece.camelCase}} extends JsonSchema {
         {{#eq this "oneOf"}}
         {{> src/main/java/org/openapitools/components/schemas/SchemaClass/_oneOf }}
         {{/eq}}
+        {{#eq this "enum"}}
+        {{> src/main/java/org/openapitools/components/schemas/SchemaClass/_enum }}
+        {{/eq}}
         {{#if @last}}
     ));
         {{/if}}
@@ -47,9 +50,6 @@ public static class {{jsonPathPiece.camelCase}} extends JsonSchema {
 {{/if}}
 {{#if defaultValue}}
     {{!> components/schemas/schema_cls/_default }}
-{{/if}}
-{{#if enumInfo}}
-    {{!> components/schemas/schema_cls/_enum }}
 {{/if}}
 {{#if constInfo}}
     {{!> components/schemas/schema_cls/_const }}

--- a/src/main/resources/java/src/main/java/org/openapitools/components/schemas/SchemaClass/_Schema_string.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/components/schemas/SchemaClass/_Schema_string.hbs
@@ -41,13 +41,13 @@ public static class {{jsonPathPiece.camelCase}} extends JsonSchema {
         {{#eq this "enum"}}
         {{> src/main/java/org/openapitools/components/schemas/SchemaClass/_enum }}
         {{/eq}}
+        {{#eq this "pattern"}}
+        {{> src/main/java/org/openapitools/components/schemas/SchemaClass/_pattern }}
+        {{/eq}}
         {{#if @last}}
     ));
         {{/if}}
     {{/each}}
-{{#if patternInfo}}
-    {{!> components/schemas/schema_cls/_pattern }}
-{{/if}}
 {{#if defaultValue}}
     {{!> components/schemas/schema_cls/_default }}
 {{/if}}

--- a/src/main/resources/java/src/main/java/org/openapitools/components/schemas/SchemaClass/_enum.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/components/schemas/SchemaClass/_enum.hbs
@@ -5,7 +5,11 @@
         {{#eq type "string"}}
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"{{{value}}}"{{#unless @last}},{{/unless}}<br>
         {{~else}}
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{{value}}{{#unless @last}},{{/unless}}<br>
+            {{#eq type "null"}}
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;null{{#unless @last}},{{/unless}}
+            {{~else}}
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{{value}}{{#unless @last}},{{/unless}}
+            {{~/eq}}
         {{~/eq}}
     {{/with}}
     {{/each}}
@@ -17,7 +21,11 @@ new KeywordEntry("enum", new EnumValidator(Set.of(
         {{#eq type "string"}}
     "{{{value}}}"{{#unless @last}},{{/unless}}
         {{else}}
+            {{#eq type "null"}}
+    null{{#unless @last}},{{/unless}}
+            {{else}}
     {{value}}{{#unless @last}},{{/unless}}
+            {{/eq}}
         {{/eq}}
     {{/with}}
     {{/each}}

--- a/src/main/resources/java/src/main/java/org/openapitools/components/schemas/SchemaClass/_enum.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/components/schemas/SchemaClass/_enum.hbs
@@ -1,0 +1,17 @@
+{{#if forDocs}}
+&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>
+    {{~#each enumInfo}}
+    {{#with @key}}
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{{value}}{{#unless @last}},{{/unless}}<br>
+    {{~/with}}
+    {{/each}}
+))){{#unless @last}},{{/unless}}<br>
+{{~else}}
+new KeywordEntry("enum", new EnumValidator(Set.of(
+    {{#each enumInfo}}
+    {{#with @key}}
+    {{value}}{{#unless @last}},{{/unless}}
+    {{/with}}
+    {{/each}}
+))){{#unless @last}},{{/unless}}
+{{/if}}

--- a/src/main/resources/java/src/main/java/org/openapitools/components/schemas/SchemaClass/_enum.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/components/schemas/SchemaClass/_enum.hbs
@@ -1,16 +1,24 @@
 {{#if forDocs}}
 &nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("enum", new EnumValidator(Set.of(<br>
-    {{~#each enumInfo}}
+    {{~#each enumInfo.valueToName}}
     {{#with @key}}
+        {{#eq type "string"}}
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"{{{value}}}"{{#unless @last}},{{/unless}}<br>
+        {{~else}}
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{{value}}{{#unless @last}},{{/unless}}<br>
-    {{~/with}}
+        {{~/eq}}
+    {{/with}}
     {{/each}}
 ))){{#unless @last}},{{/unless}}<br>
 {{~else}}
 new KeywordEntry("enum", new EnumValidator(Set.of(
-    {{#each enumInfo}}
+    {{#each enumInfo.valueToName}}
     {{#with @key}}
+        {{#eq type "string"}}
+    "{{{value}}}"{{#unless @last}},{{/unless}}
+        {{else}}
     {{value}}{{#unless @last}},{{/unless}}
+        {{/eq}}
     {{/with}}
     {{/each}}
 ))){{#unless @last}},{{/unless}}

--- a/src/main/resources/java/src/main/java/org/openapitools/components/schemas/SchemaClass/_pattern.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/components/schemas/SchemaClass/_pattern.hbs
@@ -1,0 +1,57 @@
+{{#if forDocs}}
+&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("pattern", new PatternValidator(<br>
+    {{~#with patternInfo}}
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"{{{pattern}}}"{{#if flags}},{{/if}}<br>
+        {{~#if flags}}
+            {{#eq flags.size 1}}
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{{#each flags}}Pattern.{{#eq this "i"}}CASE_INSENSITIVE{{/eq}}{{#eq this "m"}}MULTILINE{{/eq}}{{#eq this "s"}}DOTALL{{/eq}}{{#eq this "u"}}UNICODE_CHARACTER_CLASS{{/eq}}{{/each}},<br>
+            {{~else}}
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(<br>
+                {{~#each flags}}
+                    {{#eq this "i"}}
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Pattern.CASE_INSENSITIVE{{#unless @last}} |{{/unless}}<br>
+                    {{~/eq}}
+                    {{#eq this "m"}}
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Pattern.MULTILINE{{#unless @last}} |{{/unless}}<br>
+                    {{~/eq}}
+                    {{#eq this "s"}}
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Pattern.DOTALL{{#unless @last}} |{{/unless}}<br>
+                    {{~/eq}}
+                    {{#eq this "u"}}
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Pattern.UNICODE_CHARACTER_CLASS{{#unless @last}} |{{/unless}}<br>
+                    {{~/eq}}
+                {{/each}}
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;)<br>
+            {{~/eq}}
+        {{/if}}
+    {{/with}}
+&nbsp;&nbsp;&nbsp;&nbsp;))){{#unless @last}},{{/unless}}<br>
+{{~else}}
+new KeywordEntry("pattern", new PatternValidator(Pattern.compile(
+    {{#with patternInfo}}
+    "{{{pattern}}}"{{#if flags}},{{/if}}
+        {{#if flags}}
+            {{#eq flags.size 1}}
+    {{#each flags}}Pattern.{{#eq this "i"}}CASE_INSENSITIVE{{/eq}}{{#eq this "m"}}MULTILINE{{/eq}}{{#eq this "s"}}DOTALL{{/eq}}{{#eq this "u"}}UNICODE_CHARACTER_CLASS{{/eq}}{{/each}},
+            {{else}}
+    (
+                {{#each flags}}
+                    {{#eq this "i"}}
+        Pattern.CASE_INSENSITIVE{{#unless @last}} |{{/unless}}
+                    {{/eq}}
+                    {{#eq this "m"}}
+        Pattern.MULTILINE{{#unless @last}} |{{/unless}}
+                    {{/eq}}
+                    {{#eq this "s"}}
+        Pattern.DOTALL{{#unless @last}} |{{/unless}}
+                    {{/eq}}
+                    {{#eq this "u"}}
+        Pattern.UNICODE_CHARACTER_CLASS{{#unless @last}} |{{/unless}}
+                    {{/eq}}
+                {{/each}}
+    )
+            {{/eq}}
+        {{/if}}
+    {{/with}}
+))){{#unless @last}},{{/unless}}
+{{/if}}

--- a/src/main/resources/java/src/main/java/org/openapitools/components/schemas/SchemaClass/_uniqueItems.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/components/schemas/SchemaClass/_uniqueItems.hbs
@@ -1,0 +1,5 @@
+{{#if forDocs}}
+&nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("uniqueItems", new UniqueItemsValidator({{uniqueItems}})){{#unless @last}},{{/unless}}<br>
+{{~else}}
+new KeywordEntry("uniqueItems", new UniqueItemsValidator({{uniqueItems}})){{#unless @last}},{{/unless}}
+{{/if}}

--- a/src/main/resources/java/src/main/java/org/openapitools/components/schemas/docschema_fields_field.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/components/schemas/docschema_fields_field.hbs
@@ -65,6 +65,9 @@
     {{#eq this "uniqueItems"}}
 {{> src/main/java/org/openapitools/components/schemas/SchemaClass/_uniqueItems }}
     {{~/eq}}
+    {{#eq this "enum"}}
+{{> src/main/java/org/openapitools/components/schemas/SchemaClass/_enum }}
+    {{~/eq}}
     {{#if @last ~}}
 )); |
     {{/if}}

--- a/src/main/resources/java/src/main/java/org/openapitools/components/schemas/docschema_fields_field.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/components/schemas/docschema_fields_field.hbs
@@ -68,6 +68,9 @@
     {{#eq this "enum"}}
 {{> src/main/java/org/openapitools/components/schemas/SchemaClass/_enum }}
     {{~/eq}}
+    {{#eq this "pattern"}}
+{{> src/main/java/org/openapitools/components/schemas/SchemaClass/_pattern }}
+    {{~/eq}}
     {{#if @last ~}}
 )); |
     {{/if}}

--- a/src/main/resources/java/src/main/java/org/openapitools/components/schemas/docschema_fields_field.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/components/schemas/docschema_fields_field.hbs
@@ -62,6 +62,9 @@
     {{#eq this "oneOf"}}
 {{> src/main/java/org/openapitools/components/schemas/SchemaClass/_oneOf }}
     {{~/eq}}
+    {{#eq this "uniqueItems"}}
+{{> src/main/java/org/openapitools/components/schemas/SchemaClass/_uniqueItems }}
+    {{~/eq}}
     {{#if @last ~}}
 )); |
     {{/if}}

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/EnumValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/EnumValidator.hbs
@@ -1,0 +1,29 @@
+package {{{packageName}}}.schemas.validation;
+
+import {{{packageName}}}.exceptions.ValidationException;
+
+import java.util.Set;
+
+public class EnumValidator implements KeywordValidator {
+    public final Set<Object> enumValues;
+
+    public EnumValidator(Set<Object> enumValues) {
+        this.enumValues = enumValues;
+    }
+
+    @Override
+    public Object getConstraint() {
+        return enumValues;
+    }
+
+    @Override
+    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+        if (enumValues.isEmpty()) {
+            throw new ValidationException("No value can match enum because enum is empty");
+        }
+        if (!enumValues.contains(arg)) {
+            throw new ValidationException("Invalid value "+arg+" was not one of the allowed enum "+enumValues);
+        }
+        return null;
+    }
+}

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/ExclusiveMaximumValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/ExclusiveMaximumValidator.hbs
@@ -1,4 +1,4 @@
-package org.openapijsonschematools.schemas.validation;
+package {{{packageName}}}.schemas.validation;
 
 import {{{packageName}}}.exceptions.ValidationException;
 

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/ExclusiveMinimumValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/ExclusiveMinimumValidator.hbs
@@ -1,4 +1,4 @@
-package org.openapijsonschematools.schemas.validation;
+package {{{packageName}}}.schemas.validation;
 
 import {{{packageName}}}.exceptions.ValidationException;
 

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/FakeValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/FakeValidator.hbs
@@ -1,4 +1,4 @@
-package org.openapijsonschematools.schemas.validation;
+package {{{packageName}}}.schemas.validation;
 
 public class FakeValidator implements KeywordValidator {
     @Override

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/MaximumValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/MaximumValidator.hbs
@@ -1,4 +1,4 @@
-package org.openapijsonschematools.schemas.validation;
+package {{{packageName}}}.schemas.validation;
 
 import {{{packageName}}}.exceptions.ValidationException;
 

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/MinimumValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/MinimumValidator.hbs
@@ -1,4 +1,4 @@
-package org.openapijsonschematools.schemas.validation;
+package {{{packageName}}}.schemas.validation;
 
 import {{{packageName}}}.exceptions.ValidationException;
 

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/MultipleOfValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/MultipleOfValidator.hbs
@@ -1,4 +1,4 @@
-package org.openapijsonschematools.schemas.validation;
+package {{{packageName}}}.schemas.validation;
 
 import {{{packageName}}}.exceptions.ValidationException;
 

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/OneOfValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/OneOfValidator.hbs
@@ -25,7 +25,7 @@ public class OneOfValidator implements KeywordValidator {
             if (oneOfClass == cls) {
                 /*
                 optimistically assume that cls schema will pass validation
-                do not invoke _validate on it because that is recursive
+                do not invoke validate on it because that is recursive
                 */
                 validatedOneOfClasses.add(oneOfClass);
                 continue;
@@ -38,12 +38,12 @@ public class OneOfValidator implements KeywordValidator {
                 // silence exceptions because the code needs to accumulate validatedOneOfClasses
             }
         }
-        if (validatedAnyOfClasses.isEmpty()) {
+        if (validatedOneOfClasses.isEmpty()) {
             throw new ValidationException("Invalid inputs given to generate an instance of "+cls+". None "+
                     "of the oneOf schemas matched the input data."
             );
         }
-        if (validatedAnyOfClasses.size() > 1) {
+        if (validatedOneOfClasses.size() > 1) {
             throw new ValidationException("Invalid inputs given to generate an instance of "+cls+". Multiple "+
                     "oneOf schemas validated the data, but a max of one is allowed."
             );

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/PatternValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/PatternValidator.hbs
@@ -1,0 +1,29 @@
+package {{{packageName}}}.schemas.validation;
+
+import {{{packageName}}}.exceptions.ValidationException;
+
+import java.util.regex.Pattern;
+
+public class PatternValidator implements KeywordValidator {
+    public final Pattern pattern;
+
+    public PatternValidator(Pattern pattern) {
+        this.pattern = pattern;
+    }
+
+    @Override
+    public Object getConstraint() {
+        return pattern;
+    }
+
+    @Override
+    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+        if (!(arg instanceof String)) {
+            return null;
+        }
+        if (!pattern.matcher((String) arg).find()) {
+            throw new ValidationException("Invalid value "+arg+" did not find a match for pattern "+pattern);
+        }
+        return null;
+    }
+}

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/RequiredValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/RequiredValidator.hbs
@@ -1,4 +1,4 @@
-package org.openapijsonschematools.schemas.validation;
+package {{{packageName}}}.schemas.validation;
 
 import {{{packageName}}}.exceptions.ValidationException;
 

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/UniqueItemsValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/UniqueItemsValidator.hbs
@@ -15,7 +15,7 @@ public class UniqueItemsValidator implements KeywordValidator {
 
     @Override
     public Object getConstraint() {
-        return true;
+        return uniqueItems;
     }
 
     @Override

--- a/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/UniqueItemsValidator.hbs
+++ b/src/main/resources/java/src/main/java/org/openapitools/schemas/validation/UniqueItemsValidator.hbs
@@ -1,0 +1,39 @@
+package {{{packageName}}}.schemas.validation;
+
+import {{{packageName}}}.exceptions.ValidationException;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class UniqueItemsValidator implements KeywordValidator {
+    public final boolean uniqueItems;
+
+    public UniqueItemsValidator(boolean uniqueItems) {
+        this.uniqueItems = uniqueItems;
+    }
+
+    @Override
+    public Object getConstraint() {
+        return true;
+    }
+
+    @Override
+    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+        if (!(arg instanceof List)) {
+            return null;
+        }
+        if (!uniqueItems) {
+            return null;
+        }
+        Set<Object> seenItems = new HashSet<>();
+        for (Object item: (List<?>) arg) {
+            int startingSeenItemsSize = seenItems.size();
+            seenItems.add(item);
+            if (seenItems.size() == startingSeenItemsSize) {
+                throw new ValidationException("Invalid list value, list contains duplicate items when uniqueItems is true");
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
Java: adds more validators
- UniqueItems
- Enum
- Pattern

All of the openapi v3.0.0 validators have now been added to java except for the discriminator validator
Note: these will be verified with testing later when integrating the json schema test suite spec into the java generator

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
