### PR TITLE
Java, tests java clients in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,6 +146,17 @@ jobs:
       - checkout
       - command_docker_build_and_test:
           jobId: "testPythonClientSamples"
+  testJavaClientSamples:
+    machine:
+      image: ubuntu-2004:202201-02
+    working_directory: ~/OpenAPITools/openapi-json-schema-generator
+    shell: /bin/bash --login
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+    steps:
+      - command_build_and_test:
+          jobId: "testJavaClientSamples"
 workflows:
   version: 2
   build:
@@ -154,3 +165,4 @@ workflows:
       - mvnCleanInstall
       - testPython38ClientSamples
       - testPython39ClientSamples
+      - testJavaClientSamples

--- a/.circleci/parallel.sh
+++ b/.circleci/parallel.sh
@@ -25,6 +25,13 @@ elif [ "$JOB_ID" = "testPythonClientSamples" ]; then
   (cd samples/client/openapi_features/nonCompliantUseDiscriminatorIfCompositionFails/python && make test)
   (cd samples/client/openapi_features/security/python && make test)
 
+elif [ "$JOB_ID" = "testJavaClientSamples" ]; then
+  echo "Running job $JOB_ID ..."
+  java -version
+
+  (cd samples/client/petstore/java && mvn test)
+  (cd samples/client/3_0_3_unit_test/java && mvn test)
+
 else
   echo "Running job $JOB_ID"
 


### PR DESCRIPTION
Java, tests java clients in CI

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
