### PR TITLE
Java, improves schema docs, adds missing inherited validate

### DIFF
--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/Allof.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/Allof.md
@@ -144,4 +144,8 @@ extends IntJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.IntJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/AllofWithBaseSchema.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/AllofWithBaseSchema.md
@@ -68,6 +68,10 @@ extends IntJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.IntJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 ## Schema1
 public static class Schema1<br>
 extends JsonSchema

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/AllofWithTheFirstEmptySchema.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/AllofWithTheFirstEmptySchema.md
@@ -40,6 +40,10 @@ extends NumberJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.NumberJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 ## Schema0
 public static class Schema0<br>
 extends AnyTypeJsonSchema

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/AllofWithTheLastEmptySchema.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/AllofWithTheLastEmptySchema.md
@@ -50,4 +50,8 @@ extends NumberJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.NumberJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/Anyof.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/Anyof.md
@@ -63,4 +63,8 @@ extends IntJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.IntJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/AnyofComplexTypes.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/AnyofComplexTypes.md
@@ -144,4 +144,8 @@ extends IntJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.IntJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/AnyofWithOneEmptySchema.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/AnyofWithOneEmptySchema.md
@@ -50,4 +50,8 @@ extends NumberJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.NumberJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/IntegerTypeMatchesIntegers.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/IntegerTypeMatchesIntegers.md
@@ -15,4 +15,8 @@ extends IntJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.IntJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/NestedItems.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/NestedItems.md
@@ -159,4 +159,8 @@ extends NumberJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.NumberJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/Not.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/Not.md
@@ -39,4 +39,8 @@ extends IntJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.IntJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/NumberTypeMatchesNumbers.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/NumberTypeMatchesNumbers.md
@@ -15,4 +15,8 @@ extends NumberJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.NumberJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/ObjectPropertiesValidation.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/ObjectPropertiesValidation.md
@@ -75,4 +75,8 @@ extends IntJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.IntJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/Oneof.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/Oneof.md
@@ -63,4 +63,8 @@ extends IntJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.IntJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/OneofComplexTypes.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/OneofComplexTypes.md
@@ -144,4 +144,8 @@ extends IntJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.IntJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/OneofWithEmptySchema.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/OneofWithEmptySchema.md
@@ -50,4 +50,8 @@ extends NumberJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.NumberJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/PropertiesWithEscapedCharacters.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/PropertiesWithEscapedCharacters.md
@@ -72,11 +72,19 @@ extends NumberJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.NumberJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 ## Footbar
 public static class Footbar<br>
 extends NumberJsonSchema
 
 A schema class that validates payloads
+
+| Methods Inherited from class org.openapijsonschematools.client.schemas.NumberJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
 
 ## Foorbar
 public static class Foorbar<br>
@@ -84,11 +92,19 @@ extends NumberJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.NumberJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 ## Foobar1
 public static class Foobar1<br>
 extends NumberJsonSchema
 
 A schema class that validates payloads
+
+| Methods Inherited from class org.openapijsonschematools.client.schemas.NumberJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
 
 ## Foobar
 public static class Foobar<br>
@@ -96,10 +112,18 @@ extends NumberJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.NumberJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 ## Foonbar
 public static class Foonbar<br>
 extends NumberJsonSchema
 
 A schema class that validates payloads
+
+| Methods Inherited from class org.openapijsonschematools.client.schemas.NumberJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/java/docs/components/headers/int32jsoncontenttypeheader/content/applicationjson/Int32JsonContentTypeHeaderSchema.md
+++ b/samples/client/petstore/java/docs/components/headers/int32jsoncontenttypeheader/content/applicationjson/Int32JsonContentTypeHeaderSchema.md
@@ -14,3 +14,7 @@ public static class Int32JsonContentTypeHeaderSchema1<br>
 extends Int32JsonSchema
 
 A schema class that validates payloads
+
+| Methods Inherited from class org.openapijsonschematools.client.schemas.Int32JsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |

--- a/samples/client/petstore/java/docs/components/responses/successinlinecontentandheader/content/applicationjson/Schema.md
+++ b/samples/client/petstore/java/docs/components/responses/successinlinecontentandheader/content/applicationjson/Schema.md
@@ -51,3 +51,7 @@ public static class AdditionalProperties<br>
 extends Int32JsonSchema
 
 A schema class that validates payloads
