### PR TITLE
Java, adjusts KeywordValidator validate inputs

### DIFF
--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/AdditionalPropertiesValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/AdditionalPropertiesValidator.java
@@ -20,17 +20,18 @@ public class AdditionalPropertiesValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof Map)) {
             return null;
         }
         Map<String, Object> castArg = (Map<String, Object>) arg;
-        Map<String, Class<JsonSchema>> properties = (Map<String, Class<JsonSchema>>) extra;
-        if (properties == null) {
-            properties = new LinkedHashMap<>();
-        }
         Set<String> presentAdditionalProperties = new LinkedHashSet<>(castArg.keySet());
-        presentAdditionalProperties.removeAll(properties.keySet());
+        if (schema.keywordToValidator != null) {
+            KeywordValidator propertiesValidator = schema.keywordToValidator.get("properties");
+            if (propertiesValidator instanceof PropertiesValidator) {
+                presentAdditionalProperties.removeAll(((PropertiesValidator) propertiesValidator).properties.keySet());
+            }
+        }
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         // todo add handling for validatedPatternProperties
         for(String addPropName: presentAdditionalProperties) {

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/AdditionalPropertiesValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/AdditionalPropertiesValidator.java
@@ -20,7 +20,7 @@ public class AdditionalPropertiesValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Map)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/AdditionalPropertiesValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/AdditionalPropertiesValidator.java
@@ -20,7 +20,7 @@ public class AdditionalPropertiesValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Map)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/AllOfValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/AllOfValidator.java
@@ -15,7 +15,7 @@ public class AllOfValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         for(Class<? extends JsonSchema> allOfClass: allOf) {
             JsonSchema allOfSchema = JsonSchemaFactory.getInstance(allOfClass);

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/AllOfValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/AllOfValidator.java
@@ -15,7 +15,7 @@ public class AllOfValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         for(Class<? extends JsonSchema> allOfClass: allOf) {
             JsonSchema allOfSchema = JsonSchemaFactory.getInstance(allOfClass);

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/AllOfValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/AllOfValidator.java
@@ -15,7 +15,7 @@ public class AllOfValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         for(Class<? extends JsonSchema> allOfClass: allOf) {
             JsonSchema allOfSchema = JsonSchemaFactory.getInstance(allOfClass);

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/AnyOfValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/AnyOfValidator.java
@@ -18,11 +18,11 @@ public class AnyOfValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         List<Class<? extends JsonSchema>> validatedAnyOfClasses = new ArrayList<>();
         for(Class<? extends JsonSchema> anyOfClass: anyOf) {
-            if (anyOfClass == cls) {
+            if (anyOfClass == cls.getClass()) {
                 /*
                 optimistically assume that cls schema will pass validation
                 do not invoke _validate on it because that is recursive

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/AnyOfValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/AnyOfValidator.java
@@ -18,7 +18,7 @@ public class AnyOfValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         List<Class<? extends JsonSchema>> validatedAnyOfClasses = new ArrayList<>();
         for(Class<? extends JsonSchema> anyOfClass: anyOf) {

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/AnyOfValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/AnyOfValidator.java
@@ -18,13 +18,13 @@ public class AnyOfValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         List<Class<? extends JsonSchema>> validatedAnyOfClasses = new ArrayList<>();
         for(Class<? extends JsonSchema> anyOfClass: anyOf) {
-            if (anyOfClass == cls.getClass()) {
+            if (anyOfClass == schema.getClass()) {
                 /*
-                optimistically assume that cls schema will pass validation
+                optimistically assume that schema will pass validation
                 do not invoke _validate on it because that is recursive
                 */
                 validatedAnyOfClasses.add(anyOfClass);
@@ -40,7 +40,7 @@ public class AnyOfValidator implements KeywordValidator {
             }
         }
         if (validatedAnyOfClasses.isEmpty()) {
-            throw new ValidationException("Invalid inputs given to generate an instance of "+cls+". None "+
+            throw new ValidationException("Invalid inputs given to generate an instance of "+schema.getClass()+". None "+
                     "of the anyOf schemas matched the input data."
             );
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/EnumValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/EnumValidator.java
@@ -18,7 +18,7 @@ public class EnumValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (enumValues.isEmpty()) {
             throw new ValidationException("No value can match enum because enum is empty");
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/EnumValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/EnumValidator.java
@@ -18,7 +18,7 @@ public class EnumValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (enumValues.isEmpty()) {
             throw new ValidationException("No value can match enum because enum is empty");
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/EnumValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/EnumValidator.java
@@ -18,7 +18,7 @@ public class EnumValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (enumValues.isEmpty()) {
             throw new ValidationException("No value can match enum because enum is empty");
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/ExclusiveMaximumValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/ExclusiveMaximumValidator.java
@@ -16,7 +16,7 @@ public class ExclusiveMaximumValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Number)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/ExclusiveMaximumValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/ExclusiveMaximumValidator.java
@@ -16,7 +16,7 @@ public class ExclusiveMaximumValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Number)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/ExclusiveMaximumValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/ExclusiveMaximumValidator.java
@@ -16,7 +16,7 @@ public class ExclusiveMaximumValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof Number)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/ExclusiveMinimumValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/ExclusiveMinimumValidator.java
@@ -16,7 +16,7 @@ public class ExclusiveMinimumValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof Number)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/ExclusiveMinimumValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/ExclusiveMinimumValidator.java
@@ -16,7 +16,7 @@ public class ExclusiveMinimumValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Number)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/ExclusiveMinimumValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/ExclusiveMinimumValidator.java
@@ -16,7 +16,7 @@ public class ExclusiveMinimumValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Number)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/FakeValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/FakeValidator.java
@@ -7,7 +7,7 @@ public class FakeValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
         return null;
     }
 }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/FakeValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/FakeValidator.java
@@ -7,7 +7,7 @@ public class FakeValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         return null;
     }
 }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/FakeValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/FakeValidator.java
@@ -7,7 +7,7 @@ public class FakeValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         return null;
     }
 }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/FormatValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/FormatValidator.java
@@ -147,7 +147,7 @@ public class FormatValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (arg instanceof Number) {
             validateNumericFormat(
                 (Number) arg,

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/FormatValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/FormatValidator.java
@@ -147,7 +147,7 @@ public class FormatValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (arg instanceof Number) {
             validateNumericFormat(
                 (Number) arg,

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/FormatValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/FormatValidator.java
@@ -147,7 +147,7 @@ public class FormatValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (arg instanceof Number) {
             validateNumericFormat(
                 (Number) arg,

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/ItemsValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/ItemsValidator.java
@@ -16,7 +16,7 @@ public class ItemsValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof List)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/ItemsValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/ItemsValidator.java
@@ -16,7 +16,7 @@ public class ItemsValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof List)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/ItemsValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/ItemsValidator.java
@@ -16,7 +16,7 @@ public class ItemsValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof List)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/JsonSchema.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/JsonSchema.java
@@ -37,15 +37,11 @@ public abstract class JsonSchema {
                 if (disabledKeywords.contains(jsonKeyword)) {
                    continue;
                 }
-                if (jsonKeyword.equals("additionalProperties") && thisKeywordToValidator.containsKey("properties")) {
-                    extra = thisKeywordToValidator.get("properties").getConstraint();
-                }
                 KeywordValidator validator = entry.getValue();
                 PathToSchemasMap otherPathToSchemas = validator.validate(
                         jsonSchema,
                         arg,
-                        validationMetadata,
-                        extra
+                        validationMetadata
                 );
                 if (otherPathToSchemas == null) {
                     continue;

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/JsonSchema.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/JsonSchema.java
@@ -42,7 +42,7 @@ public abstract class JsonSchema {
                 }
                 KeywordValidator validator = entry.getValue();
                 PathToSchemasMap otherPathToSchemas = validator.validate(
-                        jsonSchema.getClass(),
+                        jsonSchema,
                         arg,
                         validationMetadata,
                         extra

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/KeywordValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/KeywordValidator.java
@@ -4,7 +4,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 
 public interface KeywordValidator {
     PathToSchemasMap validate(
-            JsonSchema cls,
+            JsonSchema schema,
             Object arg,
             ValidationMetadata validationMetadata,
             Object extra) throws ValidationException;

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/KeywordValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/KeywordValidator.java
@@ -6,8 +6,7 @@ public interface KeywordValidator {
     PathToSchemasMap validate(
             JsonSchema schema,
             Object arg,
-            ValidationMetadata validationMetadata,
-            Object extra) throws ValidationException;
+            ValidationMetadata validationMetadata) throws ValidationException;
 
     Object getConstraint();
 }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/KeywordValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/KeywordValidator.java
@@ -4,7 +4,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 
 public interface KeywordValidator {
     PathToSchemasMap validate(
-            Class<? extends JsonSchema> cls,
+            JsonSchema cls,
             Object arg,
             ValidationMetadata validationMetadata,
             Object extra) throws ValidationException;

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MaxItemsValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MaxItemsValidator.java
@@ -17,7 +17,7 @@ public class MaxItemsValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof List)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MaxItemsValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MaxItemsValidator.java
@@ -17,7 +17,7 @@ public class MaxItemsValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof List)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MaxItemsValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MaxItemsValidator.java
@@ -17,7 +17,7 @@ public class MaxItemsValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof List)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MaxLengthValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MaxLengthValidator.java
@@ -15,7 +15,7 @@ public class MaxLengthValidator extends LengthValidator implements KeywordValida
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof String)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MaxLengthValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MaxLengthValidator.java
@@ -15,7 +15,7 @@ public class MaxLengthValidator extends LengthValidator implements KeywordValida
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof String)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MaxLengthValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MaxLengthValidator.java
@@ -15,7 +15,7 @@ public class MaxLengthValidator extends LengthValidator implements KeywordValida
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof String)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MaxPropertiesValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MaxPropertiesValidator.java
@@ -17,7 +17,7 @@ public class MaxPropertiesValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof Map)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MaxPropertiesValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MaxPropertiesValidator.java
@@ -17,7 +17,7 @@ public class MaxPropertiesValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Map)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MaxPropertiesValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MaxPropertiesValidator.java
@@ -17,7 +17,7 @@ public class MaxPropertiesValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Map)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MaximumValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MaximumValidator.java
@@ -16,7 +16,7 @@ public class MaximumValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Number)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MaximumValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MaximumValidator.java
@@ -16,7 +16,7 @@ public class MaximumValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Number)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MaximumValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MaximumValidator.java
@@ -16,7 +16,7 @@ public class MaximumValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof Number)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MinItemsValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MinItemsValidator.java
@@ -17,7 +17,7 @@ public class MinItemsValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof List)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MinItemsValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MinItemsValidator.java
@@ -17,7 +17,7 @@ public class MinItemsValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof List)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MinItemsValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MinItemsValidator.java
@@ -17,7 +17,7 @@ public class MinItemsValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof List)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MinLengthValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MinLengthValidator.java
@@ -15,7 +15,7 @@ public class MinLengthValidator extends LengthValidator implements KeywordValida
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof String)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MinLengthValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MinLengthValidator.java
@@ -15,7 +15,7 @@ public class MinLengthValidator extends LengthValidator implements KeywordValida
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof String)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MinLengthValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MinLengthValidator.java
@@ -15,7 +15,7 @@ public class MinLengthValidator extends LengthValidator implements KeywordValida
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof String)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MinPropertiesValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MinPropertiesValidator.java
@@ -17,7 +17,7 @@ public class MinPropertiesValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof Map)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MinPropertiesValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MinPropertiesValidator.java
@@ -17,7 +17,7 @@ public class MinPropertiesValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Map)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MinPropertiesValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MinPropertiesValidator.java
@@ -17,7 +17,7 @@ public class MinPropertiesValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Map)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MinimumValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MinimumValidator.java
@@ -16,7 +16,7 @@ public class MinimumValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Number)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MinimumValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MinimumValidator.java
@@ -16,7 +16,7 @@ public class MinimumValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof Number)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MinimumValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MinimumValidator.java
@@ -16,7 +16,7 @@ public class MinimumValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Number)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MultipleOfValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MultipleOfValidator.java
@@ -31,7 +31,7 @@ public class MultipleOfValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof Number)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MultipleOfValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MultipleOfValidator.java
@@ -31,7 +31,7 @@ public class MultipleOfValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Number)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MultipleOfValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MultipleOfValidator.java
@@ -31,7 +31,7 @@ public class MultipleOfValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Number)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/NotValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/NotValidator.java
@@ -22,7 +22,7 @@ public class NotValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         PathToSchemasMap pathToSchemas;
         try {
             JsonSchema notSchema = JsonSchemaFactory.getInstance(not);
@@ -32,7 +32,7 @@ public class NotValidator implements KeywordValidator {
         }
         if (!pathToSchemas.isEmpty()) {
             throw new ValidationException(
-                    "Invalid value "+arg+" was passed in to "+cls+". "+
+                    "Invalid value "+arg+" was passed in to "+schema.getClass()+". "+
                             "Value is invalid because it is disallowed by not "+not
             );
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/NotValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/NotValidator.java
@@ -22,7 +22,7 @@ public class NotValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
         PathToSchemasMap pathToSchemas;
         try {
             JsonSchema notSchema = JsonSchemaFactory.getInstance(not);

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/NotValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/NotValidator.java
@@ -22,7 +22,7 @@ public class NotValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         PathToSchemasMap pathToSchemas;
         try {
             JsonSchema notSchema = JsonSchemaFactory.getInstance(not);

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/OneOfValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/OneOfValidator.java
@@ -18,7 +18,7 @@ public class OneOfValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         List<Class<? extends JsonSchema>> validatedOneOfClasses = new ArrayList<>();
         for(Class<? extends JsonSchema> oneOfClass: oneOf) {

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/OneOfValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/OneOfValidator.java
@@ -18,11 +18,11 @@ public class OneOfValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         List<Class<? extends JsonSchema>> validatedOneOfClasses = new ArrayList<>();
         for(Class<? extends JsonSchema> oneOfClass: oneOf) {
-            if (oneOfClass == cls) {
+            if (oneOfClass == cls.getClass()) {
                 /*
                 optimistically assume that cls schema will pass validation
                 do not invoke validate on it because that is recursive

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/OneOfValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/OneOfValidator.java
@@ -18,13 +18,13 @@ public class OneOfValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         List<Class<? extends JsonSchema>> validatedOneOfClasses = new ArrayList<>();
         for(Class<? extends JsonSchema> oneOfClass: oneOf) {
-            if (oneOfClass == cls.getClass()) {
+            if (oneOfClass == schema.getClass()) {
                 /*
-                optimistically assume that cls schema will pass validation
+                optimistically assume that schema will pass validation
                 do not invoke validate on it because that is recursive
                 */
                 validatedOneOfClasses.add(oneOfClass);
@@ -40,12 +40,12 @@ public class OneOfValidator implements KeywordValidator {
             }
         }
         if (validatedOneOfClasses.isEmpty()) {
-            throw new ValidationException("Invalid inputs given to generate an instance of "+cls+". None "+
+            throw new ValidationException("Invalid inputs given to generate an instance of "+schema.getClass()+". None "+
                     "of the oneOf schemas matched the input data."
             );
         }
         if (validatedOneOfClasses.size() > 1) {
-            throw new ValidationException("Invalid inputs given to generate an instance of "+cls+". Multiple "+
+            throw new ValidationException("Invalid inputs given to generate an instance of "+schema.getClass()+". Multiple "+
                     "oneOf schemas validated the data, but a max of one is allowed."
             );
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/PatternValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/PatternValidator.java
@@ -17,7 +17,7 @@ public class PatternValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof String)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/PatternValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/PatternValidator.java
@@ -17,7 +17,7 @@ public class PatternValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof String)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/PatternValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/PatternValidator.java
@@ -17,7 +17,7 @@ public class PatternValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof String)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/PropertiesValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/PropertiesValidator.java
@@ -19,7 +19,7 @@ public class PropertiesValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Map)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/PropertiesValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/PropertiesValidator.java
@@ -19,7 +19,7 @@ public class PropertiesValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof Map)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/PropertiesValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/PropertiesValidator.java
@@ -19,7 +19,7 @@ public class PropertiesValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Map)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/RequiredValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/RequiredValidator.java
@@ -20,7 +20,7 @@ public class RequiredValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Map)) {
             return null;
         }
@@ -34,7 +34,7 @@ public class RequiredValidator implements KeywordValidator {
                 pluralChar = "s";
             }
             throw new ValidationException(
-                cls+" is missing "+missingRequiredProperties.size()+" required argument"+pluralChar+": "+missingReqProps
+                schema.getClass()+" is missing "+missingRequiredProperties.size()+" required argument"+pluralChar+": "+missingReqProps
             );
         }
         return null;

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/RequiredValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/RequiredValidator.java
@@ -20,7 +20,7 @@ public class RequiredValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof Map)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/RequiredValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/RequiredValidator.java
@@ -20,7 +20,7 @@ public class RequiredValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Map)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/TypeValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/TypeValidator.java
@@ -17,7 +17,7 @@ public class TypeValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
         Class<?> argClass;
         if (arg == null) {
             argClass = Void.class;

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/TypeValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/TypeValidator.java
@@ -17,7 +17,7 @@ public class TypeValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         Class<?> argClass;
         if (arg == null) {
             argClass = Void.class;

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/TypeValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/TypeValidator.java
@@ -17,7 +17,7 @@ public class TypeValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         Class<?> argClass;
         if (arg == null) {
             argClass = Void.class;

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/UniqueItemsValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/UniqueItemsValidator.java
@@ -19,7 +19,7 @@ public class UniqueItemsValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof List)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/UniqueItemsValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/UniqueItemsValidator.java
@@ -19,7 +19,7 @@ public class UniqueItemsValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof List)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/UniqueItemsValidator.java
+++ b/samples/client/3_0_3_unit_test/java/src/main/java/org/openapijsonschematools/client/schemas/validation/UniqueItemsValidator.java
@@ -19,7 +19,7 @@ public class UniqueItemsValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof List)) {
             return null;
         }

