### PR TITLE
Fixes enum variable names

### DIFF
--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/PropertiesWhoseNamesAreJavascriptObjectPropertyNames.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/PropertiesWhoseNamesAreJavascriptObjectPropertyNames.md
@@ -204,10 +204,10 @@ A class that builds the Map input type
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | Map<String, @Nullable Object> | build()<br>Returns map input that should be used with Schema.validate |
-| [PropertiesWhoseNamesAreJavascriptObjectPropertyNamesMapBuilder](#propertieswhosenamesarejavascriptobjectpropertynamesmapbuilder) | setProto(int value) |
-| [PropertiesWhoseNamesAreJavascriptObjectPropertyNamesMapBuilder](#propertieswhosenamesarejavascriptobjectpropertynamesmapbuilder) | setProto(float value) |
-| [PropertiesWhoseNamesAreJavascriptObjectPropertyNamesMapBuilder](#propertieswhosenamesarejavascriptobjectpropertynamesmapbuilder) | setProto(long value) |
-| [PropertiesWhoseNamesAreJavascriptObjectPropertyNamesMapBuilder](#propertieswhosenamesarejavascriptobjectpropertynamesmapbuilder) | setProto(double value) |
+| [PropertiesWhoseNamesAreJavascriptObjectPropertyNamesMapBuilder](#propertieswhosenamesarejavascriptobjectpropertynamesmapbuilder) | setLowLineProto(int value) |
+| [PropertiesWhoseNamesAreJavascriptObjectPropertyNamesMapBuilder](#propertieswhosenamesarejavascriptobjectpropertynamesmapbuilder) | setLowLineProto(float value) |
+| [PropertiesWhoseNamesAreJavascriptObjectPropertyNamesMapBuilder](#propertieswhosenamesarejavascriptobjectpropertynamesmapbuilder) | setLowLineProto(long value) |
+| [PropertiesWhoseNamesAreJavascriptObjectPropertyNamesMapBuilder](#propertieswhosenamesarejavascriptobjectpropertynamesmapbuilder) | setLowLineProto(double value) |
 | [PropertiesWhoseNamesAreJavascriptObjectPropertyNamesMapBuilder](#propertieswhosenamesarejavascriptobjectpropertynamesmapbuilder) | setToString(Void value) |
 | [PropertiesWhoseNamesAreJavascriptObjectPropertyNamesMapBuilder](#propertieswhosenamesarejavascriptobjectpropertynamesmapbuilder) | setToString(boolean value) |
 | [PropertiesWhoseNamesAreJavascriptObjectPropertyNamesMapBuilder](#propertieswhosenamesarejavascriptobjectpropertynamesmapbuilder) | setToString(String value) |

--- a/samples/client/3_1_0_unit_test/java/docs/components/schemas/RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames.md
+++ b/samples/client/3_1_0_unit_test/java/docs/components/schemas/RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames.md
@@ -290,15 +290,15 @@ A class that builds the Map input type
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap000Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap000builder) | setProto(Void value) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap000Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap000builder) | setProto(boolean value) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap000Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap000builder) | setProto(String value) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap000Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap000builder) | setProto(int value) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap000Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap000builder) | setProto(float value) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap000Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap000builder) | setProto(long value) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap000Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap000builder) | setProto(double value) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap000Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap000builder) | setProto(List<?> value) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap000Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap000builder) | setProto(Map<String, ?> value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap000Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap000builder) | setLowLineProto(Void value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap000Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap000builder) | setLowLineProto(boolean value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap000Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap000builder) | setLowLineProto(String value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap000Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap000builder) | setLowLineProto(int value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap000Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap000builder) | setLowLineProto(float value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap000Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap000builder) | setLowLineProto(long value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap000Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap000builder) | setLowLineProto(double value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap000Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap000builder) | setLowLineProto(List<?> value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap000Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap000builder) | setLowLineProto(Map<String, ?> value) |
 
 ## RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap101Builder
 public class RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap101Builder<br>
@@ -314,15 +314,15 @@ A class that builds the Map input type
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap001Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap001builder) | setProto(Void value) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap001Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap001builder) | setProto(boolean value) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap001Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap001builder) | setProto(String value) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap001Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap001builder) | setProto(int value) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap001Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap001builder) | setProto(float value) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap001Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap001builder) | setProto(long value) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap001Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap001builder) | setProto(double value) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap001Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap001builder) | setProto(List<?> value) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap001Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap001builder) | setProto(Map<String, ?> value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap001Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap001builder) | setLowLineProto(Void value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap001Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap001builder) | setLowLineProto(boolean value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap001Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap001builder) | setLowLineProto(String value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap001Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap001builder) | setLowLineProto(int value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap001Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap001builder) | setLowLineProto(float value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap001Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap001builder) | setLowLineProto(long value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap001Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap001builder) | setLowLineProto(double value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap001Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap001builder) | setLowLineProto(List<?> value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap001Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap001builder) | setLowLineProto(Map<String, ?> value) |
 | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap100Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap100builder) | setToString(Void value) |
 | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap100Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap100builder) | setToString(boolean value) |
 | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap100Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap100builder) | setToString(String value) |