+
+| Methods Inherited from class org.openapijsonschematools.client.schemas.Int32JsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |

--- a/samples/client/petstore/java/docs/components/schemas/Address.md
+++ b/samples/client/petstore/java/docs/components/schemas/Address.md
@@ -52,4 +52,8 @@ extends IntJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.IntJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/java/docs/components/schemas/ApiResponseSchema.md
+++ b/samples/client/petstore/java/docs/components/schemas/ApiResponseSchema.md
@@ -80,4 +80,8 @@ extends Int32JsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.Int32JsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/java/docs/components/schemas/ArrayOfArrayOfNumberOnly.md
+++ b/samples/client/petstore/java/docs/components/schemas/ArrayOfArrayOfNumberOnly.md
@@ -126,4 +126,8 @@ extends NumberJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.NumberJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/java/docs/components/schemas/ArrayOfNumberOnly.md
+++ b/samples/client/petstore/java/docs/components/schemas/ArrayOfNumberOnly.md
@@ -90,4 +90,8 @@ extends NumberJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.NumberJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/java/docs/components/schemas/ArrayTest.md
+++ b/samples/client/petstore/java/docs/components/schemas/ArrayTest.md
@@ -205,6 +205,10 @@ extends Int64JsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.Int64JsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 ## ArrayOfString
 public static class ArrayOfString<br>
 extends JsonSchema

--- a/samples/client/petstore/java/docs/components/schemas/Banana.md
+++ b/samples/client/petstore/java/docs/components/schemas/Banana.md
@@ -54,4 +54,8 @@ extends NumberJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.NumberJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/java/docs/components/schemas/BananaReq.md
+++ b/samples/client/petstore/java/docs/components/schemas/BananaReq.md
@@ -66,6 +66,10 @@ extends NumberJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.NumberJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 ## AdditionalProperties
 public static class AdditionalProperties<br>
 extends NotAnyTypeJsonSchema

--- a/samples/client/petstore/java/docs/components/schemas/Category.md
+++ b/samples/client/petstore/java/docs/components/schemas/Category.md
@@ -72,4 +72,8 @@ extends Int64JsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.Int64JsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/java/docs/components/schemas/ComposedAnyOfDifferentTypesNoValidations.md
+++ b/samples/client/petstore/java/docs/components/schemas/ComposedAnyOfDifferentTypesNoValidations.md
@@ -56,17 +56,29 @@ extends Int64JsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.Int64JsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 ## Schema14
 public static class Schema14<br>
 extends Int32JsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.Int32JsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 ## Schema13
 public static class Schema13<br>
 extends IntJsonSchema
 
 A schema class that validates payloads
+
+| Methods Inherited from class org.openapijsonschematools.client.schemas.IntJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
 
 ## Schema12
 public static class Schema12<br>

--- a/samples/client/petstore/java/docs/components/schemas/ComposedAnyOfDifferentTypesNoValidations.md
+++ b/samples/client/petstore/java/docs/components/schemas/ComposedAnyOfDifferentTypesNoValidations.md
@@ -86,17 +86,29 @@ extends DoubleJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.DoubleJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 ## Schema11
 public static class Schema11<br>
 extends FloatJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.FloatJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 ## Schema10
 public static class Schema10<br>
 extends NumberJsonSchema
 
 A schema class that validates payloads
+
+| Methods Inherited from class org.openapijsonschematools.client.schemas.NumberJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
 
 ## Schema9
 public static class Schema9<br>

--- a/samples/client/petstore/java/docs/components/schemas/FormatTest.md
+++ b/samples/client/petstore/java/docs/components/schemas/FormatTest.md
@@ -272,11 +272,19 @@ extends NumberJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.NumberJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 ## Float64
 public static class Float64<br>
 extends DoubleJsonSchema
 
 A schema class that validates payloads
+
+| Methods Inherited from class org.openapijsonschematools.client.schemas.DoubleJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
 
 ## DoubleSchema
 public static class DoubleSchema<br>
@@ -298,6 +306,10 @@ public static class Float32<br>
 extends FloatJsonSchema
 
 A schema class that validates payloads
+
+| Methods Inherited from class org.openapijsonschematools.client.schemas.FloatJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
 
 ## FloatSchema
 public static class FloatSchema<br>

