### PR TITLE
Java + Python documentation fix, changes description newlines to html br

### DIFF
--- a/samples/client/petstore/java/docs/components/schemas/Capitalization.md
+++ b/samples/client/petstore/java/docs/components/schemas/Capitalization.md
@@ -109,8 +109,7 @@ type: Map<String, Object>
 | **small_Snake** | String |  | [optional] |
 | **Capital_Snake** | String |  | [optional] |
 | **SCA_ETH_Flow_Points** | String |  | [optional] |
-| **ATT_NAME** | String | Name of the pet
- | [optional] |
+| **ATT_NAME** | String | Name of the pet<br> | [optional] |
 | **anyStringName** | Object | any string name can be used but the value must be the correct type | [optional] |
 
 ## ATTNAME
@@ -120,8 +119,7 @@ extends StringJsonSchema
 A schema class that validates payloads
 
 ## Description
-Name of the pet
-
+Name of the pet<br>
 
 | Methods Inherited from class org.openapijsonschematools.client.schemas.StringJsonSchema |
 | ------------------------------------------------------------------ |

--- a/samples/client/petstore/python/README.md
+++ b/samples/client/petstore/python/README.md
@@ -398,8 +398,7 @@ Class | Description
 
 Class | Description
 ----- | ------------
-[HeadersWithNoBody](docs/components/responses/response_headers_with_no_body.md) | A response that contains headers but no body
-
+[HeadersWithNoBody](docs/components/responses/response_headers_with_no_body.md) | A response that contains headers but no body<br>
 [RefSuccessDescriptionOnly](docs/components/responses/response_ref_success_description_only.md) |
 [RefSuccessfulXmlAndJsonArrayOfPet](docs/components/responses/response_ref_successful_xml_and_json_array_of_pet.md) |
 [SuccessDescriptionOnly](docs/components/responses/response_success_description_only.md) | Success

--- a/samples/client/petstore/python/docs/components/responses/response_headers_with_no_body.md
+++ b/samples/client/petstore/python/docs/components/responses/response_headers_with_no_body.md
@@ -2,8 +2,7 @@ petstore_api.components.responses.response_headers_with_no_body
 # Response HeadersWithNoBody
 
 ## Description
-A response that contains headers but no body
-
+A response that contains headers but no body<br>
 
 ## ApiResponse
 Name | Type | Description  | Notes

--- a/samples/client/petstore/python/docs/components/schema/capitalization.md
+++ b/samples/client/petstore/python/docs/components/schema/capitalization.md
@@ -20,8 +20,7 @@ Key | Type |  Description | Notes
 **small_Snake** | str |  | [optional]
 **Capital_Snake** | str |  | [optional]
 **SCA_ETH_Flow_Points** | str |  | [optional]
-**ATT_NAME** | str | Name of the pet
- | [optional]
+**ATT_NAME** | str | Name of the pet<br> | [optional]
 **any_string_name** | dict, schemas.immutabledict, list, tuple, decimal.Decimal, float, int, str, datetime.date, datetime.datetime, uuid.UUID, bool, None, bytes, io.FileIO, io.BufferedReader, schemas.FileIO | any string name can be used but the value must be the correct type | [optional]
 
 ## CapitalizationDict
@@ -37,8 +36,7 @@ Keyword Argument | Type | Description | Notes
 **small_Snake** | str, schemas.Unset |  | [optional]
 **Capital_Snake** | str, schemas.Unset |  | [optional]
 **SCA_ETH_Flow_Points** | str, schemas.Unset |  | [optional]
-**ATT_NAME** | str, schemas.Unset | Name of the pet
- | [optional]
+**ATT_NAME** | str, schemas.Unset | Name of the pet<br> | [optional]
 **kwargs** | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO | any string name can be used but the value must be the correct type | [optional] typed value is accessed with the get_additional_property_ method
 
 ### properties
@@ -49,8 +47,7 @@ Property | Type | Description | Notes
 **small_Snake** | str, schemas.Unset |  | [optional]
 **Capital_Snake** | str, schemas.Unset |  | [optional]
 **SCA_ETH_Flow_Points** | str, schemas.Unset |  | [optional]
-**ATT_NAME** | str, schemas.Unset | Name of the pet
- | [optional]
+**ATT_NAME** | str, schemas.Unset | Name of the pet<br> | [optional]
 
 ### methods
 Method | Input Type | Return Type | Notes

--- a/samples/client/petstore/python/docs/paths/fake/post.md
+++ b/samples/client/petstore/python/docs/paths/fake/post.md
@@ -23,11 +23,7 @@ petstore_api.paths.fake.operation
 偽のエンドポイント
 가짜 엔드 포인트
  |
-| Description | Fake endpoint for testing various parameters
-假端點
-偽のエンドポイント
-가짜 엔드 포인트
- |
+| Description | Fake endpoint for testing various parameters<br>假端點<br>偽のエンドポイント<br>가짜 엔드 포인트<br> |
 | Path | "/fake" |
 | HTTP Method | post |
 

