### PR TITLE
Java, improves schema doc code samples

### DIFF
--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/EnumWith0DoesNotMatchFalse.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/EnumWith0DoesNotMatchFalse.md
@@ -30,8 +30,8 @@ import java.util.AbstractMap;
 
 static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
 
-// Number validation
-Number validatedPayload = EnumWith0DoesNotMatchFalse.EnumWith0DoesNotMatchFalse1.validate(
+// int validation
+int validatedPayload = EnumWith0DoesNotMatchFalse.EnumWith0DoesNotMatchFalse1.validate(
     0,
     configuration
 );

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/EnumWith1DoesNotMatchTrue.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/EnumWith1DoesNotMatchTrue.md
@@ -30,8 +30,8 @@ import java.util.AbstractMap;
 
 static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
 
-// Number validation
-Number validatedPayload = EnumWith1DoesNotMatchTrue.EnumWith1DoesNotMatchTrue1.validate(
+// int validation
+int validatedPayload = EnumWith1DoesNotMatchTrue.EnumWith1DoesNotMatchTrue1.validate(
     1,
     configuration
 );

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf.md
@@ -30,9 +30,9 @@ import java.util.AbstractMap;
 
 static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
 
-// Integer validation
-Integer validatedPayload = InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf.InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf1.validate(
-    1,
+// long validation
+long validatedPayload = InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf.InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf1.validate(
+    1L,
     configuration
 );
 ```

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/NestedItems.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/NestedItems.md
@@ -45,7 +45,7 @@ NestedItems.NestedItemsList validatedPayload =
         Arrays.asList(
             Arrays.asList(
                 Arrays.asList(
-                    3.14
+                    1
                 )
             )
         )
@@ -110,7 +110,7 @@ NestedItems.ItemsList2 validatedPayload =
     Arrays.asList(
         Arrays.asList(
             Arrays.asList(
-                3.14
+                1
             )
         )
     ),
@@ -173,7 +173,7 @@ NestedItems.ItemsList1 validatedPayload =
     NestedItems.Items1.validate(
     Arrays.asList(
         Arrays.asList(
-            3.14
+            1
         )
     ),
     configuration
@@ -234,7 +234,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 NestedItems.ItemsList validatedPayload =
     NestedItems.Items2.validate(
     Arrays.asList(
-        3.14
+        1
     ),
     configuration
 );

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/SimpleEnumValidation.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/SimpleEnumValidation.md
@@ -30,8 +30,8 @@ import java.util.AbstractMap;
 
 static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
 
-// Number validation
-Number validatedPayload = SimpleEnumValidation.SimpleEnumValidation1.validate(
+// int validation
+int validatedPayload = SimpleEnumValidation.SimpleEnumValidation1.validate(
     1,
     configuration
 );

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.md
@@ -38,7 +38,7 @@ TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.TheDefaultKeywordDoesNo
     MapMaker.makeMap(
         new AbstractMap.SimpleEntry<>(
             "alpha",
-            3.14
+            1
         )
     ),
     configuration
@@ -65,7 +65,7 @@ A class to store validated Map payloads
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | static [TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissingMap](#thedefaultkeyworddoesnotdoanythingifthepropertyismissingmap) | of(Map<String, Object> arg, SchemaConfiguration configuration) |
-| Number | alpha()<br>[optional] if omitted the server will use the default value of 5 |
+| Number | alpha()<br>[optional] if omitted the server will use the default value of 5.0 |
 | Object | getAdditionalProperty(String name)<br>provides type safety for additional properties |
 
 ## Input Map Keys
@@ -74,7 +74,7 @@ type: Map<String, Object>
 ```
 | Key | Type |  Description | Notes |
 | --- | ---- | ------------ | ----- |
-| **alpha** | Number |  | [optional] if omitted the server will use the default value of 5 |
+| **alpha** | Number |  | [optional] if omitted the server will use the default value of 5.0 |
 | **anyStringName** | Object | any string name can be used but the value must be the correct type | [optional] |
 
 ## Alpha
@@ -98,9 +98,9 @@ import java.util.AbstractMap;
 
 static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
 
-// Number validation
-Number validatedPayload = TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.Alpha.validate(
-    3.14,
+// int validation
+int validatedPayload = TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.Alpha.validate(
+    1,
     configuration
 );
 ```

--- a/samples/client/3_0_3_unit_test/python/docs/components/schema/the_default_keyword_does_not_do_anything_if_the_property_is_missing.md
+++ b/samples/client/3_0_3_unit_test/python/docs/components/schema/the_default_keyword_does_not_do_anything_if_the_property_is_missing.md
@@ -15,7 +15,7 @@ type: typing.Mapping[str, schemas.INPUT_TYPES_ALL]
 ```
 Key | Type |  Description | Notes
 ------------ | ------------- | ------------- | -------------
-**alpha** | float, int |  | [optional] if omitted the server will use the default value of 5
+**alpha** | float, int |  | [optional] if omitted the server will use the default value of 5.0
 **any_string_name** | dict, schemas.immutabledict, list, tuple, decimal.Decimal, float, int, str, datetime.date, datetime.datetime, uuid.UUID, bool, None, bytes, io.FileIO, io.BufferedReader, schemas.FileIO | any string name can be used but the value must be the correct type | [optional]
 
 ## TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissingDict
@@ -26,13 +26,13 @@ base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
 ### &lowbar;&lowbar;new&lowbar;&lowbar; method
 Keyword Argument | Type | Description | Notes
 ---------------- | ---- | ----------- | -----
-**alpha** | float, int, schemas.Unset |  | [optional] if omitted the server will use the default value of 5
+**alpha** | float, int, schemas.Unset |  | [optional] if omitted the server will use the default value of 5.0
 **kwargs** | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO | any string name can be used but the value must be the correct type | [optional] typed value is accessed with the get_additional_property_ method
 
 ### properties
 Property | Type | Description | Notes
 -------- | ---- | ----------- | -----
-**alpha** | float, int, schemas.Unset |  | [optional] if omitted the server will use the default value of 5
+**alpha** | float, int, schemas.Unset |  | [optional] if omitted the server will use the default value of 5.0
 
 ### methods
 Method | Input Type | Return Type | Notes

--- a/samples/client/petstore/java/docs/components/requestbodies/userarray/content/applicationjson/Schema.md
+++ b/samples/client/petstore/java/docs/components/requestbodies/userarray/content/applicationjson/Schema.md
@@ -35,6 +35,44 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 Schema.SchemaList validatedPayload =
     Schema.Schema1.validate(
     Arrays.asList(
+        MapMaker.makeMap(
+            new AbstractMap.SimpleEntry<>(
+                "id",
+                1L
+            ),
+            new AbstractMap.SimpleEntry<>(
+                "username",
+                "a"
+            ),
+            new AbstractMap.SimpleEntry<>(
+                "firstName",
+                "a"
+            ),
+            new AbstractMap.SimpleEntry<>(
+                "lastName",
+                "a"
+            ),
+            new AbstractMap.SimpleEntry<>(
+                "email",
+                "a"
+            ),
+            new AbstractMap.SimpleEntry<>(
+                "password",
+                "a"
+            ),
+            new AbstractMap.SimpleEntry<>(
+                "phone",
+                "a"
+            ),
+            new AbstractMap.SimpleEntry<>(
+                "userStatus",
+                1
+            ),
+            new AbstractMap.SimpleEntry<>(
+                "objectWithNoDeclaredPropsNullable",
+                (Void) null
+            )
+        )
     ),
     configuration
 );

--- a/samples/client/petstore/java/docs/components/responses/successfulxmlandjsonarrayofpet/content/applicationjson/Schema.md
+++ b/samples/client/petstore/java/docs/components/responses/successfulxmlandjsonarrayofpet/content/applicationjson/Schema.md
@@ -35,6 +35,50 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 Schema.SchemaList validatedPayload =
     Schema.Schema1.validate(
     Arrays.asList(
+        MapMaker.makeMap(
+            new AbstractMap.SimpleEntry<>(
+                "name",
+                "a"
+            ),
+            new AbstractMap.SimpleEntry<>(
+                "photoUrls",
+                Arrays.asList(
+                    "a"
+                )
+            ),
+            new AbstractMap.SimpleEntry<>(
+                "id",
+                1L
+            ),
+            new AbstractMap.SimpleEntry<>(
+                "category",
+                MapMaker.makeMap(
+                    new AbstractMap.SimpleEntry<>(
+                        "name",
+                        "a"
+                    ),
+                    new AbstractMap.SimpleEntry<>(
+                        "id",
+                        1L
+                    )
+                )
+            ),
+            new AbstractMap.SimpleEntry<>(
+                "tags",
+                Arrays.asList(
+                    MapMaker.makeMap(
+                        new AbstractMap.SimpleEntry<>(
+                            "name",
+                            "a"
+                        )
+                    )
+                )
+            ),
+            new AbstractMap.SimpleEntry<>(
+                "status",
+                "available"
+            )
+        )
     ),
     configuration
 );

--- a/samples/client/petstore/java/docs/components/responses/successfulxmlandjsonarrayofpet/content/applicationxml/Schema.md
+++ b/samples/client/petstore/java/docs/components/responses/successfulxmlandjsonarrayofpet/content/applicationxml/Schema.md
@@ -35,6 +35,50 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 Schema.SchemaList validatedPayload =
     Schema.Schema1.validate(
     Arrays.asList(
+        MapMaker.makeMap(
+            new AbstractMap.SimpleEntry<>(
+                "name",
+                "a"
+            ),
+            new AbstractMap.SimpleEntry<>(
+                "photoUrls",
+                Arrays.asList(
+                    "a"
+                )
+            ),
+            new AbstractMap.SimpleEntry<>(
+                "id",
+                1L
+            ),
+            new AbstractMap.SimpleEntry<>(
+                "category",
+                MapMaker.makeMap(
+                    new AbstractMap.SimpleEntry<>(
+                        "name",
+                        "a"
+                    ),
+                    new AbstractMap.SimpleEntry<>(
+                        "id",
+                        1L
+                    )
+                )
+            ),
+            new AbstractMap.SimpleEntry<>(
+                "tags",
+                Arrays.asList(
+                    MapMaker.makeMap(
+                        new AbstractMap.SimpleEntry<>(
+                            "name",
+                            "a"
+                        )
+                    )
+                )
+            ),
+            new AbstractMap.SimpleEntry<>(
+                "status",
+                "available"
+            )
+        )
     ),
     configuration
 );

--- a/samples/client/petstore/java/docs/components/schemas/AdditionalPropertiesWithArrayOfEnums.md
+++ b/samples/client/petstore/java/docs/components/schemas/AdditionalPropertiesWithArrayOfEnums.md
@@ -97,6 +97,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 AdditionalPropertiesWithArrayOfEnums.AdditionalPropertiesList validatedPayload =
     AdditionalPropertiesWithArrayOfEnums.AdditionalProperties.validate(
     Arrays.asList(
+        "_abc"
     ),
     configuration
 );

--- a/samples/client/petstore/java/docs/components/schemas/AnimalFarm.md
+++ b/samples/client/petstore/java/docs/components/schemas/AnimalFarm.md
@@ -35,6 +35,16 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 AnimalFarm.AnimalFarmList validatedPayload =
     AnimalFarm.AnimalFarm1.validate(
     Arrays.asList(
+        MapMaker.makeMap(
+            new AbstractMap.SimpleEntry<>(
+                "className",
+                "a"
+            ),
+            new AbstractMap.SimpleEntry<>(
+                "color",
+                "a"
+            )
+        )
     ),
     configuration
 );

--- a/samples/client/petstore/java/docs/components/schemas/ArrayOfArrayOfNumberOnly.md
+++ b/samples/client/petstore/java/docs/components/schemas/ArrayOfArrayOfNumberOnly.md
@@ -44,7 +44,7 @@ ArrayOfArrayOfNumberOnly.ArrayOfArrayOfNumberOnlyMap validatedPayload =
             "ArrayArrayNumber",
             Arrays.asList(
                 Arrays.asList(
-                    3.14
+                    1
                 )
             )
         )
@@ -111,7 +111,7 @@ ArrayOfArrayOfNumberOnly.ArrayArrayNumberList validatedPayload =
     ArrayOfArrayOfNumberOnly.ArrayArrayNumber.validate(
     Arrays.asList(
         Arrays.asList(
-            3.14
+            1
         )
     ),
     configuration
@@ -172,7 +172,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 ArrayOfArrayOfNumberOnly.ItemsList validatedPayload =
     ArrayOfArrayOfNumberOnly.Items.validate(
     Arrays.asList(
-        3.14
+        1
     ),
     configuration
 );

--- a/samples/client/petstore/java/docs/components/schemas/ArrayOfEnums.md
+++ b/samples/client/petstore/java/docs/components/schemas/ArrayOfEnums.md
@@ -35,6 +35,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 ArrayOfEnums.ArrayOfEnumsList validatedPayload =
     ArrayOfEnums.ArrayOfEnums1.validate(
     Arrays.asList(
+        (Void) null
     ),
     configuration
 );

--- a/samples/client/petstore/java/docs/components/schemas/ArrayOfNumberOnly.md
+++ b/samples/client/petstore/java/docs/components/schemas/ArrayOfNumberOnly.md
@@ -41,7 +41,7 @@ ArrayOfNumberOnly.ArrayOfNumberOnlyMap validatedPayload =
         new AbstractMap.SimpleEntry<>(
             "ArrayNumber",
             Arrays.asList(
-                3.14
+                1
             )
         )
     ),
@@ -106,7 +106,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 ArrayOfNumberOnly.ArrayNumberList validatedPayload =
     ArrayOfNumberOnly.ArrayNumber.validate(
     Arrays.asList(
-        3.14
+        1
     ),
     configuration
 );

--- a/samples/client/petstore/java/docs/components/schemas/ArrayTest.md
+++ b/samples/client/petstore/java/docs/components/schemas/ArrayTest.md
@@ -57,7 +57,7 @@ ArrayTest.ArrayTestMap validatedPayload =
             "array_array_of_integer",
             Arrays.asList(
                 Arrays.asList(
-                    1
+                    1L
                 )
             )
         ),
@@ -255,7 +255,7 @@ ArrayTest.ArrayArrayOfIntegerList validatedPayload =
     ArrayTest.ArrayArrayOfInteger.validate(
     Arrays.asList(
         Arrays.asList(
-            1
+            1L
         )
     ),
     configuration
@@ -316,7 +316,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 ArrayTest.ItemsList validatedPayload =
     ArrayTest.Items1.validate(
     Arrays.asList(
-        1
+        1L
     ),
     configuration
 );

--- a/samples/client/petstore/java/docs/components/schemas/ArrayTest.md
+++ b/samples/client/petstore/java/docs/components/schemas/ArrayTest.md
@@ -65,6 +65,16 @@ ArrayTest.ArrayTestMap validatedPayload =
             "array_array_of_model",
             Arrays.asList(
                 Arrays.asList(
+                    MapMaker.makeMap(
+                        new AbstractMap.SimpleEntry<>(
+                            "bar",
+                            "a"
+                        ),
+                        new AbstractMap.SimpleEntry<>(
+                            "baz",
+                            "a"
+                        )
+                    )
                 )
             )
         )
@@ -135,6 +145,16 @@ ArrayTest.ArrayArrayOfModelList validatedPayload =
     ArrayTest.ArrayArrayOfModel.validate(
     Arrays.asList(
         Arrays.asList(
+            MapMaker.makeMap(
+                new AbstractMap.SimpleEntry<>(
+                    "bar",
+                    "a"
+                ),
+                new AbstractMap.SimpleEntry<>(
+                    "baz",
+                    "a"
+                )
+            )
         )
     ),
     configuration
@@ -195,6 +215,16 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 ArrayTest.ItemsList1 validatedPayload =
     ArrayTest.Items3.validate(
     Arrays.asList(
+        MapMaker.makeMap(
+            new AbstractMap.SimpleEntry<>(
+                "bar",
+                "a"
+            ),
+            new AbstractMap.SimpleEntry<>(
+                "baz",
+                "a"
+            )
+        )
     ),
     configuration
 );

--- a/samples/client/petstore/java/docs/components/schemas/ArrayWithValidationsInItems.md
+++ b/samples/client/petstore/java/docs/components/schemas/ArrayWithValidationsInItems.md
@@ -36,7 +36,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 ArrayWithValidationsInItems.ArrayWithValidationsInItemsList validatedPayload =
     ArrayWithValidationsInItems.ArrayWithValidationsInItems1.validate(
     Arrays.asList(
-        1
+        1L
     ),
     configuration
 );
@@ -92,9 +92,9 @@ import java.util.AbstractMap;
 
 static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
 
-// Integer validation
-Integer validatedPayload = ArrayWithValidationsInItems.Items.validate(
-    1,
+// long validation
+long validatedPayload = ArrayWithValidationsInItems.Items.validate(
+    1L,
     configuration
 );
 ```

--- a/samples/client/petstore/java/docs/components/schemas/Banana.md
+++ b/samples/client/petstore/java/docs/components/schemas/Banana.md
@@ -38,7 +38,7 @@ Banana.BananaMap validatedPayload =
     MapMaker.makeMap(
         new AbstractMap.SimpleEntry<>(
             "lengthCm",
-            3.14
+            1
         )
     ),
     configuration

--- a/samples/client/petstore/java/docs/components/schemas/BananaReq.md
+++ b/samples/client/petstore/java/docs/components/schemas/BananaReq.md
@@ -40,7 +40,7 @@ BananaReq.BananaReqMap validatedPayload =
     MapMaker.makeMap(
         new AbstractMap.SimpleEntry<>(
             "lengthCm",
-            3.14
+            1
         ),
         new AbstractMap.SimpleEntry<>(
             "sweet",

--- a/samples/client/petstore/java/docs/components/schemas/Category.md
+++ b/samples/client/petstore/java/docs/components/schemas/Category.md
@@ -43,7 +43,7 @@ Category.CategoryMap validatedPayload =
         ),
         new AbstractMap.SimpleEntry<>(
             "id",
-            1
+            1L
         )
     ),
     configuration

--- a/samples/client/petstore/java/docs/components/schemas/ComposedNumber.md
+++ b/samples/client/petstore/java/docs/components/schemas/ComposedNumber.md
@@ -33,7 +33,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 
 // Number validation
 Number validatedPayload = ComposedNumber.ComposedNumber1.validate(
-    3.14,
+    1,
     configuration
 );
 ```

--- a/samples/client/petstore/java/docs/components/schemas/ComposedNumber.md
+++ b/samples/client/petstore/java/docs/components/schemas/ComposedNumber.md
@@ -31,8 +31,8 @@ import java.util.AbstractMap;
 
 static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
 
-// Number validation
-Number validatedPayload = ComposedNumber.ComposedNumber1.validate(
+// int validation
+int validatedPayload = ComposedNumber.ComposedNumber1.validate(
     1,
     configuration
 );

--- a/samples/client/petstore/java/docs/components/schemas/EnumTest.md
+++ b/samples/client/petstore/java/docs/components/schemas/EnumTest.md
@@ -167,8 +167,8 @@ import java.util.AbstractMap;
 
 static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
 
-// Integer validation
-Integer validatedPayload = EnumTest.EnumInteger.validate(
+// int validation
+int validatedPayload = EnumTest.EnumInteger.validate(
     1,
     configuration
 );

--- a/samples/client/petstore/java/docs/components/schemas/EnumTest.md
+++ b/samples/client/petstore/java/docs/components/schemas/EnumTest.md
@@ -53,7 +53,7 @@ EnumTest.EnumTestMap validatedPayload =
         ),
         new AbstractMap.SimpleEntry<>(
             "enum_number",
-            1.1
+            1.1d
         )
     ),
     configuration
@@ -131,7 +131,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 
 // Number validation
 Number validatedPayload = EnumTest.EnumNumber.validate(
-    1.1,
+    1.1d,
     configuration
 );
 ```

--- a/samples/client/petstore/java/docs/components/schemas/EnumTest.md
+++ b/samples/client/petstore/java/docs/components/schemas/EnumTest.md
@@ -129,8 +129,8 @@ import java.util.AbstractMap;
 
 static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
 
-// Number validation
-Number validatedPayload = EnumTest.EnumNumber.validate(
+// double validation
+double validatedPayload = EnumTest.EnumNumber.validate(
     1.1d,
     configuration
 );

--- a/samples/client/petstore/java/docs/components/schemas/FormatTest.md
+++ b/samples/client/petstore/java/docs/components/schemas/FormatTest.md
@@ -68,7 +68,7 @@ FormatTest.FormatTestMap validatedPayload =
         ),
         new AbstractMap.SimpleEntry<>(
             "number",
-            3.14
+            1
         ),
         new AbstractMap.SimpleEntry<>(
             "password",
@@ -92,24 +92,24 @@ FormatTest.FormatTestMap validatedPayload =
         ),
         new AbstractMap.SimpleEntry<>(
             "float",
-            3.14
+            3.14f
         ),
         new AbstractMap.SimpleEntry<>(
             "float32",
-            3.14
+            3.14f
         ),
         new AbstractMap.SimpleEntry<>(
             "double",
-            3.14
+            3.14d
         ),
         new AbstractMap.SimpleEntry<>(
             "float64",
-            3.14
+            3.14d
         ),
         new AbstractMap.SimpleEntry<>(
             "arrayWithUniqueItems",
             Arrays.asList(
-                3.14
+                1
             )
         ),
         new AbstractMap.SimpleEntry<>(
@@ -460,7 +460,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 FormatTest.ArrayWithUniqueItemsList validatedPayload =
     FormatTest.ArrayWithUniqueItems.validate(
     Arrays.asList(
-        3.14
+        1
     ),
     configuration
 );
@@ -538,7 +538,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 
 // Number validation
 Number validatedPayload = FormatTest.DoubleSchema.validate(
-    3.14,
+    3.14d,
     configuration
 );
 ```
@@ -589,7 +589,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 
 // Number validation
 Number validatedPayload = FormatTest.FloatSchema.validate(
-    3.14,
+    3.14f,
     configuration
 );
 ```
@@ -627,7 +627,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 
 // Number validation
 Number validatedPayload = FormatTest.NumberSchema.validate(
-    3.14,
+    1,
     configuration
 );
 ```

--- a/samples/client/petstore/java/docs/components/schemas/FormatTest.md
+++ b/samples/client/petstore/java/docs/components/schemas/FormatTest.md
@@ -76,7 +76,7 @@ FormatTest.FormatTestMap validatedPayload =
         ),
         new AbstractMap.SimpleEntry<>(
             "integer",
-            1
+            1L
         ),
         new AbstractMap.SimpleEntry<>(
             "int32",
@@ -88,7 +88,7 @@ FormatTest.FormatTestMap validatedPayload =
         ),
         new AbstractMap.SimpleEntry<>(
             "int64",
-            1
+            1L
         ),
         new AbstractMap.SimpleEntry<>(
             "float",
@@ -673,8 +673,8 @@ import java.util.AbstractMap;
 
 static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
 
-// Integer validation
-Integer validatedPayload = FormatTest.Int32withValidations.validate(
+// int validation
+int validatedPayload = FormatTest.Int32withValidations.validate(
     1,
     configuration
 );
@@ -721,9 +721,9 @@ import java.util.AbstractMap;
 
 static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
 
-// Integer validation
-Integer validatedPayload = FormatTest.IntegerSchema.validate(
-    1,
+// long validation
+long validatedPayload = FormatTest.IntegerSchema.validate(
+    1L,
     configuration
 );
 ```

--- a/samples/client/petstore/java/docs/components/schemas/FormatTest.md
+++ b/samples/client/petstore/java/docs/components/schemas/FormatTest.md
@@ -536,8 +536,8 @@ import java.util.AbstractMap;
 
 static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
 
-// Number validation
-Number validatedPayload = FormatTest.DoubleSchema.validate(
+// double validation
+double validatedPayload = FormatTest.DoubleSchema.validate(
     3.14d,
     configuration
 );
@@ -587,8 +587,8 @@ import java.util.AbstractMap;
 
 static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
 
-// Number validation
-Number validatedPayload = FormatTest.FloatSchema.validate(
+// float validation
+float validatedPayload = FormatTest.FloatSchema.validate(
     3.14f,
     configuration
 );
@@ -625,8 +625,8 @@ import java.util.AbstractMap;
 
 static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
 
-// Number validation
-Number validatedPayload = FormatTest.NumberSchema.validate(
+// int validation
+int validatedPayload = FormatTest.NumberSchema.validate(
     1,
     configuration
 );

--- a/samples/client/petstore/java/docs/components/schemas/FromSchema.md
+++ b/samples/client/petstore/java/docs/components/schemas/FromSchema.md
@@ -43,7 +43,7 @@ FromSchema.FromSchemaMap validatedPayload =
         ),
         new AbstractMap.SimpleEntry<>(
             "id",
-            1
+            1L
         )
     ),
     configuration

--- a/samples/client/petstore/java/docs/components/schemas/IntegerEnum.md
+++ b/samples/client/petstore/java/docs/components/schemas/IntegerEnum.md
@@ -30,8 +30,8 @@ import java.util.AbstractMap;
 
 static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
 
-// Integer validation
-Integer validatedPayload = IntegerEnum.IntegerEnum1.validate(
+// long validation
+long validatedPayload = IntegerEnum.IntegerEnum1.validate(
     0,
     configuration
 );

--- a/samples/client/petstore/java/docs/components/schemas/IntegerEnumBig.md
+++ b/samples/client/petstore/java/docs/components/schemas/IntegerEnumBig.md
@@ -30,8 +30,8 @@ import java.util.AbstractMap;
 
 static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
 
-// Integer validation
-Integer validatedPayload = IntegerEnumBig.IntegerEnumBig1.validate(
+// long validation
+long validatedPayload = IntegerEnumBig.IntegerEnumBig1.validate(
     10,
     configuration
 );

--- a/samples/client/petstore/java/docs/components/schemas/IntegerEnumOneValue.md
+++ b/samples/client/petstore/java/docs/components/schemas/IntegerEnumOneValue.md
@@ -30,8 +30,8 @@ import java.util.AbstractMap;
 
 static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
 
-// Integer validation
-Integer validatedPayload = IntegerEnumOneValue.IntegerEnumOneValue1.validate(
+// long validation
+long validatedPayload = IntegerEnumOneValue.IntegerEnumOneValue1.validate(
     0,
     configuration
 );

--- a/samples/client/petstore/java/docs/components/schemas/IntegerEnumWithDefaultValue.md
+++ b/samples/client/petstore/java/docs/components/schemas/IntegerEnumWithDefaultValue.md
@@ -30,8 +30,8 @@ import java.util.AbstractMap;
 
 static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
 
-// Integer validation
-Integer validatedPayload = IntegerEnumWithDefaultValue.IntegerEnumWithDefaultValue1.validate(
+// long validation
+long validatedPayload = IntegerEnumWithDefaultValue.IntegerEnumWithDefaultValue1.validate(
     0,
     configuration
 );

--- a/samples/client/petstore/java/docs/components/schemas/IntegerMax10.md
+++ b/samples/client/petstore/java/docs/components/schemas/IntegerMax10.md
@@ -30,9 +30,9 @@ import java.util.AbstractMap;
 
 static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
 
-// Integer validation
-Integer validatedPayload = IntegerMax10.IntegerMax101.validate(
-    1,
+// long validation
+long validatedPayload = IntegerMax10.IntegerMax101.validate(
+    1L,
     configuration
 );
 ```

--- a/samples/client/petstore/java/docs/components/schemas/IntegerMin15.md
+++ b/samples/client/petstore/java/docs/components/schemas/IntegerMin15.md
@@ -30,9 +30,9 @@ import java.util.AbstractMap;
 
 static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
 
-// Integer validation
-Integer validatedPayload = IntegerMin15.IntegerMin151.validate(
-    1,
+// long validation
+long validatedPayload = IntegerMin15.IntegerMin151.validate(
+    1L,
     configuration
 );
 ```

--- a/samples/client/petstore/java/docs/components/schemas/Money.md
+++ b/samples/client/petstore/java/docs/components/schemas/Money.md
@@ -40,6 +40,10 @@ Money.MoneyMap validatedPayload =
         new AbstractMap.SimpleEntry<>(
             "amount",
             "a"
+        ),
+        new AbstractMap.SimpleEntry<>(
+            "currency",
+            "eur"
         )
     ),
     configuration

--- a/samples/client/petstore/java/docs/components/schemas/NoAdditionalProperties.md
+++ b/samples/client/petstore/java/docs/components/schemas/NoAdditionalProperties.md
@@ -40,11 +40,11 @@ NoAdditionalProperties.NoAdditionalPropertiesMap validatedPayload =
     MapMaker.makeMap(
         new AbstractMap.SimpleEntry<>(
             "id",
-            1
+            1L
         ),
         new AbstractMap.SimpleEntry<>(
             "petId",
-            1
+            1L
         )
     ),
     configuration

--- a/samples/client/petstore/java/docs/components/schemas/NullableClass.md
+++ b/samples/client/petstore/java/docs/components/schemas/NullableClass.md
@@ -940,8 +940,8 @@ Void validatedPayload = NullableClass.NumberProp.validate(
     configuration
 );
 
-// Number validation
-Number validatedPayload = NullableClass.NumberProp.validate(
+// int validation
+int validatedPayload = NullableClass.NumberProp.validate(
     1,
     configuration
 );

--- a/samples/client/petstore/java/docs/components/schemas/NullableClass.md
+++ b/samples/client/petstore/java/docs/components/schemas/NullableClass.md
@@ -942,7 +942,7 @@ Void validatedPayload = NullableClass.NumberProp.validate(
 
 // Number validation
 Number validatedPayload = NullableClass.NumberProp.validate(
-    3.14,
+    1,
     configuration
 );
 ```

--- a/samples/client/petstore/java/docs/components/schemas/NullableClass.md
+++ b/samples/client/petstore/java/docs/components/schemas/NullableClass.md
@@ -985,9 +985,9 @@ Void validatedPayload = NullableClass.IntegerProp.validate(
     configuration
 );
 
-// Integer validation
-Integer validatedPayload = NullableClass.IntegerProp.validate(
-    1,
+// long validation
+long validatedPayload = NullableClass.IntegerProp.validate(
+    1L,
     configuration
 );
 ```

--- a/samples/client/petstore/java/docs/components/schemas/NumberOnly.md
+++ b/samples/client/petstore/java/docs/components/schemas/NumberOnly.md
@@ -38,7 +38,7 @@ NumberOnly.NumberOnlyMap validatedPayload =
     MapMaker.makeMap(
         new AbstractMap.SimpleEntry<>(
             "JustNumber",
-            3.14
+            1
         )
     ),
     configuration

--- a/samples/client/petstore/java/docs/components/schemas/NumberWithExclusiveMinMax.md
+++ b/samples/client/petstore/java/docs/components/schemas/NumberWithExclusiveMinMax.md
@@ -30,8 +30,8 @@ import java.util.AbstractMap;
 
 static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
 
-// Number validation
-Number validatedPayload = NumberWithExclusiveMinMax.NumberWithExclusiveMinMax1.validate(
+// int validation
+int validatedPayload = NumberWithExclusiveMinMax.NumberWithExclusiveMinMax1.validate(
     1,
     configuration
 );

--- a/samples/client/petstore/java/docs/components/schemas/NumberWithExclusiveMinMax.md
+++ b/samples/client/petstore/java/docs/components/schemas/NumberWithExclusiveMinMax.md
@@ -32,7 +32,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 
 // Number validation
 Number validatedPayload = NumberWithExclusiveMinMax.NumberWithExclusiveMinMax1.validate(
-    3.14,
+    1,
     configuration
 );
 ```

--- a/samples/client/petstore/java/docs/components/schemas/NumberWithValidations.md
+++ b/samples/client/petstore/java/docs/components/schemas/NumberWithValidations.md
@@ -32,7 +32,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 
 // Number validation
 Number validatedPayload = NumberWithValidations.NumberWithValidations1.validate(
-    3.14,
+    1,
     configuration
 );
 ```

--- a/samples/client/petstore/java/docs/components/schemas/NumberWithValidations.md
+++ b/samples/client/petstore/java/docs/components/schemas/NumberWithValidations.md
@@ -30,8 +30,8 @@ import java.util.AbstractMap;
 
 static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
 
-// Number validation
-Number validatedPayload = NumberWithValidations.NumberWithValidations1.validate(
+// int validation
+int validatedPayload = NumberWithValidations.NumberWithValidations1.validate(
     1,
     configuration
 );

--- a/samples/client/petstore/java/docs/components/schemas/ObjectWithDecimalProperties.md
+++ b/samples/client/petstore/java/docs/components/schemas/ObjectWithDecimalProperties.md
@@ -37,8 +37,25 @@ ObjectWithDecimalProperties.ObjectWithDecimalPropertiesMap validatedPayload =
     ObjectWithDecimalProperties.ObjectWithDecimalProperties1.validate(
     MapMaker.makeMap(
         new AbstractMap.SimpleEntry<>(
+            "length",
+            "a"
+        ),
+        new AbstractMap.SimpleEntry<>(
             "width",
             "a"
+        ),
+        new AbstractMap.SimpleEntry<>(
+            "cost",
+            MapMaker.makeMap(
+                new AbstractMap.SimpleEntry<>(
+                    "amount",
+                    "a"
+                ),
+                new AbstractMap.SimpleEntry<>(
+                    "currency",
+                    "eur"
+                )
+            )
         )
     ),
     configuration

--- a/samples/client/petstore/java/docs/components/schemas/ObjectWithDifficultlyNamedProps.md
+++ b/samples/client/petstore/java/docs/components/schemas/ObjectWithDifficultlyNamedProps.md
@@ -47,11 +47,11 @@ ObjectWithDifficultlyNamedProps.ObjectWithDifficultlyNamedPropsMap validatedPayl
         ),
         new AbstractMap.SimpleEntry<>(
             "$special[property.name]",
-            1
+            1L
         ),
         new AbstractMap.SimpleEntry<>(
             "123Number",
-            1
+            1L
         )
     ),
     configuration

--- a/samples/client/petstore/java/docs/components/schemas/ObjectWithInvalidNamedRefedProperties.md
+++ b/samples/client/petstore/java/docs/components/schemas/ObjectWithInvalidNamedRefedProperties.md
@@ -35,6 +35,25 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 ObjectWithInvalidNamedRefedProperties.ObjectWithInvalidNamedRefedPropertiesMap validatedPayload =
     ObjectWithInvalidNamedRefedProperties.ObjectWithInvalidNamedRefedProperties1.validate(
     MapMaker.makeMap(
+        new AbstractMap.SimpleEntry<>(
+            "!reference",
+            Arrays.asList(
+                1L
+            )
+        ),
+        new AbstractMap.SimpleEntry<>(
+            "from",
+            MapMaker.makeMap(
+                new AbstractMap.SimpleEntry<>(
+                    "data",
+                    "a"
+                ),
+                new AbstractMap.SimpleEntry<>(
+                    "id",
+                    1L
+                )
+            )
+        )
     ),
     configuration
 );

--- a/samples/client/petstore/java/docs/components/schemas/ObjectWithNonIntersectingValues.md
+++ b/samples/client/petstore/java/docs/components/schemas/ObjectWithNonIntersectingValues.md
@@ -39,7 +39,7 @@ ObjectWithNonIntersectingValues.ObjectWithNonIntersectingValuesMap validatedPayl
     MapMaker.makeMap(
         new AbstractMap.SimpleEntry<>(
             "a",
-            3.14
+            1
         )
     ),
     configuration

--- a/samples/client/petstore/java/docs/components/schemas/ObjectWithOnlyOptionalProps.md
+++ b/samples/client/petstore/java/docs/components/schemas/ObjectWithOnlyOptionalProps.md
@@ -44,7 +44,7 @@ ObjectWithOnlyOptionalProps.ObjectWithOnlyOptionalPropsMap validatedPayload =
         ),
         new AbstractMap.SimpleEntry<>(
             "b",
-            3.14
+            1
         )
     ),
     configuration

--- a/samples/client/petstore/java/docs/components/schemas/Order.md
+++ b/samples/client/petstore/java/docs/components/schemas/Order.md
@@ -43,11 +43,11 @@ Order.OrderMap validatedPayload =
     MapMaker.makeMap(
         new AbstractMap.SimpleEntry<>(
             "id",
-            1
+            1L
         ),
         new AbstractMap.SimpleEntry<>(
             "petId",
-            1
+            1L
         ),
         new AbstractMap.SimpleEntry<>(
             "quantity",

--- a/samples/client/petstore/java/docs/components/schemas/PaginatedResultMyObjectDto.md
+++ b/samples/client/petstore/java/docs/components/schemas/PaginatedResultMyObjectDto.md
@@ -41,7 +41,7 @@ PaginatedResultMyObjectDto.PaginatedResultMyObjectDtoMap validatedPayload =
     MapMaker.makeMap(
         new AbstractMap.SimpleEntry<>(
             "count",
-            1
+            1L
         ),
         new AbstractMap.SimpleEntry<>(
             "results",

--- a/samples/client/petstore/java/docs/components/schemas/Pet.md
+++ b/samples/client/petstore/java/docs/components/schemas/Pet.md
@@ -58,7 +58,7 @@ Pet.PetMap validatedPayload =
         ),
         new AbstractMap.SimpleEntry<>(
             "id",
-            1
+            1L
         ),
         new AbstractMap.SimpleEntry<>(
             "tags",

--- a/samples/client/petstore/java/docs/components/schemas/Pet.md
+++ b/samples/client/petstore/java/docs/components/schemas/Pet.md
@@ -61,8 +61,27 @@ Pet.PetMap validatedPayload =
             1L
         ),
         new AbstractMap.SimpleEntry<>(
+            "category",
+            MapMaker.makeMap(
+                new AbstractMap.SimpleEntry<>(
+                    "name",
+                    "a"
+                ),
+                new AbstractMap.SimpleEntry<>(
+                    "id",
+                    1L
+                )
+            )
+        ),
+        new AbstractMap.SimpleEntry<>(
             "tags",
             Arrays.asList(
+                MapMaker.makeMap(
+                    new AbstractMap.SimpleEntry<>(
+                        "name",
+                        "a"
+                    )
+                )
             )
         ),
         new AbstractMap.SimpleEntry<>(
@@ -141,6 +160,16 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 Pet.TagsList validatedPayload =
     Pet.Tags.validate(
     Arrays.asList(
+        MapMaker.makeMap(
+            new AbstractMap.SimpleEntry<>(
+                "id",
+                1L
+            ),
+            new AbstractMap.SimpleEntry<>(
+                "name",
+                "a"
+            )
+        )
     ),
     configuration
 );

--- a/samples/client/petstore/java/docs/components/schemas/ReqPropsFromExplicitAddProps.md
+++ b/samples/client/petstore/java/docs/components/schemas/ReqPropsFromExplicitAddProps.md
@@ -39,10 +39,6 @@ ReqPropsFromExplicitAddProps.ReqPropsFromExplicitAddPropsMap validatedPayload =
         new AbstractMap.SimpleEntry<>(
             "invalid-name",
             "a"
-        ),
-        new AbstractMap.SimpleEntry<>(
-            "validName",
-            "a"
         )
     ),
     configuration

--- a/samples/client/petstore/java/docs/components/schemas/Tag.md
+++ b/samples/client/petstore/java/docs/components/schemas/Tag.md
@@ -39,7 +39,7 @@ Tag.TagMap validatedPayload =
     MapMaker.makeMap(
         new AbstractMap.SimpleEntry<>(
             "id",
-            1
+            1L
         ),
         new AbstractMap.SimpleEntry<>(
             "name",

--- a/samples/client/petstore/java/docs/components/schemas/User.md
+++ b/samples/client/petstore/java/docs/components/schemas/User.md
@@ -51,7 +51,7 @@ User.UserMap validatedPayload =
     MapMaker.makeMap(
         new AbstractMap.SimpleEntry<>(
             "id",
-            1
+            1L
         ),
         new AbstractMap.SimpleEntry<>(
             "username",

--- a/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter4/Schema4.md
+++ b/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter4/Schema4.md
@@ -30,8 +30,8 @@ import java.util.AbstractMap;
 
 static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
 
-// Integer validation
-Integer validatedPayload = Schema4.Schema41.validate(
+// int validation
+int validatedPayload = Schema4.Schema41.validate(
     1,
     configuration
 );

--- a/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter5/Schema5.md
+++ b/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter5/Schema5.md
@@ -32,7 +32,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 
 // Number validation
 Number validatedPayload = Schema5.Schema51.validate(
-    1.1,
+    1.1d,
     configuration
 );
 ```

--- a/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter5/Schema5.md
+++ b/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter5/Schema5.md
@@ -30,8 +30,8 @@ import java.util.AbstractMap;
 
 static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
 
-// Number validation
-Number validatedPayload = Schema5.Schema51.validate(
+// double validation
+double validatedPayload = Schema5.Schema51.validate(
     1.1d,
     configuration
 );

--- a/samples/client/petstore/java/docs/paths/fake/post/requestbody/content/applicationxwwwformurlencoded/Schema.md
+++ b/samples/client/petstore/java/docs/paths/fake/post/requestbody/content/applicationxwwwformurlencoded/Schema.md
@@ -55,11 +55,11 @@ Schema.SchemaMap validatedPayload =
         ),
         new AbstractMap.SimpleEntry<>(
             "double",
-            3.14
+            3.14d
         ),
         new AbstractMap.SimpleEntry<>(
             "number",
-            3.14
+            1
         ),
         new AbstractMap.SimpleEntry<>(
             "pattern_without_delimiter",
@@ -79,7 +79,7 @@ Schema.SchemaMap validatedPayload =
         ),
         new AbstractMap.SimpleEntry<>(
             "float",
-            3.14
+            3.14f
         ),
         new AbstractMap.SimpleEntry<>(
             "string",
@@ -397,7 +397,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 
 // Number validation
 Number validatedPayload = Schema.DoubleSchema.validate(
-    3.14,
+    3.14d,
     configuration
 );
 ```
@@ -438,7 +438,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 
 // Number validation
 Number validatedPayload = Schema.FloatSchema.validate(
-    3.14,
+    3.14f,
     configuration
 );
 ```
@@ -479,7 +479,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 
 // Number validation
 Number validatedPayload = Schema.NumberSchema.validate(
-    3.14,
+    1,
     configuration
 );
 ```

--- a/samples/client/petstore/java/docs/paths/fake/post/requestbody/content/applicationxwwwformurlencoded/Schema.md
+++ b/samples/client/petstore/java/docs/paths/fake/post/requestbody/content/applicationxwwwformurlencoded/Schema.md
@@ -395,8 +395,8 @@ import java.util.AbstractMap;
 
 static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
 
-// Number validation
-Number validatedPayload = Schema.DoubleSchema.validate(
+// double validation
+double validatedPayload = Schema.DoubleSchema.validate(
     3.14d,
     configuration
 );
@@ -436,8 +436,8 @@ import java.util.AbstractMap;
 
 static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
 
-// Number validation
-Number validatedPayload = Schema.FloatSchema.validate(
+// float validation
+float validatedPayload = Schema.FloatSchema.validate(
     3.14f,
     configuration
 );
@@ -477,8 +477,8 @@ import java.util.AbstractMap;
 
 static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
 
-// Number validation
-Number validatedPayload = Schema.NumberSchema.validate(
+// int validation
+int validatedPayload = Schema.NumberSchema.validate(
     1,
     configuration
 );

--- a/samples/client/petstore/java/docs/paths/fake/post/requestbody/content/applicationxwwwformurlencoded/Schema.md
+++ b/samples/client/petstore/java/docs/paths/fake/post/requestbody/content/applicationxwwwformurlencoded/Schema.md
@@ -67,7 +67,7 @@ Schema.SchemaMap validatedPayload =
         ),
         new AbstractMap.SimpleEntry<>(
             "integer",
-            1
+            1L
         ),
         new AbstractMap.SimpleEntry<>(
             "int32",
@@ -75,7 +75,7 @@ Schema.SchemaMap validatedPayload =
         ),
         new AbstractMap.SimpleEntry<>(
             "int64",
-            1
+            1L
         ),
         new AbstractMap.SimpleEntry<>(
             "float",
@@ -531,8 +531,8 @@ import java.util.AbstractMap;
 
 static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
 
-// Integer validation
-Integer validatedPayload = Schema.Int32.validate(
+// int validation
+int validatedPayload = Schema.Int32.validate(
     1,
     configuration
 );
@@ -572,9 +572,9 @@ import java.util.AbstractMap;
 
 static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
 
-// Integer validation
-Integer validatedPayload = Schema.IntegerSchema.validate(
-    1,
+// long validation
+long validatedPayload = Schema.IntegerSchema.validate(
+    1L,
     configuration
 );
 ```

--- a/samples/client/petstore/java/docs/paths/foo/get/responses/responsedefault/content/applicationjson/Schema.md
+++ b/samples/client/petstore/java/docs/paths/foo/get/responses/responsedefault/content/applicationjson/Schema.md
@@ -35,6 +35,15 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 Schema.SchemaMap validatedPayload =
     Schema.Schema1.validate(
     MapMaker.makeMap(
+        new AbstractMap.SimpleEntry<>(
+            "string",
+            MapMaker.makeMap(
+                new AbstractMap.SimpleEntry<>(
+                    "bar",
+                    "a"
+                )
+            )
+        )
     ),
     configuration
 );

--- a/samples/client/petstore/java/docs/paths/storeorderorderid/get/parameters/parameter0/Schema0.md
+++ b/samples/client/petstore/java/docs/paths/storeorderorderid/get/parameters/parameter0/Schema0.md
@@ -30,9 +30,9 @@ import java.util.AbstractMap;
 
 static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
 
-// Integer validation
-Integer validatedPayload = Schema0.Schema01.validate(
-    1,
+// long validation
+long validatedPayload = Schema0.Schema01.validate(
+    1L,
     configuration
 );
 ```

--- a/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
@@ -2272,6 +2272,12 @@ public class DefaultGenerator implements Generator {
             }
         }
         // todo handle not const or not enum here
+        Object longVal = 1L;
+        if (schema.format == null) {
+            return longVal;
+        } else if ("int64".equals(schema.format)) {
+            return longVal;
+        }
         return 1;
     }
 

--- a/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
@@ -1593,6 +1593,9 @@ public class DefaultGenerator implements Generator {
         if (value instanceof Integer || value instanceof Long){
             type = "integer";
         } else if (value instanceof Double || value instanceof Float || value instanceof BigDecimal){
+            if (value instanceof BigDecimal) {
+                usedValue = ((BigDecimal) value).doubleValue();
+            }
             type = "number";
         } else if (value instanceof String) {
             type = "string";
@@ -2294,7 +2297,19 @@ public class DefaultGenerator implements Generator {
             }
         }
         // todo handle not const or not enum here
-        return 3.14;
+        if (schema.format == null) {
+            return 1;
+        } else if (schema.format.equals("int32")) {
+            return 1;
+        } else if (schema.format.equals("int64")) {
+            return 1L;
+        } else if (schema.format.equals("float")) {
+            return 3.14f;
+        } else if (schema.format.equals("double")) {
+            return 3.14d;
+        } else {
+            return 1;
+        }
     }
 
     private Object getStringFromSchema(CodegenSchema schema) {

--- a/src/main/java/org/openapijsonschematools/codegen/generators/openapimodels/EnumValue.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/openapimodels/EnumValue.java
@@ -13,6 +13,11 @@ public class EnumValue {
         this.description = description;
     }
 
+    public String javaType() {
+        // Integer etc
+        return this.value.getClass().getSimpleName();
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/resources/java/src/main/java/packagename/components/schemas/docschema_codeSample.hbs
+++ b/src/main/resources/java/src/main/java/packagename/components/schemas/docschema_codeSample.hbs
@@ -43,8 +43,13 @@ FrozenList<Object> validatedPayload = {{../../../containerJsonPathPiece.camelCas
 String validatedPayload = {{../../../containerJsonPathPiece.camelCase}}.{{../jsonPathPiece.camelCase}}.validate(
             {{else}}
                 {{#eq @key "integer"}}
-// Integer validation
-Integer validatedPayload = {{../../../containerJsonPathPiece.camelCase}}.{{../jsonPathPiece.camelCase}}.validate(
+                    {{#or (eq ../format null) (eq ../format "int64") }}
+// long validation
+long validatedPayload = {{../../../containerJsonPathPiece.camelCase}}.{{../jsonPathPiece.camelCase}}.validate(
+                    {{else}}
+// int validation
+int validatedPayload = {{../../../containerJsonPathPiece.camelCase}}.{{../jsonPathPiece.camelCase}}.validate(
+                    {{/or}}
                 {{else}}
                     {{#eq @key "number"}}
 // Number validation

--- a/src/main/resources/java/src/main/java/packagename/components/schemas/docschema_codeSample.hbs
+++ b/src/main/resources/java/src/main/java/packagename/components/schemas/docschema_codeSample.hbs
@@ -52,8 +52,23 @@ int validatedPayload = {{../../../containerJsonPathPiece.camelCase}}.{{../jsonPa
                     {{/or}}
                 {{else}}
                     {{#eq @key "number"}}
-// Number validation
+                        {{#eq ../format "int64"}}
+// long validation
 Number validatedPayload = {{../../../containerJsonPathPiece.camelCase}}.{{../jsonPathPiece.camelCase}}.validate(
+                        {{else}}
+                            {{#eq ../format "float"}}
+// float validation
+float validatedPayload = {{../../../containerJsonPathPiece.camelCase}}.{{../jsonPathPiece.camelCase}}.validate(
+                            {{else}}
+                                {{#eq ../format "double"}}
+// double validation
+double validatedPayload = {{../../../containerJsonPathPiece.camelCase}}.{{../jsonPathPiece.camelCase}}.validate(
+                                {{else}}
+// int validation
+int validatedPayload = {{../../../containerJsonPathPiece.camelCase}}.{{../jsonPathPiece.camelCase}}.validate(
+                                {{/eq}}
+                            {{/eq}}
+                        {{/eq}}
                     {{else}}
                         {{#eq @key "boolean"}}
 // boolean validation

--- a/src/main/resources/java/src/main/java/packagename/components/schemas/helpers/payload_renderer.hbs
+++ b/src/main/resources/java/src/main/java/packagename/components/schemas/helpers/payload_renderer.hbs
@@ -22,7 +22,19 @@ Arrays.asList(
 ){{endChar}}
 {{/eq}}
 {{#eq type "number"}}
-{{value}}{{endChar}}
+    {{#eq javaType "Long"}}
+{{value}}L{{endChar}}
+    {{else}}
+        {{#eq javaType "Float"}}
+{{value}}f{{endChar}}
+        {{else}}
+            {{#eq javaType "Double"}}
+{{value}}d{{endChar}}
+            {{else}}
+{{value}}{{endChar}}{{! Integer }}
+            {{/eq}}
+        {{/eq}}
+    {{/eq}}
 {{/eq}}
 {{#eq type "integer"}}
 {{value}}{{#eq javaType "Long"}}L{{/eq}}{{endChar}}

--- a/src/main/resources/java/src/main/java/packagename/components/schemas/helpers/payload_renderer.hbs
+++ b/src/main/resources/java/src/main/java/packagename/components/schemas/helpers/payload_renderer.hbs
@@ -25,7 +25,7 @@ Arrays.asList(
 {{value}}{{endChar}}
 {{/eq}}
 {{#eq type "integer"}}
-{{value}}{{endChar}}
+{{value}}{{#eq javaType "Long"}}L{{/eq}}{{endChar}}
 {{/eq}}
 {{#eq type "boolean"}}
 {{value}}{{endChar}}


### PR DESCRIPTION
Java, improves schema doc code samples
- improves integer/number/$ref code samples

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