--- a/samples/client/3_0_3_unit_test/java/src/test/java/org/openapijsonschematools/client/schemas/validation/AdditionalPropertiesValidatorTest.java
+++ b/samples/client/3_0_3_unit_test/java/src/test/java/org/openapijsonschematools/client/schemas/validation/AdditionalPropertiesValidatorTest.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesValidatorTest {
         @Override
         public Object getNewInstance(Object arg, List<Object> pathToItem, PathToSchemasMap pathToSchemas) {
             if (arg instanceof FrozenMap) {
+                @SuppressWarnings("unchecked") FrozenMap<Object> castArg = (FrozenMap<Object>) arg;
                 return arg;
             }
             throw new InvalidTypeException("Invalid input type="+arg.getClass()+". It can't be instantiated by this schema");

--- a/samples/client/3_0_3_unit_test/java/src/test/java/org/openapijsonschematools/client/schemas/validation/AdditionalPropertiesValidatorTest.java
+++ b/samples/client/3_0_3_unit_test/java/src/test/java/org/openapijsonschematools/client/schemas/validation/AdditionalPropertiesValidatorTest.java
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
 import org.openapijsonschematools.client.configurations.SchemaConfiguration;
+import org.openapijsonschematools.client.schemas.MapJsonSchema;
 import org.openapijsonschematools.client.schemas.StringJsonSchema;
 import org.openapijsonschematools.client.exceptions.ValidationException;
 
@@ -34,7 +35,7 @@ public class AdditionalPropertiesValidatorTest {
         FrozenMap<Object> arg = new FrozenMap<>(mutableMap);
         final AdditionalPropertiesValidator validator = new AdditionalPropertiesValidator(StringJsonSchema.class);
         PathToSchemasMap pathToSchemas = validator.validate(
-                JsonSchema.class,
+                MapJsonSchema.getInstance(),
                 arg,
                 validationMetadata,
                 properties
@@ -62,7 +63,7 @@ public class AdditionalPropertiesValidatorTest {
         );
         final AdditionalPropertiesValidator validator = new AdditionalPropertiesValidator(StringJsonSchema.class);
         PathToSchemasMap pathToSchemas = validator.validate(
-                JsonSchema.class,
+                MapJsonSchema.getInstance(),
                 1,
                 validationMetadata,
                 null
@@ -89,7 +90,7 @@ public class AdditionalPropertiesValidatorTest {
         FrozenMap<Object> arg = new FrozenMap<>(mutableMap);
         final AdditionalPropertiesValidator validator = new AdditionalPropertiesValidator(StringJsonSchema.class);
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                MapJsonSchema.getInstance(),
                 arg,
                 validationMetadata,
                 properties

--- a/samples/client/3_0_3_unit_test/java/src/test/java/org/openapijsonschematools/client/schemas/validation/FormatValidatorTest.java
+++ b/samples/client/3_0_3_unit_test/java/src/test/java/org/openapijsonschematools/client/schemas/validation/FormatValidatorTest.java
@@ -27,8 +27,7 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 NumberJsonSchema.getInstance(),
                 1.0f,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -39,8 +38,7 @@ public class FormatValidatorTest {
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 NumberJsonSchema.getInstance(),
                 3.14f,
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -50,8 +48,7 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 NumberJsonSchema.getInstance(),
                 1,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -62,8 +59,7 @@ public class FormatValidatorTest {
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 NumberJsonSchema.getInstance(),
                 -2147483649L,
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -73,8 +69,7 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 NumberJsonSchema.getInstance(),
                 -2147483648,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -85,8 +80,7 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 NumberJsonSchema.getInstance(),
                 2147483647,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -97,8 +91,7 @@ public class FormatValidatorTest {
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 NumberJsonSchema.getInstance(),
                 2147483648L,
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -109,8 +102,7 @@ public class FormatValidatorTest {
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 NumberJsonSchema.getInstance(),
                 new BigInteger("-9223372036854775809"),
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -120,8 +112,7 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 NumberJsonSchema.getInstance(),
                 -9223372036854775808L,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -132,8 +123,7 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 NumberJsonSchema.getInstance(),
                 9223372036854775807L,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -145,8 +135,7 @@ public class FormatValidatorTest {
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 NumberJsonSchema.getInstance(),
                 new BigInteger("9223372036854775808"),
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -156,8 +145,7 @@ public class FormatValidatorTest {
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 NumberJsonSchema.getInstance(),
                 -3.402823466385289e+38d,
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -167,8 +155,7 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 NumberJsonSchema.getInstance(),
                 -3.4028234663852886e+38f,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -179,8 +166,7 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 NumberJsonSchema.getInstance(),
                 3.4028234663852886e+38f,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -191,8 +177,7 @@ public class FormatValidatorTest {
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 NumberJsonSchema.getInstance(),
                 3.402823466385289e+38d,
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -202,8 +187,7 @@ public class FormatValidatorTest {
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 NumberJsonSchema.getInstance(),
                 new BigDecimal("-1.7976931348623157082e+308"),
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -213,8 +197,7 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 NumberJsonSchema.getInstance(),
                 -1.7976931348623157E+308d,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -225,8 +208,7 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 NumberJsonSchema.getInstance(),
                 1.7976931348623157E+308d,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -237,8 +219,7 @@ public class FormatValidatorTest {
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 NumberJsonSchema.getInstance(),
                 new BigDecimal("1.7976931348623157082e+308"),
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -248,8 +229,7 @@ public class FormatValidatorTest {
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 NumberJsonSchema.getInstance(),
                 "abc",
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -259,8 +239,7 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 NumberJsonSchema.getInstance(),
                 "3.14",
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -271,8 +250,7 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 NumberJsonSchema.getInstance(),
                 "1",
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -283,8 +261,7 @@ public class FormatValidatorTest {
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 StringJsonSchema.getInstance(),
                 "abc",
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -294,8 +271,7 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 StringJsonSchema.getInstance(),
                 "2017-01-20",
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -306,8 +282,7 @@ public class FormatValidatorTest {
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 StringJsonSchema.getInstance(),
                 "abc",
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -317,8 +292,7 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 StringJsonSchema.getInstance(),
                 "2017-07-21T17:32:28Z",
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }

--- a/samples/client/3_0_3_unit_test/java/src/test/java/org/openapijsonschematools/client/schemas/validation/FormatValidatorTest.java
+++ b/samples/client/3_0_3_unit_test/java/src/test/java/org/openapijsonschematools/client/schemas/validation/FormatValidatorTest.java
@@ -5,6 +5,8 @@ import org.junit.Test;
 import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
 import org.openapijsonschematools.client.configurations.SchemaConfiguration;
 import org.openapijsonschematools.client.exceptions.ValidationException;
+import org.openapijsonschematools.client.schemas.NumberJsonSchema;
+import org.openapijsonschematools.client.schemas.StringJsonSchema;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -23,7 +25,7 @@ public class FormatValidatorTest {
     public void testIntFormatSucceedsWithFloat() {
         final FormatValidator validator = new FormatValidator("int");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 1.0f,
                 validationMetadata,
                 null
@@ -35,7 +37,7 @@ public class FormatValidatorTest {
     public void testIntFormatFailsWithFloat() {
         final FormatValidator validator = new FormatValidator("int");
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 3.14f,
                 validationMetadata,
                 null
@@ -46,7 +48,7 @@ public class FormatValidatorTest {
     public void testIntFormatSucceedsWithInt() {
         final FormatValidator validator = new FormatValidator("int");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 1,
                 validationMetadata,
                 null
@@ -58,7 +60,7 @@ public class FormatValidatorTest {
     public void testInt32UnderMinFails() {
         final FormatValidator validator = new FormatValidator("int32");
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 -2147483649L,
                 validationMetadata,
                 null
@@ -69,7 +71,7 @@ public class FormatValidatorTest {
     public void testInt32InclusiveMinSucceeds() {
         final FormatValidator validator = new FormatValidator("int32");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 -2147483648,
                 validationMetadata,
                 null
@@ -81,7 +83,7 @@ public class FormatValidatorTest {
     public void testInt32InclusiveMaxSucceeds() {
         final FormatValidator validator = new FormatValidator("int32");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 2147483647,
                 validationMetadata,
                 null
@@ -93,7 +95,7 @@ public class FormatValidatorTest {
     public void testInt32OverMaxFails() {
         final FormatValidator validator = new FormatValidator("int32");
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 2147483648L,
                 validationMetadata,
                 null
@@ -105,7 +107,7 @@ public class FormatValidatorTest {
         final FormatValidator validator = new FormatValidator("int64");
 
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 new BigInteger("-9223372036854775809"),
                 validationMetadata,
                 null
@@ -116,7 +118,7 @@ public class FormatValidatorTest {
     public void testInt64InclusiveMinSucceeds() {
         final FormatValidator validator = new FormatValidator("int64");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 -9223372036854775808L,
                 validationMetadata,
                 null
@@ -128,7 +130,7 @@ public class FormatValidatorTest {
     public void testInt64InclusiveMaxSucceeds() {
         final FormatValidator validator = new FormatValidator("int64");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 9223372036854775807L,
                 validationMetadata,
                 null
@@ -141,7 +143,7 @@ public class FormatValidatorTest {
         final FormatValidator validator = new FormatValidator("int64");
 
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 new BigInteger("9223372036854775808"),
                 validationMetadata,
                 null
@@ -152,7 +154,7 @@ public class FormatValidatorTest {
     public void testFloatUnderMinFails() {
         final FormatValidator validator = new FormatValidator("float");
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 -3.402823466385289e+38d,
                 validationMetadata,
                 null
@@ -163,7 +165,7 @@ public class FormatValidatorTest {
     public void testFloatInclusiveMinSucceeds() {
         final FormatValidator validator = new FormatValidator("float");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 -3.4028234663852886e+38f,
                 validationMetadata,
                 null
@@ -175,7 +177,7 @@ public class FormatValidatorTest {
     public void testFloatInclusiveMaxSucceeds() {
         final FormatValidator validator = new FormatValidator("float");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 3.4028234663852886e+38f,
                 validationMetadata,
                 null
@@ -187,7 +189,7 @@ public class FormatValidatorTest {
     public void testFloatOverMaxFails() {
         final FormatValidator validator = new FormatValidator("float");
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 3.402823466385289e+38d,
                 validationMetadata,
                 null
@@ -198,7 +200,7 @@ public class FormatValidatorTest {
     public void testDoubleUnderMinFails() {
         final FormatValidator validator = new FormatValidator("double");
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 new BigDecimal("-1.7976931348623157082e+308"),
                 validationMetadata,
                 null
@@ -209,7 +211,7 @@ public class FormatValidatorTest {
     public void testDoubleInclusiveMinSucceeds() {
         final FormatValidator validator = new FormatValidator("double");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 -1.7976931348623157E+308d,
                 validationMetadata,
                 null
@@ -221,7 +223,7 @@ public class FormatValidatorTest {
     public void testDoubleInclusiveMaxSucceeds() {
         final FormatValidator validator = new FormatValidator("double");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 1.7976931348623157E+308d,
                 validationMetadata,
                 null
@@ -233,7 +235,7 @@ public class FormatValidatorTest {
     public void testDoubleOverMaxFails() {
         final FormatValidator validator = new FormatValidator("double");
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 new BigDecimal("1.7976931348623157082e+308"),
                 validationMetadata,
                 null
@@ -244,7 +246,7 @@ public class FormatValidatorTest {
     public void testInvalidNumberStringFails() {
         final FormatValidator validator = new FormatValidator("number");
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 "abc",
                 validationMetadata,
                 null
@@ -255,7 +257,7 @@ public class FormatValidatorTest {
     public void testValidFloatNumberStringSucceeds() {
         final FormatValidator validator = new FormatValidator("number");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 "3.14",
                 validationMetadata,
                 null
@@ -267,7 +269,7 @@ public class FormatValidatorTest {
     public void testValidIntNumberStringSucceeds() {
         final FormatValidator validator = new FormatValidator("number");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 "1",
                 validationMetadata,
                 null
@@ -279,7 +281,7 @@ public class FormatValidatorTest {
     public void testInvalidDateStringFails() {
         final FormatValidator validator = new FormatValidator("date");
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                StringJsonSchema.getInstance(),
                 "abc",
                 validationMetadata,
                 null
@@ -290,7 +292,7 @@ public class FormatValidatorTest {
     public void testValidDateStringSucceeds() {
         final FormatValidator validator = new FormatValidator("date");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                StringJsonSchema.getInstance(),
                 "2017-01-20",
                 validationMetadata,
                 null
@@ -302,7 +304,7 @@ public class FormatValidatorTest {
     public void testInvalidDateTimeStringFails() {
         final FormatValidator validator = new FormatValidator("date-time");
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                StringJsonSchema.getInstance(),
                 "abc",
                 validationMetadata,
                 null
@@ -313,7 +315,7 @@ public class FormatValidatorTest {
     public void testValidDateTimeStringSucceeds() {
         final FormatValidator validator = new FormatValidator("date-time");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                StringJsonSchema.getInstance(),
                 "2017-07-21T17:32:28Z",
                 validationMetadata,
                 null

--- a/samples/client/3_0_3_unit_test/java/src/test/java/org/openapijsonschematools/client/schemas/validation/ItemsValidatorTest.java
+++ b/samples/client/3_0_3_unit_test/java/src/test/java/org/openapijsonschematools/client/schemas/validation/ItemsValidatorTest.java
@@ -32,8 +32,7 @@ public class ItemsValidatorTest {
         PathToSchemasMap pathToSchemas = validator.validate(
                 ListJsonSchema.getInstance(),
                 arg,
-                validationMetadata,
-                null
+                validationMetadata
         );
         List<Object> expectedPathToItem = new ArrayList<>();
         expectedPathToItem.add("args[0]");
@@ -60,8 +59,7 @@ public class ItemsValidatorTest {
         PathToSchemasMap pathToSchemas = validator.validate(
                 ListJsonSchema.getInstance(),
                 1,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemas);
     }
@@ -83,8 +81,7 @@ public class ItemsValidatorTest {
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 ListJsonSchema.getInstance(),
                 arg,
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 }

--- a/samples/client/3_0_3_unit_test/java/src/test/java/org/openapijsonschematools/client/schemas/validation/ItemsValidatorTest.java
+++ b/samples/client/3_0_3_unit_test/java/src/test/java/org/openapijsonschematools/client/schemas/validation/ItemsValidatorTest.java
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
 import org.openapijsonschematools.client.configurations.SchemaConfiguration;
+import org.openapijsonschematools.client.schemas.ListJsonSchema;
 import org.openapijsonschematools.client.schemas.StringJsonSchema;
 import org.openapijsonschematools.client.exceptions.ValidationException;
 
@@ -29,7 +30,7 @@ public class ItemsValidatorTest {
         FrozenList<Object> arg = new FrozenList<>(mutableList);
         final ItemsValidator validator = new ItemsValidator(StringJsonSchema.class);
         PathToSchemasMap pathToSchemas = validator.validate(
-                JsonSchema.class,
+                ListJsonSchema.getInstance(),
                 arg,
                 validationMetadata,
                 null
@@ -57,7 +58,7 @@ public class ItemsValidatorTest {
         );
         final ItemsValidator validator = new ItemsValidator(StringJsonSchema.class);
         PathToSchemasMap pathToSchemas = validator.validate(
-                JsonSchema.class,
+                ListJsonSchema.getInstance(),
                 1,
                 validationMetadata,
                 null
@@ -80,7 +81,7 @@ public class ItemsValidatorTest {
         FrozenList<Object> arg = new FrozenList<>(mutableList);
         final ItemsValidator validator = new ItemsValidator(StringJsonSchema.class);
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                ListJsonSchema.getInstance(),
                 arg,
                 validationMetadata,
                 null

--- a/samples/client/3_0_3_unit_test/java/src/test/java/org/openapijsonschematools/client/schemas/validation/PropertiesValidatorTest.java
+++ b/samples/client/3_0_3_unit_test/java/src/test/java/org/openapijsonschematools/client/schemas/validation/PropertiesValidatorTest.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Map;
 
 public class PropertiesValidatorTest {
-
     @Test
     public void testCorrectPropertySucceeds() {
         Map<String, Class<? extends JsonSchema>> properties = new LinkedHashMap<>();
@@ -36,8 +35,7 @@ public class PropertiesValidatorTest {
         PathToSchemasMap pathToSchemas = validator.validate(
                 MapJsonSchema.getInstance(),
                 arg,
-                validationMetadata,
-                null
+                validationMetadata
         );
         List<Object> expectedPathToItem = new ArrayList<>();
         expectedPathToItem.add("args[0]");
@@ -66,8 +64,7 @@ public class PropertiesValidatorTest {
         PathToSchemasMap pathToSchemas = validator.validate(
                 MapJsonSchema.getInstance(),
                 1,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemas);
     }
@@ -92,8 +89,7 @@ public class PropertiesValidatorTest {
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 MapJsonSchema.getInstance(),
                 arg,
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 }

--- a/samples/client/3_0_3_unit_test/java/src/test/java/org/openapijsonschematools/client/schemas/validation/PropertiesValidatorTest.java
+++ b/samples/client/3_0_3_unit_test/java/src/test/java/org/openapijsonschematools/client/schemas/validation/PropertiesValidatorTest.java
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
 import org.openapijsonschematools.client.configurations.SchemaConfiguration;
+import org.openapijsonschematools.client.schemas.MapJsonSchema;
 import org.openapijsonschematools.client.schemas.StringJsonSchema;
 import org.openapijsonschematools.client.exceptions.ValidationException;
 
@@ -33,7 +34,7 @@ public class PropertiesValidatorTest {
         mutableMap.put("someString", "abc");
         FrozenMap<Object> arg = new FrozenMap<>(mutableMap);
         PathToSchemasMap pathToSchemas = validator.validate(
-                JsonSchema.class,
+                MapJsonSchema.getInstance(),
                 arg,
                 validationMetadata,
                 null
@@ -63,7 +64,7 @@ public class PropertiesValidatorTest {
                 new LinkedHashSet<>()
         );
         PathToSchemasMap pathToSchemas = validator.validate(
-                JsonSchema.class,
+                MapJsonSchema.getInstance(),
                 1,
                 validationMetadata,
                 null
@@ -89,7 +90,7 @@ public class PropertiesValidatorTest {
         mutableMap.put("someString", 1);
         FrozenMap<Object> arg = new FrozenMap<>(mutableMap);
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                MapJsonSchema.getInstance(),
                 arg,
                 validationMetadata,
                 null

--- a/samples/client/3_0_3_unit_test/java/src/test/java/org/openapijsonschematools/client/schemas/validation/RequiredValidatorTest.java
+++ b/samples/client/3_0_3_unit_test/java/src/test/java/org/openapijsonschematools/client/schemas/validation/RequiredValidatorTest.java
@@ -35,8 +35,7 @@ public class RequiredValidatorTest {
         PathToSchemasMap pathToSchemas = validator.validate(
                 MapJsonSchema.getInstance(),
                 arg,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemas);
     }
@@ -58,8 +57,7 @@ public class RequiredValidatorTest {
         PathToSchemasMap pathToSchemas = validator.validate(
                 MapJsonSchema.getInstance(),
                 1,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemas);
     }
@@ -84,8 +82,7 @@ public class RequiredValidatorTest {
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 MapJsonSchema.getInstance(),
                 arg,
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 }

--- a/samples/client/3_0_3_unit_test/java/src/test/java/org/openapijsonschematools/client/schemas/validation/RequiredValidatorTest.java
+++ b/samples/client/3_0_3_unit_test/java/src/test/java/org/openapijsonschematools/client/schemas/validation/RequiredValidatorTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
 import org.openapijsonschematools.client.configurations.SchemaConfiguration;
 import org.openapijsonschematools.client.exceptions.ValidationException;
+import org.openapijsonschematools.client.schemas.MapJsonSchema;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -32,7 +33,7 @@ public class RequiredValidatorTest {
         FrozenMap<Object> arg = new FrozenMap<>(mutableMap);
         final RequiredValidator validator = new RequiredValidator(requiredProperties);
         PathToSchemasMap pathToSchemas = validator.validate(
-                JsonSchema.class,
+                MapJsonSchema.getInstance(),
                 arg,
                 validationMetadata,
                 null
@@ -55,7 +56,7 @@ public class RequiredValidatorTest {
         );
         final RequiredValidator validator = new RequiredValidator(requiredProperties);
         PathToSchemasMap pathToSchemas = validator.validate(
-                JsonSchema.class,
+                MapJsonSchema.getInstance(),
                 1,
                 validationMetadata,
                 null
@@ -81,7 +82,7 @@ public class RequiredValidatorTest {
         FrozenMap<Object> arg = new FrozenMap<>(mutableMap);
         final RequiredValidator validator = new RequiredValidator(requiredProperties);
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                MapJsonSchema.getInstance(),
                 arg,
                 validationMetadata,
                 null

--- a/samples/client/3_0_3_unit_test/java/src/test/java/org/openapijsonschematools/client/schemas/validation/TypeValidatorTest.java
+++ b/samples/client/3_0_3_unit_test/java/src/test/java/org/openapijsonschematools/client/schemas/validation/TypeValidatorTest.java
@@ -26,8 +26,7 @@ public class TypeValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 StringJsonSchema.getInstance(),
                 "hi",
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -46,8 +45,7 @@ public class TypeValidatorTest {
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 StringJsonSchema.getInstance(),
                 1,
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 }

--- a/samples/client/3_0_3_unit_test/java/src/test/java/org/openapijsonschematools/client/schemas/validation/TypeValidatorTest.java
+++ b/samples/client/3_0_3_unit_test/java/src/test/java/org/openapijsonschematools/client/schemas/validation/TypeValidatorTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
 import org.openapijsonschematools.client.configurations.SchemaConfiguration;
 import org.openapijsonschematools.client.exceptions.ValidationException;
+import org.openapijsonschematools.client.schemas.StringJsonSchema;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -23,7 +24,7 @@ public class TypeValidatorTest {
                 new LinkedHashSet<>()
         );
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                StringJsonSchema.getInstance(),
                 "hi",
                 validationMetadata,
                 null
@@ -43,7 +44,7 @@ public class TypeValidatorTest {
                 new LinkedHashSet<>()
         );
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                StringJsonSchema.getInstance(),
                 1,
                 validationMetadata,
                 null

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/AdditionalPropertiesValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/AdditionalPropertiesValidator.java
@@ -20,17 +20,18 @@ public class AdditionalPropertiesValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof Map)) {
             return null;
         }
         Map<String, Object> castArg = (Map<String, Object>) arg;
-        Map<String, Class<JsonSchema>> properties = (Map<String, Class<JsonSchema>>) extra;
-        if (properties == null) {
-            properties = new LinkedHashMap<>();
-        }
         Set<String> presentAdditionalProperties = new LinkedHashSet<>(castArg.keySet());
-        presentAdditionalProperties.removeAll(properties.keySet());
+        if (schema.keywordToValidator != null) {
+            KeywordValidator propertiesValidator = schema.keywordToValidator.get("properties");
+            if (propertiesValidator instanceof PropertiesValidator) {
+                presentAdditionalProperties.removeAll(((PropertiesValidator) propertiesValidator).properties.keySet());
+            }
+        }
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         // todo add handling for validatedPatternProperties
         for(String addPropName: presentAdditionalProperties) {

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/AllOfValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/AllOfValidator.java
@@ -15,7 +15,7 @@ public class AllOfValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         for(Class<? extends JsonSchema> allOfClass: allOf) {
             JsonSchema allOfSchema = JsonSchemaFactory.getInstance(allOfClass);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/AnyOfValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/AnyOfValidator.java
@@ -18,13 +18,13 @@ public class AnyOfValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         List<Class<? extends JsonSchema>> validatedAnyOfClasses = new ArrayList<>();
         for(Class<? extends JsonSchema> anyOfClass: anyOf) {
-            if (anyOfClass == cls) {
+            if (anyOfClass == schema.getClass()) {
                 /*
-                optimistically assume that cls schema will pass validation
+                optimistically assume that schema will pass validation
                 do not invoke _validate on it because that is recursive
                 */
                 validatedAnyOfClasses.add(anyOfClass);
@@ -40,7 +40,7 @@ public class AnyOfValidator implements KeywordValidator {
             }
         }
         if (validatedAnyOfClasses.isEmpty()) {
-            throw new ValidationException("Invalid inputs given to generate an instance of "+cls+". None "+
+            throw new ValidationException("Invalid inputs given to generate an instance of "+schema.getClass()+". None "+
                     "of the anyOf schemas matched the input data."
             );
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/EnumValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/EnumValidator.java
@@ -18,7 +18,7 @@ public class EnumValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (enumValues.isEmpty()) {
             throw new ValidationException("No value can match enum because enum is empty");
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/ExclusiveMaximumValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/ExclusiveMaximumValidator.java
@@ -16,7 +16,7 @@ public class ExclusiveMaximumValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof Number)) {
             return null;
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/ExclusiveMinimumValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/ExclusiveMinimumValidator.java
@@ -16,7 +16,7 @@ public class ExclusiveMinimumValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof Number)) {
             return null;
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/FakeValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/FakeValidator.java
@@ -7,7 +7,7 @@ public class FakeValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         return null;
     }
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/FormatValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/FormatValidator.java
@@ -147,7 +147,7 @@ public class FormatValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (arg instanceof Number) {
             validateNumericFormat(
                 (Number) arg,

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/ItemsValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/ItemsValidator.java
@@ -16,7 +16,7 @@ public class ItemsValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof List)) {
             return null;
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/JsonSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/JsonSchema.java
@@ -37,15 +37,11 @@ public abstract class JsonSchema {
                 if (disabledKeywords.contains(jsonKeyword)) {
                    continue;
                 }
-                if (jsonKeyword.equals("additionalProperties") && thisKeywordToValidator.containsKey("properties")) {
-                    extra = thisKeywordToValidator.get("properties").getConstraint();
-                }
                 KeywordValidator validator = entry.getValue();
                 PathToSchemasMap otherPathToSchemas = validator.validate(
-                        jsonSchema.getClass(),
+                        jsonSchema,
                         arg,
-                        validationMetadata,
-                        extra
+                        validationMetadata
                 );
                 if (otherPathToSchemas == null) {
                     continue;

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/KeywordValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/KeywordValidator.java
@@ -4,10 +4,9 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 
 public interface KeywordValidator {
     PathToSchemasMap validate(
-            Class<? extends JsonSchema> cls,
+            JsonSchema schema,
             Object arg,
-            ValidationMetadata validationMetadata,
-            Object extra) throws ValidationException;
+            ValidationMetadata validationMetadata) throws ValidationException;
 
     Object getConstraint();
 }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MaxItemsValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MaxItemsValidator.java
@@ -17,7 +17,7 @@ public class MaxItemsValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof List)) {
             return null;
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MaxLengthValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MaxLengthValidator.java
@@ -15,7 +15,7 @@ public class MaxLengthValidator extends LengthValidator implements KeywordValida
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof String)) {
             return null;
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MaxPropertiesValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MaxPropertiesValidator.java
@@ -17,7 +17,7 @@ public class MaxPropertiesValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof Map)) {
             return null;
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MaximumValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MaximumValidator.java
@@ -16,7 +16,7 @@ public class MaximumValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof Number)) {
             return null;
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MinItemsValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MinItemsValidator.java
@@ -17,7 +17,7 @@ public class MinItemsValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof List)) {
             return null;
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MinLengthValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MinLengthValidator.java
@@ -15,7 +15,7 @@ public class MinLengthValidator extends LengthValidator implements KeywordValida
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof String)) {
             return null;
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MinPropertiesValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MinPropertiesValidator.java
@@ -17,7 +17,7 @@ public class MinPropertiesValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof Map)) {
             return null;
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MinimumValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MinimumValidator.java
@@ -16,7 +16,7 @@ public class MinimumValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof Number)) {
             return null;
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MultipleOfValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/MultipleOfValidator.java
@@ -31,7 +31,7 @@ public class MultipleOfValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof Number)) {
             return null;
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/NotValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/NotValidator.java
@@ -22,7 +22,7 @@ public class NotValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         PathToSchemasMap pathToSchemas;
         try {
             JsonSchema notSchema = JsonSchemaFactory.getInstance(not);
@@ -32,7 +32,7 @@ public class NotValidator implements KeywordValidator {
         }
         if (!pathToSchemas.isEmpty()) {
             throw new ValidationException(
-                    "Invalid value "+arg+" was passed in to "+cls+". "+
+                    "Invalid value "+arg+" was passed in to "+schema.getClass()+". "+
                             "Value is invalid because it is disallowed by not "+not
             );
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/OneOfValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/OneOfValidator.java
@@ -18,13 +18,13 @@ public class OneOfValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         List<Class<? extends JsonSchema>> validatedOneOfClasses = new ArrayList<>();
         for(Class<? extends JsonSchema> oneOfClass: oneOf) {
-            if (oneOfClass == cls) {
+            if (oneOfClass == schema.getClass()) {
                 /*
-                optimistically assume that cls schema will pass validation
+                optimistically assume that schema will pass validation
                 do not invoke validate on it because that is recursive
                 */
                 validatedOneOfClasses.add(oneOfClass);
@@ -40,12 +40,12 @@ public class OneOfValidator implements KeywordValidator {
             }
         }
         if (validatedOneOfClasses.isEmpty()) {
-            throw new ValidationException("Invalid inputs given to generate an instance of "+cls+". None "+
+            throw new ValidationException("Invalid inputs given to generate an instance of "+schema.getClass()+". None "+
                     "of the oneOf schemas matched the input data."
             );
         }
         if (validatedOneOfClasses.size() > 1) {
-            throw new ValidationException("Invalid inputs given to generate an instance of "+cls+". Multiple "+
+            throw new ValidationException("Invalid inputs given to generate an instance of "+schema.getClass()+". Multiple "+
                     "oneOf schemas validated the data, but a max of one is allowed."
             );
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/PatternValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/PatternValidator.java
@@ -17,7 +17,7 @@ public class PatternValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof String)) {
             return null;
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/PropertiesValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/PropertiesValidator.java
@@ -19,7 +19,7 @@ public class PropertiesValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof Map)) {
             return null;
         }

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/RequiredValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/RequiredValidator.java
@@ -20,7 +20,7 @@ public class RequiredValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof Map)) {
             return null;
         }
@@ -34,7 +34,7 @@ public class RequiredValidator implements KeywordValidator {
                 pluralChar = "s";
             }
             throw new ValidationException(
-                cls+" is missing "+missingRequiredProperties.size()+" required argument"+pluralChar+": "+missingReqProps
+                schema.getClass()+" is missing "+missingRequiredProperties.size()+" required argument"+pluralChar+": "+missingReqProps
             );
         }
         return null;

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/TypeValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/TypeValidator.java
@@ -17,7 +17,7 @@ public class TypeValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         Class<?> argClass;
         if (arg == null) {
             argClass = Void.class;

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/UniqueItemsValidator.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/schemas/validation/UniqueItemsValidator.java
@@ -19,7 +19,7 @@ public class UniqueItemsValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof List)) {
             return null;
         }

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/client/schemas/validation/AdditionalPropertiesValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/client/schemas/validation/AdditionalPropertiesValidatorTest.java
@@ -4,6 +4,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
 import org.openapijsonschematools.client.configurations.SchemaConfiguration;
+import org.openapijsonschematools.client.exceptions.InvalidTypeException;
+import org.openapijsonschematools.client.schemas.MapJsonSchema;
 import org.openapijsonschematools.client.schemas.StringJsonSchema;
 import org.openapijsonschematools.client.exceptions.ValidationException;
 
@@ -12,14 +14,41 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class AdditionalPropertiesValidatorTest {
 
+    public static class ObjectWithPropsSchema extends JsonSchema {
+        private static ObjectWithPropsSchema instance;
+        private ObjectWithPropsSchema() {
+            super(new LinkedHashMap<>(Map.ofEntries(
+                    new KeywordEntry("type", new TypeValidator(Set.of(FrozenMap.class))),
+                    new KeywordEntry("properties", new PropertiesValidator(Map.ofEntries(
+                            new PropertyEntry("someString", StringJsonSchema.class)
+                    )))
+            )));
+
+        }
+
+        public static ObjectWithPropsSchema getInstance() {
+            if (instance == null) {
+                instance = new ObjectWithPropsSchema();
+            }
+            return instance;
+        }
+
+        @Override
+        public Object getNewInstance(Object arg, List<Object> pathToItem, PathToSchemasMap pathToSchemas) {
+            if (arg instanceof FrozenMap) {
+                @SuppressWarnings("unchecked") FrozenMap<Object> castArg = (FrozenMap<Object>) arg;
+                return arg;
+            }
+            throw new InvalidTypeException("Invalid input type="+arg.getClass()+". It can't be instantiated by this schema");
+        }
+    }
+
     @Test
     public void testCorrectPropertySucceeds() {
-        Map<String, Class<?>> properties = new LinkedHashMap<>();
-        properties.put("someString", StringJsonSchema.class);
-
         List<Object> pathToItem = new ArrayList<>();
         pathToItem.add("args[0]");
         ValidationMetadata validationMetadata = new ValidationMetadata(
@@ -34,10 +63,9 @@ public class AdditionalPropertiesValidatorTest {
         FrozenMap<Object> arg = new FrozenMap<>(mutableMap);
         final AdditionalPropertiesValidator validator = new AdditionalPropertiesValidator(StringJsonSchema.class);
         PathToSchemasMap pathToSchemas = validator.validate(
-                JsonSchema.class,
+                ObjectWithPropsSchema.getInstance(),
                 arg,
-                validationMetadata,
-                properties
+                validationMetadata
         );
         List<Object> expectedPathToItem = new ArrayList<>();
         expectedPathToItem.add("args[0]");
@@ -62,19 +90,15 @@ public class AdditionalPropertiesValidatorTest {
         );
         final AdditionalPropertiesValidator validator = new AdditionalPropertiesValidator(StringJsonSchema.class);
         PathToSchemasMap pathToSchemas = validator.validate(
-                JsonSchema.class,
+                MapJsonSchema.getInstance(),
                 1,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemas);
     }
 
     @Test
     public void testIncorrectPropertyValueFails() {
-        Map<String, Class<?>> properties = new LinkedHashMap<>();
-        properties.put("someString", StringJsonSchema.class);
-
         List<Object> pathToItem = new ArrayList<>();
         pathToItem.add("args[0]");
         ValidationMetadata validationMetadata = new ValidationMetadata(
@@ -89,10 +113,9 @@ public class AdditionalPropertiesValidatorTest {
         FrozenMap<Object> arg = new FrozenMap<>(mutableMap);
         final AdditionalPropertiesValidator validator = new AdditionalPropertiesValidator(StringJsonSchema.class);
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                ObjectWithPropsSchema.getInstance(),
                 arg,
-                validationMetadata,
-                properties
+                validationMetadata
         ));
     }
 }

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/client/schemas/validation/FormatValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/client/schemas/validation/FormatValidatorTest.java
@@ -5,6 +5,8 @@ import org.junit.Test;
 import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
 import org.openapijsonschematools.client.configurations.SchemaConfiguration;
 import org.openapijsonschematools.client.exceptions.ValidationException;
+import org.openapijsonschematools.client.schemas.NumberJsonSchema;
+import org.openapijsonschematools.client.schemas.StringJsonSchema;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -23,10 +25,9 @@ public class FormatValidatorTest {
     public void testIntFormatSucceedsWithFloat() {
         final FormatValidator validator = new FormatValidator("int");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 1.0f,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -35,10 +36,9 @@ public class FormatValidatorTest {
     public void testIntFormatFailsWithFloat() {
         final FormatValidator validator = new FormatValidator("int");
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 3.14f,
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -46,10 +46,9 @@ public class FormatValidatorTest {
     public void testIntFormatSucceedsWithInt() {
         final FormatValidator validator = new FormatValidator("int");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 1,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -58,10 +57,9 @@ public class FormatValidatorTest {
     public void testInt32UnderMinFails() {
         final FormatValidator validator = new FormatValidator("int32");
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 -2147483649L,
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -69,10 +67,9 @@ public class FormatValidatorTest {
     public void testInt32InclusiveMinSucceeds() {
         final FormatValidator validator = new FormatValidator("int32");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 -2147483648,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -81,10 +78,9 @@ public class FormatValidatorTest {
     public void testInt32InclusiveMaxSucceeds() {
         final FormatValidator validator = new FormatValidator("int32");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 2147483647,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -93,10 +89,9 @@ public class FormatValidatorTest {
     public void testInt32OverMaxFails() {
         final FormatValidator validator = new FormatValidator("int32");
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 2147483648L,
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -105,10 +100,9 @@ public class FormatValidatorTest {
         final FormatValidator validator = new FormatValidator("int64");
 
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 new BigInteger("-9223372036854775809"),
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -116,10 +110,9 @@ public class FormatValidatorTest {
     public void testInt64InclusiveMinSucceeds() {
         final FormatValidator validator = new FormatValidator("int64");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 -9223372036854775808L,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -128,10 +121,9 @@ public class FormatValidatorTest {
     public void testInt64InclusiveMaxSucceeds() {
         final FormatValidator validator = new FormatValidator("int64");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 9223372036854775807L,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -141,10 +133,9 @@ public class FormatValidatorTest {
         final FormatValidator validator = new FormatValidator("int64");
 
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 new BigInteger("9223372036854775808"),
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -152,10 +143,9 @@ public class FormatValidatorTest {
     public void testFloatUnderMinFails() {
         final FormatValidator validator = new FormatValidator("float");
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 -3.402823466385289e+38d,
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -163,10 +153,9 @@ public class FormatValidatorTest {
     public void testFloatInclusiveMinSucceeds() {
         final FormatValidator validator = new FormatValidator("float");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 -3.4028234663852886e+38f,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -175,10 +164,9 @@ public class FormatValidatorTest {
     public void testFloatInclusiveMaxSucceeds() {
         final FormatValidator validator = new FormatValidator("float");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 3.4028234663852886e+38f,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -187,10 +175,9 @@ public class FormatValidatorTest {
     public void testFloatOverMaxFails() {
         final FormatValidator validator = new FormatValidator("float");
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 3.402823466385289e+38d,
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -198,10 +185,9 @@ public class FormatValidatorTest {
     public void testDoubleUnderMinFails() {
         final FormatValidator validator = new FormatValidator("double");
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 new BigDecimal("-1.7976931348623157082e+308"),
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -209,10 +195,9 @@ public class FormatValidatorTest {
     public void testDoubleInclusiveMinSucceeds() {
         final FormatValidator validator = new FormatValidator("double");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 -1.7976931348623157E+308d,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -221,10 +206,9 @@ public class FormatValidatorTest {
     public void testDoubleInclusiveMaxSucceeds() {
         final FormatValidator validator = new FormatValidator("double");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 1.7976931348623157E+308d,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -233,10 +217,9 @@ public class FormatValidatorTest {
     public void testDoubleOverMaxFails() {
         final FormatValidator validator = new FormatValidator("double");
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 new BigDecimal("1.7976931348623157082e+308"),
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -244,10 +227,9 @@ public class FormatValidatorTest {
     public void testInvalidNumberStringFails() {
         final FormatValidator validator = new FormatValidator("number");
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 "abc",
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -255,10 +237,9 @@ public class FormatValidatorTest {
     public void testValidFloatNumberStringSucceeds() {
         final FormatValidator validator = new FormatValidator("number");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 "3.14",
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -267,10 +248,9 @@ public class FormatValidatorTest {
     public void testValidIntNumberStringSucceeds() {
         final FormatValidator validator = new FormatValidator("number");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 "1",
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -279,10 +259,9 @@ public class FormatValidatorTest {
     public void testInvalidDateStringFails() {
         final FormatValidator validator = new FormatValidator("date");
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                StringJsonSchema.getInstance(),
                 "abc",
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -290,10 +269,9 @@ public class FormatValidatorTest {
     public void testValidDateStringSucceeds() {
         final FormatValidator validator = new FormatValidator("date");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                StringJsonSchema.getInstance(),
                 "2017-01-20",
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -302,10 +280,9 @@ public class FormatValidatorTest {
     public void testInvalidDateTimeStringFails() {
         final FormatValidator validator = new FormatValidator("date-time");
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                StringJsonSchema.getInstance(),
                 "abc",
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -313,10 +290,9 @@ public class FormatValidatorTest {
     public void testValidDateTimeStringSucceeds() {
         final FormatValidator validator = new FormatValidator("date-time");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                StringJsonSchema.getInstance(),
                 "2017-07-21T17:32:28Z",
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/client/schemas/validation/ItemsValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/client/schemas/validation/ItemsValidatorTest.java
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
 import org.openapijsonschematools.client.configurations.SchemaConfiguration;
+import org.openapijsonschematools.client.schemas.ListJsonSchema;
 import org.openapijsonschematools.client.schemas.StringJsonSchema;
 import org.openapijsonschematools.client.exceptions.ValidationException;
 
@@ -29,10 +30,9 @@ public class ItemsValidatorTest {
         FrozenList<Object> arg = new FrozenList<>(mutableList);
         final ItemsValidator validator = new ItemsValidator(StringJsonSchema.class);
         PathToSchemasMap pathToSchemas = validator.validate(
-                JsonSchema.class,
+                ListJsonSchema.getInstance(),
                 arg,
-                validationMetadata,
-                null
+                validationMetadata
         );
         List<Object> expectedPathToItem = new ArrayList<>();
         expectedPathToItem.add("args[0]");
@@ -57,10 +57,9 @@ public class ItemsValidatorTest {
         );
         final ItemsValidator validator = new ItemsValidator(StringJsonSchema.class);
         PathToSchemasMap pathToSchemas = validator.validate(
-                JsonSchema.class,
+                ListJsonSchema.getInstance(),
                 1,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemas);
     }
@@ -80,10 +79,9 @@ public class ItemsValidatorTest {
         FrozenList<Object> arg = new FrozenList<>(mutableList);
         final ItemsValidator validator = new ItemsValidator(StringJsonSchema.class);
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                ListJsonSchema.getInstance(),
                 arg,
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 }

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/client/schemas/validation/PropertiesValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/client/schemas/validation/PropertiesValidatorTest.java
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
 import org.openapijsonschematools.client.configurations.SchemaConfiguration;
+import org.openapijsonschematools.client.schemas.MapJsonSchema;
 import org.openapijsonschematools.client.schemas.StringJsonSchema;
 import org.openapijsonschematools.client.exceptions.ValidationException;
 
@@ -14,7 +15,6 @@ import java.util.List;
 import java.util.Map;
 
 public class PropertiesValidatorTest {
-
     @Test
     public void testCorrectPropertySucceeds() {
         Map<String, Class<? extends JsonSchema>> properties = new LinkedHashMap<>();
@@ -33,10 +33,9 @@ public class PropertiesValidatorTest {
         mutableMap.put("someString", "abc");
         FrozenMap<Object> arg = new FrozenMap<>(mutableMap);
         PathToSchemasMap pathToSchemas = validator.validate(
-                JsonSchema.class,
+                MapJsonSchema.getInstance(),
                 arg,
-                validationMetadata,
-                null
+                validationMetadata
         );
         List<Object> expectedPathToItem = new ArrayList<>();
         expectedPathToItem.add("args[0]");
@@ -63,10 +62,9 @@ public class PropertiesValidatorTest {
                 new LinkedHashSet<>()
         );
         PathToSchemasMap pathToSchemas = validator.validate(
-                JsonSchema.class,
+                MapJsonSchema.getInstance(),
                 1,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemas);
     }
@@ -89,10 +87,9 @@ public class PropertiesValidatorTest {
         mutableMap.put("someString", 1);
         FrozenMap<Object> arg = new FrozenMap<>(mutableMap);
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                MapJsonSchema.getInstance(),
                 arg,
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 }

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/client/schemas/validation/RequiredValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/client/schemas/validation/RequiredValidatorTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
 import org.openapijsonschematools.client.configurations.SchemaConfiguration;
 import org.openapijsonschematools.client.exceptions.ValidationException;
+import org.openapijsonschematools.client.schemas.MapJsonSchema;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -32,10 +33,9 @@ public class RequiredValidatorTest {
         FrozenMap<Object> arg = new FrozenMap<>(mutableMap);
         final RequiredValidator validator = new RequiredValidator(requiredProperties);
         PathToSchemasMap pathToSchemas = validator.validate(
-                JsonSchema.class,
+                MapJsonSchema.getInstance(),
                 arg,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemas);
     }
@@ -55,10 +55,9 @@ public class RequiredValidatorTest {
         );
         final RequiredValidator validator = new RequiredValidator(requiredProperties);
         PathToSchemasMap pathToSchemas = validator.validate(
-                JsonSchema.class,
+                MapJsonSchema.getInstance(),
                 1,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemas);
     }
@@ -81,10 +80,9 @@ public class RequiredValidatorTest {
         FrozenMap<Object> arg = new FrozenMap<>(mutableMap);
         final RequiredValidator validator = new RequiredValidator(requiredProperties);
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                MapJsonSchema.getInstance(),
                 arg,
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 }

--- a/samples/client/petstore/java/src/test/java/org/openapijsonschematools/client/schemas/validation/TypeValidatorTest.java
+++ b/samples/client/petstore/java/src/test/java/org/openapijsonschematools/client/schemas/validation/TypeValidatorTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
 import org.openapijsonschematools.client.configurations.SchemaConfiguration;
 import org.openapijsonschematools.client.exceptions.ValidationException;
+import org.openapijsonschematools.client.schemas.StringJsonSchema;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -23,10 +24,9 @@ public class TypeValidatorTest {
                 new LinkedHashSet<>()
         );
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                StringJsonSchema.getInstance(),
                 "hi",
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -43,10 +43,9 @@ public class TypeValidatorTest {
                 new LinkedHashSet<>()
         );
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                StringJsonSchema.getInstance(),
                 1,
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/AdditionalPropertiesValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/AdditionalPropertiesValidator.hbs
@@ -20,17 +20,18 @@ public class AdditionalPropertiesValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof Map)) {
             return null;
         }
         Map<String, Object> castArg = (Map<String, Object>) arg;
-        Map<String, Class<JsonSchema>> properties = (Map<String, Class<JsonSchema>>) extra;
-        if (properties == null) {
-            properties = new LinkedHashMap<>();
-        }
         Set<String> presentAdditionalProperties = new LinkedHashSet<>(castArg.keySet());
-        presentAdditionalProperties.removeAll(properties.keySet());
+        if (schema.keywordToValidator != null) {
+            KeywordValidator propertiesValidator = schema.keywordToValidator.get("properties");
+            if (propertiesValidator instanceof PropertiesValidator) {
+                presentAdditionalProperties.removeAll(((PropertiesValidator) propertiesValidator).properties.keySet());
+            }
+        }
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         // todo add handling for validatedPatternProperties
         for(String addPropName: presentAdditionalProperties) {

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/AdditionalPropertiesValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/AdditionalPropertiesValidator.hbs
@@ -20,7 +20,7 @@ public class AdditionalPropertiesValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Map)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/AllOfValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/AllOfValidator.hbs
@@ -15,7 +15,7 @@ public class AllOfValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         for(Class<? extends JsonSchema> allOfClass: allOf) {
             JsonSchema allOfSchema = JsonSchemaFactory.getInstance(allOfClass);

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/AllOfValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/AllOfValidator.hbs
@@ -15,7 +15,7 @@ public class AllOfValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         for(Class<? extends JsonSchema> allOfClass: allOf) {
             JsonSchema allOfSchema = JsonSchemaFactory.getInstance(allOfClass);

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/AnyOfValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/AnyOfValidator.hbs
@@ -18,13 +18,13 @@ public class AnyOfValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         List<Class<? extends JsonSchema>> validatedAnyOfClasses = new ArrayList<>();
         for(Class<? extends JsonSchema> anyOfClass: anyOf) {
-            if (anyOfClass == cls) {
+            if (anyOfClass == schema.getClass() {
                 /*
-                optimistically assume that cls schema will pass validation
+                optimistically assume that schema will pass validation
                 do not invoke _validate on it because that is recursive
                 */
                 validatedAnyOfClasses.add(anyOfClass);
@@ -40,7 +40,7 @@ public class AnyOfValidator implements KeywordValidator {
             }
         }
         if (validatedAnyOfClasses.isEmpty()) {
-            throw new ValidationException("Invalid inputs given to generate an instance of "+cls+". None "+
+            throw new ValidationException("Invalid inputs given to generate an instance of "+schema.getClass()+". None "+
                     "of the anyOf schemas matched the input data."
             );
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/AnyOfValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/AnyOfValidator.hbs
@@ -18,7 +18,7 @@ public class AnyOfValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         List<Class<? extends JsonSchema>> validatedAnyOfClasses = new ArrayList<>();
         for(Class<? extends JsonSchema> anyOfClass: anyOf) {

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/AnyOfValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/AnyOfValidator.hbs
@@ -22,7 +22,7 @@ public class AnyOfValidator implements KeywordValidator {
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         List<Class<? extends JsonSchema>> validatedAnyOfClasses = new ArrayList<>();
         for(Class<? extends JsonSchema> anyOfClass: anyOf) {
-            if (anyOfClass == schema.getClass() {
+            if (anyOfClass == schema.getClass()) {
                 /*
                 optimistically assume that schema will pass validation
                 do not invoke _validate on it because that is recursive

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/EnumValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/EnumValidator.hbs
@@ -18,7 +18,7 @@ public class EnumValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (enumValues.isEmpty()) {
             throw new ValidationException("No value can match enum because enum is empty");
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/EnumValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/EnumValidator.hbs
@@ -18,7 +18,7 @@ public class EnumValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (enumValues.isEmpty()) {
             throw new ValidationException("No value can match enum because enum is empty");
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/ExclusiveMaximumValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/ExclusiveMaximumValidator.hbs
@@ -16,7 +16,7 @@ public class ExclusiveMaximumValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof Number)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/ExclusiveMaximumValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/ExclusiveMaximumValidator.hbs
@@ -16,7 +16,7 @@ public class ExclusiveMaximumValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Number)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/ExclusiveMinimumValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/ExclusiveMinimumValidator.hbs
@@ -16,7 +16,7 @@ public class ExclusiveMinimumValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof Number)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/ExclusiveMinimumValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/ExclusiveMinimumValidator.hbs
@@ -16,7 +16,7 @@ public class ExclusiveMinimumValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Number)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/FakeValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/FakeValidator.hbs
@@ -7,7 +7,7 @@ public class FakeValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         return null;
     }
 }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/FakeValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/FakeValidator.hbs
@@ -7,7 +7,7 @@ public class FakeValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         return null;
     }
 }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/FormatValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/FormatValidator.hbs
@@ -147,7 +147,7 @@ public class FormatValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (arg instanceof Number) {
             validateNumericFormat(
                 (Number) arg,

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/FormatValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/FormatValidator.hbs
@@ -147,7 +147,7 @@ public class FormatValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (arg instanceof Number) {
             validateNumericFormat(
                 (Number) arg,

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/ItemsValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/ItemsValidator.hbs
@@ -16,7 +16,7 @@ public class ItemsValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof List)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/ItemsValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/ItemsValidator.hbs
@@ -16,7 +16,7 @@ public class ItemsValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof List)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/JsonSchema.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/JsonSchema.hbs
@@ -37,15 +37,11 @@ public abstract class JsonSchema {
                 if (disabledKeywords.contains(jsonKeyword)) {
                    continue;
                 }
-                if (jsonKeyword.equals("additionalProperties") && thisKeywordToValidator.containsKey("properties")) {
-                    extra = thisKeywordToValidator.get("properties").getConstraint();
-                }
                 KeywordValidator validator = entry.getValue();
                 PathToSchemasMap otherPathToSchemas = validator.validate(
                         jsonSchema,
                         arg,
-                        validationMetadata,
-                        extra
+                        validationMetadata
                 );
                 if (otherPathToSchemas == null) {
                     continue;

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/JsonSchema.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/JsonSchema.hbs
@@ -42,7 +42,7 @@ public abstract class JsonSchema {
                 }
                 KeywordValidator validator = entry.getValue();
                 PathToSchemasMap otherPathToSchemas = validator.validate(
-                        jsonSchema.getClass(),
+                        jsonSchema,
                         arg,
                         validationMetadata,
                         extra

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/KeywordValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/KeywordValidator.hbs
@@ -6,8 +6,7 @@ public interface KeywordValidator {
     PathToSchemasMap validate(
             JsonSchema schema,
             Object arg,
-            ValidationMetadata validationMetadata,
-            Object extra) throws ValidationException;
+            ValidationMetadata validationMetadata) throws ValidationException;
 
     Object getConstraint();
 }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/KeywordValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/KeywordValidator.hbs
@@ -4,7 +4,7 @@ import {{{packageName}}}.exceptions.ValidationException;
 
 public interface KeywordValidator {
     PathToSchemasMap validate(
-            Class<? extends JsonSchema> cls,
+            JsonSchema schema,
             Object arg,
             ValidationMetadata validationMetadata,
             Object extra) throws ValidationException;

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/MaxItemsValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/MaxItemsValidator.hbs
@@ -17,7 +17,7 @@ public class MaxItemsValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof List)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/MaxItemsValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/MaxItemsValidator.hbs
@@ -17,7 +17,7 @@ public class MaxItemsValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof List)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/MaxLengthValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/MaxLengthValidator.hbs
@@ -15,7 +15,7 @@ public class MaxLengthValidator extends LengthValidator implements KeywordValida
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof String)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/MaxLengthValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/MaxLengthValidator.hbs
@@ -15,7 +15,7 @@ public class MaxLengthValidator extends LengthValidator implements KeywordValida
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof String)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/MaxPropertiesValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/MaxPropertiesValidator.hbs
@@ -17,7 +17,7 @@ public class MaxPropertiesValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Map)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/MaxPropertiesValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/MaxPropertiesValidator.hbs
@@ -17,7 +17,7 @@ public class MaxPropertiesValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof Map)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/MaximumValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/MaximumValidator.hbs
@@ -16,7 +16,7 @@ public class MaximumValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Number)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/MaximumValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/MaximumValidator.hbs
@@ -16,7 +16,7 @@ public class MaximumValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof Number)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/MinItemsValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/MinItemsValidator.hbs
@@ -17,7 +17,7 @@ public class MinItemsValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof List)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/MinItemsValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/MinItemsValidator.hbs
@@ -17,7 +17,7 @@ public class MinItemsValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof List)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/MinLengthValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/MinLengthValidator.hbs
@@ -15,7 +15,7 @@ public class MinLengthValidator extends LengthValidator implements KeywordValida
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof String)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/MinLengthValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/MinLengthValidator.hbs
@@ -15,7 +15,7 @@ public class MinLengthValidator extends LengthValidator implements KeywordValida
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof String)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/MinPropertiesValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/MinPropertiesValidator.hbs
@@ -17,7 +17,7 @@ public class MinPropertiesValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof Map)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/MinPropertiesValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/MinPropertiesValidator.hbs
@@ -17,7 +17,7 @@ public class MinPropertiesValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Map)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/MinimumValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/MinimumValidator.hbs
@@ -16,7 +16,7 @@ public class MinimumValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Number)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/MinimumValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/MinimumValidator.hbs
@@ -16,7 +16,7 @@ public class MinimumValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof Number)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/MultipleOfValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/MultipleOfValidator.hbs
@@ -31,7 +31,7 @@ public class MultipleOfValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Number)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/MultipleOfValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/MultipleOfValidator.hbs
@@ -31,7 +31,7 @@ public class MultipleOfValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof Number)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/NotValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/NotValidator.hbs
@@ -22,7 +22,7 @@ public class NotValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         PathToSchemasMap pathToSchemas;
         try {
             JsonSchema notSchema = JsonSchemaFactory.getInstance(not);

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/NotValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/NotValidator.hbs
@@ -22,7 +22,7 @@ public class NotValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         PathToSchemasMap pathToSchemas;
         try {
             JsonSchema notSchema = JsonSchemaFactory.getInstance(not);
@@ -32,7 +32,7 @@ public class NotValidator implements KeywordValidator {
         }
         if (!pathToSchemas.isEmpty()) {
             throw new ValidationException(
-                    "Invalid value "+arg+" was passed in to "+cls+". "+
+                    "Invalid value "+arg+" was passed in to "+schema.getClass()+". "+
                             "Value is invalid because it is disallowed by not "+not
             );
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/OneOfValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/OneOfValidator.hbs
@@ -18,7 +18,7 @@ public class OneOfValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         List<Class<? extends JsonSchema>> validatedOneOfClasses = new ArrayList<>();
         for(Class<? extends JsonSchema> oneOfClass: oneOf) {

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/OneOfValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/OneOfValidator.hbs
@@ -18,13 +18,13 @@ public class OneOfValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         List<Class<? extends JsonSchema>> validatedOneOfClasses = new ArrayList<>();
         for(Class<? extends JsonSchema> oneOfClass: oneOf) {
-            if (oneOfClass == cls) {
+            if (oneOfClass == schema.getClass() {
                 /*
-                optimistically assume that cls schema will pass validation
+                optimistically assume that schema will pass validation
                 do not invoke validate on it because that is recursive
                 */
                 validatedOneOfClasses.add(oneOfClass);
@@ -40,12 +40,12 @@ public class OneOfValidator implements KeywordValidator {
             }
         }
         if (validatedOneOfClasses.isEmpty()) {
-            throw new ValidationException("Invalid inputs given to generate an instance of "+cls+". None "+
+            throw new ValidationException("Invalid inputs given to generate an instance of "+schema.getClass()+". None "+
                     "of the oneOf schemas matched the input data."
             );
         }
         if (validatedOneOfClasses.size() > 1) {
-            throw new ValidationException("Invalid inputs given to generate an instance of "+cls+". Multiple "+
+            throw new ValidationException("Invalid inputs given to generate an instance of "+schema.getClass()+". Multiple "+
                     "oneOf schemas validated the data, but a max of one is allowed."
             );
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/OneOfValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/OneOfValidator.hbs
@@ -22,7 +22,7 @@ public class OneOfValidator implements KeywordValidator {
         PathToSchemasMap pathToSchemas = new PathToSchemasMap();
         List<Class<? extends JsonSchema>> validatedOneOfClasses = new ArrayList<>();
         for(Class<? extends JsonSchema> oneOfClass: oneOf) {
-            if (oneOfClass == schema.getClass() {
+            if (oneOfClass == schema.getClass()) {
                 /*
                 optimistically assume that schema will pass validation
                 do not invoke validate on it because that is recursive

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/PatternValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/PatternValidator.hbs
@@ -17,7 +17,7 @@ public class PatternValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof String)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/PatternValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/PatternValidator.hbs
@@ -17,7 +17,7 @@ public class PatternValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof String)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/PropertiesValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/PropertiesValidator.hbs
@@ -19,7 +19,7 @@ public class PropertiesValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof Map)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/PropertiesValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/PropertiesValidator.hbs
@@ -19,7 +19,7 @@ public class PropertiesValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Map)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/RequiredValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/RequiredValidator.hbs
@@ -20,7 +20,7 @@ public class RequiredValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof Map)) {
             return null;
         }
@@ -34,7 +34,7 @@ public class RequiredValidator implements KeywordValidator {
                 pluralChar = "s";
             }
             throw new ValidationException(
-                cls+" is missing "+missingRequiredProperties.size()+" required argument"+pluralChar+": "+missingReqProps
+                schema.getClass()+" is missing "+missingRequiredProperties.size()+" required argument"+pluralChar+": "+missingReqProps
             );
         }
         return null;

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/RequiredValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/RequiredValidator.hbs
@@ -20,7 +20,7 @@ public class RequiredValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof Map)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/TypeValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/TypeValidator.hbs
@@ -17,7 +17,7 @@ public class TypeValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         Class<?> argClass;
         if (arg == null) {
             argClass = Void.class;

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/TypeValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/TypeValidator.hbs
@@ -17,7 +17,7 @@ public class TypeValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         Class<?> argClass;
         if (arg == null) {
             argClass = Void.class;

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/UniqueItemsValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/UniqueItemsValidator.hbs
@@ -19,7 +19,7 @@ public class UniqueItemsValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(Class<? extends JsonSchema> cls, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
         if (!(arg instanceof List)) {
             return null;
         }

--- a/src/main/resources/java/src/main/java/packagename/schemas/validation/UniqueItemsValidator.hbs
+++ b/src/main/resources/java/src/main/java/packagename/schemas/validation/UniqueItemsValidator.hbs
@@ -19,7 +19,7 @@ public class UniqueItemsValidator implements KeywordValidator {
     }
 
     @Override
-    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata, Object extra) {
+    public PathToSchemasMap validate(JsonSchema schema, Object arg, ValidationMetadata validationMetadata) {
         if (!(arg instanceof List)) {
             return null;
         }

--- a/src/main/resources/java/src/test/java/packagename/schemas/validation/AdditionalPropertiesValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/packagename/schemas/validation/AdditionalPropertiesValidatorTest.hbs
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
 import {{{packageName}}}.configurations.SchemaConfiguration;
+import {{{packageName}}}.schemas.MapJsonSchema;
 import {{{packageName}}}.schemas.StringJsonSchema;
 import {{{packageName}}}.exceptions.ValidationException;
 
@@ -34,7 +35,7 @@ public class AdditionalPropertiesValidatorTest {
         FrozenMap<Object> arg = new FrozenMap<>(mutableMap);
         final AdditionalPropertiesValidator validator = new AdditionalPropertiesValidator(StringJsonSchema.class);
         PathToSchemasMap pathToSchemas = validator.validate(
-                JsonSchema.class,
+                MapJsonSchema.getInstance(),
                 arg,
                 validationMetadata,
                 properties
@@ -62,7 +63,7 @@ public class AdditionalPropertiesValidatorTest {
         );
         final AdditionalPropertiesValidator validator = new AdditionalPropertiesValidator(StringJsonSchema.class);
         PathToSchemasMap pathToSchemas = validator.validate(
-                JsonSchema.class,
+                MapJsonSchema.getInstance(),
                 1,
                 validationMetadata,
                 null
@@ -89,7 +90,7 @@ public class AdditionalPropertiesValidatorTest {
         FrozenMap<Object> arg = new FrozenMap<>(mutableMap);
         final AdditionalPropertiesValidator validator = new AdditionalPropertiesValidator(StringJsonSchema.class);
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                MapJsonSchema.getInstance(),
                 arg,
                 validationMetadata,
                 properties

--- a/src/main/resources/java/src/test/java/packagename/schemas/validation/AdditionalPropertiesValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/packagename/schemas/validation/AdditionalPropertiesValidatorTest.hbs
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
 import {{{packageName}}}.configurations.SchemaConfiguration;
+import {{{packageName}}}.exceptions.InvalidTypeException;
 import {{{packageName}}}.schemas.MapJsonSchema;
 import {{{packageName}}}.schemas.StringJsonSchema;
 import {{{packageName}}}.exceptions.ValidationException;
@@ -13,14 +14,41 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class AdditionalPropertiesValidatorTest {
 
+    public static class ObjectWithPropsSchema extends JsonSchema {
+        private static ObjectWithPropsSchema instance;
+        private ObjectWithPropsSchema() {
+            super(new LinkedHashMap<>(Map.ofEntries(
+                    new KeywordEntry("type", new TypeValidator(Set.of(FrozenMap.class))),
+                    new KeywordEntry("properties", new PropertiesValidator(Map.ofEntries(
+                            new PropertyEntry("someString", StringJsonSchema.class)
+                    )))
+            )));
+
+        }
+
+        public static ObjectWithPropsSchema getInstance() {
+            if (instance == null) {
+                instance = new ObjectWithPropsSchema();
+            }
+            return instance;
+        }
+
+        @Override
+        public Object getNewInstance(Object arg, List<Object> pathToItem, PathToSchemasMap pathToSchemas) {
+            if (arg instanceof FrozenMap) {
+                @SuppressWarnings("unchecked") FrozenMap<Object> castArg = (FrozenMap<Object>) arg;
+                return arg;
+            }
+            throw new InvalidTypeException("Invalid input type="+arg.getClass()+". It can't be instantiated by this schema");
+        }
+    }
+
     @Test
     public void testCorrectPropertySucceeds() {
-        Map<String, Class<?>> properties = new LinkedHashMap<>();
-        properties.put("someString", StringJsonSchema.class);
-
         List<Object> pathToItem = new ArrayList<>();
         pathToItem.add("args[0]");
         ValidationMetadata validationMetadata = new ValidationMetadata(
@@ -35,10 +63,9 @@ public class AdditionalPropertiesValidatorTest {
         FrozenMap<Object> arg = new FrozenMap<>(mutableMap);
         final AdditionalPropertiesValidator validator = new AdditionalPropertiesValidator(StringJsonSchema.class);
         PathToSchemasMap pathToSchemas = validator.validate(
-                MapJsonSchema.getInstance(),
+                ObjectWithPropsSchema.getInstance(),
                 arg,
-                validationMetadata,
-                properties
+                validationMetadata
         );
         List<Object> expectedPathToItem = new ArrayList<>();
         expectedPathToItem.add("args[0]");
@@ -65,17 +92,13 @@ public class AdditionalPropertiesValidatorTest {
         PathToSchemasMap pathToSchemas = validator.validate(
                 MapJsonSchema.getInstance(),
                 1,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemas);
     }
 
     @Test
     public void testIncorrectPropertyValueFails() {
-        Map<String, Class<?>> properties = new LinkedHashMap<>();
-        properties.put("someString", StringJsonSchema.class);
-
         List<Object> pathToItem = new ArrayList<>();
         pathToItem.add("args[0]");
         ValidationMetadata validationMetadata = new ValidationMetadata(
@@ -90,10 +113,9 @@ public class AdditionalPropertiesValidatorTest {
         FrozenMap<Object> arg = new FrozenMap<>(mutableMap);
         final AdditionalPropertiesValidator validator = new AdditionalPropertiesValidator(StringJsonSchema.class);
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                MapJsonSchema.getInstance(),
+                ObjectWithPropsSchema.getInstance(),
                 arg,
-                validationMetadata,
-                properties
+                validationMetadata
         ));
     }
 }

--- a/src/main/resources/java/src/test/java/packagename/schemas/validation/FormatValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/packagename/schemas/validation/FormatValidatorTest.hbs
@@ -5,6 +5,8 @@ import org.junit.Test;
 import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
 import {{{packageName}}}.configurations.SchemaConfiguration;
 import {{{packageName}}}.exceptions.ValidationException;
+import {{{packageName}}}.schemas.NumberJsonSchema;
+import {{{packageName}}}.schemas.StringJsonSchema;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -23,7 +25,7 @@ public class FormatValidatorTest {
     public void testIntFormatSucceedsWithFloat() {
         final FormatValidator validator = new FormatValidator("int");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 1.0f,
                 validationMetadata,
                 null
@@ -35,7 +37,7 @@ public class FormatValidatorTest {
     public void testIntFormatFailsWithFloat() {
         final FormatValidator validator = new FormatValidator("int");
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 3.14f,
                 validationMetadata,
                 null
@@ -46,7 +48,7 @@ public class FormatValidatorTest {
     public void testIntFormatSucceedsWithInt() {
         final FormatValidator validator = new FormatValidator("int");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 1,
                 validationMetadata,
                 null
@@ -58,7 +60,7 @@ public class FormatValidatorTest {
     public void testInt32UnderMinFails() {
         final FormatValidator validator = new FormatValidator("int32");
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 -2147483649L,
                 validationMetadata,
                 null
@@ -69,7 +71,7 @@ public class FormatValidatorTest {
     public void testInt32InclusiveMinSucceeds() {
         final FormatValidator validator = new FormatValidator("int32");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 -2147483648,
                 validationMetadata,
                 null
@@ -81,7 +83,7 @@ public class FormatValidatorTest {
     public void testInt32InclusiveMaxSucceeds() {
         final FormatValidator validator = new FormatValidator("int32");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 2147483647,
                 validationMetadata,
                 null
@@ -93,7 +95,7 @@ public class FormatValidatorTest {
     public void testInt32OverMaxFails() {
         final FormatValidator validator = new FormatValidator("int32");
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 2147483648L,
                 validationMetadata,
                 null
@@ -105,7 +107,7 @@ public class FormatValidatorTest {
         final FormatValidator validator = new FormatValidator("int64");
 
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 new BigInteger("-9223372036854775809"),
                 validationMetadata,
                 null
@@ -116,7 +118,7 @@ public class FormatValidatorTest {
     public void testInt64InclusiveMinSucceeds() {
         final FormatValidator validator = new FormatValidator("int64");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 -9223372036854775808L,
                 validationMetadata,
                 null
@@ -128,7 +130,7 @@ public class FormatValidatorTest {
     public void testInt64InclusiveMaxSucceeds() {
         final FormatValidator validator = new FormatValidator("int64");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 9223372036854775807L,
                 validationMetadata,
                 null
@@ -141,7 +143,7 @@ public class FormatValidatorTest {
         final FormatValidator validator = new FormatValidator("int64");
 
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 new BigInteger("9223372036854775808"),
                 validationMetadata,
                 null
@@ -152,7 +154,7 @@ public class FormatValidatorTest {
     public void testFloatUnderMinFails() {
         final FormatValidator validator = new FormatValidator("float");
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 -3.402823466385289e+38d,
                 validationMetadata,
                 null
@@ -163,7 +165,7 @@ public class FormatValidatorTest {
     public void testFloatInclusiveMinSucceeds() {
         final FormatValidator validator = new FormatValidator("float");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 -3.4028234663852886e+38f,
                 validationMetadata,
                 null
@@ -175,7 +177,7 @@ public class FormatValidatorTest {
     public void testFloatInclusiveMaxSucceeds() {
         final FormatValidator validator = new FormatValidator("float");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 3.4028234663852886e+38f,
                 validationMetadata,
                 null
@@ -187,7 +189,7 @@ public class FormatValidatorTest {
     public void testFloatOverMaxFails() {
         final FormatValidator validator = new FormatValidator("float");
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 3.402823466385289e+38d,
                 validationMetadata,
                 null
@@ -198,7 +200,7 @@ public class FormatValidatorTest {
     public void testDoubleUnderMinFails() {
         final FormatValidator validator = new FormatValidator("double");
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 new BigDecimal("-1.7976931348623157082e+308"),
                 validationMetadata,
                 null
@@ -209,7 +211,7 @@ public class FormatValidatorTest {
     public void testDoubleInclusiveMinSucceeds() {
         final FormatValidator validator = new FormatValidator("double");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 -1.7976931348623157E+308d,
                 validationMetadata,
                 null
@@ -221,7 +223,7 @@ public class FormatValidatorTest {
     public void testDoubleInclusiveMaxSucceeds() {
         final FormatValidator validator = new FormatValidator("double");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 1.7976931348623157E+308d,
                 validationMetadata,
                 null
@@ -233,7 +235,7 @@ public class FormatValidatorTest {
     public void testDoubleOverMaxFails() {
         final FormatValidator validator = new FormatValidator("double");
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 new BigDecimal("1.7976931348623157082e+308"),
                 validationMetadata,
                 null
@@ -244,7 +246,7 @@ public class FormatValidatorTest {
     public void testInvalidNumberStringFails() {
         final FormatValidator validator = new FormatValidator("number");
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 "abc",
                 validationMetadata,
                 null
@@ -255,7 +257,7 @@ public class FormatValidatorTest {
     public void testValidFloatNumberStringSucceeds() {
         final FormatValidator validator = new FormatValidator("number");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 "3.14",
                 validationMetadata,
                 null
@@ -267,7 +269,7 @@ public class FormatValidatorTest {
     public void testValidIntNumberStringSucceeds() {
         final FormatValidator validator = new FormatValidator("number");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                NumberJsonSchema.getInstance(),
                 "1",
                 validationMetadata,
                 null
@@ -279,7 +281,7 @@ public class FormatValidatorTest {
     public void testInvalidDateStringFails() {
         final FormatValidator validator = new FormatValidator("date");
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                StringJsonSchema.getInstance(),
                 "abc",
                 validationMetadata,
                 null
@@ -290,7 +292,7 @@ public class FormatValidatorTest {
     public void testValidDateStringSucceeds() {
         final FormatValidator validator = new FormatValidator("date");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                StringJsonSchema.getInstance(),
                 "2017-01-20",
                 validationMetadata,
                 null
@@ -302,7 +304,7 @@ public class FormatValidatorTest {
     public void testInvalidDateTimeStringFails() {
         final FormatValidator validator = new FormatValidator("date-time");
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                StringJsonSchema.getInstance(),
                 "abc",
                 validationMetadata,
                 null
@@ -313,7 +315,7 @@ public class FormatValidatorTest {
     public void testValidDateTimeStringSucceeds() {
         final FormatValidator validator = new FormatValidator("date-time");
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                StringJsonSchema.getInstance(),
                 "2017-07-21T17:32:28Z",
                 validationMetadata,
                 null

--- a/src/main/resources/java/src/test/java/packagename/schemas/validation/FormatValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/packagename/schemas/validation/FormatValidatorTest.hbs
@@ -27,8 +27,7 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 NumberJsonSchema.getInstance(),
                 1.0f,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -39,8 +38,7 @@ public class FormatValidatorTest {
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 NumberJsonSchema.getInstance(),
                 3.14f,
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -50,8 +48,7 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 NumberJsonSchema.getInstance(),
                 1,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -62,8 +59,7 @@ public class FormatValidatorTest {
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 NumberJsonSchema.getInstance(),
                 -2147483649L,
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -73,8 +69,7 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 NumberJsonSchema.getInstance(),
                 -2147483648,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -85,8 +80,7 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 NumberJsonSchema.getInstance(),
                 2147483647,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -97,8 +91,7 @@ public class FormatValidatorTest {
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 NumberJsonSchema.getInstance(),
                 2147483648L,
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -109,8 +102,7 @@ public class FormatValidatorTest {
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 NumberJsonSchema.getInstance(),
                 new BigInteger("-9223372036854775809"),
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -120,8 +112,7 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 NumberJsonSchema.getInstance(),
                 -9223372036854775808L,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -132,8 +123,7 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 NumberJsonSchema.getInstance(),
                 9223372036854775807L,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -145,8 +135,7 @@ public class FormatValidatorTest {
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 NumberJsonSchema.getInstance(),
                 new BigInteger("9223372036854775808"),
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -156,8 +145,7 @@ public class FormatValidatorTest {
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 NumberJsonSchema.getInstance(),
                 -3.402823466385289e+38d,
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -167,8 +155,7 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 NumberJsonSchema.getInstance(),
                 -3.4028234663852886e+38f,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -179,8 +166,7 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 NumberJsonSchema.getInstance(),
                 3.4028234663852886e+38f,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -191,8 +177,7 @@ public class FormatValidatorTest {
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 NumberJsonSchema.getInstance(),
                 3.402823466385289e+38d,
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -202,8 +187,7 @@ public class FormatValidatorTest {
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 NumberJsonSchema.getInstance(),
                 new BigDecimal("-1.7976931348623157082e+308"),
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -213,8 +197,7 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 NumberJsonSchema.getInstance(),
                 -1.7976931348623157E+308d,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -225,8 +208,7 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 NumberJsonSchema.getInstance(),
                 1.7976931348623157E+308d,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -237,8 +219,7 @@ public class FormatValidatorTest {
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 NumberJsonSchema.getInstance(),
                 new BigDecimal("1.7976931348623157082e+308"),
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -248,8 +229,7 @@ public class FormatValidatorTest {
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 NumberJsonSchema.getInstance(),
                 "abc",
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -259,8 +239,7 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 NumberJsonSchema.getInstance(),
                 "3.14",
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -271,8 +250,7 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 NumberJsonSchema.getInstance(),
                 "1",
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -283,8 +261,7 @@ public class FormatValidatorTest {
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 StringJsonSchema.getInstance(),
                 "abc",
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -294,8 +271,7 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 StringJsonSchema.getInstance(),
                 "2017-01-20",
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -306,8 +282,7 @@ public class FormatValidatorTest {
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 StringJsonSchema.getInstance(),
                 "abc",
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 
@@ -317,8 +292,7 @@ public class FormatValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 StringJsonSchema.getInstance(),
                 "2017-07-21T17:32:28Z",
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }

--- a/src/main/resources/java/src/test/java/packagename/schemas/validation/ItemsValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/packagename/schemas/validation/ItemsValidatorTest.hbs
@@ -32,8 +32,7 @@ public class ItemsValidatorTest {
         PathToSchemasMap pathToSchemas = validator.validate(
                 ListJsonSchema.getInstance(),
                 arg,
-                validationMetadata,
-                null
+                validationMetadata
         );
         List<Object> expectedPathToItem = new ArrayList<>();
         expectedPathToItem.add("args[0]");
@@ -60,8 +59,7 @@ public class ItemsValidatorTest {
         PathToSchemasMap pathToSchemas = validator.validate(
                 ListJsonSchema.getInstance(),
                 1,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemas);
     }
@@ -83,8 +81,7 @@ public class ItemsValidatorTest {
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 ListJsonSchema.getInstance(),
                 arg,
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 }

--- a/src/main/resources/java/src/test/java/packagename/schemas/validation/ItemsValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/packagename/schemas/validation/ItemsValidatorTest.hbs
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
 import {{{packageName}}}.configurations.SchemaConfiguration;
+import {{{packageName}}}.ListJsonSchema;
 import {{{packageName}}}.schemas.StringJsonSchema;
 import {{{packageName}}}.exceptions.ValidationException;
 
@@ -29,7 +30,7 @@ public class ItemsValidatorTest {
         FrozenList<Object> arg = new FrozenList<>(mutableList);
         final ItemsValidator validator = new ItemsValidator(StringJsonSchema.class);
         PathToSchemasMap pathToSchemas = validator.validate(
-                JsonSchema.class,
+                ListJsonSchema.getInstance(),
                 arg,
                 validationMetadata,
                 null
@@ -57,7 +58,7 @@ public class ItemsValidatorTest {
         );
         final ItemsValidator validator = new ItemsValidator(StringJsonSchema.class);
         PathToSchemasMap pathToSchemas = validator.validate(
-                JsonSchema.class,
+                ListJsonSchema.getInstance(),
                 1,
                 validationMetadata,
                 null
@@ -80,7 +81,7 @@ public class ItemsValidatorTest {
         FrozenList<Object> arg = new FrozenList<>(mutableList);
         final ItemsValidator validator = new ItemsValidator(StringJsonSchema.class);
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                ListJsonSchema.getInstance(),
                 arg,
                 validationMetadata,
                 null

--- a/src/main/resources/java/src/test/java/packagename/schemas/validation/ItemsValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/packagename/schemas/validation/ItemsValidatorTest.hbs
@@ -4,7 +4,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
 import {{{packageName}}}.configurations.SchemaConfiguration;
-import {{{packageName}}}.ListJsonSchema;
+import {{{packageName}}}.schemas.ListJsonSchema;
 import {{{packageName}}}.schemas.StringJsonSchema;
 import {{{packageName}}}.exceptions.ValidationException;
 

--- a/src/main/resources/java/src/test/java/packagename/schemas/validation/PropertiesValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/packagename/schemas/validation/PropertiesValidatorTest.hbs
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
 import {{{packageName}}}.configurations.SchemaConfiguration;
+import {{{packageName}}}.schemas.MapJsonSchema;
 import {{{packageName}}}.schemas.StringJsonSchema;
 import {{{packageName}}}.exceptions.ValidationException;
 
@@ -33,7 +34,7 @@ public class PropertiesValidatorTest {
         mutableMap.put("someString", "abc");
         FrozenMap<Object> arg = new FrozenMap<>(mutableMap);
         PathToSchemasMap pathToSchemas = validator.validate(
-                JsonSchema.class,
+                MapJsonSchema.getInstance(),
                 arg,
                 validationMetadata,
                 null
@@ -63,7 +64,7 @@ public class PropertiesValidatorTest {
                 new LinkedHashSet<>()
         );
         PathToSchemasMap pathToSchemas = validator.validate(
-                JsonSchema.class,
+                MapJsonSchema.getInstance(),
                 1,
                 validationMetadata,
                 null
@@ -89,7 +90,7 @@ public class PropertiesValidatorTest {
         mutableMap.put("someString", 1);
         FrozenMap<Object> arg = new FrozenMap<>(mutableMap);
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                MapJsonSchema.getInstance(),
                 arg,
                 validationMetadata,
                 null

--- a/src/main/resources/java/src/test/java/packagename/schemas/validation/PropertiesValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/packagename/schemas/validation/PropertiesValidatorTest.hbs
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Map;
 
 public class PropertiesValidatorTest {
-
     @Test
     public void testCorrectPropertySucceeds() {
         Map<String, Class<? extends JsonSchema>> properties = new LinkedHashMap<>();
@@ -36,8 +35,7 @@ public class PropertiesValidatorTest {
         PathToSchemasMap pathToSchemas = validator.validate(
                 MapJsonSchema.getInstance(),
                 arg,
-                validationMetadata,
-                null
+                validationMetadata
         );
         List<Object> expectedPathToItem = new ArrayList<>();
         expectedPathToItem.add("args[0]");
@@ -66,8 +64,7 @@ public class PropertiesValidatorTest {
         PathToSchemasMap pathToSchemas = validator.validate(
                 MapJsonSchema.getInstance(),
                 1,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemas);
     }
@@ -92,8 +89,7 @@ public class PropertiesValidatorTest {
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 MapJsonSchema.getInstance(),
                 arg,
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 }

--- a/src/main/resources/java/src/test/java/packagename/schemas/validation/RequiredValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/packagename/schemas/validation/RequiredValidatorTest.hbs
@@ -35,8 +35,7 @@ public class RequiredValidatorTest {
         PathToSchemasMap pathToSchemas = validator.validate(
                 MapJsonSchema.getInstance(),
                 arg,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemas);
     }
@@ -58,8 +57,7 @@ public class RequiredValidatorTest {
         PathToSchemasMap pathToSchemas = validator.validate(
                 MapJsonSchema.getInstance(),
                 1,
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemas);
     }
@@ -84,8 +82,7 @@ public class RequiredValidatorTest {
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 MapJsonSchema.getInstance(),
                 arg,
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 }

--- a/src/main/resources/java/src/test/java/packagename/schemas/validation/RequiredValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/packagename/schemas/validation/RequiredValidatorTest.hbs
@@ -5,6 +5,7 @@ import org.junit.Test;
 import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
 import {{{packageName}}}.configurations.SchemaConfiguration;
 import {{{packageName}}}.exceptions.ValidationException;
+import {{{packageName}}}.schemas.MapJsonSchema;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -32,7 +33,7 @@ public class RequiredValidatorTest {
         FrozenMap<Object> arg = new FrozenMap<>(mutableMap);
         final RequiredValidator validator = new RequiredValidator(requiredProperties);
         PathToSchemasMap pathToSchemas = validator.validate(
-                JsonSchema.class,
+                MapJsonSchema.getInstance(),
                 arg,
                 validationMetadata,
                 null
@@ -55,7 +56,7 @@ public class RequiredValidatorTest {
         );
         final RequiredValidator validator = new RequiredValidator(requiredProperties);
         PathToSchemasMap pathToSchemas = validator.validate(
-                JsonSchema.class,
+                MapJsonSchema.getInstance(),
                 1,
                 validationMetadata,
                 null
@@ -81,7 +82,7 @@ public class RequiredValidatorTest {
         FrozenMap<Object> arg = new FrozenMap<>(mutableMap);
         final RequiredValidator validator = new RequiredValidator(requiredProperties);
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                MapJsonSchema.getInstance(),
                 arg,
                 validationMetadata,
                 null

--- a/src/main/resources/java/src/test/java/packagename/schemas/validation/TypeValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/packagename/schemas/validation/TypeValidatorTest.hbs
@@ -26,8 +26,7 @@ public class TypeValidatorTest {
         PathToSchemasMap pathToSchemasMap = validator.validate(
                 StringJsonSchema.getInstance(),
                 "hi",
-                validationMetadata,
-                null
+                validationMetadata
         );
         Assert.assertNull(pathToSchemasMap);
     }
@@ -46,8 +45,7 @@ public class TypeValidatorTest {
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
                 StringJsonSchema.getInstance(),
                 1,
-                validationMetadata,
-                null
+                validationMetadata
         ));
     }
 }

--- a/src/main/resources/java/src/test/java/packagename/schemas/validation/TypeValidatorTest.hbs
+++ b/src/main/resources/java/src/test/java/packagename/schemas/validation/TypeValidatorTest.hbs
@@ -5,6 +5,7 @@ import org.junit.Test;
 import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
 import {{{packageName}}}.configurations.SchemaConfiguration;
 import {{{packageName}}}.exceptions.ValidationException;
+import {{{packageName}}}.schemas.StringJsonSchema;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -23,7 +24,7 @@ public class TypeValidatorTest {
                 new LinkedHashSet<>()
         );
         PathToSchemasMap pathToSchemasMap = validator.validate(
-                JsonSchema.class,
+                StringJsonSchema.getInstance(),
                 "hi",
                 validationMetadata,
                 null
@@ -43,7 +44,7 @@ public class TypeValidatorTest {
                 new LinkedHashSet<>()
         );
         Assert.assertThrows(ValidationException.class, () -> validator.validate(
-                JsonSchema.class,
+                StringJsonSchema.getInstance(),
                 1,
                 validationMetadata,
                 null


### PR DESCRIPTION
Java, adjusts KeywordValidator validate inputs
- extra arg removed
- cls arg changed to schema, type changed to JsonSchema

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
