### PR TITLE
Java client, documentation improvement

### DIFF
--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/AdditionalpropertiesAllowsASchemaWhichShouldValidate.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/AdditionalpropertiesAllowsASchemaWhichShouldValidate.md
@@ -75,6 +75,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.AdditionalpropertiesAllowsASchemaWhichShouldValidate;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/AdditionalpropertiesCanExistByItself.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/AdditionalpropertiesCanExistByItself.md
@@ -59,6 +59,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.AdditionalpropertiesCanExistByItself;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/AnyofWithBaseSchema.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/AnyofWithBaseSchema.md
@@ -68,6 +68,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.AnyofWithBaseSchema;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/ArrayTypeMatchesArrays.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/ArrayTypeMatchesArrays.md
@@ -64,6 +64,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ArrayTypeMatchesArrays;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/EnumWith0DoesNotMatchFalse.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/EnumWith0DoesNotMatchFalse.md
@@ -57,6 +57,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.EnumWith0DoesNotMatchFalse;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/EnumWith1DoesNotMatchTrue.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/EnumWith1DoesNotMatchTrue.md
@@ -57,6 +57,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.EnumWith1DoesNotMatchTrue;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/EnumWithEscapedCharacters.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/EnumWithEscapedCharacters.md
@@ -54,6 +54,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.EnumWithEscapedCharacters;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/EnumWithFalseDoesNotMatch0.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/EnumWithFalseDoesNotMatch0.md
@@ -54,6 +54,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.EnumWithFalseDoesNotMatch0;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/EnumWithTrueDoesNotMatch1.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/EnumWithTrueDoesNotMatch1.md
@@ -54,6 +54,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.EnumWithTrueDoesNotMatch1;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/EnumsInProperties.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/EnumsInProperties.md
@@ -65,6 +65,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.EnumsInProperties;
 
 import java.util.Arrays;
 import java.util.List;
@@ -196,6 +197,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.EnumsInProperties;
 
 import java.util.Arrays;
 import java.util.List;
@@ -274,6 +276,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.EnumsInProperties;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf.md
@@ -52,6 +52,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/InvalidStringValueForDefault.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/InvalidStringValueForDefault.md
@@ -250,6 +250,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.InvalidStringValueForDefault;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/NestedItems.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/NestedItems.md
@@ -74,6 +74,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NestedItems;
 
 import java.util.Arrays;
 import java.util.List;
@@ -180,6 +181,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NestedItems;
 
 import java.util.Arrays;
 import java.util.List;
@@ -284,6 +286,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NestedItems;
 
 import java.util.Arrays;
 import java.util.List;
@@ -386,6 +389,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NestedItems;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/NotMoreComplexSchema.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/NotMoreComplexSchema.md
@@ -214,6 +214,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NotMoreComplexSchema;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/NulCharactersInStrings.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/NulCharactersInStrings.md
@@ -54,6 +54,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NulCharactersInStrings;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/OneofWithBaseSchema.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/OneofWithBaseSchema.md
@@ -68,6 +68,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.OneofWithBaseSchema;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/RefInAdditionalproperties.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/RefInAdditionalproperties.md
@@ -56,6 +56,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.RefInAdditionalproperties;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/RefInItems.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/RefInItems.md
@@ -56,6 +56,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.RefInItems;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/SimpleEnumValidation.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/SimpleEnumValidation.md
@@ -57,6 +57,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.SimpleEnumValidation;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_0_3_unit_test/java/docs/components/schemas/TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.md
+++ b/samples/client/3_0_3_unit_test/java/docs/components/schemas/TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.md
@@ -59,6 +59,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing;
 
 import java.util.Arrays;
 import java.util.List;
@@ -171,6 +172,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/AdditionalpropertiesCanExistByItself.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/AdditionalpropertiesCanExistByItself.md
@@ -59,6 +59,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.AdditionalpropertiesCanExistByItself;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/AdditionalpropertiesWithNullValuedInstanceProperties.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/AdditionalpropertiesWithNullValuedInstanceProperties.md
@@ -59,6 +59,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.AdditionalpropertiesWithNullValuedInstanceProperties;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/AdditionalpropertiesWithSchema.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/AdditionalpropertiesWithSchema.md
@@ -75,6 +75,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.AdditionalpropertiesWithSchema;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/AnyofWithBaseSchema.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/AnyofWithBaseSchema.md
@@ -68,6 +68,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.AnyofWithBaseSchema;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/DependentSchemasDependentSubschemaIncompatibleWithRoot.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/DependentSchemasDependentSubschemaIncompatibleWithRoot.md
@@ -410,6 +410,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.DependentSchemasDependentSubschemaIncompatibleWithRoot;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/EnumWith0DoesNotMatchFalse.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/EnumWith0DoesNotMatchFalse.md
@@ -57,6 +57,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.EnumWith0DoesNotMatchFalse;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/EnumWith1DoesNotMatchTrue.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/EnumWith1DoesNotMatchTrue.md
@@ -57,6 +57,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.EnumWith1DoesNotMatchTrue;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/EnumWithEscapedCharacters.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/EnumWithEscapedCharacters.md
@@ -54,6 +54,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.EnumWithEscapedCharacters;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/EnumWithFalseDoesNotMatch0.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/EnumWithFalseDoesNotMatch0.md
@@ -54,6 +54,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.EnumWithFalseDoesNotMatch0;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/EnumWithTrueDoesNotMatch1.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/EnumWithTrueDoesNotMatch1.md
@@ -54,6 +54,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.EnumWithTrueDoesNotMatch1;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/EnumsInProperties.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/EnumsInProperties.md
@@ -65,6 +65,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.EnumsInProperties;
 
 import java.util.Arrays;
 import java.util.List;
@@ -196,6 +197,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.EnumsInProperties;
 
 import java.util.Arrays;
 import java.util.List;
@@ -274,6 +276,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.EnumsInProperties;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/FloatDivisionInf.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/FloatDivisionInf.md
@@ -52,6 +52,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.FloatDivisionInf;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/ItemsContains.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/ItemsContains.md
@@ -72,6 +72,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ItemsContains;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/ItemsDoesNotLookInApplicatorsValidCase.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/ItemsDoesNotLookInApplicatorsValidCase.md
@@ -64,6 +64,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ItemsDoesNotLookInApplicatorsValidCase;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/ItemsWithNullInstanceElements.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/ItemsWithNullInstanceElements.md
@@ -59,6 +59,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ItemsWithNullInstanceElements;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/MultipleTypesCanBeSpecifiedInAnArray.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/MultipleTypesCanBeSpecifiedInAnArray.md
@@ -71,6 +71,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.MultipleTypesCanBeSpecifiedInAnArray;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/NestedItems.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/NestedItems.md
@@ -74,6 +74,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NestedItems;
 
 import java.util.Arrays;
 import java.util.List;
@@ -180,6 +181,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NestedItems;
 
 import java.util.Arrays;
 import java.util.List;
@@ -284,6 +286,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NestedItems;
 
 import java.util.Arrays;
 import java.util.List;
@@ -386,6 +389,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NestedItems;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/NonAsciiPatternWithAdditionalproperties.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/NonAsciiPatternWithAdditionalproperties.md
@@ -72,6 +72,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NonAsciiPatternWithAdditionalproperties;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/NotMoreComplexSchema.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/NotMoreComplexSchema.md
@@ -214,6 +214,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NotMoreComplexSchema;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/NotMultipleTypes.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/NotMultipleTypes.md
@@ -226,6 +226,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NotMultipleTypes;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/NulCharactersInStrings.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/NulCharactersInStrings.md
@@ -54,6 +54,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NulCharactersInStrings;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/OneofWithBaseSchema.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/OneofWithBaseSchema.md
@@ -68,6 +68,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.OneofWithBaseSchema;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/PrefixitemsValidationAdjustsTheStartingIndexForItems.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/PrefixitemsValidationAdjustsTheStartingIndexForItems.md
@@ -62,6 +62,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.PrefixitemsValidationAdjustsTheStartingIndexForItems;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/PropertiesPatternpropertiesAdditionalpropertiesInteraction.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/PropertiesPatternpropertiesAdditionalpropertiesInteraction.md
@@ -73,6 +73,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.PropertiesPatternpropertiesAdditionalpropertiesInteraction;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/PropertynamesValidation.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/PropertynamesValidation.md
@@ -207,6 +207,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.PropertynamesValidation;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/SimpleEnumValidation.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/SimpleEnumValidation.md
@@ -57,6 +57,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.SimpleEnumValidation;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/SmallMultipleOfLargeInteger.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/SmallMultipleOfLargeInteger.md
@@ -52,6 +52,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.SmallMultipleOfLargeInteger;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/TypeArrayObjectOrNull.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/TypeArrayObjectOrNull.md
@@ -90,6 +90,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.TypeArrayObjectOrNull;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/UnevaluateditemsWithItems.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/UnevaluateditemsWithItems.md
@@ -62,6 +62,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.UnevaluateditemsWithItems;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/UnevaluatedpropertiesNotAffectedByPropertynames.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/UnevaluatedpropertiesNotAffectedByPropertynames.md
@@ -246,6 +246,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.UnevaluatedpropertiesNotAffectedByPropertynames;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/UnevaluatedpropertiesSchema.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/UnevaluatedpropertiesSchema.md
@@ -99,6 +99,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.UnevaluatedpropertiesSchema;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/UnevaluatedpropertiesWithAdjacentAdditionalproperties.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/UnevaluatedpropertiesWithAdjacentAdditionalproperties.md
@@ -75,6 +75,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.UnevaluatedpropertiesWithAdjacentAdditionalproperties;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/.openapi-generator/FILES
+++ b/samples/client/petstore/java/.openapi-generator/FILES
@@ -28,11 +28,14 @@ docs/components/responses/SuccessDescriptionOnly.md
 docs/components/responses/SuccessInlineContentAndHeader.md
 docs/components/responses/SuccessWithJsonApiResponse.md
 docs/components/responses/SuccessfulXmlAndJsonArrayOfPet.md
+docs/components/responses/headerswithnobody/HeadersWithNoBodyHeadersSchema.md
 docs/components/responses/headerswithnobody/headers/location/LocationSchema.md
 docs/components/responses/successfulxmlandjsonarrayofpet/content/applicationjson/ApplicationjsonSchema.md
 docs/components/responses/successfulxmlandjsonarrayofpet/content/applicationxml/ApplicationxmlSchema.md
+docs/components/responses/successinlinecontentandheader/SuccessInlineContentAndHeaderHeadersSchema.md
 docs/components/responses/successinlinecontentandheader/content/applicationjson/ApplicationjsonSchema.md
 docs/components/responses/successinlinecontentandheader/headers/someheader/SomeHeaderSchema.md
+docs/components/responses/successwithjsonapiresponse/SuccessWithJsonApiResponseHeadersSchema.md
 docs/components/responses/successwithjsonapiresponse/content/applicationjson/ApplicationjsonSchema.md
 docs/components/schemas/AbstractStepMessage.md
 docs/components/schemas/AdditionalPropertiesClass.md
@@ -318,6 +321,7 @@ docs/paths/storeorderorderid/get/responses/code200response/content/applicationxm
 docs/paths/user/post/requestbody/content/applicationjson/ApplicationjsonSchema.md
 docs/paths/userlogin/get/parameters/parameter0/Schema0.md
 docs/paths/userlogin/get/parameters/parameter1/Schema1.md
+docs/paths/userlogin/get/responses/code200response/Code200ResponseHeadersSchema.md
 docs/paths/userlogin/get/responses/code200response/content/applicationjson/ApplicationjsonSchema.md
 docs/paths/userlogin/get/responses/code200response/content/applicationxml/ApplicationxmlSchema.md
 docs/paths/userlogin/get/responses/code200response/headers/xexpiresafter/XExpiresAfterSchema.md

--- a/samples/client/petstore/java/docs/components/headers/Int32JsonContentTypeHeader.md
+++ b/samples/client/petstore/java/docs/components/headers/Int32JsonContentTypeHeader.md
@@ -48,12 +48,12 @@ a class that deserializes a header value
 | @Nullable Boolean allowReserved | null |
 | @Nullable ParameterStyle | ParameterStyle.SIMPLE |
 | @Nullable Boolean explode | false |
