### PR TITLE
Java, schema documentation improvements for strings

### DIFF
--- a/samples/client/petstore/java/docs/components/schemas/Apple.md
+++ b/samples/client/petstore/java/docs/components/schemas/Apple.md
@@ -45,11 +45,11 @@ Apple.AppleMap validatedPayload =
     MapMaker.makeMap(
         new AbstractMap.SimpleEntry<>(
             "cultivar",
-            "\ziEEpmVvrKlTttzGFqCEG"
+            "IaQnEaqioxT	oASzjxaSH"
         ),
         new AbstractMap.SimpleEntry<>(
             "origin",
-            "\ziEEpmVvrKlTttzGFqCEG"
+            "IaQnEaqioxT	oASzjxaSH"
         )
     ),
     configuration
@@ -114,7 +114,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 
 // String validation
 String validatedPayload = Apple.Origin.validate(
-    "\ziEEpmVvrKlTttzGFqCEG",
+    "IaQnEaqioxT	oASzjxaSH",
     configuration
 );
 ```
@@ -152,7 +152,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 
 // String validation
 String validatedPayload = Apple.Cultivar.validate(
-    "\ziEEpmVvrKlTttzGFqCEG",
+    "IaQnEaqioxT	oASzjxaSH",
     configuration
 );
 ```

--- a/samples/client/petstore/java/docs/components/schemas/Apple.md
+++ b/samples/client/petstore/java/docs/components/schemas/Apple.md
@@ -45,11 +45,11 @@ Apple.AppleMap validatedPayload =
     MapMaker.makeMap(
         new AbstractMap.SimpleEntry<>(
             "cultivar",
-            "a"
+            "\ziEEpmVvrKlTttzGFqCEG"
         ),
         new AbstractMap.SimpleEntry<>(
             "origin",
-            "a"
+            "\ziEEpmVvrKlTttzGFqCEG"
         )
     ),
     configuration
@@ -114,7 +114,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 
 // String validation
 String validatedPayload = Apple.Origin.validate(
-    "a",
+    "\ziEEpmVvrKlTttzGFqCEG",
     configuration
 );
 ```
@@ -152,7 +152,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 
 // String validation
 String validatedPayload = Apple.Cultivar.validate(
-    "a",
+    "\ziEEpmVvrKlTttzGFqCEG",
     configuration
 );
 ```

--- a/samples/client/petstore/java/docs/components/schemas/ComposedOneOfDifferentTypes.md
+++ b/samples/client/petstore/java/docs/components/schemas/ComposedOneOfDifferentTypes.md
@@ -66,7 +66,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 
 // String validation
 String validatedPayload = ComposedOneOfDifferentTypes.Schema6.validate(
-    "a",
+    "1970-01-01T00:00:00.00Z",
     configuration
 );
 ```

--- a/samples/client/petstore/java/docs/components/schemas/ComposedOneOfDifferentTypes.md
+++ b/samples/client/petstore/java/docs/components/schemas/ComposedOneOfDifferentTypes.md
@@ -66,7 +66,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 
 // String validation
 String validatedPayload = ComposedOneOfDifferentTypes.Schema6.validate(
-    "1970-01-01T00:00:00.00Z",
+    "2020jUR,rZ#UM/?R,Fp^l6$ARj",
     configuration
 );
 ```

--- a/samples/client/petstore/java/docs/components/schemas/DateTimeTest.md
+++ b/samples/client/petstore/java/docs/components/schemas/DateTimeTest.md
@@ -32,7 +32,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 
 // String validation
 String validatedPayload = DateTimeTest.DateTimeTest1.validate(
-    "a",
+    "1970-01-01T00:00:00.00Z",
     configuration
 );
 ```

--- a/samples/client/petstore/java/docs/components/schemas/DateTimeWithValidations.md
+++ b/samples/client/petstore/java/docs/components/schemas/DateTimeWithValidations.md
@@ -32,7 +32,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 
 // String validation
 String validatedPayload = DateTimeWithValidations.DateTimeWithValidations1.validate(
-    "a",
+    "1970-01-01T00:00:00.00Z",
     configuration
 );
 ```

