### PR TITLE
Java, adds mising const info to schema docs

### DIFF
--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/ConstNulCharactersInStrings.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/ConstNulCharactersInStrings.md
@@ -21,6 +21,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
+| @Nullable Object | constValue = "hello\0there" |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.md
@@ -51,6 +51,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
+| @Nullable Object | constValue = "yes" |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
@@ -109,6 +110,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
+| @Nullable Object | constValue = "other" |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/IgnoreElseWithoutIf.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/IgnoreElseWithoutIf.md
@@ -46,6 +46,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
+| @Nullable Object | constValue = "0" |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/IgnoreIfWithoutThenOrElse.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/IgnoreIfWithoutThenOrElse.md
@@ -46,6 +46,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
+| @Nullable Object | constValue = "0" |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/IgnoreThenWithoutIf.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/IgnoreThenWithoutIf.md
@@ -46,6 +46,7 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
+| @Nullable Object | constValue = "0" |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/src/main/resources/java/src/main/java/packagename/components/schemas/docschema_fields_field.hbs
+++ b/src/main/resources/java/src/main/java/packagename/components/schemas/docschema_fields_field.hbs
@@ -70,7 +70,7 @@
 {{#if patternInfo}}
 | Pattern | {{> src/main/java/packagename/components/schemas/SchemaClass/_pattern }} |
 {{/if}}
-{{#if defaultValue}}
+{{#if defaultValueSet}}
 | @Nullable Object | {{> src/main/java/packagename/components/schemas/SchemaClass/_default }} |
 {{/if}}
 {{#if contains}}
@@ -105,4 +105,7 @@
 {{/if}}
 {{#if else_}}
 | Class<? extends JsonSchema> | {{> src/main/java/packagename/components/schemas/SchemaClass/_else }} |
+{{/if}}
+{{#if constValueSet}}
+| @Nullable Object | {{> src/main/java/packagename/components/schemas/SchemaClass/_const }} |
 {{/if}}

--- a/src/main/resources/java/src/main/java/packagename/components/schemas/docschema_fields_field.hbs
+++ b/src/main/resources/java/src/main/java/packagename/components/schemas/docschema_fields_field.hbs
@@ -70,7 +70,7 @@
 {{#if patternInfo}}
 | Pattern | {{> src/main/java/packagename/components/schemas/SchemaClass/_pattern }} |
 {{/if}}
-{{#if defaultValueSet}}
+{{#if defaultValue}}
 | @Nullable Object | {{> src/main/java/packagename/components/schemas/SchemaClass/_default }} |
 {{/if}}
 {{#if contains}}
@@ -106,6 +106,6 @@
 {{#if else_}}
 | Class<? extends JsonSchema> | {{> src/main/java/packagename/components/schemas/SchemaClass/_else }} |
 {{/if}}
-{{#if constValueSet}}
+{{#if constInfo}}
 | @Nullable Object | {{> src/main/java/packagename/components/schemas/SchemaClass/_const }} |
 {{/if}}


### PR DESCRIPTION
Java, adds mising const info to schema docs

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