--- a/samples/client/petstore/java/docs/components/schemas/FormatTest.md
+++ b/samples/client/petstore/java/docs/components/schemas/FormatTest.md
@@ -338,6 +338,10 @@ extends Int64JsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.Int64JsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 ## Int32withValidations
 public static class Int32withValidations<br>
 extends JsonSchema
@@ -358,6 +362,10 @@ public static class Int32<br>
 extends Int32JsonSchema
 
 A schema class that validates payloads
+
+| Methods Inherited from class org.openapijsonschematools.client.schemas.Int32JsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
 
 ## IntegerSchema
 public static class IntegerSchema<br>

--- a/samples/client/petstore/java/docs/components/schemas/FromSchema.md
+++ b/samples/client/petstore/java/docs/components/schemas/FromSchema.md
@@ -57,6 +57,10 @@ extends IntJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.IntJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 ## Data
 public static class Data<br>
 extends StringJsonSchema

--- a/samples/client/petstore/java/docs/components/schemas/Name.md
+++ b/samples/client/petstore/java/docs/components/schemas/Name.md
@@ -84,10 +84,18 @@ extends Int32JsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.Int32JsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 ## Name2
 public static class Name2<br>
 extends Int32JsonSchema
 
 A schema class that validates payloads
+
+| Methods Inherited from class org.openapijsonschematools.client.schemas.Int32JsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/java/docs/components/schemas/NoAdditionalProperties.md
+++ b/samples/client/petstore/java/docs/components/schemas/NoAdditionalProperties.md
@@ -56,11 +56,19 @@ extends Int64JsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.Int64JsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 ## Id
 public static class Id<br>
 extends Int64JsonSchema
 
 A schema class that validates payloads
+
+| Methods Inherited from class org.openapijsonschematools.client.schemas.Int64JsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
 
 ## AdditionalProperties
 public static class AdditionalProperties<br>

--- a/samples/client/petstore/java/docs/components/schemas/NumberOnly.md
+++ b/samples/client/petstore/java/docs/components/schemas/NumberOnly.md
@@ -54,4 +54,8 @@ extends NumberJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.NumberJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/java/docs/components/schemas/NumberSchema.md
+++ b/samples/client/petstore/java/docs/components/schemas/NumberSchema.md
@@ -15,4 +15,8 @@ extends NumberJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.NumberJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/java/docs/components/schemas/ObjectWithDifficultlyNamedProps.md
+++ b/samples/client/petstore/java/docs/components/schemas/ObjectWithDifficultlyNamedProps.md
@@ -61,6 +61,10 @@ extends IntJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.IntJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 ## Schema123list
 public static class Schema123list<br>
 extends StringJsonSchema
@@ -76,5 +80,9 @@ public static class Specialpropertyname<br>
 extends Int64JsonSchema
 
 A schema class that validates payloads
+
+| Methods Inherited from class org.openapijsonschematools.client.schemas.Int64JsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/java/docs/components/schemas/ObjectWithNonIntersectingValues.md
+++ b/samples/client/petstore/java/docs/components/schemas/ObjectWithNonIntersectingValues.md
@@ -55,6 +55,10 @@ extends NumberJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.NumberJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 ## AdditionalProperties
 public static class AdditionalProperties<br>
 extends StringJsonSchema

--- a/samples/client/petstore/java/docs/components/schemas/ObjectWithOnlyOptionalProps.md
+++ b/samples/client/petstore/java/docs/components/schemas/ObjectWithOnlyOptionalProps.md
@@ -56,6 +56,10 @@ extends NumberJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.NumberJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 ## A
 public static class A<br>
 extends StringJsonSchema

--- a/samples/client/petstore/java/docs/components/schemas/Order.md
+++ b/samples/client/petstore/java/docs/components/schemas/Order.md
@@ -107,16 +107,28 @@ extends Int32JsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.Int32JsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 ## PetId
 public static class PetId<br>
 extends Int64JsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.Int64JsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 ## Id
 public static class Id<br>
 extends Int64JsonSchema
 
 A schema class that validates payloads
+
+| Methods Inherited from class org.openapijsonschematools.client.schemas.Int64JsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/java/docs/components/schemas/PaginatedResultMyObjectDto.md
+++ b/samples/client/petstore/java/docs/components/schemas/PaginatedResultMyObjectDto.md
@@ -91,6 +91,10 @@ extends IntJsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.IntJsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 ## AdditionalProperties
 public static class AdditionalProperties<br>
 extends NotAnyTypeJsonSchema