--- a/samples/client/petstore/java/docs/components/schemas/DateTimeWithValidations.md
+++ b/samples/client/petstore/java/docs/components/schemas/DateTimeWithValidations.md
@@ -32,7 +32,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 
 // String validation
 String validatedPayload = DateTimeWithValidations.DateTimeWithValidations1.validate(
-    "1970-01-01T00:00:00.00Z",
+    "2020jUR,rZ#UM/?R,Fp^l6$ARj",
     configuration
 );
 ```

--- a/samples/client/petstore/java/docs/components/schemas/DateWithValidations.md
+++ b/samples/client/petstore/java/docs/components/schemas/DateWithValidations.md
@@ -32,7 +32,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 
 // String validation
 String validatedPayload = DateWithValidations.DateWithValidations1.validate(
-    "a",
+    "2020-12-13",
     configuration
 );
 ```

--- a/samples/client/petstore/java/docs/components/schemas/DateWithValidations.md
+++ b/samples/client/petstore/java/docs/components/schemas/DateWithValidations.md
@@ -32,7 +32,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 
 // String validation
 String validatedPayload = DateWithValidations.DateWithValidations1.validate(
-    "2020-12-13",
+    "2020jUR,rZ#UM/?R,Fp^l6$ARj",
     configuration
 );
 ```

--- a/samples/client/petstore/java/docs/components/schemas/FormatTest.md
+++ b/samples/client/petstore/java/docs/components/schemas/FormatTest.md
@@ -134,11 +134,11 @@ FormatTest.FormatTestMap validatedPayload =
         ),
         new AbstractMap.SimpleEntry<>(
             "pattern_with_digits",
-            "\dddddddddd"
+            "0480728880"
         ),
         new AbstractMap.SimpleEntry<>(
             "pattern_with_digits_and_delimiter",
-            "IMage_\dd"
+            "IMage_88"
         ),
         new AbstractMap.SimpleEntry<>(
             "noneProp",
@@ -251,7 +251,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 
 // String validation
 String validatedPayload = FormatTest.PatternWithDigitsAndDelimiter.validate(
-    "IMage_\dd",
+    "IMage_88",
     configuration
 );
 ```
@@ -292,7 +292,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 
 // String validation
 String validatedPayload = FormatTest.PatternWithDigits.validate(
-    "\dddddddddd",
+    "0480728880",
     configuration
 );
 ```

--- a/samples/client/petstore/java/docs/components/schemas/FormatTest.md
+++ b/samples/client/petstore/java/docs/components/schemas/FormatTest.md
@@ -114,7 +114,7 @@ FormatTest.FormatTestMap validatedPayload =
         ),
         new AbstractMap.SimpleEntry<>(
             "string",
-            "a"
+            "A"
         ),
         new AbstractMap.SimpleEntry<>(
             "binary",
@@ -134,11 +134,11 @@ FormatTest.FormatTestMap validatedPayload =
         ),
         new AbstractMap.SimpleEntry<>(
             "pattern_with_digits",
-            "a"
+            "\dddddddddd"
         ),
         new AbstractMap.SimpleEntry<>(
             "pattern_with_digits_and_delimiter",
-            "a"
+            "IMage_\dd"
         ),
         new AbstractMap.SimpleEntry<>(
             "noneProp",
@@ -251,7 +251,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 
 // String validation
 String validatedPayload = FormatTest.PatternWithDigitsAndDelimiter.validate(
-    "a",
+    "IMage_\dd",
     configuration
 );
 ```
@@ -292,7 +292,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 
 // String validation
 String validatedPayload = FormatTest.PatternWithDigits.validate(
-    "a",
+    "\dddddddddd",
     configuration
 );
 ```
@@ -420,7 +420,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 
 // String validation
 String validatedPayload = FormatTest.StringSchema.validate(
-    "a",
+    "A",
     configuration
 );
 ```

