### PR TITLE
Removes deprecated methods

### DIFF
--- a/src/main/java/org/openapijsonschematools/codegen/clicommands/GenerateBatch.java
+++ b/src/main/java/org/openapijsonschematools/codegen/clicommands/GenerateBatch.java
@@ -208,7 +208,7 @@ public class GenerateBatch extends AbstractCommand {
                 GlobalSettings.reset();
 
                 ClientOptInput opts = configurator.toClientOptInput();
-                Generator config = opts.getConfig();
+                Generator config = opts.config;
                 name = config.getName();
                 
                 Path target = Paths.get(config.getOutputDir());

--- a/src/main/java/org/openapijsonschematools/codegen/config/ClientOptInput.java
+++ b/src/main/java/org/openapijsonschematools/codegen/config/ClientOptInput.java
@@ -18,7 +18,6 @@
 package org.openapijsonschematools.codegen.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.parser.core.models.AuthorizationValue;
 
 import org.openapijsonschematools.codegen.generators.Generator;
 import org.openapijsonschematools.codegen.templating.TemplateDefinition;
@@ -26,89 +25,13 @@ import org.openapijsonschematools.codegen.templating.TemplateDefinition;
 import java.util.List;
 
 public class ClientOptInput {
-    private Generator config;
-    private OpenAPI openAPI;
-    private List<AuthorizationValue> auths;
-    private List<TemplateDefinition> userDefinedTemplates;
+    public Generator config;
+    public OpenAPI openAPI;
+    public List<TemplateDefinition> userDefinedTemplates;
 
-    public ClientOptInput openAPI(OpenAPI openAPI) {
-        this.setOpenAPI(openAPI);
-        return this;
-    }
-
-    public ClientOptInput config(Generator generator) {
-        this.setConfig(generator);
-        return this;
-    }
-
-    public ClientOptInput userDefinedTemplates(List<TemplateDefinition> userDefinedTemplates) {
-        this.userDefinedTemplates = userDefinedTemplates;
-        return this;
-    }
-
-    @Deprecated
-    public ClientOptInput auth(String urlEncodedAuthString) {
-        this.setAuth(urlEncodedAuthString);
-        return this;
-    }
-
-    @Deprecated
-    public String getAuth() {
-        return AuthParser.reconstruct(auths);
-    }
-
-    @Deprecated
-    public void setAuth(String urlEncodedAuthString) {
-        this.auths = AuthParser.parse(urlEncodedAuthString);
-    }
-
-    @Deprecated
-    public List<AuthorizationValue> getAuthorizationValues() {
-        return auths;
-    }
-
-    @Deprecated
-    public Generator getConfig() {
-        return config;
-    }
-
-    public List<TemplateDefinition> getUserDefinedTemplates() {
-        // not deprecated as this is added to match other functionality, we need to move to Context<?> instead of ClientOptInput.
-        return userDefinedTemplates;
-    }
-
-    /**
-     * Sets the generator/config instance
-     *
-     * @deprecated use {@link #config(Generator)} instead
-     * @param config codegen config
-     */
-    @Deprecated
-    public void setConfig(Generator config) {
-        this.config = config;
-        // TODO: ClientOptInputs needs to be retired
-        if (this.openAPI != null) {
-            this.config.setOpenAPI(this.openAPI);
-        }
-    }
-
-    @Deprecated
-    public OpenAPI getOpenAPI() {
-        return openAPI;
-    }
-
-    /**
-     * Sets the OpenAPI document
-     *
-     * @deprecated use {@link #openAPI(OpenAPI)} instead
-     * @param openAPI the specification
-     */
-    @Deprecated
-    public void setOpenAPI(OpenAPI openAPI) {
+    public ClientOptInput(OpenAPI openAPI, Generator generator, List<TemplateDefinition> userDefinedTemplates) {
         this.openAPI = openAPI;
-        // TODO: ClientOptInputs needs to be retired
-        if (this.config != null) {
-            this.config.setOpenAPI(this.openAPI);
-        }
+        this.config = generator;
+        this.userDefinedTemplates = userDefinedTemplates;
     }
 }

--- a/src/main/java/org/openapijsonschematools/codegen/config/CodegenConfigurator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/config/CodegenConfigurator.java
@@ -494,10 +494,10 @@ public class CodegenConfigurator {
             config.additionalProperties().put(CodegenConstants.TEMPLATE_DIR, workflowSettings.getTemplateDir());
         }
 
-        ClientOptInput input = new ClientOptInput()
-                .config(config)
-                .userDefinedTemplates(userDefinedTemplates);
-
-        return input.openAPI((OpenAPI)context.getSpecDocument());
+        return new ClientOptInput(
+                (OpenAPI)context.getSpecDocument(),
+                config,
+                userDefinedTemplates
+        );
     }
 }

