### PR TITLE
Removes model package references

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,6 @@ SYNOPSIS
                 [--log-to-stderr] [--minimal-update]
                 [--model-name-prefix <model name prefix>]
                 [--model-name-suffix <model name suffix>]
-                [--model-package <model package>]
                 [(-o <output directory> | --output <output directory>)] [(-p <additional properties> | --additional-properties <additional properties>)...]
                 [--package-name <package name>] [--release-note <release note>]
                 [--remove-operation-id-prefix]

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -257,7 +257,6 @@ SYNOPSIS
                 [--log-to-stderr] [--minimal-update]
                 [--model-name-prefix <model name prefix>]
                 [--model-name-suffix <model name suffix>]
-                [--model-package <model package>]
                 [(-o <output directory> | --output <output directory>)] [(-p <additional properties> | --additional-properties <additional properties>)...]
                 [--package-name <package name>] [--release-note <release note>]
                 [--remove-operation-id-prefix]
@@ -369,9 +368,6 @@ OPTIONS
 
         --model-name-suffix <model name suffix>
             Suffix that will be appended to all model names.
-
-        --model-package <model package>
-            package for generated models
 
         -o <output directory>, --output <output directory>
             where to write the generated files (current dir by default)


### PR DESCRIPTION
Removes model package references
Note: that feature was removed in an earlier PR because this tooling needs the model packages to to in a specific place so they can be imported into other locations like usage in paths.

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