@@ -347,15 +347,15 @@ A class that builds the Map input type
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap010Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap010builder) | setProto(Void value) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap010Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap010builder) | setProto(boolean value) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap010Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap010builder) | setProto(String value) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap010Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap010builder) | setProto(int value) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap010Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap010builder) | setProto(float value) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap010Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap010builder) | setProto(long value) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap010Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap010builder) | setProto(double value) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap010Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap010builder) | setProto(List<?> value) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap010Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap010builder) | setProto(Map<String, ?> value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap010Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap010builder) | setLowLineProto(Void value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap010Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap010builder) | setLowLineProto(boolean value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap010Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap010builder) | setLowLineProto(String value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap010Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap010builder) | setLowLineProto(int value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap010Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap010builder) | setLowLineProto(float value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap010Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap010builder) | setLowLineProto(long value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap010Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap010builder) | setLowLineProto(double value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap010Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap010builder) | setLowLineProto(List<?> value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap010Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap010builder) | setLowLineProto(Map<String, ?> value) |
 | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap100Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap100builder) | constructor(Void value) |
 | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap100Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap100builder) | constructor(boolean value) |
 | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap100Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap100builder) | constructor(String value) |
@@ -380,15 +380,15 @@ A class that builds the Map input type
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap011Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap011builder) | setProto(Void value) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap011Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap011builder) | setProto(boolean value) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap011Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap011builder) | setProto(String value) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap011Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap011builder) | setProto(int value) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap011Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap011builder) | setProto(float value) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap011Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap011builder) | setProto(long value) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap011Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap011builder) | setProto(double value) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap011Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap011builder) | setProto(List<?> value) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap011Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap011builder) | setProto(Map<String, ?> value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap011Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap011builder) | setLowLineProto(Void value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap011Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap011builder) | setLowLineProto(boolean value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap011Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap011builder) | setLowLineProto(String value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap011Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap011builder) | setLowLineProto(int value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap011Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap011builder) | setLowLineProto(float value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap011Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap011builder) | setLowLineProto(long value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap011Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap011builder) | setLowLineProto(double value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap011Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap011builder) | setLowLineProto(List<?> value) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap011Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap011builder) | setLowLineProto(Map<String, ?> value) |
 | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap101Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap101builder) | constructor(Void value) |
 | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap101Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap101builder) | constructor(boolean value) |
 | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap101Builder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap101builder) | constructor(String value) |