--- a/src/main/java/org/openapijsonschematools/codegen/generatorrunner/DefaultGeneratorRunner.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generatorrunner/DefaultGeneratorRunner.java
@@ -92,7 +92,6 @@ public class DefaultGeneratorRunner implements GeneratorRunner {
     protected final Logger LOGGER = LoggerFactory.getLogger(DefaultGeneratorRunner.class);
     private final boolean dryRun;
     public Generator generator;
-    protected ClientOptInput opts;
     public OpenAPI openAPI;
     protected CodegenIgnoreProcessor ignoreProcessor;
     private Boolean generateApis = null;
@@ -146,10 +145,9 @@ public class DefaultGeneratorRunner implements GeneratorRunner {
     @SuppressWarnings("deprecation")
     @Override
     public GeneratorRunner opts(ClientOptInput opts) {
-        this.opts = opts;
-        this.openAPI = opts.getOpenAPI();
-        this.generator = opts.getConfig();
-        List<TemplateDefinition> userFiles = opts.getUserDefinedTemplates();
+        this.openAPI = opts.openAPI;
+        this.generator = opts.config;
+        List<TemplateDefinition> userFiles = opts.userDefinedTemplates;
         if (userFiles != null) {
             this.userDefinedTemplates = Collections.unmodifiableList(userFiles);
         }

--- a/src/test/java/org/openapijsonschematools/codegen/generatorrunner/DefaultGeneratorRunnerTest.java
+++ b/src/test/java/org/openapijsonschematools/codegen/generatorrunner/DefaultGeneratorRunnerTest.java
@@ -278,11 +278,13 @@ public class DefaultGeneratorRunnerTest {
         openAPI.getPaths().addPathItem("path1/", new PathItem().get(new Operation().operationId("op1").responses(new ApiResponses().addApiResponse("201", new ApiResponse().description("OK")))));
         openAPI.getPaths().addPathItem("path2/", new PathItem().get(new Operation().operationId("op2").addParametersItem(new QueryParameter().name("p1").schema(new StringSchema())).responses(new ApiResponses().addApiResponse("201", new ApiResponse().description("OK")))));
 
-        ClientOptInput opts = new ClientOptInput();
-        opts.openAPI(openAPI);
         Generator config = new DefaultGenerator();
         config.setStrictSpecBehavior(false);
-        opts.config(config);
+        ClientOptInput opts = new ClientOptInput(
+                openAPI,
+                config,
+                null
+        );
 
         DefaultGeneratorRunner generator = new DefaultGeneratorRunner();
         generator.opts(opts);
@@ -306,10 +308,12 @@ public class DefaultGeneratorRunnerTest {
         openAPI.getPaths().addPathItem("/path3", new PathItem().addParametersItem(new QueryParameter().name("p1").schema(new StringSchema())).get(new Operation().operationId("op3").addParametersItem(new QueryParameter().name("p2").schema(new IntegerSchema())).responses(new ApiResponses().addApiResponse("201", new ApiResponse().description("OK")))));
         openAPI.getPaths().addPathItem("/path4", new PathItem().addParametersItem(new QueryParameter().name("p1").schema(new StringSchema())).get(new Operation().operationId("op4").responses(new ApiResponses().addApiResponse("201", new ApiResponse().description("OK")))));
 
-        ClientOptInput opts = new ClientOptInput();
-        opts.openAPI(openAPI);
         Generator config = new DefaultGenerator();
-        opts.config(config);
+        ClientOptInput opts = new ClientOptInput(
+                openAPI,
+                config,
+                null
+        );
 
         DefaultGeneratorRunner generator = new DefaultGeneratorRunner();
         generator.opts(opts);
@@ -330,12 +334,14 @@ public class DefaultGeneratorRunnerTest {
     @Test
     public void testRefModelValidationProperties() {
         OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/refAliasedPrimitiveWithValidation.yml");
-        ClientOptInput opts = new ClientOptInput();
-        opts.openAPI(openAPI);
         DefaultGenerator config = new DefaultGenerator();
         config.setModelPackage("components.schema");
         config.setStrictSpecBehavior(false);
-        opts.config(config);
+        ClientOptInput opts = new ClientOptInput(
+                openAPI,
+                config,
+                null
+        );
 
         DefaultGeneratorRunner generator = new DefaultGeneratorRunner();
         generator.opts(opts);
@@ -591,11 +597,13 @@ public class DefaultGeneratorRunnerTest {
     @Test
     public void testHandlesTrailingSlashInServers() {
         OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue_7533.yaml");
-        ClientOptInput opts = new ClientOptInput();
-        opts.openAPI(openAPI);
         DefaultGenerator config = new DefaultGenerator();
         config.setStrictSpecBehavior(false);
-        opts.config(config);
+        ClientOptInput opts = new ClientOptInput(
+                openAPI,
+                config,
+                null
+        );
         final DefaultGeneratorRunner generator = new DefaultGeneratorRunner();
         generator.opts(opts);
         generator.configureGeneratorProperties();
@@ -613,11 +621,13 @@ public class DefaultGeneratorRunnerTest {
     @Test
     public void testHandlesRelativeUrlsInServers() {
         OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue_10056.yaml");
-        ClientOptInput opts = new ClientOptInput();
-        opts.openAPI(openAPI);
         DefaultGenerator config = new DefaultGenerator();
         config.setStrictSpecBehavior(true);
-        opts.config(config);
+        ClientOptInput opts = new ClientOptInput(
+                openAPI,
+                config,
+                null
+        );
         final DefaultGeneratorRunner generator = new DefaultGeneratorRunner();
         generator.opts(opts);
         generator.configureGeneratorProperties();
@@ -693,11 +703,13 @@ public class DefaultGeneratorRunnerTest {
     @Test
     public void testRecursionBug4650() {
         OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/bugs/recursion-bug-4650.yaml");
-        ClientOptInput opts = new ClientOptInput();
-        opts.openAPI(openAPI);
         DefaultGenerator config = new DefaultGenerator();
         config.setStrictSpecBehavior(false);
-        opts.config(config);
+        ClientOptInput opts = new ClientOptInput(
+                openAPI,
+                config,
+                null
+        );
         final DefaultGeneratorRunner generator = new DefaultGeneratorRunner();
         generator.opts(opts);
         generator.configureGeneratorProperties();


### PR DESCRIPTION
Removes deprecated methods
- why are the generated file sizes off by 2, how do the ClientOptInput instances look different?
- what files are missing? dryRunWIthSUpportingFIles section has 5 or 7 files

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