--- a/samples/client/petstore/python/src/petstore_api/apis/tag_to_api.py
+++ b/samples/client/petstore/python/src/petstore_api/apis/tag_to_api.py
@@ -1,35 +1,35 @@
 import typing
 import typing_extensions
 
-from petstore_api.apis.tags.default_api import DefaultApi
 from petstore_api.apis.tags.fake_api import FakeApi
+from petstore_api.apis.tags.default_api import DefaultApi
 from petstore_api.apis.tags.pet_api import PetApi
 from petstore_api.apis.tags.fake_classname_tags123_api import FakeClassnameTags123Api
-from petstore_api.apis.tags.user_api import UserApi
 from petstore_api.apis.tags.store_api import StoreApi
 from petstore_api.apis.tags.another_fake_api import AnotherFakeApi
+from petstore_api.apis.tags.user_api import UserApi
 
 TagToApi = typing.TypedDict(
     'TagToApi',
     {
-        "default": typing.Type[DefaultApi],
         "fake": typing.Type[FakeApi],
+        "default": typing.Type[DefaultApi],
         "pet": typing.Type[PetApi],
         "fake_classname_tags 123#$%^": typing.Type[FakeClassnameTags123Api],
-        "user": typing.Type[UserApi],
         "store": typing.Type[StoreApi],
         "$another-fake?": typing.Type[AnotherFakeApi],
+        "user": typing.Type[UserApi],
     }
 )
 
 tag_to_api = TagToApi(
     {
-        "default": DefaultApi,
         "fake": FakeApi,
+        "default": DefaultApi,
         "pet": PetApi,
         "fake_classname_tags 123#$%^": FakeClassnameTags123Api,
-        "user": UserApi,
         "store": StoreApi,
         "$another-fake?": AnotherFakeApi,
+        "user": UserApi,
     }
 )

--- a/src/main/java/org/openapijsonschematools/codegen/generators/openapimodels/CodegenText.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/openapimodels/CodegenText.java
@@ -5,10 +5,12 @@ import java.util.Objects;
 public class CodegenText  {
     public final String original;
     public final String codeEscaped;
+    public final String originalWithBr;
 
     public CodegenText(String original, String codeEscaped) {
         this.original = original;
         this.codeEscaped = codeEscaped;
+        this.originalWithBr = original.replaceAll("(\r\n|\n)", "<br>");
     }
 
     @Override
@@ -17,7 +19,8 @@ public class CodegenText  {
         if (o == null || getClass() != o.getClass()) return false;
         CodegenText that = (CodegenText) o;
         return Objects.equals(original, that.original) &&
-                Objects.equals(codeEscaped, that.codeEscaped);
+                Objects.equals(codeEscaped, that.codeEscaped) &&
+                Objects.equals(originalWithBr, that.originalWithBr);
     }
 
     @Override
@@ -25,12 +28,13 @@ public class CodegenText  {
         final StringBuilder sb = new StringBuilder("CodegenText{");
         sb.append("original=").append(original);
         sb.append(", codeEscaped=").append(codeEscaped);
+        sb.append(", originalWithBr=").append(originalWithBr);
         sb.append('}');
         return sb.toString();
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(original, codeEscaped);
+        return Objects.hash(original, codeEscaped, originalWithBr);
     }
 }

--- a/src/main/java/org/openapijsonschematools/codegen/generators/openapimodels/CodegenText.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/openapimodels/CodegenText.java
@@ -1,16 +1,20 @@
 package org.openapijsonschematools.codegen.generators.openapimodels;
 
