### PR TITLE
CI, speeds up java tests via circleci cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,6 +157,10 @@ jobs:
     steps:
       - command_build_and_test:
           jobId: "testJava17ClientSamples"
+      - save_cache:
+          key: javaClientMavenCache
+          paths:
+            - ~/.m2
 workflows:
   version: 2
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,34 +33,14 @@ commands: # a reusable command with parameters
           paths:
             # This is a broad list of cache paths to include many possible development environments
             # You can probably delete some of these entries
-            - vendor/bundle
-            - ~/.pyenv
-            - ~/virtualenvs
             - ~/.m2
-            - ~/.ivy2
-            - ~/.sbt
-            - ~/.bundle
-            - ~/.gradle
-            - ~/.cache/bower
-            - ".git"
-            - ~/.stack
       # save "default" cache using the key "source-v2-"
       - save_cache:
           key: source-v2-
           paths:
             # This is a broad list of cache paths to include many possible development environments
             # You can probably delete some of these entries
-            - vendor/bundle
-            - ~/.pyenv
-            - ~/virtualenvs
             - ~/.m2
-            - ~/.ivy2
-            - ~/.sbt
-            - ~/.bundle
-            - ~/.gradle
-            - ~/.cache/bower
-            - ".git"
-            - ~/.stack
       # Teardown
       #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
       # Save test results
@@ -155,6 +135,9 @@ jobs:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     steps:
+      - restore_cache:
+          keys:
+            - javaClientMavenCache
       - command_build_and_test:
           jobId: "testJava17ClientSamples"
       - save_cache:


### PR DESCRIPTION
CI, speeds up java tests via circleci cache
- maven should not be hit to download checker framework once cache is hydrated

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