-| Map<String, [SealedMediaType](#sealedmediatype)> | content =  Map.ofEntries(<br>&nbsp;&nbsp;&nbsp;&nbsp;new AbstractMap.SimpleEntry<>("application/json", new [ApplicationjsonMediaType](#applicationjsonmediatype)())<br>)<br>the contentType to schema info |
+| Map<String, [MediaType](#mediatype)> | content =  Map.ofEntries(<br>&nbsp;&nbsp;&nbsp;&nbsp;new AbstractMap.SimpleEntry<>("application/json", new [ApplicationjsonMediaType](#applicationjsonmediatype)())<br>)<br>the contentType to schema info |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | HttpHeaders | serialize(@Nullable Object inData, String name, boolean validate, SchemaConfiguration configuration) |
-| @Nullable Object | deserialize(List<String> inData, boolean validate, SchemaConfiguration configuration)<br>deserializes the header value |
+| @Nullable Object | deserialize(List&lt;String&gt; inData, boolean validate, SchemaConfiguration configuration)<br>deserializes the header value |
 
 [[Back to top]](#top) [[Back to Component Headers]](../../../README.md#Component-Headers) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/java/docs/components/headers/Int32JsonContentTypeHeader.md
+++ b/samples/client/petstore/java/docs/components/headers/Int32JsonContentTypeHeader.md
@@ -48,7 +48,7 @@ a class that deserializes a header value
 | @Nullable Boolean allowReserved | null |
 | @Nullable ParameterStyle | ParameterStyle.SIMPLE |
 | @Nullable Boolean explode | false |
-| Map<String, [MediaType](#mediatype)> | content =  Map.ofEntries(<br>&nbsp;&nbsp;&nbsp;&nbsp;new AbstractMap.SimpleEntry<>("application/json", new [ApplicationjsonMediaType](#applicationjsonmediatype)())<br>)<br>the contentType to schema info |
+| Map<String, [ApplicationjsonMediaType](#applicationjsonmediatype)> | content =  Map.ofEntries(<br>&nbsp;&nbsp;&nbsp;&nbsp;new AbstractMap.SimpleEntry<>("application/json", new [ApplicationjsonMediaType](#applicationjsonmediatype)())<br>)<br>the contentType to schema info |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/headers/NumberHeader.md
+++ b/samples/client/petstore/java/docs/components/headers/NumberHeader.md
@@ -29,12 +29,12 @@ a class that deserializes a header value
 | @Nullable Boolean allowReserved | null |
 | @Nullable ParameterStyle | ParameterStyle.SIMPLE |
 | @Nullable Boolean explode | false |
-| JsonSchema<?> | schema = NumberHeaderSchema.NumberHeaderSchema1.getInstance()
+| JsonSchema<?> | schema = [NumberHeaderSchema.NumberHeaderSchema1](../../components/headers/numberheader/NumberHeaderSchema.md#numberheaderschema1)().getInstance()
 
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | HttpHeaders | serialize(@Nullable Object inData, String name, boolean validate, SchemaConfiguration configuration) |
-| @Nullable Object | deserialize(List<String> inData, boolean validate, SchemaConfiguration configuration)<br>deserializes the header value |
+| @Nullable Object | deserialize(List&lt;String&gt; inData, boolean validate, SchemaConfiguration configuration)<br>deserializes the header value |
 
 [[Back to top]](#top) [[Back to Component Headers]](../../../README.md#Component-Headers) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/java/docs/components/headers/RefContentSchemaHeader.md
+++ b/samples/client/petstore/java/docs/components/headers/RefContentSchemaHeader.md
@@ -48,12 +48,12 @@ a class that deserializes a header value
 | @Nullable Boolean allowReserved | null |
 | @Nullable ParameterStyle | ParameterStyle.SIMPLE |
 | @Nullable Boolean explode | false |
-| Map<String, [SealedMediaType](#sealedmediatype)> | content =  Map.ofEntries(<br>&nbsp;&nbsp;&nbsp;&nbsp;new AbstractMap.SimpleEntry<>("application/json", new [ApplicationjsonMediaType](#applicationjsonmediatype)())<br>)<br>the contentType to schema info |
+| Map<String, [MediaType](#mediatype)> | content =  Map.ofEntries(<br>&nbsp;&nbsp;&nbsp;&nbsp;new AbstractMap.SimpleEntry<>("application/json", new [ApplicationjsonMediaType](#applicationjsonmediatype)())<br>)<br>the contentType to schema info |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | HttpHeaders | serialize(@Nullable Object inData, String name, boolean validate, SchemaConfiguration configuration) |
-| @Nullable Object | deserialize(List<String> inData, boolean validate, SchemaConfiguration configuration)<br>deserializes the header value |
+| @Nullable Object | deserialize(List&lt;String&gt; inData, boolean validate, SchemaConfiguration configuration)<br>deserializes the header value |
 
 [[Back to top]](#top) [[Back to Component Headers]](../../../README.md#Component-Headers) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/java/docs/components/headers/RefContentSchemaHeader.md
+++ b/samples/client/petstore/java/docs/components/headers/RefContentSchemaHeader.md
@@ -48,7 +48,7 @@ a class that deserializes a header value
 | @Nullable Boolean allowReserved | null |
 | @Nullable ParameterStyle | ParameterStyle.SIMPLE |
 | @Nullable Boolean explode | false |
-| Map<String, [MediaType](#mediatype)> | content =  Map.ofEntries(<br>&nbsp;&nbsp;&nbsp;&nbsp;new AbstractMap.SimpleEntry<>("application/json", new [ApplicationjsonMediaType](#applicationjsonmediatype)())<br>)<br>the contentType to schema info |
+| Map<String, [ApplicationjsonMediaType](#applicationjsonmediatype)> | content =  Map.ofEntries(<br>&nbsp;&nbsp;&nbsp;&nbsp;new AbstractMap.SimpleEntry<>("application/json", new [ApplicationjsonMediaType](#applicationjsonmediatype)())<br>)<br>the contentType to schema info |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/petstore/java/docs/components/headers/RefSchemaHeader.md
+++ b/samples/client/petstore/java/docs/components/headers/RefSchemaHeader.md
@@ -29,12 +29,12 @@ a class that deserializes a header value
 | @Nullable Boolean allowReserved | null |
 | @Nullable ParameterStyle | ParameterStyle.SIMPLE |
 | @Nullable Boolean explode | false |
-| JsonSchema<?> | schema = RefSchemaHeaderSchema.RefSchemaHeaderSchema1.getInstance()
+| JsonSchema<?> | schema = [RefSchemaHeaderSchema.RefSchemaHeaderSchema1](../../components/headers/refschemaheader/RefSchemaHeaderSchema.md#refschemaheaderschema1)().getInstance()
 
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | HttpHeaders | serialize(@Nullable Object inData, String name, boolean validate, SchemaConfiguration configuration) |
-| @Nullable Object | deserialize(List<String> inData, boolean validate, SchemaConfiguration configuration)<br>deserializes the header value |
+| @Nullable Object | deserialize(List&lt;String&gt; inData, boolean validate, SchemaConfiguration configuration)<br>deserializes the header value |
 
 [[Back to top]](#top) [[Back to Component Headers]](../../../README.md#Component-Headers) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/java/docs/components/headers/StringHeader.md
+++ b/samples/client/petstore/java/docs/components/headers/StringHeader.md
@@ -29,12 +29,12 @@ a class that deserializes a header value
 | @Nullable Boolean allowReserved | null |
 | @Nullable ParameterStyle | ParameterStyle.SIMPLE |
 | @Nullable Boolean explode | false |
-| JsonSchema<?> | schema = StringHeaderSchema.StringHeaderSchema1.getInstance()
+| JsonSchema<?> | schema = [StringHeaderSchema.StringHeaderSchema1](../../components/headers/stringheader/StringHeaderSchema.md#stringheaderschema1)().getInstance()
 
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | HttpHeaders | serialize(@Nullable Object inData, String name, boolean validate, SchemaConfiguration configuration) |
-| @Nullable Object | deserialize(List<String> inData, boolean validate, SchemaConfiguration configuration)<br>deserializes the header value |
+| @Nullable Object | deserialize(List&lt;String&gt; inData, boolean validate, SchemaConfiguration configuration)<br>deserializes the header value |
 
 [[Back to top]](#top) [[Back to Component Headers]](../../../README.md#Component-Headers) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/java/docs/components/requestbodies/userarray/content/applicationjson/ApplicationjsonSchema.md
+++ b/samples/client/petstore/java/docs/components/requestbodies/userarray/content/applicationjson/ApplicationjsonSchema.md
@@ -55,6 +55,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.requestbodies.userarray.content.applicationjson.ApplicationjsonSchema;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/responses/HeadersWithNoBody.md
+++ b/samples/client/petstore/java/docs/components/responses/HeadersWithNoBody.md
@@ -13,7 +13,7 @@ A class that contains necessary nested response classes
 
 ## HeadersWithNoBody1
 public static class HeadersWithNoBody1<br>
-extends ResponseDeserializer<Void, Void, Void>
+extends ResponseDeserializer<Void, [HeadersWithNoBodyHeadersSchema.HeadersWithNoBodyHeadersSchemaMap](../../components/responses/headerswithnobody/HeadersWithNoBodyHeadersSchema.md#headerswithnobodyheadersschema1), Void>
 
 a class that deserializes responses
 

--- a/samples/client/petstore/java/docs/components/responses/HeadersWithNoBody.md
+++ b/samples/client/petstore/java/docs/components/responses/HeadersWithNoBody.md
@@ -30,6 +30,6 @@ a class that deserializes responses
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| ApiResponse<Void, Void> | deserialize(HttpResponse<byte[]> response, SchemaConfiguration configuration)<br>called by endpoint when deserialize responses |
+| ApiResponse<Void, [HeadersWithNoBodyHeadersSchema.HeadersWithNoBodyHeadersSchemaMap](../../components/responses/headerswithnobody/HeadersWithNoBodyHeadersSchema.md#headerswithnobodyheadersschema1)> | deserialize(HttpResponse<byte[]> response, SchemaConfiguration configuration)<br>called by endpoint when deserialize responses |
 
 [[Back to top]](#top) [[Back to Component Responses]](../../../README.md#Component-Responses) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/java/docs/components/responses/HeadersWithNoBody.md
+++ b/samples/client/petstore/java/docs/components/responses/HeadersWithNoBody.md
@@ -13,7 +13,7 @@ A class that contains necessary nested response classes
 
 ## HeadersWithNoBody1
 public static class HeadersWithNoBody1<br>
-extends ResponseDeserializer<Void, [HeadersWithNoBodyHeadersSchema.HeadersWithNoBodyHeadersSchemaMap](../../components/responses/headerswithnobody/HeadersWithNoBodyHeadersSchema.md#headerswithnobodyheadersschema1), Void>
+extends ResponseDeserializer<Void, [HeadersWithNoBodyHeadersSchema.HeadersWithNoBodyHeadersSchemaMap](../../components/responses/headerswithnobody/HeadersWithNoBodyHeadersSchema.md#headerswithnobodyheadersschemamap), Void>
 
 a class that deserializes responses
 
@@ -30,6 +30,6 @@ a class that deserializes responses
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| ApiResponse<Void, [HeadersWithNoBodyHeadersSchema.HeadersWithNoBodyHeadersSchemaMap](../../components/responses/headerswithnobody/HeadersWithNoBodyHeadersSchema.md#headerswithnobodyheadersschema1)> | deserialize(HttpResponse<byte[]> response, SchemaConfiguration configuration)<br>called by endpoint when deserialize responses |
+| ApiResponse<Void, [HeadersWithNoBodyHeadersSchema.HeadersWithNoBodyHeadersSchemaMap](../../components/responses/headerswithnobody/HeadersWithNoBodyHeadersSchema.md#headerswithnobodyheadersschemamap)> | deserialize(HttpResponse<byte[]> response, SchemaConfiguration configuration)<br>called by endpoint when deserialize responses |
 
 [[Back to top]](#top) [[Back to Component Responses]](../../../README.md#Component-Responses) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/java/docs/components/responses/SuccessInlineContentAndHeader.md
+++ b/samples/client/petstore/java/docs/components/responses/SuccessInlineContentAndHeader.md
@@ -68,7 +68,7 @@ A record class to store response body for contentType="application/json"
 
 ## SuccessInlineContentAndHeader1
 public static class SuccessInlineContentAndHeader1<br>
-extends ResponseDeserializer<[SealedResponseBody](#sealedresponsebody), [SuccessInlineContentAndHeaderHeadersSchema.SuccessInlineContentAndHeaderHeadersSchemaMap](../../components/responses/successinlinecontentandheader/SuccessInlineContentAndHeaderHeadersSchema.md#successinlinecontentandheaderheadersschema1), [SealedMediaType](#sealedmediatype)>
+extends ResponseDeserializer<[SealedResponseBody](#sealedresponsebody), [SuccessInlineContentAndHeaderHeadersSchema.SuccessInlineContentAndHeaderHeadersSchemaMap](../../components/responses/successinlinecontentandheader/SuccessInlineContentAndHeaderHeadersSchema.md#successinlinecontentandheaderheadersschemamap), [SealedMediaType](#sealedmediatype)>
 
 a class that deserializes responses
 
@@ -85,6 +85,6 @@ a class that deserializes responses
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| ApiResponse<[SealedResponseBody](#sealedresponsebody), [SuccessInlineContentAndHeaderHeadersSchema.SuccessInlineContentAndHeaderHeadersSchemaMap](../../components/responses/successinlinecontentandheader/SuccessInlineContentAndHeaderHeadersSchema.md#successinlinecontentandheaderheadersschema1)> | deserialize(HttpResponse<byte[]> response, SchemaConfiguration configuration)<br>called by endpoint when deserialize responses |
+| ApiResponse<[SealedResponseBody](#sealedresponsebody), [SuccessInlineContentAndHeaderHeadersSchema.SuccessInlineContentAndHeaderHeadersSchemaMap](../../components/responses/successinlinecontentandheader/SuccessInlineContentAndHeaderHeadersSchema.md#successinlinecontentandheaderheadersschemamap)> | deserialize(HttpResponse<byte[]> response, SchemaConfiguration configuration)<br>called by endpoint when deserialize responses |
 
 [[Back to top]](#top) [[Back to Component Responses]](../../../README.md#Component-Responses) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/java/docs/components/responses/SuccessInlineContentAndHeader.md
+++ b/samples/client/petstore/java/docs/components/responses/SuccessInlineContentAndHeader.md
@@ -85,6 +85,6 @@ a class that deserializes responses
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| ApiResponse<[SealedResponseBody](#sealedresponsebody), Void> | deserialize(HttpResponse<byte[]> response, SchemaConfiguration configuration)<br>called by endpoint when deserialize responses |
+| ApiResponse<[SealedResponseBody](#sealedresponsebody), [SuccessInlineContentAndHeaderHeadersSchema.SuccessInlineContentAndHeaderHeadersSchemaMap](../../components/responses/successinlinecontentandheader/SuccessInlineContentAndHeaderHeadersSchema.md#successinlinecontentandheaderheadersschema1)> | deserialize(HttpResponse<byte[]> response, SchemaConfiguration configuration)<br>called by endpoint when deserialize responses |
 
 [[Back to top]](#top) [[Back to Component Responses]](../../../README.md#Component-Responses) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/java/docs/components/responses/SuccessInlineContentAndHeader.md
+++ b/samples/client/petstore/java/docs/components/responses/SuccessInlineContentAndHeader.md
@@ -68,7 +68,7 @@ A record class to store response body for contentType="application/json"
 
 ## SuccessInlineContentAndHeader1
 public static class SuccessInlineContentAndHeader1<br>
-extends ResponseDeserializer<[SealedResponseBody](#sealedresponsebody), Void, [SealedMediaType](#sealedmediatype)>
+extends ResponseDeserializer<[SealedResponseBody](#sealedresponsebody), [SuccessInlineContentAndHeaderHeadersSchema.SuccessInlineContentAndHeaderHeadersSchemaMap](../../components/responses/successinlinecontentandheader/SuccessInlineContentAndHeaderHeadersSchema.md#successinlinecontentandheaderheadersschema1), [SealedMediaType](#sealedmediatype)>
 
 a class that deserializes responses
 

--- a/samples/client/petstore/java/docs/components/responses/SuccessWithJsonApiResponse.md
+++ b/samples/client/petstore/java/docs/components/responses/SuccessWithJsonApiResponse.md
@@ -68,7 +68,7 @@ A record class to store response body for contentType="application/json"
 
 ## SuccessWithJsonApiResponse1
 public static class SuccessWithJsonApiResponse1<br>
-extends ResponseDeserializer<[SealedResponseBody](#sealedresponsebody), [SuccessWithJsonApiResponseHeadersSchema.SuccessWithJsonApiResponseHeadersSchemaMap](../../components/responses/successwithjsonapiresponse/SuccessWithJsonApiResponseHeadersSchema.md#successwithjsonapiresponseheadersschema1), [SealedMediaType](#sealedmediatype)>
+extends ResponseDeserializer<[SealedResponseBody](#sealedresponsebody), [SuccessWithJsonApiResponseHeadersSchema.SuccessWithJsonApiResponseHeadersSchemaMap](../../components/responses/successwithjsonapiresponse/SuccessWithJsonApiResponseHeadersSchema.md#successwithjsonapiresponseheadersschemamap), [SealedMediaType](#sealedmediatype)>
 
 a class that deserializes responses
 
@@ -85,6 +85,6 @@ a class that deserializes responses
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| ApiResponse<[SealedResponseBody](#sealedresponsebody), [SuccessWithJsonApiResponseHeadersSchema.SuccessWithJsonApiResponseHeadersSchemaMap](../../components/responses/successwithjsonapiresponse/SuccessWithJsonApiResponseHeadersSchema.md#successwithjsonapiresponseheadersschema1)> | deserialize(HttpResponse<byte[]> response, SchemaConfiguration configuration)<br>called by endpoint when deserialize responses |
+| ApiResponse<[SealedResponseBody](#sealedresponsebody), [SuccessWithJsonApiResponseHeadersSchema.SuccessWithJsonApiResponseHeadersSchemaMap](../../components/responses/successwithjsonapiresponse/SuccessWithJsonApiResponseHeadersSchema.md#successwithjsonapiresponseheadersschemamap)> | deserialize(HttpResponse<byte[]> response, SchemaConfiguration configuration)<br>called by endpoint when deserialize responses |
 
 [[Back to top]](#top) [[Back to Component Responses]](../../../README.md#Component-Responses) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/java/docs/components/responses/SuccessWithJsonApiResponse.md
+++ b/samples/client/petstore/java/docs/components/responses/SuccessWithJsonApiResponse.md
@@ -85,6 +85,6 @@ a class that deserializes responses
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| ApiResponse<[SealedResponseBody](#sealedresponsebody), Void> | deserialize(HttpResponse<byte[]> response, SchemaConfiguration configuration)<br>called by endpoint when deserialize responses |
+| ApiResponse<[SealedResponseBody](#sealedresponsebody), [SuccessWithJsonApiResponseHeadersSchema.SuccessWithJsonApiResponseHeadersSchemaMap](../../components/responses/successwithjsonapiresponse/SuccessWithJsonApiResponseHeadersSchema.md#successwithjsonapiresponseheadersschema1)> | deserialize(HttpResponse<byte[]> response, SchemaConfiguration configuration)<br>called by endpoint when deserialize responses |
 
 [[Back to top]](#top) [[Back to Component Responses]](../../../README.md#Component-Responses) [[Back to README]](../../../README.md)

--- a/samples/client/petstore/java/docs/components/responses/SuccessWithJsonApiResponse.md
+++ b/samples/client/petstore/java/docs/components/responses/SuccessWithJsonApiResponse.md
@@ -68,7 +68,7 @@ A record class to store response body for contentType="application/json"
 
 ## SuccessWithJsonApiResponse1
 public static class SuccessWithJsonApiResponse1<br>
-extends ResponseDeserializer<[SealedResponseBody](#sealedresponsebody), Void, [SealedMediaType](#sealedmediatype)>
+extends ResponseDeserializer<[SealedResponseBody](#sealedresponsebody), [SuccessWithJsonApiResponseHeadersSchema.SuccessWithJsonApiResponseHeadersSchemaMap](../../components/responses/successwithjsonapiresponse/SuccessWithJsonApiResponseHeadersSchema.md#successwithjsonapiresponseheadersschema1), [SealedMediaType](#sealedmediatype)>
 
 a class that deserializes responses
 

--- a/samples/client/petstore/java/docs/components/responses/headerswithnobody/HeadersWithNoBodyHeadersSchema.md
+++ b/samples/client/petstore/java/docs/components/responses/headerswithnobody/HeadersWithNoBodyHeadersSchema.md
@@ -1,0 +1,252 @@
+# HeadersWithNoBodyHeadersSchema
+public class HeadersWithNoBodyHeadersSchema<br>
+
+A class that contains necessary nested
+- schema classes (which validate payloads), extends JsonSchema
+- sealed interfaces which store validated payloads, java version of a sum type
+- boxed classes which store validated payloads, sealed permits class implementations
+- classes to store validated map payloads, extends FrozenMap
+- classes to build inputs for map payloads
+
+## Nested Class Summary
+| Modifier and Type | Class and Description |
+| ----------------- | ---------------------- |
+| sealed interface | [HeadersWithNoBodyHeadersSchema.HeadersWithNoBodyHeadersSchema1Boxed](#headerswithnobodyheadersschema1boxed)<br> sealed interface for validated payloads |
+| record | [HeadersWithNoBodyHeadersSchema.HeadersWithNoBodyHeadersSchema1BoxedMap](#headerswithnobodyheadersschema1boxedmap)<br> boxed class to store validated Map payloads |
+| static class | [HeadersWithNoBodyHeadersSchema.HeadersWithNoBodyHeadersSchema1](#headerswithnobodyheadersschema1)<br> schema class |
+| static class | [HeadersWithNoBodyHeadersSchema.HeadersWithNoBodyHeadersSchemaMapBuilder](#headerswithnobodyheadersschemamapbuilder)<br> builder for Map payloads |
+| static class | [HeadersWithNoBodyHeadersSchema.HeadersWithNoBodyHeadersSchemaMap](#headerswithnobodyheadersschemamap)<br> output class for Map payloads |
+| sealed interface | [HeadersWithNoBodyHeadersSchema.HeadersWithNoBodyAdditionalPropertiesBoxed](#headerswithnobodyadditionalpropertiesboxed)<br> sealed interface for validated payloads |
+| record | [HeadersWithNoBodyHeadersSchema.HeadersWithNoBodyAdditionalPropertiesBoxedVoid](#headerswithnobodyadditionalpropertiesboxedvoid)<br> boxed class to store validated null payloads |
+| record | [HeadersWithNoBodyHeadersSchema.HeadersWithNoBodyAdditionalPropertiesBoxedBoolean](#headerswithnobodyadditionalpropertiesboxedboolean)<br> boxed class to store validated boolean payloads |
+| record | [HeadersWithNoBodyHeadersSchema.HeadersWithNoBodyAdditionalPropertiesBoxedNumber](#headerswithnobodyadditionalpropertiesboxednumber)<br> boxed class to store validated Number payloads |
+| record | [HeadersWithNoBodyHeadersSchema.HeadersWithNoBodyAdditionalPropertiesBoxedString](#headerswithnobodyadditionalpropertiesboxedstring)<br> boxed class to store validated String payloads |
+| record | [HeadersWithNoBodyHeadersSchema.HeadersWithNoBodyAdditionalPropertiesBoxedList](#headerswithnobodyadditionalpropertiesboxedlist)<br> boxed class to store validated List payloads |
+| record | [HeadersWithNoBodyHeadersSchema.HeadersWithNoBodyAdditionalPropertiesBoxedMap](#headerswithnobodyadditionalpropertiesboxedmap)<br> boxed class to store validated Map payloads |
+| static class | [HeadersWithNoBodyHeadersSchema.HeadersWithNoBodyAdditionalProperties](#headerswithnobodyadditionalproperties)<br> schema class |
+
+## HeadersWithNoBodyHeadersSchema1Boxed
+public sealed interface HeadersWithNoBodyHeadersSchema1Boxed<br>
+permits<br>
+[HeadersWithNoBodyHeadersSchema1BoxedMap](#headerswithnobodyheadersschema1boxedmap)
+
+sealed interface that stores validated payloads using boxed classes
+
+## HeadersWithNoBodyHeadersSchema1BoxedMap
+public record HeadersWithNoBodyHeadersSchema1BoxedMap<br>
+implements [HeadersWithNoBodyHeadersSchema1Boxed](#headerswithnobodyheadersschema1boxed)
+
+record that stores validated Map payloads, sealed permits implementation
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| HeadersWithNoBodyHeadersSchema1BoxedMap([HeadersWithNoBodyHeadersSchemaMap](#headerswithnobodyheadersschemamap) data)<br>Creates an instance, private visibility |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| [HeadersWithNoBodyHeadersSchemaMap](#headerswithnobodyheadersschemamap) | data()<br>validated payload |
+| @Nullable Object | getData()<br>validated payload |
+
+## HeadersWithNoBodyHeadersSchema1
+public static class HeadersWithNoBodyHeadersSchema1<br>
+extends JsonSchema
+
+A schema class that validates payloads
+
+### Code Sample
+```
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
+import org.openapijsonschematools.client.configurations.SchemaConfiguration;
+import org.openapijsonschematools.client.exceptions.ValidationException;
+import org.openapijsonschematools.client.schemas.validation.MapUtils;
+import org.openapijsonschematools.client.schemas.validation.FrozenList;
+import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.responses.headerswithnobody.HeadersWithNoBodyHeadersSchema;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.AbstractMap;
+
+static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
+
+// Map validation
+HeadersWithNoBodyHeadersSchema.HeadersWithNoBodyHeadersSchemaMap validatedPayload =
+    HeadersWithNoBodyHeadersSchema.HeadersWithNoBodyHeadersSchema1.validate(
+    new HeadersWithNoBodyHeadersSchema.HeadersWithNoBodyHeadersSchemaMapBuilder()
+        .location("a")
+
+    .build(),
+    configuration
+);
+```
+
+### Field Summary
+| Modifier and Type | Field and Description |
+| ----------------- | ---------------------- |
+| Set<Class<?>> | type = Set.of(Map.class) |
+| Map<String, Class<? extends JsonSchema>> | properties = Map.ofEntries(<br>&nbsp;&nbsp;&nbsp;&nbsp;new PropertyEntry("location", [LocationSchema.LocationSchema1.class](../../../components/responses/headerswithnobody/headers/location/LocationSchema.md#locationschema1))<br>)<br> |
+| Class<? extends JsonSchema> | additionalProperties = [HeadersWithNoBodyAdditionalProperties.class](#headerswithnobodyadditionalproperties) |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| [HeadersWithNoBodyHeadersSchemaMap](#headerswithnobodyheadersschemamap) | validate([Map&lt;?, ?&gt;](#headerswithnobodyheadersschemamapbuilder) arg, SchemaConfiguration configuration) |
+| [HeadersWithNoBodyHeadersSchema1BoxedMap](#headerswithnobodyheadersschema1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#headerswithnobodyheadersschemamapbuilder) arg, SchemaConfiguration configuration) |
+| [HeadersWithNoBodyHeadersSchema1Boxed](#headerswithnobodyheadersschema1boxed) | validateAndBox(@Nullable Object arg, SchemaConfiguration configuration) |
+| @Nullable Object | validate(@Nullable Object arg, SchemaConfiguration configuration) |
+
+## HeadersWithNoBodyHeadersSchemaMapBuilder
+public class HeadersWithNoBodyHeadersSchemaMapBuilder<br>
+builder for `Map<String, String>`
+
+A class that builds the Map input type
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| HeadersWithNoBodyHeadersSchemaMapBuilder()<br>Creates a builder that contains an empty map |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| Map<String, String> | build()<br>Returns map input that should be used with Schema.validate |
+| [HeadersWithNoBodyHeadersSchemaMapBuilder](#headerswithnobodyheadersschemamapbuilder) | location(String value) |
+
+## HeadersWithNoBodyHeadersSchemaMap
+public static class HeadersWithNoBodyHeadersSchemaMap<br>
+extends FrozenMap<String, String>
+
+A class to store validated Map payloads
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| static [HeadersWithNoBodyHeadersSchemaMap](#headerswithnobodyheadersschemamap) | of([Map<String, String>](#headerswithnobodyheadersschemamapbuilder) arg, SchemaConfiguration configuration) |
+| String | location()<br>[optional] |
+
+## HeadersWithNoBodyAdditionalPropertiesBoxed
+public sealed interface HeadersWithNoBodyAdditionalPropertiesBoxed<br>
+permits<br>
+[HeadersWithNoBodyAdditionalPropertiesBoxedVoid](#headerswithnobodyadditionalpropertiesboxedvoid),
+[HeadersWithNoBodyAdditionalPropertiesBoxedBoolean](#headerswithnobodyadditionalpropertiesboxedboolean),
+[HeadersWithNoBodyAdditionalPropertiesBoxedNumber](#headerswithnobodyadditionalpropertiesboxednumber),
+[HeadersWithNoBodyAdditionalPropertiesBoxedString](#headerswithnobodyadditionalpropertiesboxedstring),
+[HeadersWithNoBodyAdditionalPropertiesBoxedList](#headerswithnobodyadditionalpropertiesboxedlist),
+[HeadersWithNoBodyAdditionalPropertiesBoxedMap](#headerswithnobodyadditionalpropertiesboxedmap)
+
+sealed interface that stores validated payloads using boxed classes
+
+## HeadersWithNoBodyAdditionalPropertiesBoxedVoid
+public record HeadersWithNoBodyAdditionalPropertiesBoxedVoid<br>
+implements [HeadersWithNoBodyAdditionalPropertiesBoxed](#headerswithnobodyadditionalpropertiesboxed)
+
+record that stores validated null payloads, sealed permits implementation
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| HeadersWithNoBodyAdditionalPropertiesBoxedVoid(Void data)<br>Creates an instance, private visibility |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| Void | data()<br>validated payload |
+| @Nullable Object | getData()<br>validated payload |
+
+## HeadersWithNoBodyAdditionalPropertiesBoxedBoolean
+public record HeadersWithNoBodyAdditionalPropertiesBoxedBoolean<br>
+implements [HeadersWithNoBodyAdditionalPropertiesBoxed](#headerswithnobodyadditionalpropertiesboxed)
+
+record that stores validated boolean payloads, sealed permits implementation
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| HeadersWithNoBodyAdditionalPropertiesBoxedBoolean(boolean data)<br>Creates an instance, private visibility |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| boolean | data()<br>validated payload |
+| @Nullable Object | getData()<br>validated payload |
+
+## HeadersWithNoBodyAdditionalPropertiesBoxedNumber
+public record HeadersWithNoBodyAdditionalPropertiesBoxedNumber<br>
+implements [HeadersWithNoBodyAdditionalPropertiesBoxed](#headerswithnobodyadditionalpropertiesboxed)
+
+record that stores validated Number payloads, sealed permits implementation
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| HeadersWithNoBodyAdditionalPropertiesBoxedNumber(Number data)<br>Creates an instance, private visibility |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| Number | data()<br>validated payload |
+| @Nullable Object | getData()<br>validated payload |
+
+## HeadersWithNoBodyAdditionalPropertiesBoxedString
+public record HeadersWithNoBodyAdditionalPropertiesBoxedString<br>
+implements [HeadersWithNoBodyAdditionalPropertiesBoxed](#headerswithnobodyadditionalpropertiesboxed)
+
+record that stores validated String payloads, sealed permits implementation
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| HeadersWithNoBodyAdditionalPropertiesBoxedString(String data)<br>Creates an instance, private visibility |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| String | data()<br>validated payload |
+| @Nullable Object | getData()<br>validated payload |
+
+## HeadersWithNoBodyAdditionalPropertiesBoxedList
+public record HeadersWithNoBodyAdditionalPropertiesBoxedList<br>
+implements [HeadersWithNoBodyAdditionalPropertiesBoxed](#headerswithnobodyadditionalpropertiesboxed)
+
+record that stores validated List payloads, sealed permits implementation
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| HeadersWithNoBodyAdditionalPropertiesBoxedList(FrozenList<@Nullable Object> data)<br>Creates an instance, private visibility |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| FrozenList<@Nullable Object> | data()<br>validated payload |
+| @Nullable Object | getData()<br>validated payload |
+
+## HeadersWithNoBodyAdditionalPropertiesBoxedMap
+public record HeadersWithNoBodyAdditionalPropertiesBoxedMap<br>
+implements [HeadersWithNoBodyAdditionalPropertiesBoxed](#headerswithnobodyadditionalpropertiesboxed)
+
+record that stores validated Map payloads, sealed permits implementation
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| HeadersWithNoBodyAdditionalPropertiesBoxedMap(FrozenMap<@Nullable Object> data)<br>Creates an instance, private visibility |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| FrozenMap<@Nullable Object> | data()<br>validated payload |
+| @Nullable Object | getData()<br>validated payload |
+
+## HeadersWithNoBodyAdditionalProperties
+public static class HeadersWithNoBodyAdditionalProperties<br>
+extends NotAnyTypeJsonSchema.NotAnyTypeJsonSchema1
+
+A schema class that validates payloads
+
+| Methods Inherited from class org.openapijsonschematools.client.schemas.NotAnyTypeJsonSchema.NotAnyTypeJsonSchema1 |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+| validateAndBox                                                     |

--- a/samples/client/petstore/java/docs/components/responses/successfulxmlandjsonarrayofpet/content/applicationjson/ApplicationjsonSchema.md
+++ b/samples/client/petstore/java/docs/components/responses/successfulxmlandjsonarrayofpet/content/applicationjson/ApplicationjsonSchema.md
@@ -55,6 +55,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.responses.successfulxmlandjsonarrayofpet.content.applicationjson.ApplicationjsonSchema;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/responses/successfulxmlandjsonarrayofpet/content/applicationxml/ApplicationxmlSchema.md
+++ b/samples/client/petstore/java/docs/components/responses/successfulxmlandjsonarrayofpet/content/applicationxml/ApplicationxmlSchema.md
@@ -55,6 +55,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.responses.successfulxmlandjsonarrayofpet.content.applicationxml.ApplicationxmlSchema;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/responses/successinlinecontentandheader/SuccessInlineContentAndHeaderHeadersSchema.md
+++ b/samples/client/petstore/java/docs/components/responses/successinlinecontentandheader/SuccessInlineContentAndHeaderHeadersSchema.md
@@ -1,0 +1,252 @@
+# SuccessInlineContentAndHeaderHeadersSchema
+public class SuccessInlineContentAndHeaderHeadersSchema<br>
+
+A class that contains necessary nested
+- schema classes (which validate payloads), extends JsonSchema
+- sealed interfaces which store validated payloads, java version of a sum type
+- boxed classes which store validated payloads, sealed permits class implementations
+- classes to store validated map payloads, extends FrozenMap
+- classes to build inputs for map payloads
+
+## Nested Class Summary
+| Modifier and Type | Class and Description |
+| ----------------- | ---------------------- |
+| sealed interface | [SuccessInlineContentAndHeaderHeadersSchema.SuccessInlineContentAndHeaderHeadersSchema1Boxed](#successinlinecontentandheaderheadersschema1boxed)<br> sealed interface for validated payloads |
+| record | [SuccessInlineContentAndHeaderHeadersSchema.SuccessInlineContentAndHeaderHeadersSchema1BoxedMap](#successinlinecontentandheaderheadersschema1boxedmap)<br> boxed class to store validated Map payloads |
+| static class | [SuccessInlineContentAndHeaderHeadersSchema.SuccessInlineContentAndHeaderHeadersSchema1](#successinlinecontentandheaderheadersschema1)<br> schema class |
+| static class | [SuccessInlineContentAndHeaderHeadersSchema.SuccessInlineContentAndHeaderHeadersSchemaMapBuilder](#successinlinecontentandheaderheadersschemamapbuilder)<br> builder for Map payloads |
+| static class | [SuccessInlineContentAndHeaderHeadersSchema.SuccessInlineContentAndHeaderHeadersSchemaMap](#successinlinecontentandheaderheadersschemamap)<br> output class for Map payloads |
+| sealed interface | [SuccessInlineContentAndHeaderHeadersSchema.SuccessInlineContentAndHeaderAdditionalPropertiesBoxed](#successinlinecontentandheaderadditionalpropertiesboxed)<br> sealed interface for validated payloads |
+| record | [SuccessInlineContentAndHeaderHeadersSchema.SuccessInlineContentAndHeaderAdditionalPropertiesBoxedVoid](#successinlinecontentandheaderadditionalpropertiesboxedvoid)<br> boxed class to store validated null payloads |
+| record | [SuccessInlineContentAndHeaderHeadersSchema.SuccessInlineContentAndHeaderAdditionalPropertiesBoxedBoolean](#successinlinecontentandheaderadditionalpropertiesboxedboolean)<br> boxed class to store validated boolean payloads |
+| record | [SuccessInlineContentAndHeaderHeadersSchema.SuccessInlineContentAndHeaderAdditionalPropertiesBoxedNumber](#successinlinecontentandheaderadditionalpropertiesboxednumber)<br> boxed class to store validated Number payloads |
+| record | [SuccessInlineContentAndHeaderHeadersSchema.SuccessInlineContentAndHeaderAdditionalPropertiesBoxedString](#successinlinecontentandheaderadditionalpropertiesboxedstring)<br> boxed class to store validated String payloads |
+| record | [SuccessInlineContentAndHeaderHeadersSchema.SuccessInlineContentAndHeaderAdditionalPropertiesBoxedList](#successinlinecontentandheaderadditionalpropertiesboxedlist)<br> boxed class to store validated List payloads |
+| record | [SuccessInlineContentAndHeaderHeadersSchema.SuccessInlineContentAndHeaderAdditionalPropertiesBoxedMap](#successinlinecontentandheaderadditionalpropertiesboxedmap)<br> boxed class to store validated Map payloads |
+| static class | [SuccessInlineContentAndHeaderHeadersSchema.SuccessInlineContentAndHeaderAdditionalProperties](#successinlinecontentandheaderadditionalproperties)<br> schema class |
+
+## SuccessInlineContentAndHeaderHeadersSchema1Boxed
+public sealed interface SuccessInlineContentAndHeaderHeadersSchema1Boxed<br>
+permits<br>
+[SuccessInlineContentAndHeaderHeadersSchema1BoxedMap](#successinlinecontentandheaderheadersschema1boxedmap)
+
+sealed interface that stores validated payloads using boxed classes
+
+## SuccessInlineContentAndHeaderHeadersSchema1BoxedMap
+public record SuccessInlineContentAndHeaderHeadersSchema1BoxedMap<br>
+implements [SuccessInlineContentAndHeaderHeadersSchema1Boxed](#successinlinecontentandheaderheadersschema1boxed)
+
+record that stores validated Map payloads, sealed permits implementation
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| SuccessInlineContentAndHeaderHeadersSchema1BoxedMap([SuccessInlineContentAndHeaderHeadersSchemaMap](#successinlinecontentandheaderheadersschemamap) data)<br>Creates an instance, private visibility |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| [SuccessInlineContentAndHeaderHeadersSchemaMap](#successinlinecontentandheaderheadersschemamap) | data()<br>validated payload |
+| @Nullable Object | getData()<br>validated payload |
+
+## SuccessInlineContentAndHeaderHeadersSchema1
+public static class SuccessInlineContentAndHeaderHeadersSchema1<br>
+extends JsonSchema
+
+A schema class that validates payloads
+
+### Code Sample
+```
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
+import org.openapijsonschematools.client.configurations.SchemaConfiguration;
+import org.openapijsonschematools.client.exceptions.ValidationException;
+import org.openapijsonschematools.client.schemas.validation.MapUtils;
+import org.openapijsonschematools.client.schemas.validation.FrozenList;
+import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.responses.successinlinecontentandheader.SuccessInlineContentAndHeaderHeadersSchema;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.AbstractMap;
+
+static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
+
+// Map validation
+SuccessInlineContentAndHeaderHeadersSchema.SuccessInlineContentAndHeaderHeadersSchemaMap validatedPayload =
+    SuccessInlineContentAndHeaderHeadersSchema.SuccessInlineContentAndHeaderHeadersSchema1.validate(
+    new SuccessInlineContentAndHeaderHeadersSchema.SuccessInlineContentAndHeaderHeadersSchemaMapBuilder()
+        .someHeader("a")
+
+    .build(),
+    configuration
+);
+```
+
+### Field Summary
+| Modifier and Type | Field and Description |
+| ----------------- | ---------------------- |
+| Set<Class<?>> | type = Set.of(Map.class) |
+| Map<String, Class<? extends JsonSchema>> | properties = Map.ofEntries(<br>&nbsp;&nbsp;&nbsp;&nbsp;new PropertyEntry("someHeader", [SomeHeaderSchema.SomeHeaderSchema1.class](../../../components/responses/successinlinecontentandheader/headers/someheader/SomeHeaderSchema.md#someheaderschema1))<br>)<br> |
+| Class<? extends JsonSchema> | additionalProperties = [SuccessInlineContentAndHeaderAdditionalProperties.class](#successinlinecontentandheaderadditionalproperties) |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| [SuccessInlineContentAndHeaderHeadersSchemaMap](#successinlinecontentandheaderheadersschemamap) | validate([Map&lt;?, ?&gt;](#successinlinecontentandheaderheadersschemamapbuilder) arg, SchemaConfiguration configuration) |
+| [SuccessInlineContentAndHeaderHeadersSchema1BoxedMap](#successinlinecontentandheaderheadersschema1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#successinlinecontentandheaderheadersschemamapbuilder) arg, SchemaConfiguration configuration) |
+| [SuccessInlineContentAndHeaderHeadersSchema1Boxed](#successinlinecontentandheaderheadersschema1boxed) | validateAndBox(@Nullable Object arg, SchemaConfiguration configuration) |
+| @Nullable Object | validate(@Nullable Object arg, SchemaConfiguration configuration) |
+
+## SuccessInlineContentAndHeaderHeadersSchemaMapBuilder
+public class SuccessInlineContentAndHeaderHeadersSchemaMapBuilder<br>
+builder for `Map<String, String>`
+
+A class that builds the Map input type
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| SuccessInlineContentAndHeaderHeadersSchemaMapBuilder()<br>Creates a builder that contains an empty map |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| Map<String, String> | build()<br>Returns map input that should be used with Schema.validate |
+| [SuccessInlineContentAndHeaderHeadersSchemaMapBuilder](#successinlinecontentandheaderheadersschemamapbuilder) | someHeader(String value) |
+
+## SuccessInlineContentAndHeaderHeadersSchemaMap
+public static class SuccessInlineContentAndHeaderHeadersSchemaMap<br>
+extends FrozenMap<String, String>
+
+A class to store validated Map payloads
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| static [SuccessInlineContentAndHeaderHeadersSchemaMap](#successinlinecontentandheaderheadersschemamap) | of([Map<String, String>](#successinlinecontentandheaderheadersschemamapbuilder) arg, SchemaConfiguration configuration) |
+| String | someHeader()<br>[optional] |
+
+## SuccessInlineContentAndHeaderAdditionalPropertiesBoxed
+public sealed interface SuccessInlineContentAndHeaderAdditionalPropertiesBoxed<br>
+permits<br>
+[SuccessInlineContentAndHeaderAdditionalPropertiesBoxedVoid](#successinlinecontentandheaderadditionalpropertiesboxedvoid),
+[SuccessInlineContentAndHeaderAdditionalPropertiesBoxedBoolean](#successinlinecontentandheaderadditionalpropertiesboxedboolean),
+[SuccessInlineContentAndHeaderAdditionalPropertiesBoxedNumber](#successinlinecontentandheaderadditionalpropertiesboxednumber),
+[SuccessInlineContentAndHeaderAdditionalPropertiesBoxedString](#successinlinecontentandheaderadditionalpropertiesboxedstring),
+[SuccessInlineContentAndHeaderAdditionalPropertiesBoxedList](#successinlinecontentandheaderadditionalpropertiesboxedlist),
+[SuccessInlineContentAndHeaderAdditionalPropertiesBoxedMap](#successinlinecontentandheaderadditionalpropertiesboxedmap)
+
+sealed interface that stores validated payloads using boxed classes
+
+## SuccessInlineContentAndHeaderAdditionalPropertiesBoxedVoid
+public record SuccessInlineContentAndHeaderAdditionalPropertiesBoxedVoid<br>
+implements [SuccessInlineContentAndHeaderAdditionalPropertiesBoxed](#successinlinecontentandheaderadditionalpropertiesboxed)
+
+record that stores validated null payloads, sealed permits implementation
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| SuccessInlineContentAndHeaderAdditionalPropertiesBoxedVoid(Void data)<br>Creates an instance, private visibility |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| Void | data()<br>validated payload |
+| @Nullable Object | getData()<br>validated payload |
+
+## SuccessInlineContentAndHeaderAdditionalPropertiesBoxedBoolean
+public record SuccessInlineContentAndHeaderAdditionalPropertiesBoxedBoolean<br>
+implements [SuccessInlineContentAndHeaderAdditionalPropertiesBoxed](#successinlinecontentandheaderadditionalpropertiesboxed)
+
+record that stores validated boolean payloads, sealed permits implementation
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| SuccessInlineContentAndHeaderAdditionalPropertiesBoxedBoolean(boolean data)<br>Creates an instance, private visibility |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| boolean | data()<br>validated payload |
+| @Nullable Object | getData()<br>validated payload |
+
+## SuccessInlineContentAndHeaderAdditionalPropertiesBoxedNumber
+public record SuccessInlineContentAndHeaderAdditionalPropertiesBoxedNumber<br>
+implements [SuccessInlineContentAndHeaderAdditionalPropertiesBoxed](#successinlinecontentandheaderadditionalpropertiesboxed)
+
+record that stores validated Number payloads, sealed permits implementation
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| SuccessInlineContentAndHeaderAdditionalPropertiesBoxedNumber(Number data)<br>Creates an instance, private visibility |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| Number | data()<br>validated payload |
+| @Nullable Object | getData()<br>validated payload |
+
+## SuccessInlineContentAndHeaderAdditionalPropertiesBoxedString
+public record SuccessInlineContentAndHeaderAdditionalPropertiesBoxedString<br>
+implements [SuccessInlineContentAndHeaderAdditionalPropertiesBoxed](#successinlinecontentandheaderadditionalpropertiesboxed)
+
+record that stores validated String payloads, sealed permits implementation
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| SuccessInlineContentAndHeaderAdditionalPropertiesBoxedString(String data)<br>Creates an instance, private visibility |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| String | data()<br>validated payload |
+| @Nullable Object | getData()<br>validated payload |
+
+## SuccessInlineContentAndHeaderAdditionalPropertiesBoxedList
+public record SuccessInlineContentAndHeaderAdditionalPropertiesBoxedList<br>
+implements [SuccessInlineContentAndHeaderAdditionalPropertiesBoxed](#successinlinecontentandheaderadditionalpropertiesboxed)
+
+record that stores validated List payloads, sealed permits implementation
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| SuccessInlineContentAndHeaderAdditionalPropertiesBoxedList(FrozenList<@Nullable Object> data)<br>Creates an instance, private visibility |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| FrozenList<@Nullable Object> | data()<br>validated payload |
+| @Nullable Object | getData()<br>validated payload |
+
+## SuccessInlineContentAndHeaderAdditionalPropertiesBoxedMap
+public record SuccessInlineContentAndHeaderAdditionalPropertiesBoxedMap<br>
+implements [SuccessInlineContentAndHeaderAdditionalPropertiesBoxed](#successinlinecontentandheaderadditionalpropertiesboxed)
+
+record that stores validated Map payloads, sealed permits implementation
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| SuccessInlineContentAndHeaderAdditionalPropertiesBoxedMap(FrozenMap<@Nullable Object> data)<br>Creates an instance, private visibility |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| FrozenMap<@Nullable Object> | data()<br>validated payload |
+| @Nullable Object | getData()<br>validated payload |
+
+## SuccessInlineContentAndHeaderAdditionalProperties
+public static class SuccessInlineContentAndHeaderAdditionalProperties<br>
+extends NotAnyTypeJsonSchema.NotAnyTypeJsonSchema1
+
+A schema class that validates payloads
+
+| Methods Inherited from class org.openapijsonschematools.client.schemas.NotAnyTypeJsonSchema.NotAnyTypeJsonSchema1 |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+| validateAndBox                                                     |

--- a/samples/client/petstore/java/docs/components/responses/successinlinecontentandheader/content/applicationjson/ApplicationjsonSchema.md
+++ b/samples/client/petstore/java/docs/components/responses/successinlinecontentandheader/content/applicationjson/ApplicationjsonSchema.md
@@ -58,6 +58,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.responses.successinlinecontentandheader.content.applicationjson.ApplicationjsonSchema;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/responses/successwithjsonapiresponse/SuccessWithJsonApiResponseHeadersSchema.md
+++ b/samples/client/petstore/java/docs/components/responses/successwithjsonapiresponse/SuccessWithJsonApiResponseHeadersSchema.md
@@ -1,0 +1,527 @@
+# SuccessWithJsonApiResponseHeadersSchema
+public class SuccessWithJsonApiResponseHeadersSchema<br>
+
+A class that contains necessary nested
+- schema classes (which validate payloads), extends JsonSchema
+- sealed interfaces which store validated payloads, java version of a sum type
+- boxed classes which store validated payloads, sealed permits class implementations
+- classes to store validated map payloads, extends FrozenMap
+- classes to build inputs for map payloads
+
+## Nested Class Summary
+| Modifier and Type | Class and Description |
+| ----------------- | ---------------------- |
+| sealed interface | [SuccessWithJsonApiResponseHeadersSchema.SuccessWithJsonApiResponseHeadersSchema1Boxed](#successwithjsonapiresponseheadersschema1boxed)<br> sealed interface for validated payloads |
+| record | [SuccessWithJsonApiResponseHeadersSchema.SuccessWithJsonApiResponseHeadersSchema1BoxedMap](#successwithjsonapiresponseheadersschema1boxedmap)<br> boxed class to store validated Map payloads |
+| static class | [SuccessWithJsonApiResponseHeadersSchema.SuccessWithJsonApiResponseHeadersSchema1](#successwithjsonapiresponseheadersschema1)<br> schema class |
+| static class | [SuccessWithJsonApiResponseHeadersSchema.SuccessWithJsonApiResponseHeadersSchemaMapBuilder](#successwithjsonapiresponseheadersschemamapbuilder)<br> builder for Map payloads |
+| static class | [SuccessWithJsonApiResponseHeadersSchema.SuccessWithJsonApiResponseHeadersSchemaMap](#successwithjsonapiresponseheadersschemamap)<br> output class for Map payloads |
+| sealed interface | [SuccessWithJsonApiResponseHeadersSchema.SuccessWithJsonApiResponseAdditionalPropertiesBoxed](#successwithjsonapiresponseadditionalpropertiesboxed)<br> sealed interface for validated payloads |
+| record | [SuccessWithJsonApiResponseHeadersSchema.SuccessWithJsonApiResponseAdditionalPropertiesBoxedVoid](#successwithjsonapiresponseadditionalpropertiesboxedvoid)<br> boxed class to store validated null payloads |
+| record | [SuccessWithJsonApiResponseHeadersSchema.SuccessWithJsonApiResponseAdditionalPropertiesBoxedBoolean](#successwithjsonapiresponseadditionalpropertiesboxedboolean)<br> boxed class to store validated boolean payloads |
+| record | [SuccessWithJsonApiResponseHeadersSchema.SuccessWithJsonApiResponseAdditionalPropertiesBoxedNumber](#successwithjsonapiresponseadditionalpropertiesboxednumber)<br> boxed class to store validated Number payloads |
+| record | [SuccessWithJsonApiResponseHeadersSchema.SuccessWithJsonApiResponseAdditionalPropertiesBoxedString](#successwithjsonapiresponseadditionalpropertiesboxedstring)<br> boxed class to store validated String payloads |
+| record | [SuccessWithJsonApiResponseHeadersSchema.SuccessWithJsonApiResponseAdditionalPropertiesBoxedList](#successwithjsonapiresponseadditionalpropertiesboxedlist)<br> boxed class to store validated List payloads |
+| record | [SuccessWithJsonApiResponseHeadersSchema.SuccessWithJsonApiResponseAdditionalPropertiesBoxedMap](#successwithjsonapiresponseadditionalpropertiesboxedmap)<br> boxed class to store validated Map payloads |
+| static class | [SuccessWithJsonApiResponseHeadersSchema.SuccessWithJsonApiResponseAdditionalProperties](#successwithjsonapiresponseadditionalproperties)<br> schema class |
+
+## SuccessWithJsonApiResponseHeadersSchema1Boxed
+public sealed interface SuccessWithJsonApiResponseHeadersSchema1Boxed<br>
+permits<br>
+[SuccessWithJsonApiResponseHeadersSchema1BoxedMap](#successwithjsonapiresponseheadersschema1boxedmap)
+
+sealed interface that stores validated payloads using boxed classes
+
+## SuccessWithJsonApiResponseHeadersSchema1BoxedMap
+public record SuccessWithJsonApiResponseHeadersSchema1BoxedMap<br>
+implements [SuccessWithJsonApiResponseHeadersSchema1Boxed](#successwithjsonapiresponseheadersschema1boxed)
+
+record that stores validated Map payloads, sealed permits implementation
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| SuccessWithJsonApiResponseHeadersSchema1BoxedMap([SuccessWithJsonApiResponseHeadersSchemaMap](#successwithjsonapiresponseheadersschemamap) data)<br>Creates an instance, private visibility |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| [SuccessWithJsonApiResponseHeadersSchemaMap](#successwithjsonapiresponseheadersschemamap) | data()<br>validated payload |
+| @Nullable Object | getData()<br>validated payload |
+
+## SuccessWithJsonApiResponseHeadersSchema1
+public static class SuccessWithJsonApiResponseHeadersSchema1<br>
+extends JsonSchema
+
+A schema class that validates payloads
+
+### Code Sample
+```
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
+import org.openapijsonschematools.client.configurations.SchemaConfiguration;
+import org.openapijsonschematools.client.exceptions.ValidationException;
+import org.openapijsonschematools.client.schemas.validation.MapUtils;
+import org.openapijsonschematools.client.schemas.validation.FrozenList;
+import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.responses.successwithjsonapiresponse.SuccessWithJsonApiResponseHeadersSchema;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.AbstractMap;
+
+static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
+
+// Map validation
+SuccessWithJsonApiResponseHeadersSchema.SuccessWithJsonApiResponseHeadersSchemaMap validatedPayload =
+    SuccessWithJsonApiResponseHeadersSchema.SuccessWithJsonApiResponseHeadersSchema1.validate(
+    new SuccessWithJsonApiResponseHeadersSchema.SuccessWithJsonApiResponseHeadersSchemaMapBuilder()
+        .int32(1)
+
+        .setRefHyphenMinusContentHyphenMinusSchemaHyphenMinusHeader("a")
+
+        .stringHeader("a")
+
+        .numberHeader("3.14")
+
+    .build(),
+    configuration
+);
+```
+
+### Field Summary
+| Modifier and Type | Field and Description |
+| ----------------- | ---------------------- |
+| Set<Class<?>> | type = Set.of(Map.class) |
+| Map<String, Class<? extends JsonSchema>> | properties = Map.ofEntries(<br>&nbsp;&nbsp;&nbsp;&nbsp;new PropertyEntry("ref-schema-header", [StringWithValidation.StringWithValidation1.class](../../../components/schemas/StringWithValidation.md#stringwithvalidation1)),<br>&nbsp;&nbsp;&nbsp;&nbsp;new PropertyEntry("int32", [Int32JsonContentTypeHeaderSchema.Int32JsonContentTypeHeaderSchema1.class](../../../components/headers/int32jsoncontenttypeheader/content/applicationjson/Int32JsonContentTypeHeaderSchema.md#int32jsoncontenttypeheaderschema1)),<br>&nbsp;&nbsp;&nbsp;&nbsp;new PropertyEntry("ref-content-schema-header", [StringWithValidation.StringWithValidation1.class](../../../components/schemas/StringWithValidation.md#stringwithvalidation1)),<br>&nbsp;&nbsp;&nbsp;&nbsp;new PropertyEntry("stringHeader", [StringHeaderSchema.StringHeaderSchema1.class](../../../components/headers/stringheader/StringHeaderSchema.md#stringheaderschema1)),<br>&nbsp;&nbsp;&nbsp;&nbsp;new PropertyEntry("numberHeader", [NumberHeaderSchema.NumberHeaderSchema1.class](../../../components/headers/numberheader/NumberHeaderSchema.md#numberheaderschema1))<br>)<br> |
+| Set<String> | required = Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;"int32",<br>&nbsp;&nbsp;&nbsp;&nbsp;"ref-content-schema-header",<br>&nbsp;&nbsp;&nbsp;&nbsp;"ref-schema-header",<br>&nbsp;&nbsp;&nbsp;&nbsp;"stringHeader"<br>)<br> |
+| Class<? extends JsonSchema> | additionalProperties = [SuccessWithJsonApiResponseAdditionalProperties.class](#successwithjsonapiresponseadditionalproperties) |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| [SuccessWithJsonApiResponseHeadersSchemaMap](#successwithjsonapiresponseheadersschemamap) | validate([Map&lt;?, ?&gt;](#successwithjsonapiresponseheadersschemamapbuilder) arg, SchemaConfiguration configuration) |
+| [SuccessWithJsonApiResponseHeadersSchema1BoxedMap](#successwithjsonapiresponseheadersschema1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#successwithjsonapiresponseheadersschemamapbuilder) arg, SchemaConfiguration configuration) |
+| [SuccessWithJsonApiResponseHeadersSchema1Boxed](#successwithjsonapiresponseheadersschema1boxed) | validateAndBox(@Nullable Object arg, SchemaConfiguration configuration) |
+| @Nullable Object | validate(@Nullable Object arg, SchemaConfiguration configuration) |
+
+## SuccessWithJsonApiResponseHeadersSchemaMap0000Builder
+public class SuccessWithJsonApiResponseHeadersSchemaMap0000Builder<br>
+builder for `Map<String, @Nullable Object>`
+
+A class that builds the Map input type
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| SuccessWithJsonApiResponseHeadersSchemaMap0000Builder(Map<String, @Nullable Object> instance)<br>Creates a builder that contains the passed instance |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| Map<String, @Nullable Object> | build()<br>Returns map input that should be used with Schema.validate |
+| [SuccessWithJsonApiResponseHeadersSchemaMap0000Builder](#successwithjsonapiresponseheadersschemamap0000builder) | numberHeader(String value) |
+
+## SuccessWithJsonApiResponseHeadersSchemaMap0001Builder
+public class SuccessWithJsonApiResponseHeadersSchemaMap0001Builder<br>
+builder for `Map<String, @Nullable Object>`
+
+A class that builds the Map input type
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| SuccessWithJsonApiResponseHeadersSchemaMap0001Builder(Map<String, @Nullable Object> instance)<br>Creates a builder that contains the passed instance |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| [SuccessWithJsonApiResponseHeadersSchemaMap0000Builder](#successwithjsonapiresponseheadersschemamap0000builder) | stringHeader(String value) |
+
+## SuccessWithJsonApiResponseHeadersSchemaMap0010Builder
+public class SuccessWithJsonApiResponseHeadersSchemaMap0010Builder<br>
+builder for `Map<String, @Nullable Object>`
+
+A class that builds the Map input type
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| SuccessWithJsonApiResponseHeadersSchemaMap0010Builder(Map<String, @Nullable Object> instance)<br>Creates a builder that contains the passed instance |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| [SuccessWithJsonApiResponseHeadersSchemaMap0000Builder](#successwithjsonapiresponseheadersschemamap0000builder) | setRefHyphenMinusSchemaHyphenMinusHeader(String value) |
+
+## SuccessWithJsonApiResponseHeadersSchemaMap0011Builder
+public class SuccessWithJsonApiResponseHeadersSchemaMap0011Builder<br>
+builder for `Map<String, @Nullable Object>`
+
+A class that builds the Map input type
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| SuccessWithJsonApiResponseHeadersSchemaMap0011Builder(Map<String, @Nullable Object> instance)<br>Creates a builder that contains the passed instance |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| [SuccessWithJsonApiResponseHeadersSchemaMap0001Builder](#successwithjsonapiresponseheadersschemamap0001builder) | setRefHyphenMinusSchemaHyphenMinusHeader(String value) |
+| [SuccessWithJsonApiResponseHeadersSchemaMap0010Builder](#successwithjsonapiresponseheadersschemamap0010builder) | stringHeader(String value) |
+
+## SuccessWithJsonApiResponseHeadersSchemaMap0100Builder
+public class SuccessWithJsonApiResponseHeadersSchemaMap0100Builder<br>
+builder for `Map<String, @Nullable Object>`
+
+A class that builds the Map input type
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| SuccessWithJsonApiResponseHeadersSchemaMap0100Builder(Map<String, @Nullable Object> instance)<br>Creates a builder that contains the passed instance |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| [SuccessWithJsonApiResponseHeadersSchemaMap0000Builder](#successwithjsonapiresponseheadersschemamap0000builder) | setRefHyphenMinusContentHyphenMinusSchemaHyphenMinusHeader(String value) |
+
+## SuccessWithJsonApiResponseHeadersSchemaMap0101Builder
+public class SuccessWithJsonApiResponseHeadersSchemaMap0101Builder<br>
+builder for `Map<String, @Nullable Object>`
+
+A class that builds the Map input type
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| SuccessWithJsonApiResponseHeadersSchemaMap0101Builder(Map<String, @Nullable Object> instance)<br>Creates a builder that contains the passed instance |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| [SuccessWithJsonApiResponseHeadersSchemaMap0001Builder](#successwithjsonapiresponseheadersschemamap0001builder) | setRefHyphenMinusContentHyphenMinusSchemaHyphenMinusHeader(String value) |
+| [SuccessWithJsonApiResponseHeadersSchemaMap0100Builder](#successwithjsonapiresponseheadersschemamap0100builder) | stringHeader(String value) |
+
+## SuccessWithJsonApiResponseHeadersSchemaMap0110Builder
+public class SuccessWithJsonApiResponseHeadersSchemaMap0110Builder<br>
+builder for `Map<String, @Nullable Object>`
+
+A class that builds the Map input type
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| SuccessWithJsonApiResponseHeadersSchemaMap0110Builder(Map<String, @Nullable Object> instance)<br>Creates a builder that contains the passed instance |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| [SuccessWithJsonApiResponseHeadersSchemaMap0010Builder](#successwithjsonapiresponseheadersschemamap0010builder) | setRefHyphenMinusContentHyphenMinusSchemaHyphenMinusHeader(String value) |
+| [SuccessWithJsonApiResponseHeadersSchemaMap0100Builder](#successwithjsonapiresponseheadersschemamap0100builder) | setRefHyphenMinusSchemaHyphenMinusHeader(String value) |
+
+## SuccessWithJsonApiResponseHeadersSchemaMap0111Builder
+public class SuccessWithJsonApiResponseHeadersSchemaMap0111Builder<br>
+builder for `Map<String, @Nullable Object>`
+
+A class that builds the Map input type
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| SuccessWithJsonApiResponseHeadersSchemaMap0111Builder(Map<String, @Nullable Object> instance)<br>Creates a builder that contains the passed instance |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| [SuccessWithJsonApiResponseHeadersSchemaMap0011Builder](#successwithjsonapiresponseheadersschemamap0011builder) | setRefHyphenMinusContentHyphenMinusSchemaHyphenMinusHeader(String value) |
+| [SuccessWithJsonApiResponseHeadersSchemaMap0101Builder](#successwithjsonapiresponseheadersschemamap0101builder) | setRefHyphenMinusSchemaHyphenMinusHeader(String value) |
+| [SuccessWithJsonApiResponseHeadersSchemaMap0110Builder](#successwithjsonapiresponseheadersschemamap0110builder) | stringHeader(String value) |
+
+## SuccessWithJsonApiResponseHeadersSchemaMap1000Builder
+public class SuccessWithJsonApiResponseHeadersSchemaMap1000Builder<br>
+builder for `Map<String, @Nullable Object>`
+
+A class that builds the Map input type
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| SuccessWithJsonApiResponseHeadersSchemaMap1000Builder(Map<String, @Nullable Object> instance)<br>Creates a builder that contains the passed instance |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| [SuccessWithJsonApiResponseHeadersSchemaMap0000Builder](#successwithjsonapiresponseheadersschemamap0000builder) | int32(int value) |
+| [SuccessWithJsonApiResponseHeadersSchemaMap0000Builder](#successwithjsonapiresponseheadersschemamap0000builder) | int32(float value) |
+
+## SuccessWithJsonApiResponseHeadersSchemaMap1001Builder
+public class SuccessWithJsonApiResponseHeadersSchemaMap1001Builder<br>
+builder for `Map<String, @Nullable Object>`
+
+A class that builds the Map input type
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| SuccessWithJsonApiResponseHeadersSchemaMap1001Builder(Map<String, @Nullable Object> instance)<br>Creates a builder that contains the passed instance |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| [SuccessWithJsonApiResponseHeadersSchemaMap0001Builder](#successwithjsonapiresponseheadersschemamap0001builder) | int32(int value) |
+| [SuccessWithJsonApiResponseHeadersSchemaMap0001Builder](#successwithjsonapiresponseheadersschemamap0001builder) | int32(float value) |
+| [SuccessWithJsonApiResponseHeadersSchemaMap1000Builder](#successwithjsonapiresponseheadersschemamap1000builder) | stringHeader(String value) |
+
+## SuccessWithJsonApiResponseHeadersSchemaMap1010Builder
+public class SuccessWithJsonApiResponseHeadersSchemaMap1010Builder<br>
+builder for `Map<String, @Nullable Object>`
+
+A class that builds the Map input type
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| SuccessWithJsonApiResponseHeadersSchemaMap1010Builder(Map<String, @Nullable Object> instance)<br>Creates a builder that contains the passed instance |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| [SuccessWithJsonApiResponseHeadersSchemaMap0010Builder](#successwithjsonapiresponseheadersschemamap0010builder) | int32(int value) |
+| [SuccessWithJsonApiResponseHeadersSchemaMap0010Builder](#successwithjsonapiresponseheadersschemamap0010builder) | int32(float value) |
+| [SuccessWithJsonApiResponseHeadersSchemaMap1000Builder](#successwithjsonapiresponseheadersschemamap1000builder) | setRefHyphenMinusSchemaHyphenMinusHeader(String value) |
+
+## SuccessWithJsonApiResponseHeadersSchemaMap1011Builder
+public class SuccessWithJsonApiResponseHeadersSchemaMap1011Builder<br>
+builder for `Map<String, @Nullable Object>`
+
+A class that builds the Map input type
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| SuccessWithJsonApiResponseHeadersSchemaMap1011Builder(Map<String, @Nullable Object> instance)<br>Creates a builder that contains the passed instance |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| [SuccessWithJsonApiResponseHeadersSchemaMap0011Builder](#successwithjsonapiresponseheadersschemamap0011builder) | int32(int value) |
+| [SuccessWithJsonApiResponseHeadersSchemaMap0011Builder](#successwithjsonapiresponseheadersschemamap0011builder) | int32(float value) |
+| [SuccessWithJsonApiResponseHeadersSchemaMap1001Builder](#successwithjsonapiresponseheadersschemamap1001builder) | setRefHyphenMinusSchemaHyphenMinusHeader(String value) |
+| [SuccessWithJsonApiResponseHeadersSchemaMap1010Builder](#successwithjsonapiresponseheadersschemamap1010builder) | stringHeader(String value) |
+
+## SuccessWithJsonApiResponseHeadersSchemaMap1100Builder
+public class SuccessWithJsonApiResponseHeadersSchemaMap1100Builder<br>
+builder for `Map<String, @Nullable Object>`
+
+A class that builds the Map input type
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| SuccessWithJsonApiResponseHeadersSchemaMap1100Builder(Map<String, @Nullable Object> instance)<br>Creates a builder that contains the passed instance |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| [SuccessWithJsonApiResponseHeadersSchemaMap0100Builder](#successwithjsonapiresponseheadersschemamap0100builder) | int32(int value) |
+| [SuccessWithJsonApiResponseHeadersSchemaMap0100Builder](#successwithjsonapiresponseheadersschemamap0100builder) | int32(float value) |
+| [SuccessWithJsonApiResponseHeadersSchemaMap1000Builder](#successwithjsonapiresponseheadersschemamap1000builder) | setRefHyphenMinusContentHyphenMinusSchemaHyphenMinusHeader(String value) |
+
+## SuccessWithJsonApiResponseHeadersSchemaMap1101Builder
+public class SuccessWithJsonApiResponseHeadersSchemaMap1101Builder<br>
+builder for `Map<String, @Nullable Object>`
+
+A class that builds the Map input type
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| SuccessWithJsonApiResponseHeadersSchemaMap1101Builder(Map<String, @Nullable Object> instance)<br>Creates a builder that contains the passed instance |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| [SuccessWithJsonApiResponseHeadersSchemaMap0101Builder](#successwithjsonapiresponseheadersschemamap0101builder) | int32(int value) |
+| [SuccessWithJsonApiResponseHeadersSchemaMap0101Builder](#successwithjsonapiresponseheadersschemamap0101builder) | int32(float value) |
+| [SuccessWithJsonApiResponseHeadersSchemaMap1001Builder](#successwithjsonapiresponseheadersschemamap1001builder) | setRefHyphenMinusContentHyphenMinusSchemaHyphenMinusHeader(String value) |
+| [SuccessWithJsonApiResponseHeadersSchemaMap1100Builder](#successwithjsonapiresponseheadersschemamap1100builder) | stringHeader(String value) |
+
+## SuccessWithJsonApiResponseHeadersSchemaMap1110Builder
+public class SuccessWithJsonApiResponseHeadersSchemaMap1110Builder<br>
+builder for `Map<String, @Nullable Object>`
+
+A class that builds the Map input type
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| SuccessWithJsonApiResponseHeadersSchemaMap1110Builder(Map<String, @Nullable Object> instance)<br>Creates a builder that contains the passed instance |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| [SuccessWithJsonApiResponseHeadersSchemaMap0110Builder](#successwithjsonapiresponseheadersschemamap0110builder) | int32(int value) |
+| [SuccessWithJsonApiResponseHeadersSchemaMap0110Builder](#successwithjsonapiresponseheadersschemamap0110builder) | int32(float value) |
+| [SuccessWithJsonApiResponseHeadersSchemaMap1010Builder](#successwithjsonapiresponseheadersschemamap1010builder) | setRefHyphenMinusContentHyphenMinusSchemaHyphenMinusHeader(String value) |
+| [SuccessWithJsonApiResponseHeadersSchemaMap1100Builder](#successwithjsonapiresponseheadersschemamap1100builder) | setRefHyphenMinusSchemaHyphenMinusHeader(String value) |
+
+## SuccessWithJsonApiResponseHeadersSchemaMapBuilder
+public class SuccessWithJsonApiResponseHeadersSchemaMapBuilder<br>
+builder for `Map<String, @Nullable Object>`
+
+A class that builds the Map input type
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| SuccessWithJsonApiResponseHeadersSchemaMapBuilder()<br>Creates a builder that contains an empty map |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| [SuccessWithJsonApiResponseHeadersSchemaMap0111Builder](#successwithjsonapiresponseheadersschemamap0111builder) | int32(int value) |
+| [SuccessWithJsonApiResponseHeadersSchemaMap0111Builder](#successwithjsonapiresponseheadersschemamap0111builder) | int32(float value) |
+| [SuccessWithJsonApiResponseHeadersSchemaMap1011Builder](#successwithjsonapiresponseheadersschemamap1011builder) | setRefHyphenMinusContentHyphenMinusSchemaHyphenMinusHeader(String value) |
+| [SuccessWithJsonApiResponseHeadersSchemaMap1101Builder](#successwithjsonapiresponseheadersschemamap1101builder) | setRefHyphenMinusSchemaHyphenMinusHeader(String value) |
+| [SuccessWithJsonApiResponseHeadersSchemaMap1110Builder](#successwithjsonapiresponseheadersschemamap1110builder) | stringHeader(String value) |
+
+## SuccessWithJsonApiResponseHeadersSchemaMap
+public static class SuccessWithJsonApiResponseHeadersSchemaMap<br>
+extends FrozenMap<String, @Nullable Object>
+
+A class to store validated Map payloads
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| static [SuccessWithJsonApiResponseHeadersSchemaMap](#successwithjsonapiresponseheadersschemamap) | of([Map<String, ? extends @Nullable Object>](#successwithjsonapiresponseheadersschemamapbuilder) arg, SchemaConfiguration configuration) |
+| Number | int32()<br> |
+| String | stringHeader()<br> |
+| String | numberHeader()<br>[optional] |
+| @Nullable Object | get(String key)<br>This schema has invalid Java names so this method must be used when you access instance["ref-content-schema-header"], instance["ref-schema-header"],  |
+
+## SuccessWithJsonApiResponseAdditionalPropertiesBoxed
+public sealed interface SuccessWithJsonApiResponseAdditionalPropertiesBoxed<br>
+permits<br>
+[SuccessWithJsonApiResponseAdditionalPropertiesBoxedVoid](#successwithjsonapiresponseadditionalpropertiesboxedvoid),
+[SuccessWithJsonApiResponseAdditionalPropertiesBoxedBoolean](#successwithjsonapiresponseadditionalpropertiesboxedboolean),
+[SuccessWithJsonApiResponseAdditionalPropertiesBoxedNumber](#successwithjsonapiresponseadditionalpropertiesboxednumber),
+[SuccessWithJsonApiResponseAdditionalPropertiesBoxedString](#successwithjsonapiresponseadditionalpropertiesboxedstring),
+[SuccessWithJsonApiResponseAdditionalPropertiesBoxedList](#successwithjsonapiresponseadditionalpropertiesboxedlist),
+[SuccessWithJsonApiResponseAdditionalPropertiesBoxedMap](#successwithjsonapiresponseadditionalpropertiesboxedmap)
+
+sealed interface that stores validated payloads using boxed classes
+
+## SuccessWithJsonApiResponseAdditionalPropertiesBoxedVoid
+public record SuccessWithJsonApiResponseAdditionalPropertiesBoxedVoid<br>
+implements [SuccessWithJsonApiResponseAdditionalPropertiesBoxed](#successwithjsonapiresponseadditionalpropertiesboxed)
+
+record that stores validated null payloads, sealed permits implementation
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| SuccessWithJsonApiResponseAdditionalPropertiesBoxedVoid(Void data)<br>Creates an instance, private visibility |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| Void | data()<br>validated payload |
+| @Nullable Object | getData()<br>validated payload |
+
+## SuccessWithJsonApiResponseAdditionalPropertiesBoxedBoolean
+public record SuccessWithJsonApiResponseAdditionalPropertiesBoxedBoolean<br>
+implements [SuccessWithJsonApiResponseAdditionalPropertiesBoxed](#successwithjsonapiresponseadditionalpropertiesboxed)
+
+record that stores validated boolean payloads, sealed permits implementation
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| SuccessWithJsonApiResponseAdditionalPropertiesBoxedBoolean(boolean data)<br>Creates an instance, private visibility |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| boolean | data()<br>validated payload |
+| @Nullable Object | getData()<br>validated payload |
+
+## SuccessWithJsonApiResponseAdditionalPropertiesBoxedNumber
+public record SuccessWithJsonApiResponseAdditionalPropertiesBoxedNumber<br>
+implements [SuccessWithJsonApiResponseAdditionalPropertiesBoxed](#successwithjsonapiresponseadditionalpropertiesboxed)
+
+record that stores validated Number payloads, sealed permits implementation
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| SuccessWithJsonApiResponseAdditionalPropertiesBoxedNumber(Number data)<br>Creates an instance, private visibility |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| Number | data()<br>validated payload |
+| @Nullable Object | getData()<br>validated payload |
+
+## SuccessWithJsonApiResponseAdditionalPropertiesBoxedString
+public record SuccessWithJsonApiResponseAdditionalPropertiesBoxedString<br>
+implements [SuccessWithJsonApiResponseAdditionalPropertiesBoxed](#successwithjsonapiresponseadditionalpropertiesboxed)
+
+record that stores validated String payloads, sealed permits implementation
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| SuccessWithJsonApiResponseAdditionalPropertiesBoxedString(String data)<br>Creates an instance, private visibility |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| String | data()<br>validated payload |
+| @Nullable Object | getData()<br>validated payload |
+
+## SuccessWithJsonApiResponseAdditionalPropertiesBoxedList
+public record SuccessWithJsonApiResponseAdditionalPropertiesBoxedList<br>
+implements [SuccessWithJsonApiResponseAdditionalPropertiesBoxed](#successwithjsonapiresponseadditionalpropertiesboxed)
+
+record that stores validated List payloads, sealed permits implementation
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| SuccessWithJsonApiResponseAdditionalPropertiesBoxedList(FrozenList<@Nullable Object> data)<br>Creates an instance, private visibility |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| FrozenList<@Nullable Object> | data()<br>validated payload |
+| @Nullable Object | getData()<br>validated payload |
+
+## SuccessWithJsonApiResponseAdditionalPropertiesBoxedMap
+public record SuccessWithJsonApiResponseAdditionalPropertiesBoxedMap<br>
+implements [SuccessWithJsonApiResponseAdditionalPropertiesBoxed](#successwithjsonapiresponseadditionalpropertiesboxed)
+
+record that stores validated Map payloads, sealed permits implementation
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| SuccessWithJsonApiResponseAdditionalPropertiesBoxedMap(FrozenMap<@Nullable Object> data)<br>Creates an instance, private visibility |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| FrozenMap<@Nullable Object> | data()<br>validated payload |
+| @Nullable Object | getData()<br>validated payload |
+
+## SuccessWithJsonApiResponseAdditionalProperties
+public static class SuccessWithJsonApiResponseAdditionalProperties<br>
+extends NotAnyTypeJsonSchema.NotAnyTypeJsonSchema1
+
+A schema class that validates payloads
+
+| Methods Inherited from class org.openapijsonschematools.client.schemas.NotAnyTypeJsonSchema.NotAnyTypeJsonSchema1 |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+| validateAndBox                                                     |

--- a/samples/client/petstore/java/docs/components/schemas/AbstractStepMessage.md
+++ b/samples/client/petstore/java/docs/components/schemas/AbstractStepMessage.md
@@ -62,6 +62,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.AbstractStepMessage;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/AdditionalPropertiesClass.md
+++ b/samples/client/petstore/java/docs/components/schemas/AdditionalPropertiesClass.md
@@ -125,6 +125,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.AdditionalPropertiesClass;
 
 import java.util.Arrays;
 import java.util.List;
@@ -291,6 +292,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.AdditionalPropertiesClass;
 
 import java.util.Arrays;
 import java.util.List;
@@ -428,6 +430,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.AdditionalPropertiesClass;
 
 import java.util.Arrays;
 import java.util.List;
@@ -648,6 +651,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.AdditionalPropertiesClass;
 
 import java.util.Arrays;
 import java.util.List;
@@ -1073,6 +1077,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.AdditionalPropertiesClass;
 
 import java.util.Arrays;
 import java.util.List;
@@ -1179,6 +1184,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.AdditionalPropertiesClass;
 
 import java.util.Arrays;
 import java.util.List;
@@ -1313,6 +1319,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.AdditionalPropertiesClass;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/AdditionalPropertiesSchema.md
+++ b/samples/client/petstore/java/docs/components/schemas/AdditionalPropertiesSchema.md
@@ -137,6 +137,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.AdditionalPropertiesSchema;
 
 import java.util.Arrays;
 import java.util.List;
@@ -389,6 +390,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.AdditionalPropertiesSchema;
 
 import java.util.Arrays;
 import java.util.List;
@@ -641,6 +643,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.AdditionalPropertiesSchema;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/AdditionalPropertiesWithArrayOfEnums.md
+++ b/samples/client/petstore/java/docs/components/schemas/AdditionalPropertiesWithArrayOfEnums.md
@@ -63,6 +63,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.AdditionalPropertiesWithArrayOfEnums;
 
 import java.util.Arrays;
 import java.util.List;
@@ -166,6 +167,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.AdditionalPropertiesWithArrayOfEnums;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/Address.md
+++ b/samples/client/petstore/java/docs/components/schemas/Address.md
@@ -59,6 +59,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Address;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/Animal.md
+++ b/samples/client/petstore/java/docs/components/schemas/Animal.md
@@ -62,6 +62,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Animal;
 
 import java.util.Arrays;
 import java.util.List;
@@ -191,6 +192,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Animal;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/AnimalFarm.md
+++ b/samples/client/petstore/java/docs/components/schemas/AnimalFarm.md
@@ -56,6 +56,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.AnimalFarm;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/AnyTypeAndFormat.md
+++ b/samples/client/petstore/java/docs/components/schemas/AnyTypeAndFormat.md
@@ -128,6 +128,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.AnyTypeAndFormat;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ApiResponseSchema.md
+++ b/samples/client/petstore/java/docs/components/schemas/ApiResponseSchema.md
@@ -65,6 +65,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ApiResponseSchema;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/Apple.md
+++ b/samples/client/petstore/java/docs/components/schemas/Apple.md
@@ -81,6 +81,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Apple;
 
 import java.util.Arrays;
 import java.util.List;
@@ -218,6 +219,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Apple;
 
 import java.util.Arrays;
 import java.util.List;
@@ -284,6 +286,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Apple;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/AppleReq.md
+++ b/samples/client/petstore/java/docs/components/schemas/AppleReq.md
@@ -70,6 +70,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.AppleReq;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ArrayHoldingAnyType.md
+++ b/samples/client/petstore/java/docs/components/schemas/ArrayHoldingAnyType.md
@@ -64,6 +64,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ArrayHoldingAnyType;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ArrayOfArrayOfNumberOnly.md
+++ b/samples/client/petstore/java/docs/components/schemas/ArrayOfArrayOfNumberOnly.md
@@ -71,6 +71,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ArrayOfArrayOfNumberOnly;
 
 import java.util.Arrays;
 import java.util.List;
@@ -185,6 +186,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ArrayOfArrayOfNumberOnly;
 
 import java.util.Arrays;
 import java.util.List;
@@ -287,6 +289,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ArrayOfArrayOfNumberOnly;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ArrayOfEnums.md
+++ b/samples/client/petstore/java/docs/components/schemas/ArrayOfEnums.md
@@ -56,6 +56,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ArrayOfEnums;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ArrayOfNumberOnly.md
+++ b/samples/client/petstore/java/docs/components/schemas/ArrayOfNumberOnly.md
@@ -66,6 +66,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ArrayOfNumberOnly;
 
 import java.util.Arrays;
 import java.util.List;
@@ -178,6 +179,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ArrayOfNumberOnly;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ArrayTest.md
+++ b/samples/client/petstore/java/docs/components/schemas/ArrayTest.md
@@ -89,6 +89,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ArrayTest;
 
 import java.util.Arrays;
 import java.util.List;
@@ -228,6 +229,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ArrayTest;
 
 import java.util.Arrays;
 import java.util.List;
@@ -339,6 +341,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ArrayTest;
 
 import java.util.Arrays;
 import java.util.List;
@@ -448,6 +451,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ArrayTest;
 
 import java.util.Arrays;
 import java.util.List;
@@ -550,6 +554,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ArrayTest;
 
 import java.util.Arrays;
 import java.util.List;
@@ -687,6 +692,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ArrayTest;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ArrayWithValidationsInItems.md
+++ b/samples/client/petstore/java/docs/components/schemas/ArrayWithValidationsInItems.md
@@ -59,6 +59,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ArrayWithValidationsInItems;
 
 import java.util.Arrays;
 import java.util.List;
@@ -162,6 +163,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ArrayWithValidationsInItems;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/Banana.md
+++ b/samples/client/petstore/java/docs/components/schemas/Banana.md
@@ -59,6 +59,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Banana;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/BananaReq.md
+++ b/samples/client/petstore/java/docs/components/schemas/BananaReq.md
@@ -70,6 +70,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.BananaReq;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/Bar.md
+++ b/samples/client/petstore/java/docs/components/schemas/Bar.md
@@ -52,6 +52,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Bar;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/BasquePig.md
+++ b/samples/client/petstore/java/docs/components/schemas/BasquePig.md
@@ -61,6 +61,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.BasquePig;
 
 import java.util.Arrays;
 import java.util.List;
@@ -187,6 +188,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.BasquePig;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/BooleanEnum.md
+++ b/samples/client/petstore/java/docs/components/schemas/BooleanEnum.md
@@ -54,6 +54,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.BooleanEnum;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/Capitalization.md
+++ b/samples/client/petstore/java/docs/components/schemas/Capitalization.md
@@ -74,6 +74,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Capitalization;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/Cat.md
+++ b/samples/client/petstore/java/docs/components/schemas/Cat.md
@@ -214,6 +214,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Cat;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/Category.md
+++ b/samples/client/petstore/java/docs/components/schemas/Category.md
@@ -62,6 +62,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Category;
 
 import java.util.Arrays;
 import java.util.List;
@@ -194,6 +195,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Category;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ChildCat.md
+++ b/samples/client/petstore/java/docs/components/schemas/ChildCat.md
@@ -214,6 +214,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ChildCat;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/Client.md
+++ b/samples/client/petstore/java/docs/components/schemas/Client.md
@@ -59,6 +59,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Client;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ComplexQuadrilateral.md
+++ b/samples/client/petstore/java/docs/components/schemas/ComplexQuadrilateral.md
@@ -216,6 +216,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ComplexQuadrilateral;
 
 import java.util.Arrays;
 import java.util.List;
@@ -326,6 +327,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ComplexQuadrilateral;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ComposedAnyOfDifferentTypesNoValidations.md
+++ b/samples/client/petstore/java/docs/components/schemas/ComposedAnyOfDifferentTypesNoValidations.md
@@ -473,6 +473,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ComposedAnyOfDifferentTypesNoValidations;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ComposedArray.md
+++ b/samples/client/petstore/java/docs/components/schemas/ComposedArray.md
@@ -64,6 +64,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ComposedArray;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ComposedBool.md
+++ b/samples/client/petstore/java/docs/components/schemas/ComposedBool.md
@@ -60,6 +60,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ComposedBool;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ComposedNone.md
+++ b/samples/client/petstore/java/docs/components/schemas/ComposedNone.md
@@ -60,6 +60,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ComposedNone;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ComposedNumber.md
+++ b/samples/client/petstore/java/docs/components/schemas/ComposedNumber.md
@@ -60,6 +60,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ComposedNumber;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ComposedOneOfDifferentTypes.md
+++ b/samples/client/petstore/java/docs/components/schemas/ComposedOneOfDifferentTypes.md
@@ -234,6 +234,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ComposedOneOfDifferentTypes;
 
 import java.util.Arrays;
 import java.util.List;
@@ -301,6 +302,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ComposedOneOfDifferentTypes;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ComposedString.md
+++ b/samples/client/petstore/java/docs/components/schemas/ComposedString.md
@@ -60,6 +60,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ComposedString;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/Currency.md
+++ b/samples/client/petstore/java/docs/components/schemas/Currency.md
@@ -54,6 +54,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Currency;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/DanishPig.md
+++ b/samples/client/petstore/java/docs/components/schemas/DanishPig.md
@@ -61,6 +61,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.DanishPig;
 
 import java.util.Arrays;
 import java.util.List;
@@ -187,6 +188,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.DanishPig;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/DateTimeTest.md
+++ b/samples/client/petstore/java/docs/components/schemas/DateTimeTest.md
@@ -52,6 +52,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.DateTimeTest;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/DateTimeWithValidations.md
+++ b/samples/client/petstore/java/docs/components/schemas/DateTimeWithValidations.md
@@ -52,6 +52,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.DateTimeWithValidations;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/DateWithValidations.md
+++ b/samples/client/petstore/java/docs/components/schemas/DateWithValidations.md
@@ -52,6 +52,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.DateWithValidations;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/Dog.md
+++ b/samples/client/petstore/java/docs/components/schemas/Dog.md
@@ -214,6 +214,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Dog;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/Drawing.md
+++ b/samples/client/petstore/java/docs/components/schemas/Drawing.md
@@ -63,6 +63,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Drawing;
 
 import java.util.Arrays;
 import java.util.List;
@@ -205,6 +206,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Drawing;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/EnumArrays.md
+++ b/samples/client/petstore/java/docs/components/schemas/EnumArrays.md
@@ -72,6 +72,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.EnumArrays;
 
 import java.util.Arrays;
 import java.util.List;
@@ -189,6 +190,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.EnumArrays;
 
 import java.util.Arrays;
 import java.util.List;
@@ -289,6 +291,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.EnumArrays;
 
 import java.util.Arrays;
 import java.util.List;
@@ -368,6 +371,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.EnumArrays;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/EnumClass.md
+++ b/samples/client/petstore/java/docs/components/schemas/EnumClass.md
@@ -54,6 +54,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.EnumClass;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/EnumTest.md
+++ b/samples/client/petstore/java/docs/components/schemas/EnumTest.md
@@ -77,6 +77,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.EnumTest;
 
 import java.util.Arrays;
 import java.util.List;
@@ -261,6 +262,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.EnumTest;
 
 import java.util.Arrays;
 import java.util.List;
@@ -352,6 +354,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.EnumTest;
 
 import java.util.Arrays;
 import java.util.List;
@@ -467,6 +470,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.EnumTest;
 
 import java.util.Arrays;
 import java.util.List;
@@ -547,6 +551,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.EnumTest;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/EquilateralTriangle.md
+++ b/samples/client/petstore/java/docs/components/schemas/EquilateralTriangle.md
@@ -216,6 +216,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.EquilateralTriangle;
 
 import java.util.Arrays;
 import java.util.List;
@@ -326,6 +327,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.EquilateralTriangle;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/File.md
+++ b/samples/client/petstore/java/docs/components/schemas/File.md
@@ -62,6 +62,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.File;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/FileSchemaTestClass.md
+++ b/samples/client/petstore/java/docs/components/schemas/FileSchemaTestClass.md
@@ -63,6 +63,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.FileSchemaTestClass;
 
 import java.util.Arrays;
 import java.util.List;
@@ -176,6 +177,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.FileSchemaTestClass;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/Foo.md
+++ b/samples/client/petstore/java/docs/components/schemas/Foo.md
@@ -56,6 +56,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Foo;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/FormatTest.md
+++ b/samples/client/petstore/java/docs/components/schemas/FormatTest.md
@@ -125,6 +125,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.FormatTest;
 
 import java.util.Arrays;
 import java.util.List;
@@ -647,6 +648,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.FormatTest;
 
 import java.util.Arrays;
 import java.util.List;
@@ -716,6 +718,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.FormatTest;
 
 import java.util.Arrays;
 import java.util.List;
@@ -782,6 +785,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.FormatTest;
 
 import java.util.Arrays;
 import java.util.List;
@@ -1032,6 +1036,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.FormatTest;
 
 import java.util.Arrays;
 import java.util.List;
@@ -1098,6 +1103,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.FormatTest;
 
 import java.util.Arrays;
 import java.util.List;
@@ -1271,6 +1277,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.FormatTest;
 
 import java.util.Arrays;
 import java.util.List;
@@ -1377,6 +1384,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.FormatTest;
 
 import java.util.Arrays;
 import java.util.List;
@@ -1445,6 +1453,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.FormatTest;
 
 import java.util.Arrays;
 import java.util.List;
@@ -1548,6 +1557,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.FormatTest;
 
 import java.util.Arrays;
 import java.util.List;
@@ -1651,6 +1661,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.FormatTest;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/FromSchema.md
+++ b/samples/client/petstore/java/docs/components/schemas/FromSchema.md
@@ -62,6 +62,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.FromSchema;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/GrandparentAnimal.md
+++ b/samples/client/petstore/java/docs/components/schemas/GrandparentAnimal.md
@@ -59,6 +59,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.GrandparentAnimal;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/HasOnlyReadOnly.md
+++ b/samples/client/petstore/java/docs/components/schemas/HasOnlyReadOnly.md
@@ -62,6 +62,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.HasOnlyReadOnly;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/HealthCheckResult.md
+++ b/samples/client/petstore/java/docs/components/schemas/HealthCheckResult.md
@@ -63,6 +63,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.HealthCheckResult;
 
 import java.util.Arrays;
 import java.util.List;
@@ -191,6 +192,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.HealthCheckResult;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/IntegerEnum.md
+++ b/samples/client/petstore/java/docs/components/schemas/IntegerEnum.md
@@ -57,6 +57,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.IntegerEnum;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/IntegerEnumBig.md
+++ b/samples/client/petstore/java/docs/components/schemas/IntegerEnumBig.md
@@ -57,6 +57,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.IntegerEnumBig;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/IntegerEnumOneValue.md
+++ b/samples/client/petstore/java/docs/components/schemas/IntegerEnumOneValue.md
@@ -57,6 +57,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.IntegerEnumOneValue;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/IntegerEnumWithDefaultValue.md
+++ b/samples/client/petstore/java/docs/components/schemas/IntegerEnumWithDefaultValue.md
@@ -57,6 +57,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.IntegerEnumWithDefaultValue;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/IntegerMax10.md
+++ b/samples/client/petstore/java/docs/components/schemas/IntegerMax10.md
@@ -52,6 +52,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.IntegerMax10;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/IntegerMin15.md
+++ b/samples/client/petstore/java/docs/components/schemas/IntegerMin15.md
@@ -52,6 +52,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.IntegerMin15;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/IsoscelesTriangle.md
+++ b/samples/client/petstore/java/docs/components/schemas/IsoscelesTriangle.md
@@ -216,6 +216,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.IsoscelesTriangle;
 
 import java.util.Arrays;
 import java.util.List;
@@ -326,6 +327,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.IsoscelesTriangle;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/Items.md
+++ b/samples/client/petstore/java/docs/components/schemas/Items.md
@@ -62,6 +62,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Items;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/JSONPatchRequest.md
+++ b/samples/client/petstore/java/docs/components/schemas/JSONPatchRequest.md
@@ -64,6 +64,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.JSONPatchRequest;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/JSONPatchRequestAddReplaceTest.md
+++ b/samples/client/petstore/java/docs/components/schemas/JSONPatchRequestAddReplaceTest.md
@@ -80,6 +80,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.JSONPatchRequestAddReplaceTest;
 
 import java.util.Arrays;
 import java.util.List;
@@ -340,6 +341,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.JSONPatchRequestAddReplaceTest;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/JSONPatchRequestMoveCopy.md
+++ b/samples/client/petstore/java/docs/components/schemas/JSONPatchRequestMoveCopy.md
@@ -75,6 +75,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.JSONPatchRequestMoveCopy;
 
 import java.util.Arrays;
 import java.util.List;
@@ -305,6 +306,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.JSONPatchRequestMoveCopy;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/JSONPatchRequestRemove.md
+++ b/samples/client/petstore/java/docs/components/schemas/JSONPatchRequestRemove.md
@@ -72,6 +72,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.JSONPatchRequestRemove;
 
 import java.util.Arrays;
 import java.util.List;
@@ -229,6 +230,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.JSONPatchRequestRemove;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/MapTest.md
+++ b/samples/client/petstore/java/docs/components/schemas/MapTest.md
@@ -87,6 +87,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.MapTest;
 
 import java.util.Arrays;
 import java.util.List;
@@ -229,6 +230,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.MapTest;
 
 import java.util.Arrays;
 import java.util.List;
@@ -363,6 +365,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.MapTest;
 
 import java.util.Arrays;
 import java.util.List;
@@ -463,6 +466,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.MapTest;
 
 import java.util.Arrays;
 import java.util.List;
@@ -542,6 +546,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.MapTest;
 
 import java.util.Arrays;
 import java.util.List;
@@ -648,6 +653,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.MapTest;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/client/petstore/java/docs/components/schemas/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -67,6 +67,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.MixedPropertiesAndAdditionalPropertiesClass;
 
 import java.util.Arrays;
 import java.util.List;
@@ -198,6 +199,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.MixedPropertiesAndAdditionalPropertiesClass;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/Money.md
+++ b/samples/client/petstore/java/docs/components/schemas/Money.md
@@ -67,6 +67,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Money;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/MyObjectDto.md
+++ b/samples/client/petstore/java/docs/components/schemas/MyObjectDto.md
@@ -67,6 +67,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.MyObjectDto;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/NoAdditionalProperties.md
+++ b/samples/client/petstore/java/docs/components/schemas/NoAdditionalProperties.md
@@ -70,6 +70,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NoAdditionalProperties;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/NullableClass.md
+++ b/samples/client/petstore/java/docs/components/schemas/NullableClass.md
@@ -142,6 +142,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NullableClass;
 
 import java.util.Arrays;
 import java.util.List;
@@ -316,6 +317,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NullableClass;
 
 import java.util.Arrays;
 import java.util.List;
@@ -434,6 +436,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NullableClass;
 
 import java.util.Arrays;
 import java.util.List;
@@ -519,6 +522,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NullableClass;
 
 import java.util.Arrays;
 import java.util.List;
@@ -645,6 +649,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NullableClass;
 
 import java.util.Arrays;
 import java.util.List;
@@ -730,6 +735,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NullableClass;
 
 import java.util.Arrays;
 import java.util.List;
@@ -870,6 +876,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NullableClass;
 
 import java.util.Arrays;
 import java.util.List;
@@ -988,6 +995,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NullableClass;
 
 import java.util.Arrays;
 import java.util.List;
@@ -1073,6 +1081,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NullableClass;
 
 import java.util.Arrays;
 import java.util.List;
@@ -1199,6 +1208,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NullableClass;
 
 import java.util.Arrays;
 import java.util.List;
@@ -1284,6 +1294,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NullableClass;
 
 import java.util.Arrays;
 import java.util.List;
@@ -1442,6 +1453,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NullableClass;
 
 import java.util.Arrays;
 import java.util.List;
@@ -1534,6 +1546,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NullableClass;
 
 import java.util.Arrays;
 import java.util.List;
@@ -1626,6 +1639,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NullableClass;
 
 import java.util.Arrays;
 import java.util.List;
@@ -1717,6 +1731,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NullableClass;
 
 import java.util.Arrays;
 import java.util.List;
@@ -1808,6 +1823,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NullableClass;
 
 import java.util.Arrays;
 import java.util.List;
@@ -1899,6 +1915,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NullableClass;
 
 import java.util.Arrays;
 import java.util.List;
@@ -1991,6 +2008,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NullableClass;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/NullableString.md
+++ b/samples/client/petstore/java/docs/components/schemas/NullableString.md
@@ -71,6 +71,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NullableString;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/NumberOnly.md
+++ b/samples/client/petstore/java/docs/components/schemas/NumberOnly.md
@@ -59,6 +59,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NumberOnly;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/NumberWithExclusiveMinMax.md
+++ b/samples/client/petstore/java/docs/components/schemas/NumberWithExclusiveMinMax.md
@@ -52,6 +52,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NumberWithExclusiveMinMax;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/NumberWithValidations.md
+++ b/samples/client/petstore/java/docs/components/schemas/NumberWithValidations.md
@@ -52,6 +52,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.NumberWithValidations;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ObjWithRequiredProps.md
+++ b/samples/client/petstore/java/docs/components/schemas/ObjWithRequiredProps.md
@@ -59,6 +59,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ObjWithRequiredProps;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ObjWithRequiredPropsBase.md
+++ b/samples/client/petstore/java/docs/components/schemas/ObjWithRequiredPropsBase.md
@@ -59,6 +59,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ObjWithRequiredPropsBase;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ObjectModelWithArgAndArgsProperties.md
+++ b/samples/client/petstore/java/docs/components/schemas/ObjectModelWithArgAndArgsProperties.md
@@ -62,6 +62,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ObjectModelWithArgAndArgsProperties;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ObjectModelWithRefProps.md
+++ b/samples/client/petstore/java/docs/components/schemas/ObjectModelWithRefProps.md
@@ -59,6 +59,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ObjectModelWithRefProps;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ObjectWithAllOfWithReqTestPropFromUnsetAddProp.md
+++ b/samples/client/petstore/java/docs/components/schemas/ObjectWithAllOfWithReqTestPropFromUnsetAddProp.md
@@ -214,6 +214,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ObjectWithAllOfWithReqTestPropFromUnsetAddProp;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ObjectWithCollidingProperties.md
+++ b/samples/client/petstore/java/docs/components/schemas/ObjectWithCollidingProperties.md
@@ -65,6 +65,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ObjectWithCollidingProperties;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ObjectWithDecimalProperties.md
+++ b/samples/client/petstore/java/docs/components/schemas/ObjectWithDecimalProperties.md
@@ -59,6 +59,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ObjectWithDecimalProperties;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ObjectWithDifficultlyNamedProps.md
+++ b/samples/client/petstore/java/docs/components/schemas/ObjectWithDifficultlyNamedProps.md
@@ -68,6 +68,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ObjectWithDifficultlyNamedProps;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ObjectWithInlineCompositionProperty.md
+++ b/samples/client/petstore/java/docs/components/schemas/ObjectWithInlineCompositionProperty.md
@@ -67,6 +67,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ObjectWithInlineCompositionProperty;
 
 import java.util.Arrays;
 import java.util.List;
@@ -329,6 +330,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ObjectWithInlineCompositionProperty;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ObjectWithInvalidNamedRefedProperties.md
+++ b/samples/client/petstore/java/docs/components/schemas/ObjectWithInvalidNamedRefedProperties.md
@@ -56,6 +56,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ObjectWithInvalidNamedRefedProperties;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ObjectWithNonIntersectingValues.md
+++ b/samples/client/petstore/java/docs/components/schemas/ObjectWithNonIntersectingValues.md
@@ -62,6 +62,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ObjectWithNonIntersectingValues;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ObjectWithOnlyOptionalProps.md
+++ b/samples/client/petstore/java/docs/components/schemas/ObjectWithOnlyOptionalProps.md
@@ -70,6 +70,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ObjectWithOnlyOptionalProps;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ObjectWithOptionalTestProp.md
+++ b/samples/client/petstore/java/docs/components/schemas/ObjectWithOptionalTestProp.md
@@ -59,6 +59,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ObjectWithOptionalTestProp;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/Order.md
+++ b/samples/client/petstore/java/docs/components/schemas/Order.md
@@ -76,6 +76,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Order;
 
 import java.util.Arrays;
 import java.util.List;
@@ -251,6 +252,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Order;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/PaginatedResultMyObjectDto.md
+++ b/samples/client/petstore/java/docs/components/schemas/PaginatedResultMyObjectDto.md
@@ -74,6 +74,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.PaginatedResultMyObjectDto;
 
 import java.util.Arrays;
 import java.util.List;
@@ -234,6 +235,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.PaginatedResultMyObjectDto;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/Pet.md
+++ b/samples/client/petstore/java/docs/components/schemas/Pet.md
@@ -85,6 +85,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Pet;
 
 import java.util.Arrays;
 import java.util.List;
@@ -287,6 +288,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Pet;
 
 import java.util.Arrays;
 import java.util.List;
@@ -399,6 +401,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Pet;
 
 import java.util.Arrays;
 import java.util.List;
@@ -479,6 +482,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Pet;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/Player.md
+++ b/samples/client/petstore/java/docs/components/schemas/Player.md
@@ -62,6 +62,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Player;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/PublicKey.md
+++ b/samples/client/petstore/java/docs/components/schemas/PublicKey.md
@@ -62,6 +62,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.PublicKey;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/QuadrilateralInterface.md
+++ b/samples/client/petstore/java/docs/components/schemas/QuadrilateralInterface.md
@@ -342,6 +342,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.QuadrilateralInterface;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ReadOnlyFirst.md
+++ b/samples/client/petstore/java/docs/components/schemas/ReadOnlyFirst.md
@@ -62,6 +62,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ReadOnlyFirst;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ReqPropsFromExplicitAddProps.md
+++ b/samples/client/petstore/java/docs/components/schemas/ReqPropsFromExplicitAddProps.md
@@ -59,6 +59,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ReqPropsFromExplicitAddProps;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ReqPropsFromTrueAddProps.md
+++ b/samples/client/petstore/java/docs/components/schemas/ReqPropsFromTrueAddProps.md
@@ -64,6 +64,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ReqPropsFromTrueAddProps;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ReqPropsFromUnsetAddProps.md
+++ b/samples/client/petstore/java/docs/components/schemas/ReqPropsFromUnsetAddProps.md
@@ -56,6 +56,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ReqPropsFromUnsetAddProps;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/ScaleneTriangle.md
+++ b/samples/client/petstore/java/docs/components/schemas/ScaleneTriangle.md
@@ -216,6 +216,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ScaleneTriangle;
 
 import java.util.Arrays;
 import java.util.List;
@@ -326,6 +327,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.ScaleneTriangle;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/SelfReferencingArrayModel.md
+++ b/samples/client/petstore/java/docs/components/schemas/SelfReferencingArrayModel.md
@@ -56,6 +56,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.SelfReferencingArrayModel;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/SelfReferencingObjectModel.md
+++ b/samples/client/petstore/java/docs/components/schemas/SelfReferencingObjectModel.md
@@ -56,6 +56,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.SelfReferencingObjectModel;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/SimpleQuadrilateral.md
+++ b/samples/client/petstore/java/docs/components/schemas/SimpleQuadrilateral.md
@@ -216,6 +216,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.SimpleQuadrilateral;
 
 import java.util.Arrays;
 import java.util.List;
@@ -326,6 +327,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.SimpleQuadrilateral;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/SpecialModelname.md
+++ b/samples/client/petstore/java/docs/components/schemas/SpecialModelname.md
@@ -62,6 +62,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.SpecialModelname;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/StringBooleanMap.md
+++ b/samples/client/petstore/java/docs/components/schemas/StringBooleanMap.md
@@ -59,6 +59,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.StringBooleanMap;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/StringEnum.md
+++ b/samples/client/petstore/java/docs/components/schemas/StringEnum.md
@@ -74,6 +74,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.StringEnum;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/StringEnumWithDefaultValue.md
+++ b/samples/client/petstore/java/docs/components/schemas/StringEnumWithDefaultValue.md
@@ -54,6 +54,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.StringEnumWithDefaultValue;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/StringWithValidation.md
+++ b/samples/client/petstore/java/docs/components/schemas/StringWithValidation.md
@@ -52,6 +52,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.StringWithValidation;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/Tag.md
+++ b/samples/client/petstore/java/docs/components/schemas/Tag.md
@@ -62,6 +62,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Tag;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/TriangleInterface.md
+++ b/samples/client/petstore/java/docs/components/schemas/TriangleInterface.md
@@ -342,6 +342,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.TriangleInterface;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/UUIDString.md
+++ b/samples/client/petstore/java/docs/components/schemas/UUIDString.md
@@ -52,6 +52,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.UUIDString;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/User.md
+++ b/samples/client/petstore/java/docs/components/schemas/User.md
@@ -114,6 +114,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.User;
 
 import java.util.Arrays;
 import java.util.List;
@@ -754,6 +755,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.User;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/Whale.md
+++ b/samples/client/petstore/java/docs/components/schemas/Whale.md
@@ -67,6 +67,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Whale;
 
 import java.util.Arrays;
 import java.util.List;
@@ -201,6 +202,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Whale;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/components/schemas/Zebra.md
+++ b/samples/client/petstore/java/docs/components/schemas/Zebra.md
@@ -73,6 +73,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Zebra;
 
 import java.util.Arrays;
 import java.util.List;
@@ -205,6 +206,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Zebra;
 
 import java.util.Arrays;
 import java.util.List;
@@ -283,6 +285,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.components.schemas.Zebra;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/commonparamsubdir/delete/parameters/parameter1/Schema1.md
+++ b/samples/client/petstore/java/docs/paths/commonparamsubdir/delete/parameters/parameter1/Schema1.md
@@ -53,6 +53,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.commonparamsubdir.delete.parameters.parameter1.Schema1;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/commonparamsubdir/parameters/parameter0/PathParamSchema0.md
+++ b/samples/client/petstore/java/docs/paths/commonparamsubdir/parameters/parameter0/PathParamSchema0.md
@@ -53,6 +53,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.commonparamsubdir.parameters.parameter0.PathParamSchema0;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/fake/delete/parameters/parameter1/Schema1.md
+++ b/samples/client/petstore/java/docs/paths/fake/delete/parameters/parameter1/Schema1.md
@@ -53,6 +53,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fake.delete.parameters.parameter1.Schema1;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/fake/delete/parameters/parameter4/Schema4.md
+++ b/samples/client/petstore/java/docs/paths/fake/delete/parameters/parameter4/Schema4.md
@@ -53,6 +53,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fake.delete.parameters.parameter4.Schema4;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter0/Schema0.md
+++ b/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter0/Schema0.md
@@ -60,6 +60,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fake.get.parameters.parameter0.Schema0;
 
 import java.util.Arrays;
 import java.util.List;
@@ -160,6 +161,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fake.get.parameters.parameter0.Schema0;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter1/Schema1.md
+++ b/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter1/Schema1.md
@@ -53,6 +53,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fake.get.parameters.parameter1.Schema1;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter2/Schema2.md
+++ b/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter2/Schema2.md
@@ -60,6 +60,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fake.get.parameters.parameter2.Schema2;
 
 import java.util.Arrays;
 import java.util.List;
@@ -160,6 +161,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fake.get.parameters.parameter2.Schema2;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter3/Schema3.md
+++ b/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter3/Schema3.md
@@ -53,6 +53,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fake.get.parameters.parameter3.Schema3;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter4/Schema4.md
+++ b/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter4/Schema4.md
@@ -56,6 +56,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fake.get.parameters.parameter4.Schema4;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter5/Schema5.md
+++ b/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter5/Schema5.md
@@ -54,6 +54,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fake.get.parameters.parameter5.Schema5;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/fake/get/requestbody/content/applicationxwwwformurlencoded/ApplicationxwwwformurlencodedSchema.md
+++ b/samples/client/petstore/java/docs/paths/fake/get/requestbody/content/applicationxwwwformurlencoded/ApplicationxwwwformurlencodedSchema.md
@@ -71,6 +71,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fake.get.requestbody.content.applicationxwwwformurlencoded.ApplicationxwwwformurlencodedSchema;
 
 import java.util.Arrays;
 import java.util.List;
@@ -191,6 +192,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fake.get.requestbody.content.applicationxwwwformurlencoded.ApplicationxwwwformurlencodedSchema;
 
 import java.util.Arrays;
 import java.util.List;
@@ -275,6 +277,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fake.get.requestbody.content.applicationxwwwformurlencoded.ApplicationxwwwformurlencodedSchema;
 
 import java.util.Arrays;
 import java.util.List;
@@ -375,6 +378,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fake.get.requestbody.content.applicationxwwwformurlencoded.ApplicationxwwwformurlencodedSchema;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/fake/post/requestbody/content/applicationxwwwformurlencoded/ApplicationxwwwformurlencodedSchema.md
+++ b/samples/client/petstore/java/docs/paths/fake/post/requestbody/content/applicationxwwwformurlencoded/ApplicationxwwwformurlencodedSchema.md
@@ -96,6 +96,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fake.post.requestbody.content.applicationxwwwformurlencoded.ApplicationxwwwformurlencodedSchema;
 
 import java.util.Arrays;
 import java.util.List;
@@ -605,6 +606,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fake.post.requestbody.content.applicationxwwwformurlencoded.ApplicationxwwwformurlencodedSchema;
 
 import java.util.Arrays;
 import java.util.List;
@@ -676,6 +678,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fake.post.requestbody.content.applicationxwwwformurlencoded.ApplicationxwwwformurlencodedSchema;
 
 import java.util.Arrays;
 import java.util.List;
@@ -832,6 +835,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fake.post.requestbody.content.applicationxwwwformurlencoded.ApplicationxwwwformurlencodedSchema;
 
 import java.util.Arrays;
 import java.util.List;
@@ -901,6 +905,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fake.post.requestbody.content.applicationxwwwformurlencoded.ApplicationxwwwformurlencodedSchema;
 
 import java.util.Arrays;
 import java.util.List;
@@ -970,6 +975,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fake.post.requestbody.content.applicationxwwwformurlencoded.ApplicationxwwwformurlencodedSchema;
 
 import java.util.Arrays;
 import java.util.List;
@@ -1041,6 +1047,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fake.post.requestbody.content.applicationxwwwformurlencoded.ApplicationxwwwformurlencodedSchema;
 
 import java.util.Arrays;
 import java.util.List;
@@ -1111,6 +1118,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fake.post.requestbody.content.applicationxwwwformurlencoded.ApplicationxwwwformurlencodedSchema;
 
 import java.util.Arrays;
 import java.util.List;
@@ -1219,6 +1227,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fake.post.requestbody.content.applicationxwwwformurlencoded.ApplicationxwwwformurlencodedSchema;
 
 import java.util.Arrays;
 import java.util.List;
@@ -1290,6 +1299,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fake.post.requestbody.content.applicationxwwwformurlencoded.ApplicationxwwwformurlencodedSchema;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/fakeinlineadditionalproperties/post/requestbody/content/applicationjson/ApplicationjsonSchema.md
+++ b/samples/client/petstore/java/docs/paths/fakeinlineadditionalproperties/post/requestbody/content/applicationjson/ApplicationjsonSchema.md
@@ -58,6 +58,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fakeinlineadditionalproperties.post.requestbody.content.applicationjson.ApplicationjsonSchema;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/fakeinlinecomposition/post/parameters/parameter0/Schema0.md
+++ b/samples/client/petstore/java/docs/paths/fakeinlinecomposition/post/parameters/parameter0/Schema0.md
@@ -206,6 +206,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fakeinlinecomposition.post.parameters.parameter0.Schema0;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/fakeinlinecomposition/post/parameters/parameter1/Schema1.md
+++ b/samples/client/petstore/java/docs/paths/fakeinlinecomposition/post/parameters/parameter1/Schema1.md
@@ -66,6 +66,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fakeinlinecomposition.post.parameters.parameter1.Schema1;
 
 import java.util.Arrays;
 import java.util.List;
@@ -328,6 +329,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fakeinlinecomposition.post.parameters.parameter1.Schema1;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/fakeinlinecomposition/post/requestbody/content/applicationjson/ApplicationjsonSchema.md
+++ b/samples/client/petstore/java/docs/paths/fakeinlinecomposition/post/requestbody/content/applicationjson/ApplicationjsonSchema.md
@@ -206,6 +206,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fakeinlinecomposition.post.requestbody.content.applicationjson.ApplicationjsonSchema;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/fakeinlinecomposition/post/requestbody/content/multipartformdata/MultipartformdataSchema.md
+++ b/samples/client/petstore/java/docs/paths/fakeinlinecomposition/post/requestbody/content/multipartformdata/MultipartformdataSchema.md
@@ -66,6 +66,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fakeinlinecomposition.post.requestbody.content.multipartformdata.MultipartformdataSchema;
 
 import java.util.Arrays;
 import java.util.List;
@@ -328,6 +329,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fakeinlinecomposition.post.requestbody.content.multipartformdata.MultipartformdataSchema;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/fakeinlinecomposition/post/responses/code200response/content/applicationjson/ApplicationjsonSchema.md
+++ b/samples/client/petstore/java/docs/paths/fakeinlinecomposition/post/responses/code200response/content/applicationjson/ApplicationjsonSchema.md
@@ -206,6 +206,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fakeinlinecomposition.post.responses.code200response.content.applicationjson.ApplicationjsonSchema;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/fakeinlinecomposition/post/responses/code200response/content/multipartformdata/MultipartformdataSchema.md
+++ b/samples/client/petstore/java/docs/paths/fakeinlinecomposition/post/responses/code200response/content/multipartformdata/MultipartformdataSchema.md
@@ -66,6 +66,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fakeinlinecomposition.post.responses.code200response.content.multipartformdata.MultipartformdataSchema;
 
 import java.util.Arrays;
 import java.util.List;
@@ -328,6 +329,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fakeinlinecomposition.post.responses.code200response.content.multipartformdata.MultipartformdataSchema;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/fakejsonformdata/get/requestbody/content/applicationxwwwformurlencoded/ApplicationxwwwformurlencodedSchema.md
+++ b/samples/client/petstore/java/docs/paths/fakejsonformdata/get/requestbody/content/applicationxwwwformurlencoded/ApplicationxwwwformurlencodedSchema.md
@@ -61,6 +61,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fakejsonformdata.get.requestbody.content.applicationxwwwformurlencoded.ApplicationxwwwformurlencodedSchema;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/fakemultiplerequestbodycontenttypes/post/requestbody/content/applicationjson/ApplicationjsonSchema.md
+++ b/samples/client/petstore/java/docs/paths/fakemultiplerequestbodycontenttypes/post/requestbody/content/applicationjson/ApplicationjsonSchema.md
@@ -58,6 +58,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fakemultiplerequestbodycontenttypes.post.requestbody.content.applicationjson.ApplicationjsonSchema;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/fakemultiplerequestbodycontenttypes/post/requestbody/content/multipartformdata/MultipartformdataSchema.md
+++ b/samples/client/petstore/java/docs/paths/fakemultiplerequestbodycontenttypes/post/requestbody/content/multipartformdata/MultipartformdataSchema.md
@@ -58,6 +58,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fakemultiplerequestbodycontenttypes.post.requestbody.content.multipartformdata.MultipartformdataSchema;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/fakeobjinquery/get/parameters/parameter0/Schema0.md
+++ b/samples/client/petstore/java/docs/paths/fakeobjinquery/get/parameters/parameter0/Schema0.md
@@ -58,6 +58,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fakeobjinquery.get.parameters.parameter0.Schema0;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/fakepetiduploadimagewithrequiredfile/post/requestbody/content/multipartformdata/MultipartformdataSchema.md
+++ b/samples/client/petstore/java/docs/paths/fakepetiduploadimagewithrequiredfile/post/requestbody/content/multipartformdata/MultipartformdataSchema.md
@@ -60,6 +60,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fakepetiduploadimagewithrequiredfile.post.requestbody.content.multipartformdata.MultipartformdataSchema;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/faketestqueryparamters/put/parameters/parameter0/Schema0.md
+++ b/samples/client/petstore/java/docs/paths/faketestqueryparamters/put/parameters/parameter0/Schema0.md
@@ -58,6 +58,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.faketestqueryparamters.put.parameters.parameter0.Schema0;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/faketestqueryparamters/put/parameters/parameter1/Schema1.md
+++ b/samples/client/petstore/java/docs/paths/faketestqueryparamters/put/parameters/parameter1/Schema1.md
@@ -58,6 +58,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.faketestqueryparamters.put.parameters.parameter1.Schema1;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/faketestqueryparamters/put/parameters/parameter2/Schema2.md
+++ b/samples/client/petstore/java/docs/paths/faketestqueryparamters/put/parameters/parameter2/Schema2.md
@@ -58,6 +58,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.faketestqueryparamters.put.parameters.parameter2.Schema2;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/faketestqueryparamters/put/parameters/parameter3/Schema3.md
+++ b/samples/client/petstore/java/docs/paths/faketestqueryparamters/put/parameters/parameter3/Schema3.md
@@ -58,6 +58,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.faketestqueryparamters.put.parameters.parameter3.Schema3;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/faketestqueryparamters/put/parameters/parameter4/Schema4.md
+++ b/samples/client/petstore/java/docs/paths/faketestqueryparamters/put/parameters/parameter4/Schema4.md
@@ -58,6 +58,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.faketestqueryparamters.put.parameters.parameter4.Schema4;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/fakeuploadfile/post/requestbody/content/multipartformdata/MultipartformdataSchema.md
+++ b/samples/client/petstore/java/docs/paths/fakeuploadfile/post/requestbody/content/multipartformdata/MultipartformdataSchema.md
@@ -60,6 +60,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fakeuploadfile.post.requestbody.content.multipartformdata.MultipartformdataSchema;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/fakeuploadfiles/post/requestbody/content/multipartformdata/MultipartformdataSchema.md
+++ b/samples/client/petstore/java/docs/paths/fakeuploadfiles/post/requestbody/content/multipartformdata/MultipartformdataSchema.md
@@ -64,6 +64,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fakeuploadfiles.post.requestbody.content.multipartformdata.MultipartformdataSchema;
 
 import java.util.Arrays;
 import java.util.List;
@@ -176,6 +177,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.fakeuploadfiles.post.requestbody.content.multipartformdata.MultipartformdataSchema;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/foo/get/responses/codedefaultresponse/content/applicationjson/ApplicationjsonSchema.md
+++ b/samples/client/petstore/java/docs/paths/foo/get/responses/codedefaultresponse/content/applicationjson/ApplicationjsonSchema.md
@@ -55,6 +55,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.foo.get.responses.codedefaultresponse.content.applicationjson.ApplicationjsonSchema;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/petfindbystatus/get/parameters/parameter0/Schema0.md
+++ b/samples/client/petstore/java/docs/paths/petfindbystatus/get/parameters/parameter0/Schema0.md
@@ -60,6 +60,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.petfindbystatus.get.parameters.parameter0.Schema0;
 
 import java.util.Arrays;
 import java.util.List;
@@ -160,6 +161,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.petfindbystatus.get.parameters.parameter0.Schema0;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/petfindbytags/get/parameters/parameter0/Schema0.md
+++ b/samples/client/petstore/java/docs/paths/petfindbytags/get/parameters/parameter0/Schema0.md
@@ -58,6 +58,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.petfindbytags.get.parameters.parameter0.Schema0;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/petpetid/post/requestbody/content/applicationxwwwformurlencoded/ApplicationxwwwformurlencodedSchema.md
+++ b/samples/client/petstore/java/docs/paths/petpetid/post/requestbody/content/applicationxwwwformurlencoded/ApplicationxwwwformurlencodedSchema.md
@@ -61,6 +61,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.petpetid.post.requestbody.content.applicationxwwwformurlencoded.ApplicationxwwwformurlencodedSchema;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/petpetiduploadimage/post/requestbody/content/multipartformdata/MultipartformdataSchema.md
+++ b/samples/client/petstore/java/docs/paths/petpetiduploadimage/post/requestbody/content/multipartformdata/MultipartformdataSchema.md
@@ -60,6 +60,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.petpetiduploadimage.post.requestbody.content.multipartformdata.MultipartformdataSchema;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/storeorderorderid/get/parameters/parameter0/Schema0.md
+++ b/samples/client/petstore/java/docs/paths/storeorderorderid/get/parameters/parameter0/Schema0.md
@@ -51,6 +51,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.storeorderorderid.get.parameters.parameter0.Schema0;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/paths/userlogin/get/responses/code200response/Code200ResponseHeadersSchema.md
+++ b/samples/client/petstore/java/docs/paths/userlogin/get/responses/code200response/Code200ResponseHeadersSchema.md
@@ -1,0 +1,389 @@
+# Code200ResponseHeadersSchema
+public class Code200ResponseHeadersSchema<br>
+
+A class that contains necessary nested
+- schema classes (which validate payloads), extends JsonSchema
+- sealed interfaces which store validated payloads, java version of a sum type
+- boxed classes which store validated payloads, sealed permits class implementations
+- classes to store validated map payloads, extends FrozenMap
+- classes to build inputs for map payloads
+
+## Nested Class Summary
+| Modifier and Type | Class and Description |
+| ----------------- | ---------------------- |
+| sealed interface | [Code200ResponseHeadersSchema.Code200ResponseHeadersSchema1Boxed](#code200responseheadersschema1boxed)<br> sealed interface for validated payloads |
+| record | [Code200ResponseHeadersSchema.Code200ResponseHeadersSchema1BoxedMap](#code200responseheadersschema1boxedmap)<br> boxed class to store validated Map payloads |
+| static class | [Code200ResponseHeadersSchema.Code200ResponseHeadersSchema1](#code200responseheadersschema1)<br> schema class |
+| static class | [Code200ResponseHeadersSchema.Code200ResponseHeadersSchemaMapBuilder](#code200responseheadersschemamapbuilder)<br> builder for Map payloads |
+| static class | [Code200ResponseHeadersSchema.Code200ResponseHeadersSchemaMap](#code200responseheadersschemamap)<br> output class for Map payloads |
+| sealed interface | [Code200ResponseHeadersSchema.Code200ResponseAdditionalPropertiesBoxed](#code200responseadditionalpropertiesboxed)<br> sealed interface for validated payloads |
+| record | [Code200ResponseHeadersSchema.Code200ResponseAdditionalPropertiesBoxedVoid](#code200responseadditionalpropertiesboxedvoid)<br> boxed class to store validated null payloads |
+| record | [Code200ResponseHeadersSchema.Code200ResponseAdditionalPropertiesBoxedBoolean](#code200responseadditionalpropertiesboxedboolean)<br> boxed class to store validated boolean payloads |
+| record | [Code200ResponseHeadersSchema.Code200ResponseAdditionalPropertiesBoxedNumber](#code200responseadditionalpropertiesboxednumber)<br> boxed class to store validated Number payloads |
+| record | [Code200ResponseHeadersSchema.Code200ResponseAdditionalPropertiesBoxedString](#code200responseadditionalpropertiesboxedstring)<br> boxed class to store validated String payloads |
+| record | [Code200ResponseHeadersSchema.Code200ResponseAdditionalPropertiesBoxedList](#code200responseadditionalpropertiesboxedlist)<br> boxed class to store validated List payloads |
+| record | [Code200ResponseHeadersSchema.Code200ResponseAdditionalPropertiesBoxedMap](#code200responseadditionalpropertiesboxedmap)<br> boxed class to store validated Map payloads |
+| static class | [Code200ResponseHeadersSchema.Code200ResponseAdditionalProperties](#code200responseadditionalproperties)<br> schema class |
+
+## Code200ResponseHeadersSchema1Boxed
+public sealed interface Code200ResponseHeadersSchema1Boxed<br>
+permits<br>
+[Code200ResponseHeadersSchema1BoxedMap](#code200responseheadersschema1boxedmap)
+
+sealed interface that stores validated payloads using boxed classes
+
+## Code200ResponseHeadersSchema1BoxedMap
+public record Code200ResponseHeadersSchema1BoxedMap<br>
+implements [Code200ResponseHeadersSchema1Boxed](#code200responseheadersschema1boxed)
+
+record that stores validated Map payloads, sealed permits implementation
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| Code200ResponseHeadersSchema1BoxedMap([Code200ResponseHeadersSchemaMap](#code200responseheadersschemamap) data)<br>Creates an instance, private visibility |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| [Code200ResponseHeadersSchemaMap](#code200responseheadersschemamap) | data()<br>validated payload |
+| @Nullable Object | getData()<br>validated payload |
+
+## Code200ResponseHeadersSchema1
+public static class Code200ResponseHeadersSchema1<br>
+extends JsonSchema
+
+A schema class that validates payloads
+
+### Code Sample
+```
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
+import org.openapijsonschematools.client.configurations.SchemaConfiguration;
+import org.openapijsonschematools.client.exceptions.ValidationException;
+import org.openapijsonschematools.client.schemas.validation.MapUtils;
+import org.openapijsonschematools.client.schemas.validation.FrozenList;
+import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.paths.userlogin.get.responses.code200response.Code200ResponseHeadersSchema;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.AbstractMap;
+
+static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSchemaKeywordFlags.ofNone());
+
+// Map validation
+Code200ResponseHeadersSchema.Code200ResponseHeadersSchemaMap validatedPayload =
+    Code200ResponseHeadersSchema.Code200ResponseHeadersSchema1.validate(
+    new Code200ResponseHeadersSchema.Code200ResponseHeadersSchemaMapBuilder()
+        .setXHyphenMinusRateHyphenMinusLimit(1)
+
+        .int32(1)
+
+        .setRefHyphenMinusContentHyphenMinusSchemaHyphenMinusHeader("a")
+
+        .setXHyphenMinusExpiresHyphenMinusAfter("1970-01-01T00:00:00.00Z")
+
+        .numberHeader("3.14")
+
+    .build(),
+    configuration
+);
+```
+
+### Field Summary
+| Modifier and Type | Field and Description |
+| ----------------- | ---------------------- |
+| Set<Class<?>> | type = Set.of(Map.class) |
+| Map<String, Class<? extends JsonSchema>> | properties = Map.ofEntries(<br>&nbsp;&nbsp;&nbsp;&nbsp;new PropertyEntry("X-Rate-Limit", [XRateLimitSchema.XRateLimitSchema1.class](../../../../../../paths/userlogin/get/responses/code200response/headers/xratelimit/content/applicationjson/XRateLimitSchema.md#xratelimitschema1)),<br>&nbsp;&nbsp;&nbsp;&nbsp;new PropertyEntry("int32", [Int32JsonContentTypeHeaderSchema.Int32JsonContentTypeHeaderSchema1.class](../../../../../../components/headers/int32jsoncontenttypeheader/content/applicationjson/Int32JsonContentTypeHeaderSchema.md#int32jsoncontenttypeheaderschema1)),<br>&nbsp;&nbsp;&nbsp;&nbsp;new PropertyEntry("X-Expires-After", [XExpiresAfterSchema.XExpiresAfterSchema1.class](../../../../../../paths/userlogin/get/responses/code200response/headers/xexpiresafter/XExpiresAfterSchema.md#xexpiresafterschema1)),<br>&nbsp;&nbsp;&nbsp;&nbsp;new PropertyEntry("ref-content-schema-header", [StringWithValidation.StringWithValidation1.class](../../../../../../components/schemas/StringWithValidation.md#stringwithvalidation1)),<br>&nbsp;&nbsp;&nbsp;&nbsp;new PropertyEntry("numberHeader", [NumberHeaderSchema.NumberHeaderSchema1.class](../../../../../../components/headers/numberheader/NumberHeaderSchema.md#numberheaderschema1))<br>)<br> |
+| Set<String> | required = Set.of(<br>&nbsp;&nbsp;&nbsp;&nbsp;"X-Rate-Limit",<br>&nbsp;&nbsp;&nbsp;&nbsp;"int32",<br>&nbsp;&nbsp;&nbsp;&nbsp;"ref-content-schema-header"<br>)<br> |
+| Class<? extends JsonSchema> | additionalProperties = [Code200ResponseAdditionalProperties.class](#code200responseadditionalproperties) |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| [Code200ResponseHeadersSchemaMap](#code200responseheadersschemamap) | validate([Map&lt;?, ?&gt;](#code200responseheadersschemamapbuilder) arg, SchemaConfiguration configuration) |
+| [Code200ResponseHeadersSchema1BoxedMap](#code200responseheadersschema1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#code200responseheadersschemamapbuilder) arg, SchemaConfiguration configuration) |
+| [Code200ResponseHeadersSchema1Boxed](#code200responseheadersschema1boxed) | validateAndBox(@Nullable Object arg, SchemaConfiguration configuration) |
+| @Nullable Object | validate(@Nullable Object arg, SchemaConfiguration configuration) |
+
+## Code200ResponseHeadersSchemaMap000Builder
+public class Code200ResponseHeadersSchemaMap000Builder<br>
+builder for `Map<String, @Nullable Object>`
+
+A class that builds the Map input type
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| Code200ResponseHeadersSchemaMap000Builder(Map<String, @Nullable Object> instance)<br>Creates a builder that contains the passed instance |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| Map<String, @Nullable Object> | build()<br>Returns map input that should be used with Schema.validate |
+| [Code200ResponseHeadersSchemaMap000Builder](#code200responseheadersschemamap000builder) | setXHyphenMinusExpiresHyphenMinusAfter(String value) |
+| [Code200ResponseHeadersSchemaMap000Builder](#code200responseheadersschemamap000builder) | numberHeader(String value) |
+
+## Code200ResponseHeadersSchemaMap001Builder
+public class Code200ResponseHeadersSchemaMap001Builder<br>
+builder for `Map<String, @Nullable Object>`
+
+A class that builds the Map input type
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| Code200ResponseHeadersSchemaMap001Builder(Map<String, @Nullable Object> instance)<br>Creates a builder that contains the passed instance |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| [Code200ResponseHeadersSchemaMap000Builder](#code200responseheadersschemamap000builder) | setRefHyphenMinusContentHyphenMinusSchemaHyphenMinusHeader(String value) |
+
+## Code200ResponseHeadersSchemaMap010Builder
+public class Code200ResponseHeadersSchemaMap010Builder<br>
+builder for `Map<String, @Nullable Object>`
+
+A class that builds the Map input type
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| Code200ResponseHeadersSchemaMap010Builder(Map<String, @Nullable Object> instance)<br>Creates a builder that contains the passed instance |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| [Code200ResponseHeadersSchemaMap000Builder](#code200responseheadersschemamap000builder) | int32(int value) |
+| [Code200ResponseHeadersSchemaMap000Builder](#code200responseheadersschemamap000builder) | int32(float value) |
+
+## Code200ResponseHeadersSchemaMap011Builder
+public class Code200ResponseHeadersSchemaMap011Builder<br>
+builder for `Map<String, @Nullable Object>`
+
+A class that builds the Map input type
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| Code200ResponseHeadersSchemaMap011Builder(Map<String, @Nullable Object> instance)<br>Creates a builder that contains the passed instance |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| [Code200ResponseHeadersSchemaMap001Builder](#code200responseheadersschemamap001builder) | int32(int value) |
+| [Code200ResponseHeadersSchemaMap001Builder](#code200responseheadersschemamap001builder) | int32(float value) |
+| [Code200ResponseHeadersSchemaMap010Builder](#code200responseheadersschemamap010builder) | setRefHyphenMinusContentHyphenMinusSchemaHyphenMinusHeader(String value) |
+
+## Code200ResponseHeadersSchemaMap100Builder
+public class Code200ResponseHeadersSchemaMap100Builder<br>
+builder for `Map<String, @Nullable Object>`
+
+A class that builds the Map input type
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| Code200ResponseHeadersSchemaMap100Builder(Map<String, @Nullable Object> instance)<br>Creates a builder that contains the passed instance |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| [Code200ResponseHeadersSchemaMap000Builder](#code200responseheadersschemamap000builder) | setXHyphenMinusRateHyphenMinusLimit(int value) |
+| [Code200ResponseHeadersSchemaMap000Builder](#code200responseheadersschemamap000builder) | setXHyphenMinusRateHyphenMinusLimit(float value) |
+
+## Code200ResponseHeadersSchemaMap101Builder
+public class Code200ResponseHeadersSchemaMap101Builder<br>
+builder for `Map<String, @Nullable Object>`
+
+A class that builds the Map input type
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| Code200ResponseHeadersSchemaMap101Builder(Map<String, @Nullable Object> instance)<br>Creates a builder that contains the passed instance |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| [Code200ResponseHeadersSchemaMap001Builder](#code200responseheadersschemamap001builder) | setXHyphenMinusRateHyphenMinusLimit(int value) |
+| [Code200ResponseHeadersSchemaMap001Builder](#code200responseheadersschemamap001builder) | setXHyphenMinusRateHyphenMinusLimit(float value) |
+| [Code200ResponseHeadersSchemaMap100Builder](#code200responseheadersschemamap100builder) | setRefHyphenMinusContentHyphenMinusSchemaHyphenMinusHeader(String value) |
+
+## Code200ResponseHeadersSchemaMap110Builder
+public class Code200ResponseHeadersSchemaMap110Builder<br>
+builder for `Map<String, @Nullable Object>`
+
+A class that builds the Map input type
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| Code200ResponseHeadersSchemaMap110Builder(Map<String, @Nullable Object> instance)<br>Creates a builder that contains the passed instance |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| [Code200ResponseHeadersSchemaMap010Builder](#code200responseheadersschemamap010builder) | setXHyphenMinusRateHyphenMinusLimit(int value) |
+| [Code200ResponseHeadersSchemaMap010Builder](#code200responseheadersschemamap010builder) | setXHyphenMinusRateHyphenMinusLimit(float value) |
+| [Code200ResponseHeadersSchemaMap100Builder](#code200responseheadersschemamap100builder) | int32(int value) |
+| [Code200ResponseHeadersSchemaMap100Builder](#code200responseheadersschemamap100builder) | int32(float value) |
+
+## Code200ResponseHeadersSchemaMapBuilder
+public class Code200ResponseHeadersSchemaMapBuilder<br>
+builder for `Map<String, @Nullable Object>`
+
+A class that builds the Map input type
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| Code200ResponseHeadersSchemaMapBuilder()<br>Creates a builder that contains an empty map |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| [Code200ResponseHeadersSchemaMap011Builder](#code200responseheadersschemamap011builder) | setXHyphenMinusRateHyphenMinusLimit(int value) |
+| [Code200ResponseHeadersSchemaMap011Builder](#code200responseheadersschemamap011builder) | setXHyphenMinusRateHyphenMinusLimit(float value) |
+| [Code200ResponseHeadersSchemaMap101Builder](#code200responseheadersschemamap101builder) | int32(int value) |
+| [Code200ResponseHeadersSchemaMap101Builder](#code200responseheadersschemamap101builder) | int32(float value) |
+| [Code200ResponseHeadersSchemaMap110Builder](#code200responseheadersschemamap110builder) | setRefHyphenMinusContentHyphenMinusSchemaHyphenMinusHeader(String value) |
+
+## Code200ResponseHeadersSchemaMap
+public static class Code200ResponseHeadersSchemaMap<br>
+extends FrozenMap<String, @Nullable Object>
+
+A class to store validated Map payloads
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| static [Code200ResponseHeadersSchemaMap](#code200responseheadersschemamap) | of([Map<String, ? extends @Nullable Object>](#code200responseheadersschemamapbuilder) arg, SchemaConfiguration configuration) |
+| Number | int32()<br> |
+| String | numberHeader()<br>[optional] |
+| @Nullable Object | get(String key)<br>This schema has invalid Java names so this method must be used when you access instance["X-Rate-Limit"], instance["ref-content-schema-header"], instance["X-Expires-After"],  |
+
+## Code200ResponseAdditionalPropertiesBoxed
+public sealed interface Code200ResponseAdditionalPropertiesBoxed<br>
+permits<br>
+[Code200ResponseAdditionalPropertiesBoxedVoid](#code200responseadditionalpropertiesboxedvoid),
+[Code200ResponseAdditionalPropertiesBoxedBoolean](#code200responseadditionalpropertiesboxedboolean),
+[Code200ResponseAdditionalPropertiesBoxedNumber](#code200responseadditionalpropertiesboxednumber),
+[Code200ResponseAdditionalPropertiesBoxedString](#code200responseadditionalpropertiesboxedstring),
+[Code200ResponseAdditionalPropertiesBoxedList](#code200responseadditionalpropertiesboxedlist),
+[Code200ResponseAdditionalPropertiesBoxedMap](#code200responseadditionalpropertiesboxedmap)
+
+sealed interface that stores validated payloads using boxed classes
+
+## Code200ResponseAdditionalPropertiesBoxedVoid
+public record Code200ResponseAdditionalPropertiesBoxedVoid<br>
+implements [Code200ResponseAdditionalPropertiesBoxed](#code200responseadditionalpropertiesboxed)
+
+record that stores validated null payloads, sealed permits implementation
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| Code200ResponseAdditionalPropertiesBoxedVoid(Void data)<br>Creates an instance, private visibility |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| Void | data()<br>validated payload |
+| @Nullable Object | getData()<br>validated payload |
+
+## Code200ResponseAdditionalPropertiesBoxedBoolean
+public record Code200ResponseAdditionalPropertiesBoxedBoolean<br>
+implements [Code200ResponseAdditionalPropertiesBoxed](#code200responseadditionalpropertiesboxed)
+
+record that stores validated boolean payloads, sealed permits implementation
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| Code200ResponseAdditionalPropertiesBoxedBoolean(boolean data)<br>Creates an instance, private visibility |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| boolean | data()<br>validated payload |
+| @Nullable Object | getData()<br>validated payload |
+
+## Code200ResponseAdditionalPropertiesBoxedNumber
+public record Code200ResponseAdditionalPropertiesBoxedNumber<br>
+implements [Code200ResponseAdditionalPropertiesBoxed](#code200responseadditionalpropertiesboxed)
+
+record that stores validated Number payloads, sealed permits implementation
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| Code200ResponseAdditionalPropertiesBoxedNumber(Number data)<br>Creates an instance, private visibility |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| Number | data()<br>validated payload |
+| @Nullable Object | getData()<br>validated payload |
+
+## Code200ResponseAdditionalPropertiesBoxedString
+public record Code200ResponseAdditionalPropertiesBoxedString<br>
+implements [Code200ResponseAdditionalPropertiesBoxed](#code200responseadditionalpropertiesboxed)
+
+record that stores validated String payloads, sealed permits implementation
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| Code200ResponseAdditionalPropertiesBoxedString(String data)<br>Creates an instance, private visibility |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| String | data()<br>validated payload |
+| @Nullable Object | getData()<br>validated payload |
+
+## Code200ResponseAdditionalPropertiesBoxedList
+public record Code200ResponseAdditionalPropertiesBoxedList<br>
+implements [Code200ResponseAdditionalPropertiesBoxed](#code200responseadditionalpropertiesboxed)
+
+record that stores validated List payloads, sealed permits implementation
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| Code200ResponseAdditionalPropertiesBoxedList(FrozenList<@Nullable Object> data)<br>Creates an instance, private visibility |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| FrozenList<@Nullable Object> | data()<br>validated payload |
+| @Nullable Object | getData()<br>validated payload |
+
+## Code200ResponseAdditionalPropertiesBoxedMap
+public record Code200ResponseAdditionalPropertiesBoxedMap<br>
+implements [Code200ResponseAdditionalPropertiesBoxed](#code200responseadditionalpropertiesboxed)
+
+record that stores validated Map payloads, sealed permits implementation
+
+### Constructor Summary
+| Constructor and Description |
+| --------------------------- |
+| Code200ResponseAdditionalPropertiesBoxedMap(FrozenMap<@Nullable Object> data)<br>Creates an instance, private visibility |
+
+### Method Summary
+| Modifier and Type | Method and Description |
+| ----------------- | ---------------------- |
+| FrozenMap<@Nullable Object> | data()<br>validated payload |
+| @Nullable Object | getData()<br>validated payload |
+
+## Code200ResponseAdditionalProperties
+public static class Code200ResponseAdditionalProperties<br>
+extends NotAnyTypeJsonSchema.NotAnyTypeJsonSchema1
+
+A schema class that validates payloads
+
+| Methods Inherited from class org.openapijsonschematools.client.schemas.NotAnyTypeJsonSchema.NotAnyTypeJsonSchema1 |
+| ------------------------------------------------------------------ |
+| validate                                                           |
+| validateAndBox                                                     |

--- a/samples/client/petstore/java/docs/servers/Server0.md
+++ b/samples/client/petstore/java/docs/servers/Server0.md
@@ -93,6 +93,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.servers.server0.Variables;
 
 import java.util.Arrays;
 import java.util.List;
@@ -252,6 +253,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.servers.server0.Variables;
 
 import java.util.Arrays;
 import java.util.List;
@@ -335,6 +337,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.servers.server0.Variables;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/java/docs/servers/Server1.md
+++ b/samples/client/petstore/java/docs/servers/Server1.md
@@ -89,6 +89,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.servers.server1.Variables;
 
 import java.util.Arrays;
 import java.util.List;
@@ -206,6 +207,7 @@ import org.openapijsonschematools.client.exceptions.ValidationException;
 import org.openapijsonschematools.client.schemas.validation.MapUtils;
 import org.openapijsonschematools.client.schemas.validation.FrozenList;
 import org.openapijsonschematools.client.schemas.validation.FrozenMap;
+import org.openapijsonschematools.client.servers.server1.Variables;
 
 import java.util.Arrays;
 import java.util.List;

--- a/samples/client/petstore/python/.openapi-generator/FILES
+++ b/samples/client/petstore/python/.openapi-generator/FILES
@@ -36,15 +36,18 @@ docs/components/request_bodies/request_body_ref_user_array.md
 docs/components/request_bodies/request_body_user_array.md
 docs/components/request_bodies/request_body_user_array/content/application_json/schema.md
 docs/components/responses/response_headers_with_no_body.md
+docs/components/responses/response_headers_with_no_body/header_parameters.md
 docs/components/responses/response_headers_with_no_body/headers/header_location/schema.md
 docs/components/responses/response_ref_success_description_only.md
 docs/components/responses/response_ref_successful_xml_and_json_array_of_pet.md
 docs/components/responses/response_success_description_only.md
 docs/components/responses/response_success_inline_content_and_header.md
 docs/components/responses/response_success_inline_content_and_header/content/application_json/schema.md
+docs/components/responses/response_success_inline_content_and_header/header_parameters.md
 docs/components/responses/response_success_inline_content_and_header/headers/header_some_header/schema.md
 docs/components/responses/response_success_with_json_api_response.md
 docs/components/responses/response_success_with_json_api_response/content/application_json/schema.md
+docs/components/responses/response_success_with_json_api_response/header_parameters.md
 docs/components/responses/response_successful_xml_and_json_array_of_pet.md
 docs/components/responses/response_successful_xml_and_json_array_of_pet/content/application_json/schema.md
 docs/components/responses/response_successful_xml_and_json_array_of_pet/content/application_xml/schema.md
@@ -397,6 +400,7 @@ docs/paths/user_login/get/parameters/parameter_0/schema.md
 docs/paths/user_login/get/parameters/parameter_1/schema.md
 docs/paths/user_login/get/responses/response_200/content/application_json/schema.md
 docs/paths/user_login/get/responses/response_200/content/application_xml/schema.md
+docs/paths/user_login/get/responses/response_200/header_parameters.md
 docs/paths/user_login/get/responses/response_200/headers/header_x_expires_after/schema.md
 docs/paths/user_login/get/responses/response_200/headers/header_x_rate_limit/content/application_json/schema.md
 docs/paths/user_logout/get.md

--- a/samples/client/petstore/python/docs/components/responses/response_headers_with_no_body/header_parameters.md
+++ b/samples/client/petstore/python/docs/components/responses/response_headers_with_no_body/header_parameters.md
@@ -1,0 +1,37 @@
+# Headers
+```
+type: schemas.Schema
+```
+
+## validate method
+Input Type | Return Type | Notes
+------------ | ------------- | -------------
+[HeadersDictInput](#headersdictinput), [HeadersDict](#headersdict) | [HeadersDict](#headersdict) |
+
+## HeadersDictInput
+```
+type: typing.TypedDict
+```
+Key | Type |  Description | Notes
+------------ | ------------- | ------------- | -------------
+**location** | str |  | [optional]
+
+## HeadersDict
+```
+base class: schemas.immutabledict[str, str]
+
+```
+### &lowbar;&lowbar;new&lowbar;&lowbar; method
+Keyword Argument | Type | Description | Notes
+---------------- | ---- | ----------- | -----
+**location** | str, schemas.Unset |  | [optional]
+
+### properties
+Property | Type | Description | Notes
+-------- | ---- | ----------- | -----
+**location** | str, schemas.Unset |  | [optional]
+
+### methods
+Method | Input Type | Return Type | Notes
+------ | ---------- | ----------- | ------
+from_dict_ | [HeadersDictInput](#headersdictinput), [HeadersDict](#headersdict) | [HeadersDict](#headersdict) | a constructor

--- a/samples/client/petstore/python/docs/components/responses/response_success_inline_content_and_header/header_parameters.md
+++ b/samples/client/petstore/python/docs/components/responses/response_success_inline_content_and_header/header_parameters.md
@@ -1,0 +1,37 @@
+# Headers
+```
+type: schemas.Schema
+```
+
+## validate method
+Input Type | Return Type | Notes
+------------ | ------------- | -------------
+[HeadersDictInput](#headersdictinput), [HeadersDict](#headersdict) | [HeadersDict](#headersdict) |
+
+## HeadersDictInput
+```
+type: typing.TypedDict
+```
+Key | Type |  Description | Notes
+------------ | ------------- | ------------- | -------------
+**someHeader** | str |  | [optional]
+
+## HeadersDict
+```
+base class: schemas.immutabledict[str, str]
+
+```
+### &lowbar;&lowbar;new&lowbar;&lowbar; method
+Keyword Argument | Type | Description | Notes
+---------------- | ---- | ----------- | -----
+**someHeader** | str, schemas.Unset |  | [optional]
+
+### properties
+Property | Type | Description | Notes
+-------- | ---- | ----------- | -----
+**someHeader** | str, schemas.Unset |  | [optional]
+
+### methods
+Method | Input Type | Return Type | Notes
+------ | ---------- | ----------- | ------
+from_dict_ | [HeadersDictInput](#headersdictinput), [HeadersDict](#headersdict) | [HeadersDict](#headersdict) | a constructor

--- a/samples/client/petstore/python/docs/components/responses/response_success_with_json_api_response/header_parameters.md
+++ b/samples/client/petstore/python/docs/components/responses/response_success_with_json_api_response/header_parameters.md
@@ -1,0 +1,46 @@
+# Headers
+```
+type: schemas.Schema
+```
+
+## validate method
+Input Type | Return Type | Notes
+------------ | ------------- | -------------
+[HeadersDictInput](#headersdictinput), [HeadersDict](#headersdict) | [HeadersDict](#headersdict) |
+
+## HeadersDictInput
+```
+type: typing.TypedDict
+```
+Key | Type |  Description | Notes
+------------ | ------------- | ------------- | -------------
+**int32** | int |  |
+**ref-content-schema-header** | str |  |
+**ref-schema-header** | str |  |
+**stringHeader** | str |  |
+**numberHeader** | str |  | [optional]
+
+## HeadersDict
+```
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
+```
+### &lowbar;&lowbar;new&lowbar;&lowbar; method
+Keyword Argument | Type | Description | Notes
+---------------- | ---- | ----------- | -----
+**int32** | int |  |
+**stringHeader** | str |  |
+**numberHeader** | str, schemas.Unset |  | [optional]
+
+### properties
+Property | Type | Description | Notes
+-------- | ---- | ----------- | -----
+**int32** | int |  |
+**stringHeader** | str |  |
+**numberHeader** | str, schemas.Unset |  | [optional]
+
+### methods
+Method | Input Type | Return Type | Notes
+------ | ---------- | ----------- | ------
+from_dict_ | [HeadersDictInput](#headersdictinput), [HeadersDict](#headersdict) | [HeadersDict](#headersdict) | a constructor
+&lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["ref-content-schema-header"], instance["ref-schema-header"], 

--- a/samples/client/petstore/python/docs/paths/user_login/get/responses/response_200/header_parameters.md
+++ b/samples/client/petstore/python/docs/paths/user_login/get/responses/response_200/header_parameters.md
@@ -1,0 +1,44 @@
+# Headers
+```
+type: schemas.Schema
+```
+
+## validate method
+Input Type | Return Type | Notes
+------------ | ------------- | -------------
+[HeadersDictInput](#headersdictinput), [HeadersDict](#headersdict) | [HeadersDict](#headersdict) |
+
+## HeadersDictInput
+```
+type: typing.TypedDict
+```
+Key | Type |  Description | Notes
+------------ | ------------- | ------------- | -------------
+**X-Rate-Limit** | int |  |
+**int32** | int |  |
+**ref-content-schema-header** | str |  |
+**X-Expires-After** | str, datetime.datetime |  | [optional]
+**numberHeader** | str |  | [optional]
+
+## HeadersDict
+```
+base class: schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]
+
+```
+### &lowbar;&lowbar;new&lowbar;&lowbar; method
+Keyword Argument | Type | Description | Notes
+---------------- | ---- | ----------- | -----
+**int32** | int |  |
+**numberHeader** | str, schemas.Unset |  | [optional]
+
+### properties
+Property | Type | Description | Notes
+-------- | ---- | ----------- | -----
+**int32** | int |  |
+**numberHeader** | str, schemas.Unset |  | [optional]
+
+### methods
+Method | Input Type | Return Type | Notes
+------ | ---------- | ----------- | ------
+from_dict_ | [HeadersDictInput](#headersdictinput), [HeadersDict](#headersdict) | [HeadersDict](#headersdict) | a constructor
+&lowbar;&lowbar;getitem&lowbar;&lowbar; | str | schemas.immutabledict, str, float, int, bool, None, tuple, bytes, io.FileIO | This model has invalid python names so this method is used under the hood when you access instance["X-Rate-Limit"], instance["ref-content-schema-header"], instance["X-Expires-After"], 

--- a/src/main/java/org/openapijsonschematools/codegen/generatorrunner/DefaultGeneratorRunner.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generatorrunner/DefaultGeneratorRunner.java
@@ -662,6 +662,7 @@ public class DefaultGeneratorRunner implements GeneratorRunner {
             }
             // synthetic json path
             generateSchema(files, response.headersObjectSchema, response.headersObjectSchema.jsonPath);
+            generateSchemaDocumentation(files, response.headersObjectSchema, response.headersObjectSchema.jsonPath, docRoot + "../");
         }
         LinkedHashMap<CodegenKey, CodegenMediaType> content = response.content;
         if (content != null && !content.isEmpty()) {

--- a/src/main/resources/java/src/main/java/packagename/components/headers/HeaderDoc.hbs
+++ b/src/main/resources/java/src/main/java/packagename/components/headers/HeaderDoc.hbs
@@ -79,16 +79,16 @@ a class that deserializes a header value
 | @Nullable ParameterStyle | ParameterStyle.SIMPLE |
 | @Nullable Boolean explode | {{explode}} |
     {{#if content}}
-| Map<String, [SealedMediaType](#sealedmediatype)> | content =  Map.ofEntries(<br>{{#each content}}&nbsp;&nbsp;&nbsp;&nbsp;new AbstractMap.SimpleEntry<>("{{{@key.original}}}", new [{{@key.pascalCase}}MediaType](#{{@key.kebabCase}}mediatype)()){{#unless @last}},{{/unless}}<br>{{/each}})<br>the contentType to schema info |
+| Map<String, [{{@key.pascalCase}}MediaType](#{{@key.kebabCase}}mediatype)> | content =  Map.ofEntries(<br>{{#each content}}&nbsp;&nbsp;&nbsp;&nbsp;new AbstractMap.SimpleEntry<>("{{{@key.original}}}", new [{{@key.pascalCase}}MediaType](#{{@key.kebabCase}}mediatype)()){{#unless @last}},{{/unless}}<br>{{/each}})<br>the contentType to schema info |
     {{else}}
-| JsonSchema<?> | schema = {{#with schema}}{{containerJsonPathPiece.pascalCase}}.{{jsonPathPiece.pascalCase}}.getInstance(){{/with}}
+| JsonSchema<?> | schema = {{#with schema}}[{{containerJsonPathPiece.pascalCase}}.{{jsonPathPiece.pascalCase}}]({{docRoot}}{{pathFromDocRoot}}.md#{{jsonPathPiece.kebabCase}})().getInstance(){{/with}}
     {{/if}}
 
 {{headerSize}}## Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | HttpHeaders | serialize(@Nullable Object inData, String name, boolean validate, SchemaConfiguration configuration) |
-| @Nullable Object | deserialize(List<String> inData, boolean validate, SchemaConfiguration configuration)<br>deserializes the header value |
+| @Nullable Object | deserialize(List&lt;String&gt; inData, boolean validate, SchemaConfiguration configuration)<br>deserializes the header value |
 {{/if}}
 {{#if componentModule}}
 

--- a/src/main/resources/java/src/main/java/packagename/components/headers/HeaderDoc.hbs
+++ b/src/main/resources/java/src/main/java/packagename/components/headers/HeaderDoc.hbs
@@ -78,11 +78,11 @@ a class that deserializes a header value
 | @Nullable Boolean allowReserved | null |
 | @Nullable ParameterStyle | ParameterStyle.SIMPLE |
 | @Nullable Boolean explode | {{explode}} |
-    {{#if content}}
-| Map<String, [{{@key.pascalCase}}MediaType](#{{@key.kebabCase}}mediatype)> | content =  Map.ofEntries(<br>{{#each content}}&nbsp;&nbsp;&nbsp;&nbsp;new AbstractMap.SimpleEntry<>("{{{@key.original}}}", new [{{@key.pascalCase}}MediaType](#{{@key.kebabCase}}mediatype)()){{#unless @last}},{{/unless}}<br>{{/each}})<br>the contentType to schema info |
+    {{#each content}}
+| Map<String, [{{@key.pascalCase}}MediaType](#{{@key.kebabCase}}mediatype)> | content =  Map.ofEntries(<br>&nbsp;&nbsp;&nbsp;&nbsp;new AbstractMap.SimpleEntry<>("{{{@key.original}}}", new [{{@key.pascalCase}}MediaType](#{{@key.kebabCase}}mediatype)())<br>)<br>the contentType to schema info |
     {{else}}
 | JsonSchema<?> | schema = {{#with schema}}[{{containerJsonPathPiece.pascalCase}}.{{jsonPathPiece.pascalCase}}]({{docRoot}}{{pathFromDocRoot}}.md#{{jsonPathPiece.kebabCase}})().getInstance(){{/with}}
-    {{/if}}
+    {{/each}}
 
 {{headerSize}}## Method Summary
 | Modifier and Type | Method and Description |

--- a/src/main/resources/java/src/main/java/packagename/components/responses/ResponseDoc.hbs
+++ b/src/main/resources/java/src/main/java/packagename/components/responses/ResponseDoc.hbs
@@ -110,7 +110,7 @@ A record class to store response body for contentType="{{{@key.original}}}"
 
 {{> src/main/java/packagename/components/_helper_header_from_identifier_pieces headerSize=(join headerSize "#" "") identifierPieces=(append identifierPieces (join jsonPathPiece.pascalCase "1" "")) }}
 public static class {{jsonPathPiece.pascalCase}}1<br>
-extends ResponseDeserializer<{{#if hasContentSchema}}[SealedResponseBody](#sealedresponsebody){{else}}Void{{/if}}, Void, {{#if hasContentSchema}}[SealedMediaType](#sealedmediatype){{else}}Void{{/if}}>
+extends ResponseDeserializer<{{#if hasContentSchema}}[SealedResponseBody](#sealedresponsebody){{else}}Void{{/if}}, {{#with headersObjectSchema}}[{{containerJsonPathPiece.pascalCase}}.{{mapOutputJsonPathPiece.pascalCase}}]({{docRoot}}{{pathFromDocRoot}}.md#{{jsonPathPiece.kebabCase}}){{else}}Void{{/with}}, {{#if hasContentSchema}}[SealedMediaType](#sealedmediatype){{else}}Void{{/if}}>
 
 a class that deserializes responses
 

--- a/src/main/resources/java/src/main/java/packagename/components/responses/ResponseDoc.hbs
+++ b/src/main/resources/java/src/main/java/packagename/components/responses/ResponseDoc.hbs
@@ -110,7 +110,7 @@ A record class to store response body for contentType="{{{@key.original}}}"
 
 {{> src/main/java/packagename/components/_helper_header_from_identifier_pieces headerSize=(join headerSize "#" "") identifierPieces=(append identifierPieces (join jsonPathPiece.pascalCase "1" "")) }}
 public static class {{jsonPathPiece.pascalCase}}1<br>
-extends ResponseDeserializer<{{#if hasContentSchema}}[SealedResponseBody](#sealedresponsebody){{else}}Void{{/if}}, {{#with headersObjectSchema}}[{{containerJsonPathPiece.pascalCase}}.{{mapOutputJsonPathPiece.pascalCase}}]({{docRoot}}{{pathFromDocRoot}}.md#{{jsonPathPiece.kebabCase}}){{else}}Void{{/with}}, {{#if hasContentSchema}}[SealedMediaType](#sealedmediatype){{else}}Void{{/if}}>
+extends ResponseDeserializer<{{#if hasContentSchema}}[SealedResponseBody](#sealedresponsebody){{else}}Void{{/if}}, {{#with headersObjectSchema}}[{{containerJsonPathPiece.pascalCase}}.{{mapOutputJsonPathPiece.pascalCase}}]({{docRoot}}{{pathFromDocRoot}}.md#{{mapOutputJsonPathPiece.kebabCase}}){{else}}Void{{/with}}, {{#if hasContentSchema}}[SealedMediaType](#sealedmediatype){{else}}Void{{/if}}>
 
 a class that deserializes responses
 
@@ -131,7 +131,7 @@ a class that deserializes responses
 {{headerSize}}## Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| ApiResponse<{{#if hasContentSchema}}[SealedResponseBody](#sealedresponsebody){{else}}Void{{/if}}, {{#with headersObjectSchema}}[{{containerJsonPathPiece.pascalCase}}.{{mapOutputJsonPathPiece.pascalCase}}]({{docRoot}}{{pathFromDocRoot}}.md#{{jsonPathPiece.kebabCase}}){{else}}Void{{/with}}> | deserialize(HttpResponse<byte[]> response, SchemaConfiguration configuration)<br>called by endpoint when deserialize responses |
+| ApiResponse<{{#if hasContentSchema}}[SealedResponseBody](#sealedresponsebody){{else}}Void{{/if}}, {{#with headersObjectSchema}}[{{containerJsonPathPiece.pascalCase}}.{{mapOutputJsonPathPiece.pascalCase}}]({{docRoot}}{{pathFromDocRoot}}.md#{{mapOutputJsonPathPiece.kebabCase}}){{else}}Void{{/with}}> | deserialize(HttpResponse<byte[]> response, SchemaConfiguration configuration)<br>called by endpoint when deserialize responses |
 {{/if}}
 {{#if componentModule}}
 

--- a/src/main/resources/java/src/main/java/packagename/components/responses/ResponseDoc.hbs
+++ b/src/main/resources/java/src/main/java/packagename/components/responses/ResponseDoc.hbs
@@ -131,7 +131,7 @@ a class that deserializes responses
 {{headerSize}}## Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| ApiResponse<{{#if hasContentSchema}}[SealedResponseBody](#sealedresponsebody){{else}}Void{{/if}}, Void> | deserialize(HttpResponse<byte[]> response, SchemaConfiguration configuration)<br>called by endpoint when deserialize responses |
+| ApiResponse<{{#if hasContentSchema}}[SealedResponseBody](#sealedresponsebody){{else}}Void{{/if}}, {{#with headersObjectSchema}}[{{containerJsonPathPiece.pascalCase}}.{{mapOutputJsonPathPiece.pascalCase}}]({{docRoot}}{{pathFromDocRoot}}.md#{{jsonPathPiece.kebabCase}}){{else}}Void{{/with}}> | deserialize(HttpResponse<byte[]> response, SchemaConfiguration configuration)<br>called by endpoint when deserialize responses |
 {{/if}}
 {{#if componentModule}}
 

--- a/src/main/resources/java/src/main/java/packagename/components/schemas/docschema_codeSample.hbs
+++ b/src/main/resources/java/src/main/java/packagename/components/schemas/docschema_codeSample.hbs
@@ -6,6 +6,7 @@ import {{{packageName}}}.exceptions.ValidationException;
 import {{{packageName}}}.schemas.validation.MapUtils;
 import {{{packageName}}}.schemas.validation.FrozenList;
 import {{{packageName}}}.schemas.validation.FrozenMap;
+import {{{packageName}}}.{{../../subpackage}}.{{../../containerJsonPathPiece.pascalCase}};
 
 import java.util.Arrays;
 import java.util.List;


### PR DESCRIPTION
Java client, documentation improvement
- schema docs, added schema class import
- header docs, describes the content map as string to the specific MediaType class
- add response header link in response documentation

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