+import com.github.jknack.handlebars.Handlebars;
+
 import java.util.Objects;
 
 public class CodegenText  {
     public final String original;
     public final String codeEscaped;
-    public final String originalWithBr;
+    public final Handlebars.SafeString originalWithBr;
 
     public CodegenText(String original, String codeEscaped) {
         this.original = original;
         this.codeEscaped = codeEscaped;
-        this.originalWithBr = original.replaceAll("(\r\n|\n)", "<br>");
+        String escaped = (String) Handlebars.Utils.escapeExpression(original);
+        escaped = escaped.replaceAll("(\r\n|\n)", "<br>");
+        this.originalWithBr =  new Handlebars.SafeString(escaped);
     }
 
     @Override

--- a/src/main/resources/java/README.hbs
+++ b/src/main/resources/java/README.hbs
@@ -164,7 +164,7 @@ allowed input and output types.
 | ----- | ----------- |
 {{#each schemas}}
     {{#with this}}
-| [{{containerJsonPathPiece.camelCase}}.{{jsonPathPiece.camelCase}}](docs/components/schemas/{{containerJsonPathPiece.camelCase}}.md#{{jsonPathPiece.anchorPiece}}) |{{#if description}} {{description.original}}{{/if}} |
+| [{{containerJsonPathPiece.camelCase}}.{{jsonPathPiece.camelCase}}](docs/components/schemas/{{containerJsonPathPiece.camelCase}}.md#{{jsonPathPiece.anchorPiece}}) |{{#if description}} {{description.originalWithBr}}{{/if}} |
     {{/with}}
 {{/each}}
 {{/if}}

--- a/src/main/resources/java/src/main/java/packagename/components/schemas/Schema_doc.hbs
+++ b/src/main/resources/java/src/main/java/packagename/components/schemas/Schema_doc.hbs
@@ -42,7 +42,7 @@ A schema class that validates payloads
         {{#if description}}
 
 {{headerSize}}# Description
-{{description.original}}
+{{description.originalWithBr}}
         {{/if}}
         {{#if isCustomSchema}}
             {{#if typeToExample}}
@@ -116,17 +116,17 @@ type: Map<String, Object>
 | Key | Type |  Description | Notes |
 | --- | ---- | ------------ | ----- |
                 {{#each requiredProperties}}
-| **{{@key.original}}** | {{> src/main/java/packagename/components/schemas/types/schema_input_type sourceJsonPath=../jsonPath }} | {{#if description}}{{description.original}}{{/if}} |{{> src/main/java/packagename/components/schemas/helpers/notes_msg defaultUser="server" }} |
+| **{{@key.original}}** | {{> src/main/java/packagename/components/schemas/types/schema_input_type sourceJsonPath=../jsonPath }} | {{#if description}}{{description.originalWithBr}}{{/if}} |{{> src/main/java/packagename/components/schemas/helpers/notes_msg defaultUser="server" }} |
                 {{/each}}
                 {{#each optionalProperties}}
-| **{{@key.original}}** | {{> src/main/java/packagename/components/schemas/types/schema_input_type sourceJsonPath=../jsonPath }} | {{#if description}}{{description.original}}{{/if}} | [optional]{{> src/main/java/packagename/components/schemas/helpers/notes_msg defaultUser="server" }} |
+| **{{@key.original}}** | {{> src/main/java/packagename/components/schemas/types/schema_input_type sourceJsonPath=../jsonPath }} | {{#if description}}{{description.originalWithBr}}{{/if}} | [optional]{{> src/main/java/packagename/components/schemas/helpers/notes_msg defaultUser="server" }} |
                 {{/each}}
                 {{#with additionalProperties}}
                     {{#unless isBooleanSchemaFalse}}
                         {{#if isBooleanSchemaTrue}}
-| **anyStringName** | Object | any string name can be used but the value must be the correct type{{#if description}} {{description.original}}{{/if}} | [optional] |
+| **anyStringName** | Object | any string name can be used but the value must be the correct type{{#if description}} {{description.originalWithBr}}{{/if}} | [optional] |
                         {{else}}
-| **anyStringName** | {{> src/main/java/packagename/components/schemas/types/schema_input_type sourceJsonPath=../jsonPath }} | any string name can be used but the value must be the correct type{{#if description}} {{description.original}}{{/if}} | [optional]{{> src/main/java/packagename/components/schemas/helpers/notes_msg defaultUser="server" }} |
+| **anyStringName** | {{> src/main/java/packagename/components/schemas/types/schema_input_type sourceJsonPath=../jsonPath }} | any string name can be used but the value must be the correct type{{#if description}} {{description.originalWithBr}}{{/if}} | [optional]{{> src/main/java/packagename/components/schemas/helpers/notes_msg defaultUser="server" }} |
                         {{/if}}
                     {{/unless}}
                 {{else}}
@@ -154,7 +154,7 @@ type: List<{{#with items}}{{> src/main/java/packagename/components/schemas/types
 List Item Type | Description | Notes
 -------------------- | ------------- | -------------
                 {{#with items}}
-{{> src/main/java/packagename/components/schemas/types/schema_input_type sourceJsonPath=../jsonPath forceNull=true }} | {{#if description}}{{description.original}}{{/if}} |{{> src/main/java/packagename/components/schemas/helpers/notes_msg defaultUser="server" }}
+{{> src/main/java/packagename/components/schemas/types/schema_input_type sourceJsonPath=../jsonPath forceNull=true }} | {{#if description}}{{description.originalWithBr}}{{/if}} |{{> src/main/java/packagename/components/schemas/helpers/notes_msg defaultUser="server" }}
                 {{/with}}
             {{/eq}}
         {{/eq}}

--- a/src/main/resources/python/_helper_readme_common.hbs
+++ b/src/main/resources/python/_helper_readme_common.hbs
@@ -13,7 +13,7 @@
 server_index | Class | Description
 ------------ | ----- | ------------
 {{#each servers}}
-{{@key}} | [{{jsonPathPiece.camelCase}}](docs/servers/{{jsonPathPiece.snakeCase}}.md) |{{#if description}} {{description.original}}{{/if}}
+{{@key}} | [{{jsonPathPiece.camelCase}}](docs/servers/{{jsonPathPiece.snakeCase}}.md) |{{#if description}} {{description.originalWithBr}}{{/if}}
 {{/each}}
 {{/if}}
 {{#if security}}
@@ -55,7 +55,7 @@ Class | Description
 ----- | ------------
 {{#each schemas}}
     {{#with this}}
-[{{jsonPathPiece.camelCase}}]({{modelDocPath}}{{jsonPathPiece.snakeCase}}.md) |{{#if description}} {{description.original}}{{/if}}
+[{{jsonPathPiece.camelCase}}]({{modelDocPath}}{{jsonPathPiece.snakeCase}}.md) |{{#if description}} {{description.originalWithBr}}{{/if}}
     {{/with}}
 {{/each}}
 {{/if}}
@@ -67,7 +67,7 @@ Class | Description
 ----- | ------------
 {{#each requestBodies}}
     {{#with this}}
-[{{jsonPathPiece.camelCase}}](docs/components/request_bodies/{{jsonPathPiece.snakeCase}}.md) |{{#if description}} {{description.original}}{{/if}}
+[{{jsonPathPiece.camelCase}}](docs/components/request_bodies/{{jsonPathPiece.snakeCase}}.md) |{{#if description}} {{description.originalWithBr}}{{/if}}
     {{/with}}
 {{/each}}
 {{/if}}
@@ -79,7 +79,7 @@ Class | Description
 ----- | ------------
 {{#each responses}}
     {{#with this}}
-[{{jsonPathPiece.camelCase}}](docs/components/responses/{{jsonPathPiece.snakeCase}}.md) |{{#if description}} {{description.original}}{{/if}}
+[{{jsonPathPiece.camelCase}}](docs/components/responses/{{jsonPathPiece.snakeCase}}.md) |{{#if description}} {{description.originalWithBr}}{{/if}}
     {{/with}}
 {{/each}}
 {{/if}}
@@ -91,7 +91,7 @@ Class | Description
 ----- | ------------
 {{#each headers}}
     {{#with this}}
-[{{jsonPathPiece.camelCase}}](docs/components/headers/{{jsonPathPiece.snakeCase}}.md) |{{#if description}} {{description.original}}{{/if}}
+[{{jsonPathPiece.camelCase}}](docs/components/headers/{{jsonPathPiece.snakeCase}}.md) |{{#if description}} {{description.originalWithBr}}{{/if}}
     {{/with}}
 {{/each}}
 {{/if}}
@@ -103,7 +103,7 @@ Class | Description
 ----- | ------------
 {{#each parameters}}
     {{#with this}}
-[{{jsonPathPiece.camelCase}}](docs/components/parameters/{{jsonPathPiece.snakeCase}}.md) |{{#if description}} {{description.original}}{{/if}}
+[{{jsonPathPiece.camelCase}}](docs/components/parameters/{{jsonPathPiece.snakeCase}}.md) |{{#if description}} {{description.originalWithBr}}{{/if}}
     {{/with}}
 {{/each}}
 {{/if}}
@@ -115,7 +115,7 @@ Class | Description
 ----- | ------------
     {{#each securitySchemes}}
         {{#with this}}
-[{{jsonPathPiece.camelCase}}](docs/components/security_schemes/{{jsonPathPiece.snakeCase}}.md) |{{#if description}} {{description.original}}{{/if}}
+[{{jsonPathPiece.camelCase}}](docs/components/security_schemes/{{jsonPathPiece.snakeCase}}.md) |{{#if description}} {{description.originalWithBr}}{{/if}}
         {{/with}}
     {{/each}}
 

--- a/src/main/resources/python/apis/tags/api_doc.hbs
+++ b/src/main/resources/python/apis/tags/api_doc.hbs
@@ -5,7 +5,7 @@
     {{#if description}}
 
 ## Description
-{{description.original}}
+{{description.originalWithBr}}
     {{/if}}
 {{/with}}
 

--- a/src/main/resources/python/components/headers/header_doc.hbs
+++ b/src/main/resources/python/components/headers/header_doc.hbs
@@ -10,7 +10,7 @@
     {{#if description}}
 
 {{headerSize}}# Description
-{{description.original}}
+{{description.originalWithBr}}
     {{/if}}
     {{#if refInfo}}
         {{#with getDeepestRef}}
@@ -19,7 +19,7 @@
 {{> components/_helper_header_from_identifier_pieces headerSize=(join headerSize "#" "") identifierPieces=(append (newArray ) jsonPathPiece) }}
 Ref Class | Input Type | Accessed Type | Description
 --------- | ---------- | ------------- | ------------
-[{{../../refInfo.refClass}}.schema](../../components/headers/{{../../refInfo.refModule}}.md#{{> components/_helper_anchor_id identifierPieces=(append (newArray ) jsonPathPiece) }}) | {{> _helper_schema_python_types }} | {{> components/_helper_schema_accessed_types }} | {{#if ../../description}}{{../../description.original}}{{/if}}
+[{{../../refInfo.refClass}}.schema](../../components/headers/{{../../refInfo.refModule}}.md#{{> components/_helper_anchor_id identifierPieces=(append (newArray ) jsonPathPiece) }}) | {{> _helper_schema_python_types }} | {{> components/_helper_schema_accessed_types }} | {{#if ../../description}}{{../../description.originalWithBr}}{{/if}}
                 {{/with}}
             {{/if}}
             {{#each content}}
@@ -36,7 +36,7 @@ Content-Type | Schema
 {{> components/_helper_header_from_identifier_pieces headerSize=(join headerSize "#" "") identifierPieces=(append (newArray ) "content" ../@key jsonPathPiece) }}
 Ref Class | Input Type | Accessed Type | Description
 --------- | ---------- | ------------- | ------------
-[{{../../../refInfo.refClass}}.content.{{../@key.snakeCase}}.schema](../../components/headers/{{../../../refInfo.refModule}}.md#{{> components/_helper_anchor_id identifierPieces=(append (newArray ) "content" ../@key jsonPathPiece) }}) | {{> _helper_schema_python_types }} | {{> components/_helper_schema_accessed_types }} | {{#if ../../../description}}{{../../../description.original}}{{/if}}
+[{{../../../refInfo.refClass}}.content.{{../@key.snakeCase}}.schema](../../components/headers/{{../../../refInfo.refModule}}.md#{{> components/_helper_anchor_id identifierPieces=(append (newArray ) "content" ../@key jsonPathPiece) }}) | {{> _helper_schema_python_types }} | {{> components/_helper_schema_accessed_types }} | {{#if ../../../description}}{{../../../description.originalWithBr}}{{/if}}
                 {{/with}}
             {{/each}}
         {{/with}}

--- a/src/main/resources/python/components/parameters/parameter_doc.hbs
+++ b/src/main/resources/python/components/parameters/parameter_doc.hbs
@@ -10,7 +10,7 @@
 {{#if description}}
 
 {{headerSize}}# Description
-{{description.original}}
+{{description.originalWithBr}}
 {{/if}}
 {{#if refInfo}}
     {{#with getDeepestRef}}
@@ -19,7 +19,7 @@
 {{> components/_helper_header_from_identifier_pieces headerSize=(join headerSize "#" "") identifierPieces=(append (newArray ) jsonPathPiece) }}
 Ref Class | Input Type | Accessed Type | Description
 --------- | ---------- | ------------- | ------------
-[{{../../refInfo.refClass}}.schema](../../components/parameters/{{../../refInfo.refModule}}.md#{{> components/_helper_anchor_id identifierPieces=(append (newArray ) jsonPathPiece) }}) | {{> _helper_schema_python_types }} | {{> components/_helper_schema_accessed_types }} | {{#if ../../description}}{{../../description.original}}{{/if}}
+[{{../../refInfo.refClass}}.schema](../../components/parameters/{{../../refInfo.refModule}}.md#{{> components/_helper_anchor_id identifierPieces=(append (newArray ) jsonPathPiece) }}) | {{> _helper_schema_python_types }} | {{> components/_helper_schema_accessed_types }} | {{#if ../../description}}{{../../description.originalWithBr}}{{/if}}
             {{/with}}
         {{else}}
             {{#each getDeepestRef.content}}
@@ -36,7 +36,7 @@ Content-Type | Schema
 {{> components/_helper_header_from_identifier_pieces headerSize=(join headerSize "#" "") identifierPieces=(append (newArray ) "content" ../@key jsonPathPiece) }}
 Ref Class | Input Type | Accessed Type | Description
 --------- | ---------- | ------------- | ------------
-[{{../../../refInfo.refClass}}.content.{{../@key.snakeCase}}.schema](../../components/parameters/{{../../../refInfo.refModule}}.md#{{> components/_helper_anchor_id identifierPieces=(append (newArray ) "content" ../@key jsonPathPiece) }}) | {{> _helper_schema_python_types }} | {{> components/_helper_schema_accessed_types }} | {{#if ../../../description}}{{../../../description.original}}{{/if}}
+[{{../../../refInfo.refClass}}.content.{{../@key.snakeCase}}.schema](../../components/parameters/{{../../../refInfo.refModule}}.md#{{> components/_helper_anchor_id identifierPieces=(append (newArray ) "content" ../@key jsonPathPiece) }}) | {{> _helper_schema_python_types }} | {{> components/_helper_schema_accessed_types }} | {{#if ../../../description}}{{../../../description.originalWithBr}}{{/if}}
                 {{/with}}
             {{/each}}
         {{/if}}

--- a/src/main/resources/python/components/request_bodies/request_body_doc.hbs
+++ b/src/main/resources/python/components/request_bodies/request_body_doc.hbs
@@ -10,7 +10,7 @@
 {{#if description}}
 
 {{headerSize}}# Description
-{{description.original}}
+{{description.originalWithBr}}
 {{/if}}
 {{#if refInfo}}
     {{#with getDeepestRef}}
@@ -29,7 +29,7 @@ Content-Type | Schema
 {{> components/_helper_header_from_identifier_pieces headerSize=(join headerSize "#" "") identifierPieces=(append (newArray ) "content" ../@key jsonPathPiece) }}
 Ref Class | Input Type | Accessed Type | Description
 --------- | ---------- | ------------- | ------------
-[{{../../../refInfo.refClass}}.content.{{../@key.snakeCase}}.schema](../../components/request_bodies/{{../../../refInfo.refModule}}.md#{{> components/_helper_anchor_id identifierPieces=(append (newArray ) "content" ../@key jsonPathPiece) }}) | {{> _helper_schema_python_types }} | {{> components/_helper_schema_accessed_types }} | {{#if ../../../description}}{{../../../description.original}}{{/if}}
+[{{../../../refInfo.refClass}}.content.{{../@key.snakeCase}}.schema](../../components/request_bodies/{{../../../refInfo.refModule}}.md#{{> components/_helper_anchor_id identifierPieces=(append (newArray ) "content" ../@key jsonPathPiece) }}) | {{> _helper_schema_python_types }} | {{> components/_helper_schema_accessed_types }} | {{#if ../../../description}}{{../../../description.originalWithBr}}{{/if}}
             {{/with}}
         {{/each}}
     {{/with}}

--- a/src/main/resources/python/components/responses/response_doc.hbs
+++ b/src/main/resources/python/components/responses/response_doc.hbs
@@ -10,7 +10,7 @@
 {{#if description}}
 
 {{headerSize}}# Description
-{{description.original}}
+{{description.originalWithBr}}
 {{/if}}
 
 {{#if refInfo}}

--- a/src/main/resources/python/components/schemas/schema_doc.hbs
+++ b/src/main/resources/python/components/schemas/schema_doc.hbs
@@ -17,7 +17,7 @@ type: schemas.Schema
 {{#if description}}
 
 {{headerSize}}# Description
-{{description.original}}
+{{description.originalWithBr}}
 {{/if}}
 
 {{#if refInfo}}
@@ -115,17 +115,17 @@ type: typing.Mapping[str, schemas.INPUT_TYPES_ALL]
 Key | Type |  Description | Notes
 ------------ | ------------- | ------------- | -------------
         {{#each requiredProperties}}
-**{{@key.original}}** | {{> components/schemas/types/docschema_io_types }} | {{#if description}}{{description.original}}{{/if}} |{{> components/schemas/helpers/notes_msg defaultUser="server" }}
+**{{@key.original}}** | {{> components/schemas/types/docschema_io_types }} | {{#if description}}{{description.originalWithBr}}{{/if}} |{{> components/schemas/helpers/notes_msg defaultUser="server" }}
         {{/each}}
         {{#each optionalProperties}}
-**{{@key.original}}** | {{> components/schemas/types/docschema_io_types }} | {{#if description}}{{description.original}}{{/if}} | [optional]{{> components/schemas/helpers/notes_msg defaultUser="server" }}
+**{{@key.original}}** | {{> components/schemas/types/docschema_io_types }} | {{#if description}}{{description.originalWithBr}}{{/if}} | [optional]{{> components/schemas/helpers/notes_msg defaultUser="server" }}
         {{/each}}
         {{#with additionalProperties}}
             {{#unless isBooleanSchemaFalse}}
                 {{#if isBooleanSchemaTrue}}
-**any_string_name** | {{> _helper_schema_python_types }} | any string name can be used but the value must be the correct type{{#if description}} {{description.original}}{{/if}} | [optional]
+**any_string_name** | {{> _helper_schema_python_types }} | any string name can be used but the value must be the correct type{{#if description}} {{description.originalWithBr}}{{/if}} | [optional]
             {{else}}
-**any_string_name** | {{> components/schemas/types/docschema_io_types }} | any string name can be used but the value must be the correct type{{#if description}} {{description.original}}{{/if}} | [optional]{{> components/schemas/helpers/notes_msg defaultUser="server" }}
+**any_string_name** | {{> components/schemas/types/docschema_io_types }} | any string name can be used but the value must be the correct type{{#if description}} {{description.originalWithBr}}{{/if}} | [optional]{{> components/schemas/helpers/notes_msg defaultUser="server" }}
                 {{/if}}
             {{/unless}}
         {{else}}
@@ -149,24 +149,24 @@ Keyword Argument | Type | Description | Notes
 ---------------- | ---- | ----------- | -----
         {{#each requiredProperties}}
             {{#if @key.isValid}}
-**{{@key.original}}** | {{> components/schemas/types/docschema_io_types }} | {{#if description}}{{description.original}}{{/if}} |{{> components/schemas/helpers/notes_msg defaultUser="server" }}
+**{{@key.original}}** | {{> components/schemas/types/docschema_io_types }} | {{#if description}}{{description.originalWithBr}}{{/if}} |{{> components/schemas/helpers/notes_msg defaultUser="server" }}
             {{/if}}
         {{/each}}
         {{#each optionalProperties}}
             {{#if @key.isValid}}
-**{{@key.original}}** | {{> components/schemas/types/docschema_io_types optional=true }} | {{#if description}}{{description.original}}{{/if}} | [optional]{{> components/schemas/helpers/notes_msg defaultUser="server" }}
+**{{@key.original}}** | {{> components/schemas/types/docschema_io_types optional=true }} | {{#if description}}{{description.originalWithBr}}{{/if}} | [optional]{{> components/schemas/helpers/notes_msg defaultUser="server" }}
             {{/if}}
         {{/each}}
         {{#with additionalProperties}}
             {{#unless isBooleanSchemaFalse}}
                 {{#if isBooleanSchemaTrue}}
-**kwargs** | {{> _helper_schema_python_types }} | any string name can be used but the value must be the correct type{{#if description}} {{description.original}}{{/if}} | [optional] typed value is accessed with the get_additional_property_ method
+**kwargs** | {{> _helper_schema_python_types }} | any string name can be used but the value must be the correct type{{#if description}} {{description.originalWithBr}}{{/if}} | [optional] typed value is accessed with the get_additional_property_ method
             {{else}}
-**kwargs** | {{> components/schemas/types/docschema_io_types }} | any string name can be used but the value must be the correct type{{#if description}} {{description.original}}{{/if}} | [optional]{{> components/schemas/helpers/notes_msg defaultUser="server" }} typed value is accessed with the get_additional_property_ method
+**kwargs** | {{> components/schemas/types/docschema_io_types }} | any string name can be used but the value must be the correct type{{#if description}} {{description.originalWithBr}}{{/if}} | [optional]{{> components/schemas/helpers/notes_msg defaultUser="server" }} typed value is accessed with the get_additional_property_ method
                 {{/if}}
             {{/unless}}
         {{else}}
-**kwargs** | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO | any string name can be used but the value must be the correct type{{#if description}} {{description.original}}{{/if}} | [optional] typed value is accessed with the get_additional_property_ method
+**kwargs** | schemas.immutabledict, tuple, float, int, str, bool, None, bytes, schemas.FileIO | any string name can be used but the value must be the correct type{{#if description}} {{description.originalWithBr}}{{/if}} | [optional] typed value is accessed with the get_additional_property_ method
         {{/with}}
         {{#or (and requiredProperties requiredProperties.hasValidKey) (and optionalProperties optionalProperties.hasValidKey) }}
 
@@ -175,12 +175,12 @@ Property | Type | Description | Notes
 -------- | ---- | ----------- | -----
             {{#each requiredProperties}}
                 {{#if @key.isValid}}
-**{{@key.original}}** | {{> components/schemas/types/docschema_output_types }} | {{#if description}}{{description.original}}{{/if}} |{{> components/schemas/helpers/notes_msg defaultUser="server" }}
+**{{@key.original}}** | {{> components/schemas/types/docschema_output_types }} | {{#if description}}{{description.originalWithBr}}{{/if}} |{{> components/schemas/helpers/notes_msg defaultUser="server" }}
                 {{/if}}
             {{/each}}
             {{#each optionalProperties}}
                 {{#if @key.isValid}}
-**{{@key.original}}** | {{> components/schemas/types/docschema_output_types optional=true }} | {{#if description}}{{description.original}}{{/if}} | [optional]{{> components/schemas/helpers/notes_msg defaultUser="server" }}
+**{{@key.original}}** | {{> components/schemas/types/docschema_output_types optional=true }} | {{#if description}}{{description.originalWithBr}}{{/if}} | [optional]{{> components/schemas/helpers/notes_msg defaultUser="server" }}
                 {{/if}}
             {{/each}}
         {{/or}}
@@ -229,7 +229,7 @@ type: typing.Union[
 List/Tuple Item Type | Description | Notes
 -------------------- | ------------- | -------------
         {{#with items}}
-{{> components/schemas/types/docschema_io_types }} | {{#if description}}{{description.original}}{{/if}} |{{> components/schemas/helpers/notes_msg defaultUser="server" }}
+{{> components/schemas/types/docschema_io_types }} | {{#if description}}{{description.originalWithBr}}{{/if}} |{{> components/schemas/helpers/notes_msg defaultUser="server" }}
         {{/with}}
 
         {{#if arrayOutputJsonPathPiece}}

--- a/src/main/resources/python/components/security_schemes/security_scheme_doc.hbs
+++ b/src/main/resources/python/components/security_schemes/security_scheme_doc.hbs
@@ -8,12 +8,12 @@
     {{#if description}}
 
 {{headerSize}}# Description
-{{description.original}}
+{{description.originalWithBr}}
     {{/if}}
     {{#if refInfo}}
 | Ref Class | Description |
 | --------- | ----------- |
-| [{{refInfo.refClass}}](../../components/security_schemes/{{refInfo.refModule}}.{{refInfo.refClass}}.md#) |{{#with getDeepestRef}}{{#if description}} {{description.original}}{{/if}}{{/with}}
+| [{{refInfo.refClass}}](../../components/security_schemes/{{refInfo.refModule}}.{{refInfo.refClass}}.md#) |{{#with getDeepestRef}}{{#if description}} {{description.originalWithBr}}{{/if}}{{/with}}
     {{else}}
 
 {{headerSize}}# Type

--- a/src/main/resources/python/paths/path/verb/operation_doc.hbs
+++ b/src/main/resources/python/paths/path/verb/operation_doc.hbs
@@ -35,7 +35,7 @@
 | Summary | {{summary.original}} |
 {{/if}}
 {{#if description}}
-| Description | {{description.original}} |
+| Description | {{description.originalWithBr}} |
 {{/if}}
 | Path | "{{{path.original}}}" |
 | HTTP Method | {{{httpMethod.original}}} |
@@ -129,17 +129,17 @@ n/a | api_response.ApiResponseWithoutDeserialization | When skip_deserialization
 {{#if defaultResponse}}
     {{#with defaultResponse}}
         {{#if refInfo}}
-default | [{{refInfo.refClass}}.ApiResponse](../../components/responses/{{refInfo.refModule}}.md#apiresponse) | {{#with getDeepestRef}}{{description.original}}{{/with}}
+default | [{{refInfo.refClass}}.ApiResponse](../../components/responses/{{refInfo.refModule}}.md#apiresponse) | {{#with getDeepestRef}}{{description.originalWithBr}}{{/with}}
         {{else}}
-default | [{{jsonPathPiece.camelCase}}.ApiResponse](#{{jsonPathPiece.anchorPiece}}-apiresponse) | {{description.original}}
+default | [{{jsonPathPiece.camelCase}}.ApiResponse](#{{jsonPathPiece.anchorPiece}}-apiresponse) | {{description.originalWithBr}}
         {{/if}}
     {{/with}}
 {{/if}}
 {{#each nonDefaultResponses}}
     {{#if refInfo}}
-{{@key}} | [{{refInfo.refClass}}.ApiResponse](../../components/responses/{{refInfo.refModule}}.md#apiresponse) | {{#with getDeepestRef}}{{description.original}}{{/with}}
+{{@key}} | [{{refInfo.refClass}}.ApiResponse](../../components/responses/{{refInfo.refModule}}.md#apiresponse) | {{#with getDeepestRef}}{{description.originalWithBr}}{{/with}}
     {{else}}
-{{@key}} | [{{jsonPathPiece.camelCase}}.ApiResponse](#{{jsonPathPiece.anchorPiece}}-apiresponse) | {{description.original}}
+{{@key}} | [{{jsonPathPiece.camelCase}}.ApiResponse](#{{jsonPathPiece.anchorPiece}}-apiresponse) | {{description.originalWithBr}}
     {{/if}}
 {{/each}}
 {{#each responses}}
@@ -220,16 +220,16 @@ server_index | Class | Description
 ------------ | ----- | ------------
 {{#if servers}}
     {{#each servers}}
-{{@key}} | [{{jsonPathPiece.camelCase}}](#{{jsonPathPiece.anchorPiece}}) |{{#if description}} {{description.original}}{{/if}}
+{{@key}} | [{{jsonPathPiece.camelCase}}](#{{jsonPathPiece.anchorPiece}}) |{{#if description}} {{description.originalWithBr}}{{/if}}
     {{/each}}
 {{else}}
     {{#if pathItem.servers}}
         {{#each pathItem.servers}}
-{{@key}} | [{{jsonPathPiece.camelCase}}](#{{jsonPathPiece.anchorPiece}}) |{{#if description}} {{description.original}}{{/if}}
+{{@key}} | [{{jsonPathPiece.camelCase}}](#{{jsonPathPiece.anchorPiece}}) |{{#if description}} {{description.originalWithBr}}{{/if}}
         {{/each}}
     {{else}}
         {{#each ../servers}}
-{{@key}} | [{{jsonPathPiece.camelCase}}](../../servers/{{jsonPathPiece.snakeCase}}.md) |{{#if description}} {{description.original}}{{/if}}
+{{@key}} | [{{jsonPathPiece.camelCase}}](../../servers/{{jsonPathPiece.snakeCase}}.md) |{{#if description}} {{description.originalWithBr}}{{/if}}
         {{/each}}
     {{/if}}
 {{/if}}

--- a/src/main/resources/python/servers/server_doc.hbs
+++ b/src/main/resources/python/servers/server_doc.hbs
@@ -10,12 +10,12 @@
     {{#if description}}
 
 {{headerSize}}# Description
-{{description.original}}
+{{description.originalWithBr}}
     {{/if}}
     {{#if refInfo}}
 | Ref Class | Description |
 | --------- | ----------- |
-| [{{refInfo.refClass}}](../../servers/{{refInfo.refModule}}.{{refInfo.refClass}}.md#) |{{#with getDeepestRef}}{{#if description}} {{description.original}}{{/if}}{{/with}}
+| [{{refInfo.refClass}}](../../servers/{{refInfo.refModule}}.{{refInfo.refClass}}.md#) |{{#with getDeepestRef}}{{#if description}} {{description.originalWithBr}}{{/if}}{{/with}}
     {{else}}
 
 {{headerSize}}# Url
@@ -27,7 +27,7 @@ Key | Type | Description | Notes
 --- | ---- | ----------- | ------
             {{#with variables}}
                 {{#each properties}}
-**{{@key.original}}** | {{> _helper_schema_python_types }} | {{#if description}}{{description.original}}{{/if}} | {{> components/schemas/helpers/notes_msg defaultUser="client" }}
+**{{@key.original}}** | {{> _helper_schema_python_types }} | {{#if description}}{{description.originalWithBr}}{{/if}} | {{> components/schemas/helpers/notes_msg defaultUser="client" }}
                 {{/each}}
             {{/with}}
         {{/if}}


### PR DESCRIPTION
Java + Python documentation fix, changes description newlines to html br

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
