### PR TITLE
Removes unused org.codehaus.janino library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -438,11 +438,6 @@
             <artifactId>logback-core</artifactId>
             <version>${logback.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.codehaus.janino</groupId>
-            <artifactId>janino</artifactId>
-            <version>3.1.11</version>
-        </dependency>
     </dependencies>
     <properties>
         <!-- RELEASE_VERSION -->


### PR DESCRIPTION
Removes unused org.codehaus.janino library

The latest version of logback requires org.codehaus.janino to evaulate conditional logic per https://stackoverflow.com/questions/11017148/how-does-the-condition-functionality-work-in-logback. In this case the logback config doesn't use conditional logic so it is not needed. I will remove it.
per https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/pull/317#discussion_r1414497800

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