--- a/samples/client/petstore/java/docs/components/schemas/Pet.md
+++ b/samples/client/petstore/java/docs/components/schemas/Pet.md
@@ -180,4 +180,8 @@ extends Int64JsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.Int64JsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/java/docs/components/schemas/ReturnSchema.md
+++ b/samples/client/petstore/java/docs/components/schemas/ReturnSchema.md
@@ -68,4 +68,8 @@ A schema class that validates payloads
 ## Description
 this is a reserved python keyword
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.Int32JsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/java/docs/components/schemas/Schema200Response.md
+++ b/samples/client/petstore/java/docs/components/schemas/Schema200Response.md
@@ -81,4 +81,8 @@ extends Int32JsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.Int32JsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/java/docs/components/schemas/Tag.md
+++ b/samples/client/petstore/java/docs/components/schemas/Tag.md
@@ -67,4 +67,8 @@ extends Int64JsonSchema
 
 A schema class that validates payloads
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.Int64JsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/java/docs/components/schemas/User.md
+++ b/samples/client/petstore/java/docs/components/schemas/User.md
@@ -188,6 +188,10 @@ A schema class that validates payloads
 ## Description
 User Status
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.Int32JsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 ## Phone
 public static class Phone<br>
 extends StringJsonSchema
@@ -253,5 +257,9 @@ public static class Id<br>
 extends Int64JsonSchema
 
 A schema class that validates payloads