--- a/samples/client/3_1_0_unit_test/java/src/main/java/org/openapijsonschematools/client/components/schemas/PropertiesWhoseNamesAreJavascriptObjectPropertyNames.java
+++ b/samples/client/3_1_0_unit_test/java/src/main/java/org/openapijsonschematools/client/components/schemas/PropertiesWhoseNamesAreJavascriptObjectPropertyNames.java
@@ -460,25 +460,25 @@ public class PropertiesWhoseNamesAreJavascriptObjectPropertyNames {
         Map<String, @Nullable Object> getInstance();
         T getBuilderAfterProto(Map<String, @Nullable Object> instance);
         
-        default T setProto(int value) {
+        default T setLowLineProto(int value) {
             var instance = getInstance();
             instance.put("__proto__", value);
             return getBuilderAfterProto(instance);
         }
         
-        default T setProto(float value) {
+        default T setLowLineProto(float value) {
             var instance = getInstance();
             instance.put("__proto__", value);
             return getBuilderAfterProto(instance);
         }
         
-        default T setProto(long value) {
+        default T setLowLineProto(long value) {
             var instance = getInstance();
             instance.put("__proto__", value);
             return getBuilderAfterProto(instance);
         }
         
-        default T setProto(double value) {
+        default T setLowLineProto(double value) {
             var instance = getInstance();
             instance.put("__proto__", value);
             return getBuilderAfterProto(instance);

--- a/samples/client/3_1_0_unit_test/java/src/main/java/org/openapijsonschematools/client/components/schemas/RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames.java
+++ b/samples/client/3_1_0_unit_test/java/src/main/java/org/openapijsonschematools/client/components/schemas/RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames.java
@@ -65,55 +65,55 @@ public class RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames {
         Map<String, @Nullable Object> getInstance();
         T getBuilderAfterProto(Map<String, @Nullable Object> instance);
         
-        default T setProto(Void value) {
+        default T setLowLineProto(Void value) {
             var instance = getInstance();
             instance.put("__proto__", null);
             return getBuilderAfterProto(instance);
         }
         
-        default T setProto(boolean value) {
+        default T setLowLineProto(boolean value) {
             var instance = getInstance();
             instance.put("__proto__", value);
             return getBuilderAfterProto(instance);
         }
         
-        default T setProto(String value) {
+        default T setLowLineProto(String value) {
             var instance = getInstance();
             instance.put("__proto__", value);
             return getBuilderAfterProto(instance);
         }
         
-        default T setProto(int value) {
+        default T setLowLineProto(int value) {
             var instance = getInstance();
             instance.put("__proto__", value);
             return getBuilderAfterProto(instance);
         }
         
-        default T setProto(float value) {
+        default T setLowLineProto(float value) {
             var instance = getInstance();
             instance.put("__proto__", value);
             return getBuilderAfterProto(instance);
         }
         
-        default T setProto(long value) {
+        default T setLowLineProto(long value) {
             var instance = getInstance();
             instance.put("__proto__", value);
             return getBuilderAfterProto(instance);
         }
         
-        default T setProto(double value) {
+        default T setLowLineProto(double value) {
             var instance = getInstance();
             instance.put("__proto__", value);
             return getBuilderAfterProto(instance);
         }
         
-        default T setProto(List<?> value) {
+        default T setLowLineProto(List<?> value) {
             var instance = getInstance();
             instance.put("__proto__", value);
             return getBuilderAfterProto(instance);
         }
         
-        default T setProto(Map<String, ?> value) {
+        default T setLowLineProto(Map<String, ?> value) {
             var instance = getInstance();
             instance.put("__proto__", value);
             return getBuilderAfterProto(instance);

--- a/samples/client/petstore/java/docs/components/schemas/ClassModel.md
+++ b/samples/client/petstore/java/docs/components/schemas/ClassModel.md
@@ -191,7 +191,7 @@ A class that builds the Map input type
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | Map<String, @Nullable Object> | build()<br>Returns map input that should be used with Schema.validate |
-| [ClassModelMapBuilder](#classmodelmapbuilder) | setClass(String value) |
+| [ClassModelMapBuilder](#classmodelmapbuilder) | setLowLineClass(String value) |
 | [ClassModelMapBuilder](#classmodelmapbuilder) | additionalProperty(String key, Void value) |
 | [ClassModelMapBuilder](#classmodelmapbuilder) | additionalProperty(String key, boolean value) |
 | [ClassModelMapBuilder](#classmodelmapbuilder) | additionalProperty(String key, String value) |

--- a/samples/client/petstore/java/docs/components/schemas/EnumClass.md
+++ b/samples/client/petstore/java/docs/components/schemas/EnumClass.md
@@ -94,7 +94,7 @@ A class that stores String enum values
 ### Enum Constant Summary
 | Enum Constant | Description |
 | ------------- | ----------- |
-| _ABC | value = "_abc" |
+| LOW_LINE_ABC | value = "_abc" |
 | HYPHEN_MINUS_EFG | value = "-efg" |
 | LEFT_PARENTHESIS_XYZ_RIGHT_PARENTHESIS | value = "(xyz)" |
 | COUNT_1M | value = "COUNT_1M" |

--- a/samples/client/petstore/java/docs/components/schemas/ObjectWithDifficultlyNamedProps.md
+++ b/samples/client/petstore/java/docs/components/schemas/ObjectWithDifficultlyNamedProps.md
@@ -80,11 +80,11 @@ static final SchemaConfiguration configuration = new SchemaConfiguration(JsonSch
 ObjectWithDifficultlyNamedProps.ObjectWithDifficultlyNamedPropsMap validatedPayload =
     ObjectWithDifficultlyNamedProps.ObjectWithDifficultlyNamedProps1.validate(
     new ObjectWithDifficultlyNamedProps.ObjectWithDifficultlyNamedPropsMapBuilder()
-        .set123HyphenMinusList("a")
+        .setDigitOne23HyphenMinusList("a")
 
         .setDollarSignSpecialLeftSquareBracketPropertyFullStopNameRightSquareBracket(1L)
 
-        .set123number(1)
+        .setDigitOne23number(1)
 
     .build(),
     configuration
@@ -125,10 +125,10 @@ A class that builds the Map input type
 | [ObjectWithDifficultlyNamedPropsMap0Builder](#objectwithdifficultlynamedpropsmap0builder) | setDollarSignSpecialLeftSquareBracketPropertyFullStopNameRightSquareBracket(float value) |
 | [ObjectWithDifficultlyNamedPropsMap0Builder](#objectwithdifficultlynamedpropsmap0builder) | setDollarSignSpecialLeftSquareBracketPropertyFullStopNameRightSquareBracket(long value) |
 | [ObjectWithDifficultlyNamedPropsMap0Builder](#objectwithdifficultlynamedpropsmap0builder) | setDollarSignSpecialLeftSquareBracketPropertyFullStopNameRightSquareBracket(double value) |
-| [ObjectWithDifficultlyNamedPropsMap0Builder](#objectwithdifficultlynamedpropsmap0builder) | set123number(int value) |
-| [ObjectWithDifficultlyNamedPropsMap0Builder](#objectwithdifficultlynamedpropsmap0builder) | set123number(float value) |
-| [ObjectWithDifficultlyNamedPropsMap0Builder](#objectwithdifficultlynamedpropsmap0builder) | set123number(long value) |
-| [ObjectWithDifficultlyNamedPropsMap0Builder](#objectwithdifficultlynamedpropsmap0builder) | set123number(double value) |
+| [ObjectWithDifficultlyNamedPropsMap0Builder](#objectwithdifficultlynamedpropsmap0builder) | setDigitOne23number(int value) |
+| [ObjectWithDifficultlyNamedPropsMap0Builder](#objectwithdifficultlynamedpropsmap0builder) | setDigitOne23number(float value) |
+| [ObjectWithDifficultlyNamedPropsMap0Builder](#objectwithdifficultlynamedpropsmap0builder) | setDigitOne23number(long value) |
+| [ObjectWithDifficultlyNamedPropsMap0Builder](#objectwithdifficultlynamedpropsmap0builder) | setDigitOne23number(double value) |
 | [ObjectWithDifficultlyNamedPropsMap0Builder](#objectwithdifficultlynamedpropsmap0builder) | additionalProperty(String key, Void value) |
 | [ObjectWithDifficultlyNamedPropsMap0Builder](#objectwithdifficultlynamedpropsmap0builder) | additionalProperty(String key, boolean value) |
 | [ObjectWithDifficultlyNamedPropsMap0Builder](#objectwithdifficultlynamedpropsmap0builder) | additionalProperty(String key, String value) |
@@ -153,7 +153,7 @@ A class that builds the Map input type
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| [ObjectWithDifficultlyNamedPropsMap0Builder](#objectwithdifficultlynamedpropsmap0builder) | set123HyphenMinusList(String value) |
+| [ObjectWithDifficultlyNamedPropsMap0Builder](#objectwithdifficultlynamedpropsmap0builder) | setDigitOne23HyphenMinusList(String value) |
 
 ## ObjectWithDifficultlyNamedPropsMap
 public static class ObjectWithDifficultlyNamedPropsMap<br>

--- a/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter1/Schema1.md
+++ b/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter1/Schema1.md
@@ -93,6 +93,6 @@ A class that stores String enum values
 ### Enum Constant Summary
 | Enum Constant | Description |
 | ------------- | ----------- |
-| _ABC | value = "_abc" |
+| LOW_LINE_ABC | value = "_abc" |
 | HYPHEN_MINUS_EFG | value = "-efg" |
 | LEFT_PARENTHESIS_XYZ_RIGHT_PARENTHESIS | value = "(xyz)" |

--- a/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter3/Schema3.md
+++ b/samples/client/petstore/java/docs/paths/fake/get/parameters/parameter3/Schema3.md
@@ -93,6 +93,6 @@ A class that stores String enum values
 ### Enum Constant Summary
 | Enum Constant | Description |
 | ------------- | ----------- |
-| _ABC | value = "_abc" |
+| LOW_LINE_ABC | value = "_abc" |
 | HYPHEN_MINUS_EFG | value = "-efg" |
 | LEFT_PARENTHESIS_XYZ_RIGHT_PARENTHESIS | value = "(xyz)" |

--- a/samples/client/petstore/java/docs/paths/fake/get/requestbody/content/applicationxwwwformurlencoded/ApplicationxwwwformurlencodedSchema.md
+++ b/samples/client/petstore/java/docs/paths/fake/get/requestbody/content/applicationxwwwformurlencoded/ApplicationxwwwformurlencodedSchema.md
@@ -232,7 +232,7 @@ A class that stores String enum values
 ### Enum Constant Summary
 | Enum Constant | Description |
 | ------------- | ----------- |
-| _ABC | value = "_abc" |
+| LOW_LINE_ABC | value = "_abc" |
 | HYPHEN_MINUS_EFG | value = "-efg" |
 | LEFT_PARENTHESIS_XYZ_RIGHT_PARENTHESIS | value = "(xyz)" |
 

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/components/schemas/ClassModel.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/components/schemas/ClassModel.java
@@ -72,7 +72,7 @@ public class ClassModel {
         Map<String, @Nullable Object> getInstance();
         T getBuilderAfterClassSchema(Map<String, @Nullable Object> instance);
         
-        default T setClass(String value) {
+        default T setLowLineClass(String value) {
             var instance = getInstance();
             instance.put("_class", value);
             return getBuilderAfterClassSchema(instance);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/components/schemas/EnumClass.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/components/schemas/EnumClass.java
@@ -23,7 +23,7 @@ public class EnumClass {
     // nest classes so all schemas and input/output classes can be public
     
     public enum StringEnumClassEnums implements StringValueMethod {
-        _ABC("_abc"),
+        LOW_LINE_ABC("_abc"),
         HYPHEN_MINUS_EFG("-efg"),
         LEFT_PARENTHESIS_XYZ_RIGHT_PARENTHESIS("(xyz)"),
         COUNT_1M("COUNT_1M"),

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/components/schemas/ObjectWithDifficultlyNamedProps.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/components/schemas/ObjectWithDifficultlyNamedProps.java
@@ -90,7 +90,7 @@ public class ObjectWithDifficultlyNamedProps {
         Map<String, @Nullable Object> getInstance();
         T getBuilderAfterSchema123list(Map<String, @Nullable Object> instance);
         
-        default T set123HyphenMinusList(String value) {
+        default T setDigitOne23HyphenMinusList(String value) {
             var instance = getInstance();
             instance.put("123-list", value);
             return getBuilderAfterSchema123list(instance);
@@ -130,25 +130,25 @@ public class ObjectWithDifficultlyNamedProps {
         Map<String, @Nullable Object> getInstance();
         T getBuilderAfterSchema123Number(Map<String, @Nullable Object> instance);
         
-        default T set123number(int value) {
+        default T setDigitOne23number(int value) {
             var instance = getInstance();
             instance.put("123Number", value);
             return getBuilderAfterSchema123Number(instance);
         }
         
-        default T set123number(float value) {
+        default T setDigitOne23number(float value) {
             var instance = getInstance();
             instance.put("123Number", value);
             return getBuilderAfterSchema123Number(instance);
         }
         
-        default T set123number(long value) {
+        default T setDigitOne23number(long value) {
             var instance = getInstance();
             instance.put("123Number", value);
             return getBuilderAfterSchema123Number(instance);
         }
         
-        default T set123number(double value) {
+        default T setDigitOne23number(double value) {
             var instance = getInstance();
             instance.put("123Number", value);
             return getBuilderAfterSchema123Number(instance);

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/paths/fake/get/parameters/parameter1/Schema1.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/paths/fake/get/parameters/parameter1/Schema1.java
@@ -23,7 +23,7 @@ public class Schema1 {
     // nest classes so all schemas and input/output classes can be public
     
     public enum StringSchemaEnums1 implements StringValueMethod {
-        _ABC("_abc"),
+        LOW_LINE_ABC("_abc"),
         HYPHEN_MINUS_EFG("-efg"),
         LEFT_PARENTHESIS_XYZ_RIGHT_PARENTHESIS("(xyz)");
         private final String value;

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/paths/fake/get/parameters/parameter3/Schema3.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/paths/fake/get/parameters/parameter3/Schema3.java
@@ -23,7 +23,7 @@ public class Schema3 {
     // nest classes so all schemas and input/output classes can be public
     
     public enum StringSchemaEnums3 implements StringValueMethod {
-        _ABC("_abc"),
+        LOW_LINE_ABC("_abc"),
         HYPHEN_MINUS_EFG("-efg"),
         LEFT_PARENTHESIS_XYZ_RIGHT_PARENTHESIS("(xyz)");
         private final String value;

--- a/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/paths/fake/get/requestbody/content/applicationxwwwformurlencoded/ApplicationxwwwformurlencodedSchema.java
+++ b/samples/client/petstore/java/src/main/java/org/openapijsonschematools/client/paths/fake/get/requestbody/content/applicationxwwwformurlencoded/ApplicationxwwwformurlencodedSchema.java
@@ -260,7 +260,7 @@ public class ApplicationxwwwformurlencodedSchema {
         }
     }    
     public enum StringApplicationxwwwformurlencodedEnumFormStringEnums implements StringValueMethod {
-        _ABC("_abc"),
+        LOW_LINE_ABC("_abc"),
         HYPHEN_MINUS_EFG("-efg"),
         LEFT_PARENTHESIS_XYZ_RIGHT_PARENTHESIS("(xyz)");
         private final String value;

--- a/samples/client/petstore/python/src/petstore_api/components/schema/enum_class.py
+++ b/samples/client/petstore/python/src/petstore_api/components/schema/enum_class.py
@@ -15,7 +15,7 @@ from petstore_api.shared_imports.schema_imports import *  # pyright: ignore [rep
 class EnumClassEnums:
 
     @schemas.classproperty
-    def _ABC(cls) -> typing.Literal["_abc"]:
+    def LOW_LINE_ABC(cls) -> typing.Literal["_abc"]:
         return EnumClass.validate("_abc")
 
     @schemas.classproperty
@@ -50,7 +50,7 @@ class EnumClass(
     default: typing.Literal["-efg"] = "-efg"
     enum_value_to_name: typing.Mapping[typing.Union[int, float, str, schemas.Bool, None], str] = dataclasses.field(
         default_factory=lambda: {
-            "_abc": "_ABC",
+            "_abc": "LOW_LINE_ABC",
             "-efg": "HYPHEN_MINUS_EFG",
             "(xyz)": "LEFT_PARENTHESIS_XYZ_RIGHT_PARENTHESIS",
             "COUNT_1M": "COUNT_1M",

--- a/samples/client/petstore/python/src/petstore_api/paths/fake/get/parameters/parameter_1/schema.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake/get/parameters/parameter_1/schema.py
@@ -15,7 +15,7 @@ from petstore_api.shared_imports.schema_imports import *  # pyright: ignore [rep
 class SchemaEnums:
 
     @schemas.classproperty
-    def _ABC(cls) -> typing.Literal["_abc"]:
+    def LOW_LINE_ABC(cls) -> typing.Literal["_abc"]:
         return Schema.validate("_abc")
 
     @schemas.classproperty
@@ -37,7 +37,7 @@ class Schema(
     default: typing.Literal["-efg"] = "-efg"
     enum_value_to_name: typing.Mapping[typing.Union[int, float, str, schemas.Bool, None], str] = dataclasses.field(
         default_factory=lambda: {
-            "_abc": "_ABC",
+            "_abc": "LOW_LINE_ABC",
             "-efg": "HYPHEN_MINUS_EFG",
             "(xyz)": "LEFT_PARENTHESIS_XYZ_RIGHT_PARENTHESIS",
         }

--- a/samples/client/petstore/python/src/petstore_api/paths/fake/get/parameters/parameter_3/schema.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake/get/parameters/parameter_3/schema.py
@@ -15,7 +15,7 @@ from petstore_api.shared_imports.schema_imports import *  # pyright: ignore [rep
 class SchemaEnums:
 
     @schemas.classproperty
-    def _ABC(cls) -> typing.Literal["_abc"]:
+    def LOW_LINE_ABC(cls) -> typing.Literal["_abc"]:
         return Schema.validate("_abc")
 
     @schemas.classproperty
@@ -37,7 +37,7 @@ class Schema(
     default: typing.Literal["-efg"] = "-efg"
     enum_value_to_name: typing.Mapping[typing.Union[int, float, str, schemas.Bool, None], str] = dataclasses.field(
         default_factory=lambda: {
-            "_abc": "_ABC",
+            "_abc": "LOW_LINE_ABC",
             "-efg": "HYPHEN_MINUS_EFG",
             "(xyz)": "LEFT_PARENTHESIS_XYZ_RIGHT_PARENTHESIS",
         }

--- a/samples/client/petstore/python/src/petstore_api/paths/fake/get/request_body/content/application_x_www_form_urlencoded/schema.py
+++ b/samples/client/petstore/python/src/petstore_api/paths/fake/get/request_body/content/application_x_www_form_urlencoded/schema.py
@@ -140,7 +140,7 @@ class EnumFormStringArray(
 class EnumFormStringEnums:
 
     @schemas.classproperty
-    def _ABC(cls) -> typing.Literal["_abc"]:
+    def LOW_LINE_ABC(cls) -> typing.Literal["_abc"]:
         return EnumFormString.validate("_abc")
 
     @schemas.classproperty
@@ -162,7 +162,7 @@ class EnumFormString(
     default: typing.Literal["-efg"] = "-efg"
     enum_value_to_name: typing.Mapping[typing.Union[int, float, str, schemas.Bool, None], str] = dataclasses.field(
         default_factory=lambda: {
-            "_abc": "_ABC",
+            "_abc": "LOW_LINE_ABC",
             "-efg": "HYPHEN_MINUS_EFG",
             "(xyz)": "LEFT_PARENTHESIS_XYZ_RIGHT_PARENTHESIS",
         }

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -2168,10 +2168,20 @@ public class JavaClientGenerator extends DefaultGenerator implements Generator {
         usedValue = usedValue.replaceAll("[ ]+", "_");
 
         // replace all invalid characters with their character name descriptions
-        Pattern nonWordCharPattern = Pattern.compile("\\W+");
-        Matcher matcher = nonWordCharPattern.matcher(usedValue);
+        // replace all invalid characters with their character name descriptions
         Stack<AbstractMap.SimpleEntry<Integer, String>> matchStartToGroup = new Stack<>();
+        Pattern nonLetterCharPattern = Pattern.compile("^[^a-zA-Z]");
+        Matcher matcher = nonLetterCharPattern.matcher(usedValue);
         while (matcher.find()) {
+            matchStartToGroup.add(new AbstractMap.SimpleEntry<>(matcher.start(), matcher.group()));
+        }
+        Pattern nonWordPattern = Pattern.compile("\\W+");
+        matcher = nonWordPattern.matcher(usedValue);
+        while (matcher.find()) {
+            if (matcher.start() == 0) {
+                // skip adding first because it was already added
+                continue;
+            }
             matchStartToGroup.add(new AbstractMap.SimpleEntry<>(matcher.start(), matcher.group()));
         }
         char underscore = '_';

--- a/src/main/java/org/openapijsonschematools/codegen/generators/PythonClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/PythonClientGenerator.java
@@ -1113,12 +1113,22 @@ public class PythonClientGenerator extends DefaultGenerator implements Generator
         usedValue = usedValue.replaceAll("[ ]+", "_");
 
         // replace all invalid characters with their character name descriptions
-        Pattern nonWordCharPattern = Pattern.compile("\\W+");
-        Matcher matcher = nonWordCharPattern.matcher(usedValue);
         Stack<AbstractMap.SimpleEntry<Integer, String>> matchStartToGroup = new Stack<>();
+        Pattern nonLetterCharPattern = Pattern.compile("^[^a-zA-Z]");
+        Matcher matcher = nonLetterCharPattern.matcher(usedValue);
         while (matcher.find()) {
             matchStartToGroup.add(new AbstractMap.SimpleEntry<>(matcher.start(), matcher.group()));
         }
+        Pattern nonWordPattern = Pattern.compile("\\W+");
+        matcher = nonWordPattern.matcher(usedValue);
+        while (matcher.find()) {
+            if (matcher.start() == 0) {
+                // skip adding first because it was already added
+                continue;
+            }
+            matchStartToGroup.add(new AbstractMap.SimpleEntry<>(matcher.start(), matcher.group()));
+        }
+
         char underscore = '_';
         while (!matchStartToGroup.isEmpty()) {
             AbstractMap.SimpleEntry<Integer, String> entry = matchStartToGroup.pop();

--- a/src/test/java/org/openapijsonschematools/codegen/generators/JavaClientGeneratorTest.java
+++ b/src/test/java/org/openapijsonschematools/codegen/generators/JavaClientGeneratorTest.java
@@ -17,14 +17,19 @@
 
 package org.openapijsonschematools.codegen.generators;
 
+import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
+import org.openapijsonschematools.codegen.TestUtils;
 import org.openapijsonschematools.codegen.generators.openapimodels.CodegenParameter;
+import org.openapijsonschematools.codegen.generators.openapimodels.CodegenSchema;
+import org.openapijsonschematools.codegen.generators.openapimodels.EnumValue;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
+import java.util.Map;
 
 public class JavaClientGeneratorTest {
 
@@ -125,5 +130,27 @@ public class JavaClientGeneratorTest {
         parameter.setSchema(sc);
         final CodegenParameter p = generator.fromParameter(parameter, "#/components/parameters/uuidGivenExample");
         Assert.assertEquals(p.example, "UUID.fromString(\"13b48713-b931-45ea-bd60-b07491245960\")");
+    }
+
+    @Test
+    public void testEnumNames() {
+        OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/70_schema_enum_names.yaml");
+        var javaGenerator = new JavaClientGenerator();
+        javaGenerator.setOpenAPI(openAPI);
+
+        String modelName = "StringEnum";
+        Schema schema = openAPI.getComponents().getSchemas().get(modelName);
+
+        CodegenSchema cm = javaGenerator.fromSchema(
+                schema,
+                "#/components/schemas/" + modelName,
+                "#/components/schemas/" + modelName
+        );
+
+        Map<EnumValue, String> enumVars = cm.enumInfo.valueToName;
+        Assert.assertEquals(enumVars.size(), 3);
+        Assert.assertEquals(enumVars.get(new EnumValue("#367B9C", "string", null)), "NUMBER_SIGN_367B9C");
+        Assert.assertEquals(enumVars.get(new EnumValue("#FFA5A4", "string", null)), "NUMBER_SIGN_FFA5A4");
+        Assert.assertEquals(enumVars.get(new EnumValue("2D_Object", "string", null)), "DIGIT_TWO_D_OBJECT");
     }
 }

--- a/src/test/java/org/openapijsonschematools/codegen/generators/PythonClientGeneratorTest.java
+++ b/src/test/java/org/openapijsonschematools/codegen/generators/PythonClientGeneratorTest.java
@@ -224,15 +224,11 @@ public class PythonClientGeneratorTest {
                 "#/components/schemas/" + modelName
         );
 
-        TreeMap<String, CodegenSchema> schemas = new TreeMap<>();
-        schemas.put("StringEnum", cm);
-
-        codegen.postProcessModels(schemas);
-
         Map<EnumValue, String> enumVars = cm.enumInfo.valueToName;
-        Assert.assertEquals(enumVars.size(), 2);
+        Assert.assertEquals(enumVars.size(), 3);
         Assert.assertEquals(enumVars.get(new EnumValue("#367B9C", "string", null)), "NUMBER_SIGN_367B9C");
         Assert.assertEquals(enumVars.get(new EnumValue("#FFA5A4", "string", null)), "NUMBER_SIGN_FFA5A4");
+        Assert.assertEquals(enumVars.get(new EnumValue("2D_Object", "string", null)), "DIGIT_TWO_D_OBJECT");
     }
 
     @Test(description = "format imports of models using a package containing dots")

--- a/src/test/resources/3_0/70_schema_enum_names.yaml
+++ b/src/test/resources/3_0/70_schema_enum_names.yaml
@@ -10,3 +10,4 @@ components:
       enum:
         - "#367B9C"
         - "#FFA5A4"
+        - "2D_Object"


### PR DESCRIPTION
Fixes enum variable names
- only allows a-ZA-Z characters in for the first character, if it isn't, convert it using the character name
- for later characters only allow 0-9a-z-A-Z, if it isn't, convert it using the character name

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/python*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