--- a/samples/client/petstore/java/docs/components/schemas/FormatTest.md
+++ b/samples/client/petstore/java/docs/components/schemas/FormatTest.md
@@ -64,7 +64,7 @@ FormatTest.FormatTestMap validatedPayload =
         ),
         new AbstractMap.SimpleEntry<>(
             "date",
-            "a"
+            "2020-12-13"
         ),
         new AbstractMap.SimpleEntry<>(
             "number",
@@ -122,15 +122,15 @@ FormatTest.FormatTestMap validatedPayload =
         ),
         new AbstractMap.SimpleEntry<>(
             "dateTime",
-            "a"
+            "1970-01-01T00:00:00.00Z"
         ),
         new AbstractMap.SimpleEntry<>(
             "uuid",
-            "a"
+            "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
         ),
         new AbstractMap.SimpleEntry<>(
             "uuidNoExample",
-            "a"
+            "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
         ),
         new AbstractMap.SimpleEntry<>(
             "pattern_with_digits",

--- a/samples/client/petstore/java/docs/components/schemas/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/client/petstore/java/docs/components/schemas/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -41,11 +41,11 @@ MixedPropertiesAndAdditionalPropertiesClass.MixedPropertiesAndAdditionalProperti
     MapMaker.makeMap(
         new AbstractMap.SimpleEntry<>(
             "uuid",
-            "a"
+            "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
         ),
         new AbstractMap.SimpleEntry<>(
             "dateTime",
-            "a"
+            "1970-01-01T00:00:00.00Z"
         ),
         new AbstractMap.SimpleEntry<>(
             "map",

--- a/samples/client/petstore/java/docs/components/schemas/Money.md
+++ b/samples/client/petstore/java/docs/components/schemas/Money.md
@@ -39,7 +39,7 @@ Money.MoneyMap validatedPayload =
     MapMaker.makeMap(
         new AbstractMap.SimpleEntry<>(
             "amount",
-            "a"
+            "3.14"
         ),
         new AbstractMap.SimpleEntry<>(
             "currency",

--- a/samples/client/petstore/java/docs/components/schemas/MyObjectDto.md
+++ b/samples/client/petstore/java/docs/components/schemas/MyObjectDto.md
@@ -39,7 +39,7 @@ MyObjectDto.MyObjectDtoMap validatedPayload =
     MapMaker.makeMap(
         new AbstractMap.SimpleEntry<>(
             "id",
-            "a"
+            "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
         )
     ),
     configuration

--- a/samples/client/petstore/java/docs/components/schemas/NullableClass.md
+++ b/samples/client/petstore/java/docs/components/schemas/NullableClass.md
@@ -762,7 +762,7 @@ Void validatedPayload = NullableClass.DatetimeProp.validate(
 
 // String validation
 String validatedPayload = NullableClass.DatetimeProp.validate(
-    "a",
+    "1970-01-01T00:00:00.00Z",
     configuration
 );
 ```
@@ -807,7 +807,7 @@ Void validatedPayload = NullableClass.DateProp.validate(
 
 // String validation
 String validatedPayload = NullableClass.DateProp.validate(
-    "a",
+    "2020-12-13",
     configuration
 );
 ```

--- a/samples/client/petstore/java/docs/components/schemas/ObjectWithDecimalProperties.md
+++ b/samples/client/petstore/java/docs/components/schemas/ObjectWithDecimalProperties.md
@@ -38,18 +38,18 @@ ObjectWithDecimalProperties.ObjectWithDecimalPropertiesMap validatedPayload =
     MapMaker.makeMap(
         new AbstractMap.SimpleEntry<>(
             "length",
-            "a"
+            "3.14"
         ),
         new AbstractMap.SimpleEntry<>(
             "width",
-            "a"
+            "3.14"
         ),
         new AbstractMap.SimpleEntry<>(
             "cost",
             MapMaker.makeMap(
                 new AbstractMap.SimpleEntry<>(
                     "amount",
-                    "a"
+                    "3.14"
                 ),
                 new AbstractMap.SimpleEntry<>(
                     "currency",

--- a/samples/client/petstore/java/docs/components/schemas/Order.md
+++ b/samples/client/petstore/java/docs/components/schemas/Order.md
@@ -55,7 +55,7 @@ Order.OrderMap validatedPayload =
         ),
         new AbstractMap.SimpleEntry<>(
             "shipDate",
-            "a"
+            "1970-01-01T00:00:00.00Z"
         ),
         new AbstractMap.SimpleEntry<>(
             "status",

--- a/samples/client/petstore/java/docs/components/schemas/UUIDString.md
+++ b/samples/client/petstore/java/docs/components/schemas/UUIDString.md
@@ -32,7 +32,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 
 // String validation
 String validatedPayload = UUIDString.UUIDString1.validate(
-    "a",
+    "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
     configuration
 );
 ```

--- a/samples/client/petstore/java/docs/paths/fake/post/requestbody/content/applicationxwwwformurlencoded/Schema.md
+++ b/samples/client/petstore/java/docs/paths/fake/post/requestbody/content/applicationxwwwformurlencoded/Schema.md
@@ -63,7 +63,7 @@ Schema.SchemaMap validatedPayload =
         ),
         new AbstractMap.SimpleEntry<>(
             "pattern_without_delimiter",
-            "a"
+            "AUR,rZ#UM/?R,Fp^l6$ARjbhJk C>"
         ),
         new AbstractMap.SimpleEntry<>(
             "integer",
@@ -83,7 +83,7 @@ Schema.SchemaMap validatedPayload =
         ),
         new AbstractMap.SimpleEntry<>(
             "string",
-            "a"
+            "A"
         ),
         new AbstractMap.SimpleEntry<>(
             "binary",
@@ -315,7 +315,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 
 // String validation
 String validatedPayload = Schema.PatternWithoutDelimiter.validate(
-    "a",
+    "AUR,rZ#UM/?R,Fp^l6$ARjbhJk C>",
     configuration
 );
 ```
@@ -356,7 +356,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 
 // String validation
 String validatedPayload = Schema.StringSchema.validate(
-    "a",
+    "A",
     configuration
 );
 ```

--- a/samples/client/petstore/java/docs/paths/fake/post/requestbody/content/applicationxwwwformurlencoded/Schema.md
+++ b/samples/client/petstore/java/docs/paths/fake/post/requestbody/content/applicationxwwwformurlencoded/Schema.md
@@ -91,11 +91,11 @@ Schema.SchemaMap validatedPayload =
         ),
         new AbstractMap.SimpleEntry<>(
             "date",
-            "a"
+            "2020-12-13"
         ),
         new AbstractMap.SimpleEntry<>(
             "dateTime",
-            "a"
+            "1970-01-01T00:00:00.00Z"
         ),
         new AbstractMap.SimpleEntry<>(
             "password",
@@ -243,7 +243,7 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 
 // String validation
 String validatedPayload = Schema.DateTime.validate(
-    "a",
+    "1970-01-01T00:00:00.00Z",
     configuration
 );
 ```

--- a/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
@@ -2316,7 +2316,7 @@ public class DefaultGenerator implements Generator {
     }
 
     private String getPatternExample(CodegenPatternInfo patternInfo) {
-        String extractedPattern = patternInfo.pattern;
+        String extractedPattern = patternInfo.pattern.original;
         LinkedHashSet<String> regexFlags = patternInfo.flags;
                 /*
                 RxGen does not support our ECMA dialect https://github.com/curious-odd-man/RgxGen/issues/56
@@ -2334,7 +2334,8 @@ public class DefaultGenerator implements Generator {
 
         // this seed makes it so if we have [a-z] we pick a
         Random random = new Random(18);
-        return rgxGen.generate(random);
+        String result = rgxGen.generate(random);
+        return result;
     }
 
     private Object getStringFromSchema(CodegenSchema schema) {
@@ -4704,7 +4705,10 @@ public class DefaultGenerator implements Generator {
      */
     public CodegenPatternInfo addRegularExpressionDelimiter(String pattern) {
         if (StringUtils.isEmpty(pattern)) {
-            return new CodegenPatternInfo(pattern, null);
+            return new CodegenPatternInfo(
+                    new CodegenText(pattern, escapeUnsafeCharacters(pattern)),
+                    null
+            );
         }
 
         String usedPattern = pattern;
@@ -4712,7 +4716,10 @@ public class DefaultGenerator implements Generator {
             usedPattern = "/" + pattern.replaceAll("/", "\\\\/") + "/";
         }
 
-        return new CodegenPatternInfo(usedPattern, null);
+        return new CodegenPatternInfo(
+                new CodegenText(usedPattern, escapeUnsafeCharacters(usedPattern)),
+                null
+        );
     }
 
     /**

--- a/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
@@ -2325,6 +2325,15 @@ public class DefaultGenerator implements Generator {
             }
         }
         // todo handle not const or not enum here
+        if ("date".equals(schema.format)) {
+            return "2020-12-13";
+        } else if ("date-time".equals(schema.format)) {
+            return "1970-01-01T00:00:00.00Z";
+        } else if ("number".equals(schema.format)) {
+            return "3.14";
+        } else if ("uuid".equals(schema.format)) {
+            return "046b6c7f-0b8a-43b9-b35d-6489e6daee91";
+        }
         return "a";
     }
 

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -139,7 +139,6 @@ public class JavaClientGenerator extends AbstractJavaGenerator
     protected Map<String, MpRestClientVersion> mpRestClientVersions = new HashMap<>();
     protected boolean useSingleRequestParameter = false;
     protected HashMap<String, String> schemaJsonPathToModelName = new HashMap<>();
-    private final Pattern patternRegex = Pattern.compile("^/?(.+?)/?([simu]{0,4})$");
 
     private static class MpRestClientVersion {
         public final String rootPackage;
@@ -1815,62 +1814,5 @@ public class JavaClientGenerator extends AbstractJavaGenerator
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
         return String.join(File.separator, finalPathPieces);
-    }
-
-    /**
-     * Notes:
-     * RgxGen does not support our ECMA dialect
-     * <a href="https://github.com/curious-odd-man/RgxGen/issues/56">...</a>
-     * So strip off the leading / and trailing / and turn on ignore case if we have it
-     *
-     * json schema test cases omit the leading and trailing /s, so make sure that the regex allows that
-     *
-     * Flags:
-     * <a href="https://262.ecma-international.org/13.0/#sec-get-regexp.prototype.flags">...</a>
-     * d hasIndices: indicates that the result of a regular expression match should contain the start and end indices of the substrings of each capture group
-     * g global: the regular expression should be tested against all possible matches in a string
-     * i ignoreCase: case should be ignored while attempting a match in a string
-     * m multiline: a multiline input string should be treated as multiple lines
-     * s dotAll: the dot special character (.) should additionally match 4 line terminator ("newline") characters in a string
-     * u unicode: enables various Unicode-related features such as unicode code point escapes
-     * y sticky: the regex attempts to match the target string only from the index indicated by the lastIndex property
-     *
-     * Python flags:
-     * <a href="https://docs.python.org/3/library/re.html#flags">...</a>
-     * i, m, s u
-     *
-     * @param pattern the pattern (regular expression)
-     * @return the resultant regex for python
-     */
-    @Override
-    public CodegenPatternInfo getPatternInfo(String pattern) {
-        if (pattern == null) {
-            return null;
-        }
-        Matcher m = patternRegex.matcher(pattern);
-        if (m.find()) {
-            int groupCount = m.groupCount();
-            boolean patternWithNoFlags = groupCount == 1;
-            boolean patternWithFlags = groupCount == 2;
-            if (patternWithNoFlags) {
-                String isolatedPattern = m.group(1);
-                CodegenText usedPattern = new CodegenText(isolatedPattern, escapeUnsafeCharacters(isolatedPattern));
-                return new CodegenPatternInfo(usedPattern, null);
-            } else if (patternWithFlags) {
-                String isolatedPattern = m.group(1);
-                CodegenText usedPattern = new CodegenText(isolatedPattern, escapeUnsafeCharacters(isolatedPattern));
-                String foundFlags = m.group(2);
-                if (foundFlags.isEmpty()) {
-                    return new CodegenPatternInfo(usedPattern, null);
-                }
-                LinkedHashSet<String> flags = new LinkedHashSet<>();
-                for (Character c: foundFlags.toCharArray()) {
-                    flags.add(c.toString());
-                }
-                return new CodegenPatternInfo(usedPattern, flags);
-            }
-        }
-        CodegenText usedPattern = new CodegenText(pattern, escapeUnsafeCharacters(pattern));
-        return new CodegenPatternInfo(usedPattern, null);
     }
 }

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -35,6 +35,7 @@ import org.openapijsonschematools.codegen.generators.openapimodels.CodegenReques
 import org.openapijsonschematools.codegen.generators.openapimodels.CodegenResponse;
 import org.openapijsonschematools.codegen.generators.openapimodels.CodegenSchema;
 import org.openapijsonschematools.codegen.generators.openapimodels.CodegenSecurityScheme;
+import org.openapijsonschematools.codegen.generators.openapimodels.CodegenText;
 import org.openapijsonschematools.codegen.generators.openapimodels.EnumInfo;
 import org.openapijsonschematools.codegen.templating.HandlebarsEngineAdapter;
 import org.openapijsonschematools.codegen.templating.SupportingFile;
@@ -1846,28 +1847,30 @@ public class JavaClientGenerator extends AbstractJavaGenerator
         if (pattern == null) {
             return null;
         }
-        String usedPattern = escapeUnsafeCharacters(pattern);
-        Matcher m = patternRegex.matcher(usedPattern);
+        Matcher m = patternRegex.matcher(pattern);
         if (m.find()) {
             int groupCount = m.groupCount();
-            if (groupCount == 1) {
-                // only pattern found
+            boolean patternWithNoFlags = groupCount == 1;
+            boolean patternWithFlags = groupCount == 2;
+            if (patternWithNoFlags) {
                 String isolatedPattern = m.group(1);
-                return new CodegenPatternInfo(isolatedPattern, null);
-            } else if (groupCount == 2) {
-                // patterns and flag found
+                CodegenText usedPattern = new CodegenText(isolatedPattern, escapeUnsafeCharacters(isolatedPattern));
+                return new CodegenPatternInfo(usedPattern, null);
+            } else if (patternWithFlags) {
                 String isolatedPattern = m.group(1);
+                CodegenText usedPattern = new CodegenText(isolatedPattern, escapeUnsafeCharacters(isolatedPattern));
                 String foundFlags = m.group(2);
                 if (foundFlags.isEmpty()) {
-                    return new CodegenPatternInfo(isolatedPattern, null);
+                    return new CodegenPatternInfo(usedPattern, null);
                 }
                 LinkedHashSet<String> flags = new LinkedHashSet<>();
                 for (Character c: foundFlags.toCharArray()) {
                     flags.add(c.toString());
                 }
-                return new CodegenPatternInfo(isolatedPattern, flags);
+                return new CodegenPatternInfo(usedPattern, flags);
             }
         }
+        CodegenText usedPattern = new CodegenText(pattern, escapeUnsafeCharacters(pattern));
         return new CodegenPatternInfo(usedPattern, null);
     }
 }

--- a/src/main/java/org/openapijsonschematools/codegen/generators/PythonClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/PythonClientGenerator.java
@@ -80,7 +80,6 @@ public class PythonClientGenerator extends AbstractPythonGenerator {
     // nose is a python testing framework, we use pytest if USE_NOSE is unset
     public static final String USE_NOSE = "useNose";
     public static final String RECURSION_LIMIT = "recursionLimit";
-    private final Pattern patternRegex = Pattern.compile("^/?(.+?)/?([simu]{0,4})$");
 
     protected String packageUrl;
     protected String apiDocPath = "docs/apis/tags/";
@@ -1755,63 +1754,6 @@ public class PythonClientGenerator extends AbstractPythonGenerator {
             modelNameToSchemaCache = Collections.unmodifiableMap(m);
         }
         return modelNameToSchemaCache;
-    }
-
-    /**
-     * Notes:
-     * RgxGen does not support our ECMA dialect
-     * <a href="https://github.com/curious-odd-man/RgxGen/issues/56">...</a>
-     * So strip off the leading / and trailing / and turn on ignore case if we have it
-     *
-     * json schema test cases omit the leading and trailing /s, so make sure that the regex allows that
-     *
-      * Flags:
-     * <a href="https://262.ecma-international.org/13.0/#sec-get-regexp.prototype.flags">...</a>
-     * d hasIndices: indicates that the result of a regular expression match should contain the start and end indices of the substrings of each capture group
-     * g global: the regular expression should be tested against all possible matches in a string
-     * i ignoreCase: case should be ignored while attempting a match in a string
-     * m multiline: a multiline input string should be treated as multiple lines
-     * s dotAll: the dot special character (.) should additionally match 4 line terminator ("newline") characters in a string
-     * u unicode: enables various Unicode-related features such as unicode code point escapes
-     * y sticky: the regex attempts to match the target string only from the index indicated by the lastIndex property
-     *
-     * Python flags:
-     * <a href="https://docs.python.org/3/library/re.html#flags">...</a>
-     * i, m, s u
-     *
-     * @param pattern the pattern (regular expression)
-     * @return the resultant regex for python
-     */
-    @Override
-    public CodegenPatternInfo getPatternInfo(String pattern) {
-        if (pattern == null) {
-            return null;
-        }
-        Matcher m = patternRegex.matcher(pattern);
-        if (m.find()) {
-            int groupCount = m.groupCount();
-            boolean patternWithNoFlags = groupCount == 1;
-            boolean patternWithFlags = groupCount == 2;
-            if (patternWithNoFlags) {
-                String isolatedPattern = m.group(1);
-                CodegenText usedPattern = new CodegenText(isolatedPattern, escapeUnsafeCharacters(isolatedPattern));
-                return new CodegenPatternInfo(usedPattern, null);
-            } else if (patternWithFlags) {
-                String isolatedPattern = m.group(1);
-                CodegenText usedPattern = new CodegenText(isolatedPattern, escapeUnsafeCharacters(isolatedPattern));
-                String foundFlags = m.group(2);
-                if (foundFlags.isEmpty()) {
-                    return new CodegenPatternInfo(usedPattern, null);
-                }
-                LinkedHashSet<String> flags = new LinkedHashSet<>();
-                for (Character c: foundFlags.toCharArray()) {
-                    flags.add(c.toString());
-                }
-                return new CodegenPatternInfo(usedPattern, flags);
-            }
-        }
-        CodegenText usedPattern = new CodegenText(pattern, escapeUnsafeCharacters(pattern));
-        return new CodegenPatternInfo(usedPattern, null);
     }
 
     @Override

--- a/src/main/java/org/openapijsonschematools/codegen/generators/openapimodels/CodegenPatternInfo.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/openapimodels/CodegenPatternInfo.java
@@ -3,10 +3,10 @@ package org.openapijsonschematools.codegen.generators.openapimodels;
 import java.util.LinkedHashSet;
 
 public class CodegenPatternInfo {
-    public final String pattern;
+    public final CodegenText pattern;
     public final LinkedHashSet<String> flags;
 
-    public CodegenPatternInfo(String pattern, LinkedHashSet<String> flags) {
+    public CodegenPatternInfo(CodegenText pattern, LinkedHashSet<String> flags) {
         this.pattern = pattern;
         this.flags = flags;
     }

--- a/src/main/resources/java/src/main/java/packagename/components/schemas/SchemaClass/_pattern.hbs
+++ b/src/main/resources/java/src/main/java/packagename/components/schemas/SchemaClass/_pattern.hbs
@@ -1,7 +1,7 @@
 {{#if forDocs}}
 &nbsp;&nbsp;&nbsp;&nbsp;new KeywordEntry("pattern", new PatternValidator(<br>
     {{~#with patternInfo}}
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"{{{pattern}}}"{{#if flags}},{{/if}}<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"{{{pattern.codeEscaped}}}"{{#if flags}},{{/if}}<br>
         {{~#if flags}}
             {{#eq flags.size 1}}
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{{#each flags}}Pattern.{{#eq this "i"}}CASE_INSENSITIVE{{/eq}}{{#eq this "m"}}MULTILINE{{/eq}}{{#eq this "s"}}DOTALL{{/eq}}{{#eq this "u"}}UNICODE_CHARACTER_CLASS{{/eq}}{{/each}}<br>
@@ -29,7 +29,7 @@
 {{~else}}
 new KeywordEntry("pattern", new PatternValidator(Pattern.compile(
     {{#with patternInfo}}
-    "{{{pattern}}}"{{#if flags}},{{/if}}
+    "{{{pattern.codeEscaped}}}"{{#if flags}},{{/if}}
         {{#if flags}}
             {{#eq flags.size 1}}
     {{#each flags}}Pattern.{{#eq this "i"}}CASE_INSENSITIVE{{/eq}}{{#eq this "m"}}MULTILINE{{/eq}}{{#eq this "s"}}DOTALL{{/eq}}{{#eq this "u"}}UNICODE_CHARACTER_CLASS{{/eq}}{{/each}}

--- a/src/main/resources/java/src/main/java/packagename/components/schemas/docschema_codeSample.hbs
+++ b/src/main/resources/java/src/main/java/packagename/components/schemas/docschema_codeSample.hbs
@@ -54,7 +54,7 @@ int validatedPayload = {{../../../containerJsonPathPiece.camelCase}}.{{../jsonPa
                     {{#eq @key "number"}}
                         {{#eq ../format "int64"}}
 // long validation
-Number validatedPayload = {{../../../containerJsonPathPiece.camelCase}}.{{../jsonPathPiece.camelCase}}.validate(
+long validatedPayload = {{../../../containerJsonPathPiece.camelCase}}.{{../jsonPathPiece.camelCase}}.validate(
                         {{else}}
                             {{#eq ../format "float"}}
 // float validation

--- a/src/main/resources/python/components/schemas/schema_cls/__pattern_info.hbs
+++ b/src/main/resources/python/components/schemas/schema_cls/__pattern_info.hbs
@@ -1,6 +1,6 @@
 {{#if propertyName}}{{propertyName}}: schemas.PatternInfo = {{/if}}schemas.PatternInfo(
 {{#with patternInfo}}
-    pattern=r'{{{pattern}}}'{{#if flags}},{{/if}}  # noqa: E501
+    pattern=r'{{{pattern.original}}}'{{#if flags}},{{/if}}  # noqa: E501
     {{#if flags}}
         {{#eq flags.size 1}}
     flags={{#each flags}}re.{{#eq this "i"}}I{{/eq}}{{#eq this "m"}}M{{/eq}}{{#eq this "s"}}S{{/eq}}{{#eq this "u"}}U{{/eq}}{{/each}},

--- a/src/test/java/org/openapijsonschematools/codegen/generatorrunner/DefaultGeneratorRunnerTest.java
+++ b/src/test/java/org/openapijsonschematools/codegen/generatorrunner/DefaultGeneratorRunnerTest.java
@@ -342,7 +342,7 @@ public class DefaultGeneratorRunnerTest {
 
         String expectedPattern = "^\\d{3}-\\d{2}-\\d{4}$";
         // NOTE: double-escaped regex for when the value is intended to be dumped in template into a String location.
-        String escapedPattern = config.getPatternInfo(expectedPattern).pattern;
+        String escapedPattern = config.getPatternInfo(expectedPattern).pattern.original;
 
         Schema stringRegex = openAPI.getComponents().getSchemas().get("StringRegex");
         // Sanity check.
@@ -358,7 +358,7 @@ public class DefaultGeneratorRunnerTest {
                 "#/components/schemas/A",
                 "#/components/schemas/A"
         );
-        Assert.assertEquals(stringRegexProperty.patternInfo.pattern, escapedPattern);
+        Assert.assertEquals(stringRegexProperty.patternInfo.pattern.original, escapedPattern);
 
         config.fromSchema(
                 openAPI.getComponents().getSchemas().get("StringRegex"),
@@ -378,13 +378,13 @@ public class DefaultGeneratorRunnerTest {
                 body, "#/paths/~1fake~1StringRegex/post/requestBody");
 
         CodegenKey ck = config.getKey("*/*", "misc");
-        Assert.assertEquals(codegenParameter.content.get(ck).schema.refInfo.ref.patternInfo.pattern, escapedPattern);
+        Assert.assertEquals(codegenParameter.content.get(ck).schema.refInfo.ref.patternInfo.pattern.original, escapedPattern);
 
         // Validate when converting to response
         ApiResponse response = operation.getResponses().get("200");
         CodegenResponse codegenResponse = config.fromResponse(response, "#/paths/~1fake~1StringRegex/post/responses/200");
 
-        Assert.assertEquals(codegenResponse.content.get(ck).schema.refInfo.ref.patternInfo.pattern, escapedPattern);
+        Assert.assertEquals(codegenResponse.content.get(ck).schema.refInfo.ref.patternInfo.pattern.original, escapedPattern);
     }
 
     @Test

--- a/src/test/java/org/openapijsonschematools/codegen/generators/PythonClientGeneratorTest.java
+++ b/src/test/java/org/openapijsonschematools/codegen/generators/PythonClientGeneratorTest.java
@@ -186,7 +186,7 @@ public class PythonClientGeneratorTest {
                 "#/components/schemas/" + modelName
         );
         String expectedRegexPattern = "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}";
-        Assert.assertEquals(cm.patternInfo.pattern, expectedRegexPattern);
+        Assert.assertEquals(cm.patternInfo.pattern.original, expectedRegexPattern);
         Assert.assertNull(cm.patternInfo.flags);
     }
 
@@ -205,7 +205,7 @@ public class PythonClientGeneratorTest {
                 "#/components/schemas/" + modelName
         );
         String expectedRegexPattern = "a.";
-        Assert.assertEquals(cm.patternInfo.pattern, expectedRegexPattern);
+        Assert.assertEquals(cm.patternInfo.pattern.original, expectedRegexPattern);
         Assert.assertEquals(cm.patternInfo.flags, new LinkedHashSet<>(Arrays.asList("s", "i", "m")));
     }
 


### PR DESCRIPTION
Java, schema documentation improvements for strings
- adds date example
- adds date-time example
- adds uuid example
- adds number example
- adds pattern example

### Breaking Change with Fallback
- CodegenPatternInfo.pattern had its type changed from String to CodegenText to allow python to use the original value and for Java to use the codeEscaped value, and for example generation to use the original
- To fix you templates use {{pattern.original}} to keep accessing the original string

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