+
+| Methods Inherited from class org.openapijsonschematools.client.schemas.Int64JsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
 
 [[Back to top]](#top) [[Back to Component Schemas]](../../../README.md#Component-Schemas) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/java/docs/paths/fake/delete/parameters/parameter2/Schema2.md
+++ b/samples/client/petstore/java/docs/paths/fake/delete/parameters/parameter2/Schema2.md
@@ -14,3 +14,7 @@ public static class Schema21<br>
 extends Int64JsonSchema
 
 A schema class that validates payloads
+
+| Methods Inherited from class org.openapijsonschematools.client.schemas.Int64JsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |

--- a/samples/client/petstore/java/docs/paths/fake/delete/parameters/parameter5/Schema5.md
+++ b/samples/client/petstore/java/docs/paths/fake/delete/parameters/parameter5/Schema5.md
@@ -14,3 +14,7 @@ public static class Schema51<br>
 extends Int64JsonSchema
 
 A schema class that validates payloads
+
+| Methods Inherited from class org.openapijsonschematools.client.schemas.Int64JsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |

--- a/samples/client/petstore/java/docs/paths/fake/post/requestbody/content/applicationxwwwformurlencoded/Schema.md
+++ b/samples/client/petstore/java/docs/paths/fake/post/requestbody/content/applicationxwwwformurlencoded/Schema.md
@@ -261,6 +261,10 @@ A schema class that validates payloads
 ## Description
 None
 
+| Methods Inherited from class org.openapijsonschematools.client.schemas.Int64JsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+
 ## Int32
 public static class Int32<br>
 extends JsonSchema

--- a/samples/client/petstore/java/docs/paths/fakepetiduploadimagewithrequiredfile/post/parameters/parameter0/Schema0.md
+++ b/samples/client/petstore/java/docs/paths/fakepetiduploadimagewithrequiredfile/post/parameters/parameter0/Schema0.md
@@ -14,3 +14,7 @@ public static class Schema01<br>
 extends Int64JsonSchema
 
 A schema class that validates payloads
+
+| Methods Inherited from class org.openapijsonschematools.client.schemas.Int64JsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |

--- a/samples/client/petstore/java/docs/paths/petpetid/delete/parameters/parameter1/Schema1.md
+++ b/samples/client/petstore/java/docs/paths/petpetid/delete/parameters/parameter1/Schema1.md
@@ -14,3 +14,7 @@ public static class Schema11<br>
 extends Int64JsonSchema
 
 A schema class that validates payloads
+
+| Methods Inherited from class org.openapijsonschematools.client.schemas.Int64JsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |

--- a/samples/client/petstore/java/docs/paths/petpetid/get/parameters/parameter0/Schema0.md
+++ b/samples/client/petstore/java/docs/paths/petpetid/get/parameters/parameter0/Schema0.md
@@ -14,3 +14,7 @@ public static class Schema01<br>
 extends Int64JsonSchema
 
 A schema class that validates payloads
+
+| Methods Inherited from class org.openapijsonschematools.client.schemas.Int64JsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |

--- a/samples/client/petstore/java/docs/paths/petpetid/post/parameters/parameter0/Schema0.md
+++ b/samples/client/petstore/java/docs/paths/petpetid/post/parameters/parameter0/Schema0.md
@@ -14,3 +14,7 @@ public static class Schema01<br>
 extends Int64JsonSchema
 
 A schema class that validates payloads
+
+| Methods Inherited from class org.openapijsonschematools.client.schemas.Int64JsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |

--- a/samples/client/petstore/java/docs/paths/petpetiduploadimage/post/parameters/parameter0/Schema0.md
+++ b/samples/client/petstore/java/docs/paths/petpetiduploadimage/post/parameters/parameter0/Schema0.md
@@ -14,3 +14,7 @@ public static class Schema01<br>
 extends Int64JsonSchema
 
 A schema class that validates payloads
+
+| Methods Inherited from class org.openapijsonschematools.client.schemas.Int64JsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |

--- a/samples/client/petstore/java/docs/paths/userlogin/get/responses/response200/headers/xratelimit/content/applicationjson/XRateLimitSchema.md
+++ b/samples/client/petstore/java/docs/paths/userlogin/get/responses/response200/headers/xratelimit/content/applicationjson/XRateLimitSchema.md
@@ -14,3 +14,7 @@ public static class XRateLimitSchema1<br>
 extends Int32JsonSchema
 
 A schema class that validates payloads
+
+| Methods Inherited from class org.openapijsonschematools.client.schemas.Int32JsonSchema |
+| ------------------------------------------------------------------ |
+| validate                                                           |

--- a/src/main/resources/java/src/main/java/packagename/components/schemas/_docschema_methodsInherited.hbs
+++ b/src/main/resources/java/src/main/java/packagename/components/schemas/_docschema_methodsInherited.hbs
@@ -42,7 +42,7 @@
                                     {{/eq}}
                                 {{/and}}
                             {{else}}
-                                {{#if eq this "number" }}
+                                {{#eq this "number" }}
                                     {{#and isSimpleNumber (eq ../refInfo null) }}
                                     {{#eq ../format null}}
 {{> src/main/java/packagename/components/schemas/_docschema_methodsInheritedFn className="NumberJsonSchema" }}
@@ -88,7 +88,7 @@
 {{> src/main/java/packagename/components/schemas/_docschema_methodsInheritedFn className="NumberJsonSchema" }}
                                         {{/and}}
                                     {{/eq}}
-                                {{/if}}
+                                {{/eq}}
                             {{/eq}}
                         {{/eq}}
                     {{/eq}}

--- a/src/main/resources/java/src/main/java/packagename/components/schemas/_docschema_methodsInherited.hbs
+++ b/src/main/resources/java/src/main/java/packagename/components/schemas/_docschema_methodsInherited.hbs
@@ -6,7 +6,7 @@
     {{/if}}
 {{else}}
     {{#eq types null }}
-        {{#and isSimpleAnyType (eq ../refInfo null) }}
+        {{#and isSimpleAnyType (eq refInfo null) }}
 {{> src/main/java/packagename/components/schemas/_docschema_methodsInheritedFn className="AnyTypeJsonSchema" }}
         {{/and}}
     {{else}}
@@ -29,7 +29,7 @@
 {{> src/main/java/packagename/components/schemas/_docschema_methodsInheritedFn className="BooleanJsonSchema" }}
                             {{/and}}
                         {{else}}
-                            {{#if eq this "integer" }}
+                            {{#eq this "integer" }}
                                 {{#and isSimpleInteger (eq ../refInfo null) }}
                                     {{#eq ../format null }}
 {{> src/main/java/packagename/components/schemas/_docschema_methodsInheritedFn className="IntJsonSchema" }}
@@ -89,7 +89,7 @@
                                         {{/and}}
                                     {{/eq}}
                                 {{/if}}
-                            {{/if}}
+                            {{/eq}}
                         {{/eq}}
                     {{/eq}}
                 {{/eq}}


### PR DESCRIPTION
improves schema docs, adds missing inherited validate

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
