### PR TITLE
Generator layer, refactors filename methods

### DIFF
--- a/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
@@ -919,11 +919,6 @@ public class DefaultGenerator implements Generator {
     public String toModuleFilename(String name, String jsonPath) {
         return org.openapijsonschematools.codegen.common.StringUtils.camelize(name);
     }
-    
-    @Override
-    public String toOperationFilename(String name, String jsonPath) {
-        return name;
-    }
 
     @Override
     public String toSecuritySchemeFilename(String basename, String jsonPath) {
@@ -3399,6 +3394,8 @@ public class DefaultGenerator implements Generator {
     @Override
     public String getFilename(CodegenKeyType type, String lastJsonPathFragment, String jsonPath) {
         switch(type) {
+            case OPERATION:
+                return lastJsonPathFragment;
             case CONTENT_TYPE:
                 return toModuleFilename(lastJsonPathFragment, null);
             case PATH:
@@ -3982,7 +3979,7 @@ public class DefaultGenerator implements Generator {
             }
         } else if (pathPieces.length == 4) {
             // #/paths/SomePath/get
-            pathPieces[3] = toOperationFilename(pathPieces[3], jsonPath);
+            pathPieces[3] = getFilename(CodegenKeyType.OPERATION, pathPieces[3], jsonPath);
             return;
         }
         if (xParameters.contains(pathPieces[4])) {

--- a/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
@@ -921,11 +921,6 @@ public class DefaultGenerator implements Generator {
     }
 
     @Override
-    public String toSecuritySchemeFilename(String basename, String jsonPath) {
-        return toModuleFilename(basename, jsonPath);
-    }
-
-    @Override
     public String toServerFilename(String basename, String jsonPath) {
         return toModuleFilename(basename, jsonPath);
     }
@@ -3401,6 +3396,7 @@ public class DefaultGenerator implements Generator {
             case PATH:
             case PARAMETER:
             case SECURITY:
+            case SECURITY_SCHEME:
             case REQUEST_BODY:
                 return toModuleFilename(lastJsonPathFragment, jsonPath);
             default:
@@ -3928,7 +3924,7 @@ public class DefaultGenerator implements Generator {
                 }
             }
         } else if (pathPieces[2].equals(securitySchemesIdentifier)) {
-            pathPieces[3] = toSecuritySchemeFilename(pathPieces[3], null);
+            pathPieces[3] = getFilename(CodegenKeyType.SECURITY_SCHEME, pathPieces[3], null);
         }
     }
 
@@ -4746,7 +4742,7 @@ public class DefaultGenerator implements Generator {
                 // 2. #/paths/~1pet~1{petId}/get/parameters/0/schema (other schemas: parameters, response headers etc)
                 return getSchemaFilename(ref);
             case "securitySchemes":
-                return toSecuritySchemeFilename(refPieces[3], ref);
+                return getFilename(CodegenKeyType.SECURITY_SCHEME, refPieces[3], ref);
         }
         return null;
     }
@@ -4997,7 +4993,7 @@ public class DefaultGenerator implements Generator {
             case "securitySchemes":
                 usedKey = escapeUnsafeCharacters(key);
                 isValid = isValid(usedKey);
-                snakeCaseName = toSecuritySchemeFilename(usedKey, sourceJsonPath);
+                snakeCaseName = getFilename(CodegenKeyType.SECURITY_SCHEME, usedKey, sourceJsonPath);
                 pascalCaseName = getPascalCase(CodegenKeyType.SECURITY_SCHEME, usedKey, sourceJsonPath);
                 break;
             case "servers":

--- a/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
@@ -919,12 +919,7 @@ public class DefaultGenerator implements Generator {
     public String toModuleFilename(String name, String jsonPath) {
         return org.openapijsonschematools.codegen.common.StringUtils.camelize(name);
     }
-
-    @Override
-    public String toParameterFilename(String basename, String jsonPath) {
-        return toModuleFilename(basename, jsonPath);
-    }
-
+    
     @Override
     public String toOperationFilename(String name, String jsonPath) {
         return name;
@@ -3407,6 +3402,7 @@ public class DefaultGenerator implements Generator {
             case CONTENT_TYPE:
                 return toModuleFilename(lastJsonPathFragment, null);
             case PATH:
+            case PARAMETER:
             case SECURITY:
             case REQUEST_BODY:
                 return toModuleFilename(lastJsonPathFragment, jsonPath);
@@ -3866,7 +3862,7 @@ public class DefaultGenerator implements Generator {
                 }
             }
         } else if (pathPieces[2].equals("parameters")) {
-            pathPieces[3] = toParameterFilename(pathPieces[3], jsonPath);
+            pathPieces[3] = getFilename(CodegenKeyType.PARAMETER, pathPieces[3], jsonPath);
             if (pathPieces.length == 5 && pathPieces[4].equals("schema")) {
                 pathPieces[4] = getSchemaFilename(jsonPath);
             } else if (pathPieces.length >= 6 && pathPieces[4].equals("content")) {
@@ -3970,7 +3966,7 @@ public class DefaultGenerator implements Generator {
                 return;
             }
             // #/paths/somePath/parameters/0
-            pathPieces[4] = toParameterFilename(pathPieces[4], jsonPath);
+            pathPieces[4] = getFilename(CodegenKeyType.PARAMETER, pathPieces[4], jsonPath);
             if (pathPieces.length >= 7 && pathPieces[5].equals("content")) {
                 // #/paths/somePath/parameters/0/content/application-json -> length 7
                 String contentType = ModelUtils.decodeSlashes(pathPieces[6]);
@@ -4068,11 +4064,11 @@ public class DefaultGenerator implements Generator {
         } else if (pathPieces[4].equals("parameters")) {
             if (pathPieces.length == 5) {
                 // #/paths/somePath/get/parameters -> length 5
-                pathPieces[4] = toParameterFilename(pathPieces[4], jsonPath);
+                pathPieces[4] = getFilename(CodegenKeyType.PARAMETER, pathPieces[4], jsonPath);
                 return;
             }
             // #/paths/somePath/get/parameters/0 -> length 6
-            pathPieces[5] = toParameterFilename(pathPieces[5], jsonPath);
+            pathPieces[5] = getFilename(CodegenKeyType.PARAMETER, pathPieces[5], jsonPath);
 
             if (pathPieces.length >= 8 && pathPieces[6].equals("content")) {
                 // #/paths/somePath/get/parameters/1/content/application-json -> length 8
@@ -4742,7 +4738,7 @@ public class DefaultGenerator implements Generator {
             case "headers":
                 return getFilename(CodegenKeyType.HEADER, refPieces[3], ref);
             case "parameters":
-                return toParameterFilename(refPieces[3], ref);
+                return getFilename(CodegenKeyType.PARAMETER, refPieces[3], ref);
             case "schemas":
                 if (ref.equals(sourceJsonPath)) {
                     // property is of type self
@@ -4980,7 +4976,7 @@ public class DefaultGenerator implements Generator {
             case "parameters":
                 usedKey = escapeUnsafeCharacters(key);
                 isValid = isValid(usedKey);
-                snakeCaseName = toParameterFilename(usedKey, sourceJsonPath);
+                snakeCaseName = getFilename(CodegenKeyType.PARAMETER, usedKey, sourceJsonPath);
                 pascalCaseName = getPascalCase(CodegenKeyType.PARAMETER, usedKey, sourceJsonPath);
                 break;
             case "requestBodies":

--- a/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
@@ -918,11 +918,6 @@ public class DefaultGenerator implements Generator {
     }
 
     @Override
-    public String toContentTypeFilename(String name) {
-        return name;
-    }
-
-    @Override
     public String toModuleFilename(String name, String jsonPath) {
         return org.openapijsonschematools.codegen.common.StringUtils.camelize(name);
     }
@@ -3397,6 +3392,7 @@ public class DefaultGenerator implements Generator {
             case RESPONSE:
                 return toModelName(lastJsonPathFragment, null);
             case MISC:
+            case CONTENT_TYPE:
             case OPERATION:
             case REQUEST_BODY:
             case HEADER:
@@ -3866,7 +3862,7 @@ public class DefaultGenerator implements Generator {
             } else if (pathPieces.length >= 6 && pathPieces[4].equals("content")) {
                 // #/components/headers/someHeader/content/application-json -> length 6
                 String contentType = ModelUtils.decodeSlashes(pathPieces[5]);
-                pathPieces[5] = toContentTypeFilename(contentType);
+                pathPieces[5] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, null);
                 if (pathPieces.length == 7) {
                     pathPieces[6] = getSchemaFilename(jsonPath);
                 }
@@ -3878,7 +3874,7 @@ public class DefaultGenerator implements Generator {
             } else if (pathPieces.length >= 6 && pathPieces[4].equals("content")) {
                 // #/components/parameters/someParam/content/application-json -> length 6
                 String contentType = ModelUtils.decodeSlashes(pathPieces[5]);
-                pathPieces[5] = toContentTypeFilename(contentType);
+                pathPieces[5] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, null);
                 if (pathPieces.length == 7) {
                     pathPieces[6] = getSchemaFilename(jsonPath);
                 }
@@ -3888,7 +3884,7 @@ public class DefaultGenerator implements Generator {
             if (pathPieces.length >= 6 && pathPieces[4].equals("content")) {
                 // #/components/requestBodies/someBody/content/application-json -> length 6
                 String contentType = ModelUtils.decodeSlashes(pathPieces[5]);
-                pathPieces[5] = toContentTypeFilename(contentType);
+                pathPieces[5] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, null);
                 if (pathPieces.length == 7) {
                     pathPieces[6] = getSchemaFilename(jsonPath);
                 }
@@ -3922,7 +3918,7 @@ public class DefaultGenerator implements Generator {
                 } else if (pathPieces.length >= 8 && pathPieces[6].equals("content")) {
                     // #/components/responses/someResponse/headers/SomeHeader/content/application-json -> length 8
                     String contentType = ModelUtils.decodeSlashes(pathPieces[7]);
-                    pathPieces[7] = toContentTypeFilename(contentType);
+                    pathPieces[7] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, null);
                     if (pathPieces.length == 9) {
                         // #/components/responses/someResponse/headers/SomeHeader/content/application-json/schema
                         pathPieces[8] = getSchemaFilename(jsonPath);
@@ -3935,7 +3931,7 @@ public class DefaultGenerator implements Generator {
                 }
                 // #/components/responses/someResponse/content/application-json -> length 6
                 String contentType = ModelUtils.decodeSlashes(pathPieces[5]);
-                pathPieces[5] = toContentTypeFilename(contentType);
+                pathPieces[5] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, null);
                 if (pathPieces.length == 7) {
                     pathPieces[6] = getSchemaFilename(jsonPath);
                 }
@@ -3980,7 +3976,7 @@ public class DefaultGenerator implements Generator {
             if (pathPieces.length >= 7 && pathPieces[5].equals("content")) {
                 // #/paths/somePath/parameters/0/content/application-json -> length 7
                 String contentType = ModelUtils.decodeSlashes(pathPieces[6]);
-                pathPieces[6] = toContentTypeFilename(contentType);
+                pathPieces[6] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, null);
                 if (pathPieces.length == 8) {
                     pathPieces[7] = getSchemaFilename(jsonPath);
                     return;
@@ -4047,7 +4043,7 @@ public class DefaultGenerator implements Generator {
                 }
                 // #/paths/somePath/get/responses/200/content/application-json -> length 8
                 String contentType = ModelUtils.decodeSlashes(pathPieces[7]);
-                pathPieces[7] = toContentTypeFilename(contentType);
+                pathPieces[7] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, null);
                 if (pathPieces.length == 9) {
                     pathPieces[8] = getSchemaFilename(jsonPath);
                 }
@@ -4063,7 +4059,7 @@ public class DefaultGenerator implements Generator {
                 if (pathPieces.length >= 10 && pathPieces[8].equals("content")) {
                     // #/paths/somePath/get/responses/200/headers/someHeader/content/application-json -> length 10
                     String contentType = ModelUtils.decodeSlashes(pathPieces[9]);
-                    pathPieces[9] = toContentTypeFilename(contentType);
+                    pathPieces[9] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, null);
                     if (pathPieces.length == 11) {
                         pathPieces[10] = getSchemaFilename(jsonPath);
                     }
@@ -4083,7 +4079,7 @@ public class DefaultGenerator implements Generator {
             if (pathPieces.length >= 8 && pathPieces[6].equals("content")) {
                 // #/paths/somePath/get/parameters/1/content/application-json -> length 8
                 String contentType = ModelUtils.decodeSlashes(pathPieces[7]);
-                pathPieces[7] = toContentTypeFilename(contentType);
+                pathPieces[7] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, null);
                 if (pathPieces.length == 9) {
                     pathPieces[8] = getSchemaFilename(jsonPath);
                 }
@@ -4101,7 +4097,7 @@ public class DefaultGenerator implements Generator {
             if (pathPieces.length >= 7 && pathPieces[5].equals("content")) {
                 // #/paths/somePath/get/requestBody/content/application-json -> length 7
                 String contentType = ModelUtils.decodeSlashes(pathPieces[6]);
-                pathPieces[6] = toContentTypeFilename(contentType);
+                pathPieces[6] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, null);
                 if (pathPieces.length == 8) {
                     // #/paths/somePath/get/requestBody/content/application-json/schema
                     pathPieces[7] = getSchemaFilename(jsonPath);

--- a/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
@@ -3410,7 +3410,10 @@ public class DefaultGenerator implements Generator {
     @Override
     public String getFilename(CodegenKeyType type, String lastJsonPathFragment, String jsonPath) {
         switch(type) {
+            case CONTENT_TYPE:
+                return toModuleFilename(lastJsonPathFragment, null);
             case SECURITY:
+            case REQUEST_BODY:
                 return toModuleFilename(lastJsonPathFragment, jsonPath);
             default:
                 return null;
@@ -3880,7 +3883,7 @@ public class DefaultGenerator implements Generator {
                 }
             }
         } else if (pathPieces[2].equals(requestBodiesIdentifier)) {
-            pathPieces[3] = toRequestBodyFilename(pathPieces[3], jsonPath);
+            pathPieces[3] = getFilename(CodegenKeyType.REQUEST_BODY, pathPieces[3], jsonPath);
             if (pathPieces.length >= 6 && pathPieces[4].equals("content")) {
                 // #/components/requestBodies/someBody/content/application-json -> length 6
                 String contentType = ModelUtils.decodeSlashes(pathPieces[5]);
@@ -4090,7 +4093,7 @@ public class DefaultGenerator implements Generator {
         } else if (pathPieces[4].equals("requestBody")) {
             if (pathPieces.length == 5) {
                 // #/paths/somePath/get/requestBody
-                pathPieces[4] = toRequestBodyFilename("requestBody", jsonPath);
+                pathPieces[4] = getFilename(CodegenKeyType.REQUEST_BODY, "requestBody", jsonPath);
                 return;
             }
             pathPieces[4] = requestBodyIdentifier;
@@ -4715,10 +4718,6 @@ public class DefaultGenerator implements Generator {
         return cmtContent;
     }
 
-    public String toRequestBodyFilename(String componentName, String jsonPath) {
-        return toModuleFilename(componentName, jsonPath);
-    }
-
     protected String toRefModule(String ref, String sourceJsonPath, String expectedComponentType) {
         if (ref == null) {
             return null;
@@ -4742,7 +4741,7 @@ public class DefaultGenerator implements Generator {
         }
         switch (expectedComponentType) {
             case "requestBodies":
-                return toRequestBodyFilename(refPieces[3], ref);
+                return getFilename(CodegenKeyType.REQUEST_BODY, refPieces[3], ref);
             case "responses":
                 return toResponseModuleName(refPieces[3], ref);
             case "headers":
@@ -4992,7 +4991,7 @@ public class DefaultGenerator implements Generator {
             case "requestBodies":
                 usedKey = escapeUnsafeCharacters(key);
                 isValid = isValid(usedKey);
-                snakeCaseName = toRequestBodyFilename(usedKey, sourceJsonPath);
+                snakeCaseName = getFilename(CodegenKeyType.REQUEST_BODY, usedKey, sourceJsonPath);
                 pascalCaseName = getPascalCase(CodegenKeyType.REQUEST_BODY, usedKey, sourceJsonPath);
                 break;
             case "headers":

--- a/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
@@ -3842,7 +3842,7 @@ public class DefaultGenerator implements Generator {
             } else if (pathPieces.length >= 6 && pathPieces[4].equals("content")) {
                 // #/components/headers/someHeader/content/application-json -> length 6
                 String contentType = ModelUtils.decodeSlashes(pathPieces[5]);
-                pathPieces[5] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, null);
+                pathPieces[5] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, jsonPath);
                 if (pathPieces.length == 7) {
                     pathPieces[6] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath) ;
                 }
@@ -3854,7 +3854,7 @@ public class DefaultGenerator implements Generator {
             } else if (pathPieces.length >= 6 && pathPieces[4].equals("content")) {
                 // #/components/parameters/someParam/content/application-json -> length 6
                 String contentType = ModelUtils.decodeSlashes(pathPieces[5]);
-                pathPieces[5] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, null);
+                pathPieces[5] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, jsonPath);
                 if (pathPieces.length == 7) {
                     pathPieces[6] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath) ;
                 }
@@ -3864,7 +3864,7 @@ public class DefaultGenerator implements Generator {
             if (pathPieces.length >= 6 && pathPieces[4].equals("content")) {
                 // #/components/requestBodies/someBody/content/application-json -> length 6
                 String contentType = ModelUtils.decodeSlashes(pathPieces[5]);
-                pathPieces[5] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, null);
+                pathPieces[5] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, jsonPath);
                 if (pathPieces.length == 7) {
                     pathPieces[6] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath) ;
                 }
@@ -3898,7 +3898,7 @@ public class DefaultGenerator implements Generator {
                 } else if (pathPieces.length >= 8 && pathPieces[6].equals("content")) {
                     // #/components/responses/someResponse/headers/SomeHeader/content/application-json -> length 8
                     String contentType = ModelUtils.decodeSlashes(pathPieces[7]);
-                    pathPieces[7] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, null);
+                    pathPieces[7] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, jsonPath);
                     if (pathPieces.length == 9) {
                         // #/components/responses/someResponse/headers/SomeHeader/content/application-json/schema
                         pathPieces[8] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath) ;
@@ -3911,13 +3911,13 @@ public class DefaultGenerator implements Generator {
                 }
                 // #/components/responses/someResponse/content/application-json -> length 6
                 String contentType = ModelUtils.decodeSlashes(pathPieces[5]);
-                pathPieces[5] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, null);
+                pathPieces[5] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, jsonPath);
                 if (pathPieces.length == 7) {
                     pathPieces[6] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath) ;
                 }
             }
         } else if (pathPieces[2].equals(securitySchemesIdentifier)) {
-            pathPieces[3] = getFilename(CodegenKeyType.SECURITY_SCHEME, pathPieces[3], null);
+            pathPieces[3] = getFilename(CodegenKeyType.SECURITY_SCHEME, pathPieces[3], jsonPath);
         }
     }
 
@@ -3956,7 +3956,7 @@ public class DefaultGenerator implements Generator {
             if (pathPieces.length >= 7 && pathPieces[5].equals("content")) {
                 // #/paths/somePath/parameters/0/content/application-json -> length 7
                 String contentType = ModelUtils.decodeSlashes(pathPieces[6]);
-                pathPieces[6] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, null);
+                pathPieces[6] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, jsonPath);
                 if (pathPieces.length == 8) {
                     pathPieces[7] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath) ;
                     return;
@@ -4023,7 +4023,7 @@ public class DefaultGenerator implements Generator {
                 }
                 // #/paths/somePath/get/responses/200/content/application-json -> length 8
                 String contentType = ModelUtils.decodeSlashes(pathPieces[7]);
-                pathPieces[7] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, null);
+                pathPieces[7] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, jsonPath);
                 if (pathPieces.length == 9) {
                     pathPieces[8] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath) ;
                 }
@@ -4039,7 +4039,7 @@ public class DefaultGenerator implements Generator {
                 if (pathPieces.length >= 10 && pathPieces[8].equals("content")) {
                     // #/paths/somePath/get/responses/200/headers/someHeader/content/application-json -> length 10
                     String contentType = ModelUtils.decodeSlashes(pathPieces[9]);
-                    pathPieces[9] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, null);
+                    pathPieces[9] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, jsonPath);
                     if (pathPieces.length == 11) {
                         pathPieces[10] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath) ;
                     }
@@ -4059,7 +4059,7 @@ public class DefaultGenerator implements Generator {
             if (pathPieces.length >= 8 && pathPieces[6].equals("content")) {
                 // #/paths/somePath/get/parameters/1/content/application-json -> length 8
                 String contentType = ModelUtils.decodeSlashes(pathPieces[7]);
-                pathPieces[7] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, null);
+                pathPieces[7] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, jsonPath);
                 if (pathPieces.length == 9) {
                     pathPieces[8] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath) ;
                 }
@@ -4077,7 +4077,7 @@ public class DefaultGenerator implements Generator {
             if (pathPieces.length >= 7 && pathPieces[5].equals("content")) {
                 // #/paths/somePath/get/requestBody/content/application-json -> length 7
                 String contentType = ModelUtils.decodeSlashes(pathPieces[6]);
-                pathPieces[6] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, null);
+                pathPieces[6] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, jsonPath);
                 if (pathPieces.length == 8) {
                     // #/paths/somePath/get/requestBody/content/application-json/schema
                     pathPieces[7] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath) ;

--- a/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
@@ -920,10 +920,6 @@ public class DefaultGenerator implements Generator {
         return org.openapijsonschematools.codegen.common.StringUtils.camelize(name);
     }
 
-    public String toPathFilename(String name, String jsonPath) {
-        return toModuleFilename(name, jsonPath);
-    }
-
     @Override
     public String toParameterFilename(String basename, String jsonPath) {
         return toModuleFilename(basename, jsonPath);
@@ -3385,7 +3381,7 @@ public class DefaultGenerator implements Generator {
                 usedKey = usedKey + suffix;
                 return usedKey;
             case PATH:
-                return camelize(toPathFilename(lastJsonPathFragment, jsonPath));
+                return camelize(getFilename(CodegenKeyType.PATH, lastJsonPathFragment, jsonPath));
             case PARAMETER:
             case RESPONSE:
                 return toModelName(lastJsonPathFragment, null);
@@ -3410,6 +3406,7 @@ public class DefaultGenerator implements Generator {
         switch(type) {
             case CONTENT_TYPE:
                 return toModuleFilename(lastJsonPathFragment, null);
+            case PATH:
             case SECURITY:
             case REQUEST_BODY:
                 return toModuleFilename(lastJsonPathFragment, jsonPath);
@@ -3950,7 +3947,7 @@ public class DefaultGenerator implements Generator {
             return;
         }
         // #/paths/somePath
-        pathPieces[2] = toPathFilename(ModelUtils.decodeSlashes(pathPieces[2]), jsonPath);
+        pathPieces[2] = getFilename(CodegenKeyType.PATH, ModelUtils.decodeSlashes(pathPieces[2]), jsonPath);
         if (pathPieces.length < 4) {
             return;
         }
@@ -4151,7 +4148,7 @@ public class DefaultGenerator implements Generator {
         if (pathPieces[2].equals("tags")) {
             pathPieces[3] = toApiFilename(pathPieces[3]);
         } else if (pathPieces[2].equals("paths")) {
-            pathPieces[3] = toPathFilename(ModelUtils.decodeSlashes(pathPieces[3]), jsonPath);
+            pathPieces[3] = getFilename(CodegenKeyType.PATH, ModelUtils.decodeSlashes(pathPieces[3]), jsonPath);
         }
     }
 
@@ -4963,7 +4960,7 @@ public class DefaultGenerator implements Generator {
             case "paths":
                 usedKey = escapeUnsafeCharacters(key);
                 isValid = isValid(usedKey);
-                snakeCaseName = toPathFilename(usedKey, sourceJsonPath);
+                snakeCaseName = getFilename(CodegenKeyType.PATH, usedKey, sourceJsonPath);
                 pascalCaseName = getPascalCase(CodegenKeyType.PATH, usedKey, sourceJsonPath);
                 break;
             case "misc":

--- a/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
@@ -742,9 +742,7 @@ public class DefaultGenerator implements Generator {
 
     @Deprecated
     public String getPascalCaseResponse(String componentName, String jsonPath) { return getPascalCase(CodegenKeyType.RESPONSE, componentName, jsonPath); }
-
-    public String toHeaderFilename(String componentName, String jsonPath) { return toModuleFilename(componentName, jsonPath); }
-
+    
     @Override
     public Map<String, Object> additionalProperties() {
         return additionalProperties;
@@ -3858,7 +3856,7 @@ public class DefaultGenerator implements Generator {
         }
         if (pathPieces[2].equals("headers")) {
             // #/components/headers
-            pathPieces[3] = toHeaderFilename(pathPieces[3], jsonPath);
+            pathPieces[3] = getFilename(CodegenKeyType.HEADER, pathPieces[3], jsonPath);
             if (pathPieces.length == 5 && pathPieces[4].equals("schema")) {
                 // #/components/headers/someHeader/schema
                 pathPieces[4] = getSchemaFilename(jsonPath);
@@ -3909,12 +3907,12 @@ public class DefaultGenerator implements Generator {
 
             if (pathPieces[4].equals("headers")) {
                 if (pathPieces.length == 5) {
-                    pathPieces[4] = toHeaderFilename(pathPieces[4], jsonPath);
+                    pathPieces[4] = getFilename(CodegenKeyType.HEADER, pathPieces[4], jsonPath);
                     // #/components/responses/someResponse/headers
                     return;
                 }
                 // #/components/responses/someResponse/headers/SomeHeader-> length 6
-                pathPieces[5] = toHeaderFilename(pathPieces[5], jsonPath);
+                pathPieces[5] = getFilename(CodegenKeyType.HEADER, pathPieces[5], jsonPath);
                 if (pathPieces.length == 7 && pathPieces[6].equals("schema")) {
                     // #/components/responses/someResponse/headers/SomeHeader/schema
                     pathPieces[6] = getSchemaFilename(jsonPath);
@@ -4053,11 +4051,11 @@ public class DefaultGenerator implements Generator {
             } else if (pathPieces[6].equals("headers")) {
                 if (pathPieces.length == 7) {
                     // #/paths/somePath/get/responses/200/headers
-                    pathPieces[6] = toHeaderFilename(pathPieces[6], jsonPath);
+                    pathPieces[6] = getFilename(CodegenKeyType.HEADER, pathPieces[6], jsonPath);
                     return;
                 }
                 // #/paths/somePath/get/responses/200/headers/someHeader -> length 8
-                pathPieces[7] = toHeaderFilename(pathPieces[7], jsonPath);
+                pathPieces[7] = getFilename(CodegenKeyType.HEADER, pathPieces[7], jsonPath);
 
                 if (pathPieces.length >= 10 && pathPieces[8].equals("content")) {
                     // #/paths/somePath/get/responses/200/headers/someHeader/content/application-json -> length 10
@@ -4745,7 +4743,7 @@ public class DefaultGenerator implements Generator {
             case "responses":
                 return toResponseModuleName(refPieces[3], ref);
             case "headers":
-                return toHeaderFilename(refPieces[3], ref);
+                return getFilename(CodegenKeyType.HEADER, refPieces[3], ref);
             case "parameters":
                 return toParameterFilename(refPieces[3], ref);
             case "schemas":
@@ -4997,7 +4995,7 @@ public class DefaultGenerator implements Generator {
             case "headers":
                 usedKey = escapeUnsafeCharacters(key);
                 isValid = isValid(usedKey);
-                snakeCaseName = toHeaderFilename(usedKey, sourceJsonPath);
+                snakeCaseName = getFilename(CodegenKeyType.HEADER, usedKey, sourceJsonPath);
                 pascalCaseName = getPascalCase(CodegenKeyType.HEADER, usedKey, sourceJsonPath);
                 break;
             case "responses":

--- a/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
@@ -920,11 +920,6 @@ public class DefaultGenerator implements Generator {
         return org.openapijsonschematools.codegen.common.StringUtils.camelize(name);
     }
 
-    @Override
-    public String toServerFilename(String basename, String jsonPath) {
-        return toModuleFilename(basename, jsonPath);
-    }
-
     @Deprecated
     public String getPascalCaseParameter(String basename, String jsonPath) {
         return getPascalCase(CodegenKeyType.PARAMETER, basename, null);
@@ -3394,6 +3389,7 @@ public class DefaultGenerator implements Generator {
             case CONTENT_TYPE:
                 return toModuleFilename(lastJsonPathFragment, null);
             case PATH:
+            case SERVER:
             case PARAMETER:
             case SECURITY:
             case SECURITY_SCHEME:
@@ -3943,10 +3939,10 @@ public class DefaultGenerator implements Generator {
         if (pathPieces[3].equals("servers")) {
             if (pathPieces.length == 4) {
                 // #/paths/somePath/servers
-                pathPieces[3] = toServerFilename("servers", jsonPath);
+                pathPieces[3] = getFilename(CodegenKeyType.SERVER, "servers", jsonPath);
             } else if (pathPieces.length == 5) {
                 // #/paths/somePath/servers/0
-                pathPieces[4] = toServerFilename(pathPieces[4], jsonPath);
+                pathPieces[4] = getFilename(CodegenKeyType.SERVER, pathPieces[4], jsonPath);
             } else {
                 // #/paths/somePath/servers/0/variables
                 pathPieces[4] = "server" + pathPieces[4];
@@ -3985,10 +3981,10 @@ public class DefaultGenerator implements Generator {
         } else if (pathPieces[4].equals("servers")) {
             if (pathPieces.length == 5) {
                 // #/paths/somePath/get/servers
-                pathPieces[4] = toServerFilename("servers", jsonPath);
+                pathPieces[4] = getFilename(CodegenKeyType.SERVER, "servers", jsonPath);
             } else if (pathPieces.length == 6) {
                 // #/paths/somePath/get/servers/0
-                pathPieces[5] = toServerFilename(pathPieces[5], jsonPath);
+                pathPieces[5] = getFilename(CodegenKeyType.SERVER, pathPieces[5], jsonPath);
             } else {
                 // #/paths/somePath/get/servers/0/variables
                 pathPieces[5] = "server" + pathPieces[5];
@@ -4101,10 +4097,10 @@ public class DefaultGenerator implements Generator {
             // #/servers
         } else if (pathPieces.length == 3) {
             // #/servers/0
-            pathPieces[2] = toServerFilename(pathPieces[2], jsonPath);
+            pathPieces[2] = getFilename(CodegenKeyType.SERVER, pathPieces[2], jsonPath);
         } else {
             // #/servers/0/variables
-            pathPieces[2] = toServerFilename(pathPieces[2], jsonPath).toLowerCase(Locale.ROOT);
+            pathPieces[2] = getFilename(CodegenKeyType.SERVER, pathPieces[2], jsonPath).toLowerCase(Locale.ROOT);
             pathPieces[3] = "Variables";
         }
     }
@@ -4999,7 +4995,7 @@ public class DefaultGenerator implements Generator {
             case "servers":
                 usedKey = escapeUnsafeCharacters(key);
                 isValid = isValid(usedKey);
-                snakeCaseName = toServerFilename(usedKey, sourceJsonPath);
+                snakeCaseName = getFilename(CodegenKeyType.SERVER, usedKey, sourceJsonPath);
                 pascalCaseName = getPascalCase(CodegenKeyType.SERVER, usedKey, sourceJsonPath);
                 camelCaseName = camelize(pascalCaseName, true);
                 break;

--- a/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
@@ -951,11 +951,6 @@ public class DefaultGenerator implements Generator {
         return toModuleFilename(basename, jsonPath);
     }
 
-    @Override
-    public String toSecurityFilename(String basename, String jsonPath) {
-        return toModuleFilename(basename, jsonPath);
-    }
-
     @Deprecated
     @Override
     public String getPascalCaseServer(String basename, String jsonPath) {
@@ -3416,7 +3411,17 @@ public class DefaultGenerator implements Generator {
             case SERVER:
                 return "Server" + lastJsonPathFragment;
             case SECURITY:
-                return toSecurityFilename(lastJsonPathFragment, jsonPath);
+                return getFilename(CodegenKeyType.SECURITY, lastJsonPathFragment, jsonPath);
+            default:
+                return null;
+        }
+    }
+
+    @Override
+    public String getFilename(CodegenKeyType type, String lastJsonPathFragment, String jsonPath) {
+        switch(type) {
+            case SECURITY:
+                return toModuleFilename(lastJsonPathFragment, jsonPath);
             default:
                 return null;
         }
@@ -4015,10 +4020,10 @@ public class DefaultGenerator implements Generator {
         } else if (pathPieces[4].equals("security")) {
             // #/paths/somePath/get/security
             if (pathPieces.length == 5) {
-                pathPieces[4] = toSecurityFilename("security", jsonPath);
+                pathPieces[4] = getFilename(CodegenKeyType.SECURITY, "security", jsonPath);
             } else {
                 // #/paths/somePath/get/security/0
-                pathPieces[5] = toSecurityFilename(pathPieces[5], jsonPath);
+                pathPieces[5] = getFilename(CodegenKeyType.SECURITY, pathPieces[5], jsonPath);
             }
             return;
         } else if (pathPieces[4].equals("responses")) {
@@ -4131,11 +4136,11 @@ public class DefaultGenerator implements Generator {
         String jsonPath = String.join("/", pathPieces);
         if (pathPieces.length < 3) {
             // #/security
-            pathPieces[1] = toSecurityFilename("security", jsonPath);
+            pathPieces[1] = getFilename(CodegenKeyType.SECURITY, "security", jsonPath);
             return;
         }
         // #/security/0
-        pathPieces[2] = toSecurityFilename(pathPieces[2], jsonPath);
+        pathPieces[2] = getFilename(CodegenKeyType.SECURITY, pathPieces[2], jsonPath);
     }
 
     private void updateApisFilepath(String[] pathPieces) {

--- a/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
@@ -952,12 +952,6 @@ public class DefaultGenerator implements Generator {
     }
 
     @Deprecated
-    @Override
-    public String getPascalCaseServer(String basename, String jsonPath) {
-        return getPascalCase(CodegenKeyType.SERVER, basename, jsonPath);
-    }
-
-    @Deprecated
     public String getPascalCaseParameter(String basename, String jsonPath) {
         return getPascalCase(CodegenKeyType.PARAMETER, basename, null);
     }
@@ -4949,12 +4943,6 @@ public class DefaultGenerator implements Generator {
     @Override
     public CodegenKey getKey(String key, String keyType) {
         return getKey(key, keyType, null);
-    }
-
-    @Deprecated
-    @Override
-    public String getSchemaPascalCaseName(String name, @NotNull String sourceJsonPath) {
-        return getPascalCase(CodegenKeyType.SCHEMA, name, sourceJsonPath);
     }
 
     protected String getCamelCaseName(String key) {

--- a/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/DefaultGenerator.java
@@ -3384,6 +3384,9 @@ public class DefaultGenerator implements Generator {
     @Override
     public String getFilename(CodegenKeyType type, String lastJsonPathFragment, String jsonPath) {
         switch(type) {
+            case SCHEMA:
+                String[] schemaPieces = jsonPath.split("/");
+                return schemaPieces[schemaPieces.length-1];
             case OPERATION:
                 return lastJsonPathFragment;
             case CONTENT_TYPE:
@@ -3798,13 +3801,7 @@ public class DefaultGenerator implements Generator {
     public String modelPackagePathFragment() {
         return modelPackage.replace('.', File.separatorChar);
     }
-
-    @Override
-    public String getSchemaFilename(String jsonPath) {
-        String[] pieces = jsonPath.split("/");
-        return pieces[pieces.length-1];
-    }
-
+    
     protected void updateComponentsFilepath(String[] pathPieces) {
         if (pathPieces.length < 3) {
             return;
@@ -3823,7 +3820,7 @@ public class DefaultGenerator implements Generator {
                 pathPieces[2] = fragments[1];
                 if (pathPieces.length == 4) {
                     // #/components/schemas/SomeSchema
-                    pathPieces[3] = getSchemaFilename(jsonPath);
+                    pathPieces[3] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath);
                 }
                 return;
             case "requestBodies":
@@ -3841,25 +3838,25 @@ public class DefaultGenerator implements Generator {
             pathPieces[3] = getFilename(CodegenKeyType.HEADER, pathPieces[3], jsonPath);
             if (pathPieces.length == 5 && pathPieces[4].equals("schema")) {
                 // #/components/headers/someHeader/schema
-                pathPieces[4] = getSchemaFilename(jsonPath);
+                pathPieces[4] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath) ;
             } else if (pathPieces.length >= 6 && pathPieces[4].equals("content")) {
                 // #/components/headers/someHeader/content/application-json -> length 6
                 String contentType = ModelUtils.decodeSlashes(pathPieces[5]);
                 pathPieces[5] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, null);
                 if (pathPieces.length == 7) {
-                    pathPieces[6] = getSchemaFilename(jsonPath);
+                    pathPieces[6] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath) ;
                 }
             }
         } else if (pathPieces[2].equals("parameters")) {
             pathPieces[3] = getFilename(CodegenKeyType.PARAMETER, pathPieces[3], jsonPath);
             if (pathPieces.length == 5 && pathPieces[4].equals("schema")) {
-                pathPieces[4] = getSchemaFilename(jsonPath);
+                pathPieces[4] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath) ;
             } else if (pathPieces.length >= 6 && pathPieces[4].equals("content")) {
                 // #/components/parameters/someParam/content/application-json -> length 6
                 String contentType = ModelUtils.decodeSlashes(pathPieces[5]);
                 pathPieces[5] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, null);
                 if (pathPieces.length == 7) {
-                    pathPieces[6] = getSchemaFilename(jsonPath);
+                    pathPieces[6] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath) ;
                 }
             }
         } else if (pathPieces[2].equals(requestBodiesIdentifier)) {
@@ -3869,7 +3866,7 @@ public class DefaultGenerator implements Generator {
                 String contentType = ModelUtils.decodeSlashes(pathPieces[5]);
                 pathPieces[5] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, null);
                 if (pathPieces.length == 7) {
-                    pathPieces[6] = getSchemaFilename(jsonPath);
+                    pathPieces[6] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath) ;
                 }
             }
         } else if (pathPieces[2].equals("responses")) {
@@ -3883,7 +3880,7 @@ public class DefaultGenerator implements Generator {
             if (pathPieces.length == 5 && pathPieces[4].equals(headersSchemaFragment)) {
                 // synthetic json path
                 // #/components/responses/someResponse/Headers
-                pathPieces[4] = getSchemaFilename(jsonPath);
+                pathPieces[4] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath) ;
                 return;
             }
 
@@ -3897,14 +3894,14 @@ public class DefaultGenerator implements Generator {
                 pathPieces[5] = getFilename(CodegenKeyType.HEADER, pathPieces[5], jsonPath);
                 if (pathPieces.length == 7 && pathPieces[6].equals("schema")) {
                     // #/components/responses/someResponse/headers/SomeHeader/schema
-                    pathPieces[6] = getSchemaFilename(jsonPath);
+                    pathPieces[6] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath) ;
                 } else if (pathPieces.length >= 8 && pathPieces[6].equals("content")) {
                     // #/components/responses/someResponse/headers/SomeHeader/content/application-json -> length 8
                     String contentType = ModelUtils.decodeSlashes(pathPieces[7]);
                     pathPieces[7] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, null);
                     if (pathPieces.length == 9) {
                         // #/components/responses/someResponse/headers/SomeHeader/content/application-json/schema
-                        pathPieces[8] = getSchemaFilename(jsonPath);
+                        pathPieces[8] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath) ;
                     }
                 }
             } else if (pathPieces[4].equals("content")) {
@@ -3916,7 +3913,7 @@ public class DefaultGenerator implements Generator {
                 String contentType = ModelUtils.decodeSlashes(pathPieces[5]);
                 pathPieces[5] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, null);
                 if (pathPieces.length == 7) {
-                    pathPieces[6] = getSchemaFilename(jsonPath);
+                    pathPieces[6] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath) ;
                 }
             }
         } else if (pathPieces[2].equals(securitySchemesIdentifier)) {
@@ -3946,7 +3943,7 @@ public class DefaultGenerator implements Generator {
             } else {
                 // #/paths/somePath/servers/0/variables
                 pathPieces[4] = "server" + pathPieces[4];
-                pathPieces[5] = getSchemaFilename(jsonPath);
+                pathPieces[5] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath) ;
             }
             return;
         } else if (pathPieces[3].equals("parameters")) {
@@ -3961,12 +3958,12 @@ public class DefaultGenerator implements Generator {
                 String contentType = ModelUtils.decodeSlashes(pathPieces[6]);
                 pathPieces[6] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, null);
                 if (pathPieces.length == 8) {
-                    pathPieces[7] = getSchemaFilename(jsonPath);
+                    pathPieces[7] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath) ;
                     return;
                 }
             } else if (pathPieces.length == 6 && pathPieces[5].equals("schema")) {
                 // #/paths/somePath/parameters/0/schema -> length 7
-                pathPieces[5] = getSchemaFilename(jsonPath);
+                pathPieces[5] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath) ;
                 return;
             }
         } else if (pathPieces.length == 4) {
@@ -3977,7 +3974,7 @@ public class DefaultGenerator implements Generator {
         if (xParameters.contains(pathPieces[4])) {
             // #/paths/somePath/get/PathParameters
             // synthetic jsonPath
-            pathPieces[4] = getSchemaFilename(jsonPath);
+            pathPieces[4] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath) ;
         } else if (pathPieces[4].equals("servers")) {
             if (pathPieces.length == 5) {
                 // #/paths/somePath/get/servers
@@ -3988,7 +3985,7 @@ public class DefaultGenerator implements Generator {
             } else {
                 // #/paths/somePath/get/servers/0/variables
                 pathPieces[5] = "server" + pathPieces[5];
-                pathPieces[6] = getSchemaFilename(jsonPath);
+                pathPieces[6] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath) ;
             }
         } else if (pathPieces[4].equals("security")) {
             // #/paths/somePath/get/security
@@ -4015,7 +4012,7 @@ public class DefaultGenerator implements Generator {
             if (pathPieces.length == 7 && pathPieces[6].equals(headersSchemaFragment)) {
                 // synthetic json path
                 // #/paths/user_login/get/responses/200/Headers
-                pathPieces[6] = getSchemaFilename(jsonPath);
+                pathPieces[6] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath) ;
                 return;
             }
 
@@ -4028,7 +4025,7 @@ public class DefaultGenerator implements Generator {
                 String contentType = ModelUtils.decodeSlashes(pathPieces[7]);
                 pathPieces[7] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, null);
                 if (pathPieces.length == 9) {
-                    pathPieces[8] = getSchemaFilename(jsonPath);
+                    pathPieces[8] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath) ;
                 }
             } else if (pathPieces[6].equals("headers")) {
                 if (pathPieces.length == 7) {
@@ -4044,10 +4041,10 @@ public class DefaultGenerator implements Generator {
                     String contentType = ModelUtils.decodeSlashes(pathPieces[9]);
                     pathPieces[9] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, null);
                     if (pathPieces.length == 11) {
-                        pathPieces[10] = getSchemaFilename(jsonPath);
+                        pathPieces[10] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath) ;
                     }
                 } else if (pathPieces.length == 9 && pathPieces[8].equals("schema")) {
-                    pathPieces[8] = getSchemaFilename(jsonPath);
+                    pathPieces[8] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath) ;
                 }
             }
         } else if (pathPieces[4].equals("parameters")) {
@@ -4064,11 +4061,11 @@ public class DefaultGenerator implements Generator {
                 String contentType = ModelUtils.decodeSlashes(pathPieces[7]);
                 pathPieces[7] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, null);
                 if (pathPieces.length == 9) {
-                    pathPieces[8] = getSchemaFilename(jsonPath);
+                    pathPieces[8] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath) ;
                 }
             } else if (pathPieces.length == 7 && pathPieces[6].equals("schema")) {
                 // #/paths/somePath/get/parameters/0/schema -> length 7
-                pathPieces[6] = getSchemaFilename(jsonPath);
+                pathPieces[6] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath) ;
             }
         } else if (pathPieces[4].equals("requestBody")) {
             if (pathPieces.length == 5) {
@@ -4083,7 +4080,7 @@ public class DefaultGenerator implements Generator {
                 pathPieces[6] = getFilename(CodegenKeyType.CONTENT_TYPE, contentType, null);
                 if (pathPieces.length == 8) {
                     // #/paths/somePath/get/requestBody/content/application-json/schema
-                    pathPieces[7] = getSchemaFilename(jsonPath);
+                    pathPieces[7] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath) ;
                 }
             }
         }
@@ -4736,7 +4733,7 @@ public class DefaultGenerator implements Generator {
                 // Two use cases
                 // 1. #/components/schemas/SomeSchema (component schemas)
                 // 2. #/paths/~1pet~1{petId}/get/parameters/0/schema (other schemas: parameters, response headers etc)
-                return getSchemaFilename(ref);
+                return getFilename(CodegenKeyType.SCHEMA, refPieces[refPieces.length-1], ref);
             case "securitySchemes":
                 return getFilename(CodegenKeyType.SECURITY_SCHEME, refPieces[3], ref);
         }

--- a/src/main/java/org/openapijsonschematools/codegen/generators/Generator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/Generator.java
@@ -113,7 +113,10 @@ public interface Generator {
         return getPascalCase(CodegenKeyType.SCHEMA, name, sourceJsonPath);
     }
     Set<String> getImports(String sourceJsonPath, CodegenSchema schema, FeatureSet featureSet);
-    String toContentTypeFilename(String name);
+    @Deprecated
+    default String toContentTypeFilename(String name) {
+        return getFilename(CodegenKeyType.CONTENT_TYPE, name, null);
+    }
 
     String toParamName(String name);
 

--- a/src/main/java/org/openapijsonschematools/codegen/generators/Generator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/Generator.java
@@ -222,7 +222,10 @@ public interface Generator {
         return getFilename(CodegenKeyType.SECURITY_SCHEME, baseName, jsonPath);
     }
 
-    String toServerFilename(String baseName, String jsonPath);
+    @Deprecated
+    default String toServerFilename(String baseName, String jsonPath) {
+        return getFilename(CodegenKeyType.SERVER, baseName, jsonPath);
+    }
 
     @Deprecated
     default String toSecurityFilename(String baseName, String jsonPath) {

--- a/src/main/java/org/openapijsonschematools/codegen/generators/Generator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/Generator.java
@@ -197,7 +197,10 @@ public interface Generator {
         return getFilename(CodegenKeyType.REQUEST_BODY, componentName, jsonPath);
     }
 
-    String toHeaderFilename(String componentName, String jsonPath);
+    @Deprecated
+    default String toHeaderFilename(String componentName, String jsonPath) {
+        return getFilename(CodegenKeyType.HEADER, componentName, jsonPath);
+    }
 
     String toPathFilename(String path, String jsonPath);
 

--- a/src/main/java/org/openapijsonschematools/codegen/generators/Generator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/Generator.java
@@ -217,7 +217,10 @@ public interface Generator {
         return getFilename(CodegenKeyType.OPERATION, name, jsonPath);
     }
 
-    String toSecuritySchemeFilename(String baseName, String jsonPath);
+    @Deprecated
+    default String toSecuritySchemeFilename(String baseName, String jsonPath) {
+        return getFilename(CodegenKeyType.SECURITY_SCHEME, baseName, jsonPath);
+    }
 
     String toServerFilename(String baseName, String jsonPath);
 

--- a/src/main/java/org/openapijsonschematools/codegen/generators/Generator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/Generator.java
@@ -109,7 +109,9 @@ public interface Generator {
     String getSchemaFilename(String jsonPath);
 
     @Deprecated
-    String getSchemaPascalCaseName(String name, @NotNull String sourceJsonPath);
+    default String getSchemaPascalCaseName(String name, @NotNull String sourceJsonPath) {
+        return getPascalCase(CodegenKeyType.SCHEMA, name, sourceJsonPath);
+    }
     Set<String> getImports(String sourceJsonPath, CodegenSchema schema, FeatureSet featureSet);
     String toContentTypeFilename(String name);
 
@@ -207,8 +209,9 @@ public interface Generator {
     }
 
     @Deprecated
-    String getPascalCaseServer(String baseName, String jsonPath);
-
+    default String getPascalCaseServer(String basename, String jsonPath) {
+        return getPascalCase(CodegenKeyType.SERVER, basename, jsonPath);
+    }
     String toModelImport(String refClass);
 
     TreeMap<String, CodegenSchema> updateAllModels(TreeMap<String, CodegenSchema> models);

--- a/src/main/java/org/openapijsonschematools/codegen/generators/Generator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/Generator.java
@@ -201,7 +201,10 @@ public interface Generator {
 
     String toServerFilename(String baseName, String jsonPath);
 
-    String toSecurityFilename(String baseName, String jsonPath);
+    @Deprecated
+    default String toSecurityFilename(String baseName, String jsonPath) {
+        return getFilename(CodegenKeyType.SECURITY, baseName, jsonPath);
+    }
 
     @Deprecated
     String getPascalCaseServer(String baseName, String jsonPath);
@@ -310,4 +313,5 @@ public interface Generator {
     boolean shouldGenerateFile(String jsonPath, boolean isDoc);
 
     String getPascalCase(CodegenKeyType type, String lastJsonPathFragment, String jsonPath);
+    String getFilename(CodegenKeyType type, String lastJsonPathFragment, String jsonPath);
 }

--- a/src/main/java/org/openapijsonschematools/codegen/generators/Generator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/Generator.java
@@ -202,7 +202,10 @@ public interface Generator {
         return getFilename(CodegenKeyType.HEADER, componentName, jsonPath);
     }
 
-    String toPathFilename(String path, String jsonPath);
+    @Deprecated
+    default String toPathFilename(String path, String jsonPath) {
+        return getFilename(CodegenKeyType.PATH, path, jsonPath);
+    }
 
     String toParameterFilename(String baseName, String jsonPath);
 

--- a/src/main/java/org/openapijsonschematools/codegen/generators/Generator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/Generator.java
@@ -192,7 +192,10 @@ public interface Generator {
 
     String toModuleFilename(String name, String jsonPath);
 
-    String toRequestBodyFilename(String componentName, String jsonPath);
+    @Deprecated
+    default String toRequestBodyFilename(String componentName, String jsonPath) {
+        return getFilename(CodegenKeyType.REQUEST_BODY, componentName, jsonPath);
+    }
 
     String toHeaderFilename(String componentName, String jsonPath);
 

--- a/src/main/java/org/openapijsonschematools/codegen/generators/Generator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/Generator.java
@@ -207,7 +207,10 @@ public interface Generator {
         return getFilename(CodegenKeyType.PATH, path, jsonPath);
     }
 
-    String toParameterFilename(String baseName, String jsonPath);
+    @Deprecated
+    default String toParameterFilename(String baseName, String jsonPath) {
+        return getFilename(CodegenKeyType.PARAMETER, baseName, jsonPath);
+    }
 
     String toOperationFilename(String name, String jsonPath);
 

--- a/src/main/java/org/openapijsonschematools/codegen/generators/Generator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/Generator.java
@@ -106,7 +106,11 @@ public interface Generator {
 
     String toModelName(String name, String jsonPath);
 
-    String getSchemaFilename(String jsonPath);
+    @Deprecated
+    default String getSchemaFilename(String jsonPath) {
+        String[] pathPieces = jsonPath.split("/");
+        return getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath);
+    }
 
     @Deprecated
     default String getSchemaPascalCaseName(String name, @NotNull String sourceJsonPath) {

--- a/src/main/java/org/openapijsonschematools/codegen/generators/Generator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/Generator.java
@@ -212,7 +212,10 @@ public interface Generator {
         return getFilename(CodegenKeyType.PARAMETER, baseName, jsonPath);
     }
 
-    String toOperationFilename(String name, String jsonPath);
+    @Deprecated
+    default String toOperationFilename(String name, String jsonPath) {
+        return getFilename(CodegenKeyType.OPERATION, name, jsonPath);
+    }
 
     String toSecuritySchemeFilename(String baseName, String jsonPath);
 

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -1341,19 +1341,6 @@ public class JavaClientGenerator extends DefaultGenerator implements Generator {
         return true;
     }
 
-    public String toPathFilename(String name, String jsonPath) {
-        String[] pathPieces = jsonPath.split("/");
-        boolean pathClassCase = (pathPieces.length == 3 || (pathPieces.length == 4 && pathPieces[1].equals("apis")));
-        if (pathClassCase) {
-            // #/paths/somePath -> Somepath
-            // #/apis/paths/somePath -> Somepath
-            String moduleFilename = toModuleFilename(name, jsonPath);
-            return camelize(moduleFilename, false);
-        }
-        // #/paths/somePath/blah -> somepath
-        return toModuleFilename(name, jsonPath);
-    }
-
     @Override
     public String toParameterFilename(String name, String jsonPath) {
         // adds prefix parameter_ onto the result so modules do not start with _
@@ -2546,7 +2533,7 @@ public class JavaClientGenerator extends DefaultGenerator implements Generator {
         // #/paths/somePath/get -> SomepathGet
         String[] pathPieces = jsonPath.split("/");
         String pathJsonPath = "#/paths/"+pathPieces[2];
-        String pathClassName = toPathFilename(ModelUtils.decodeSlashes(pathPieces[2]), pathJsonPath);
+        String pathClassName = getFilename(CodegenKeyType.PATH, ModelUtils.decodeSlashes(pathPieces[2]), pathJsonPath);
         return pathClassName + StringUtils.capitalize(pathPieces[3]);
     }
 
@@ -2554,7 +2541,7 @@ public class JavaClientGenerator extends DefaultGenerator implements Generator {
     public String toOperationFilename(String name, String jsonPath) {
         String[] pathPieces = jsonPath.split("/");
         String pathJsonPath = "#/paths/"+pathPieces[2];
-        String pathClassName = toPathFilename(ModelUtils.decodeSlashes(pathPieces[2]), pathJsonPath);
+        String pathClassName = getFilename(CodegenKeyType.PATH, ModelUtils.decodeSlashes(pathPieces[2]), pathJsonPath);
         String operationFileName = pathClassName + StringUtils.capitalize(name);
         return operationFileName;
     }
@@ -2565,7 +2552,7 @@ public class JavaClientGenerator extends DefaultGenerator implements Generator {
             case SCHEMA:
                 return getSchemaPascalCaseName(lastJsonPathFragment, jsonPath, true);
             case PATH:
-                return camelize(toPathFilename(lastJsonPathFragment, jsonPath));
+                return camelize(getFilename(CodegenKeyType.PATH, lastJsonPathFragment, jsonPath));
             case REQUEST_BODY:
                 if (jsonPath.startsWith("#/paths")) {
                     String prefix = getPathClassNamePrefix(jsonPath);
@@ -3156,6 +3143,16 @@ public class JavaClientGenerator extends DefaultGenerator implements Generator {
     public String getFilename(CodegenKeyType type, String lastJsonPathFragment, String jsonPath) {
         String[] pathPieces = jsonPath.split("/");
         switch(type) {
+            case PATH:
+                boolean pathClassCase = (pathPieces.length == 3 || (pathPieces.length == 4 && pathPieces[1].equals("apis")));
+                if (pathClassCase) {
+                    // #/paths/somePath -> Somepath
+                    // #/apis/paths/somePath -> Somepath
+                    String moduleFilename = toModuleFilename(lastJsonPathFragment, jsonPath);
+                    return camelize(moduleFilename, false);
+                }
+                // #/paths/somePath/blah -> somepath
+                return toModuleFilename(lastJsonPathFragment, jsonPath);
             case HEADER:
                 if (jsonPath.startsWith("#/components/headers/")) {
                     if (pathPieces.length == 4) {

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -141,17 +141,12 @@ public class JavaClientGenerator extends DefaultGenerator implements Generator {
             pathPieces[1] = "RootServerInfo";
         } else if (pathPieces.length == 3) {
             // #/servers/0
-            pathPieces[2] = toServerFilename(pathPieces[2], jsonPath);
+            pathPieces[2] = getFilename(CodegenKeyType.SERVER, pathPieces[2], jsonPath);
         } else {
             // #/servers/0/variables
-            pathPieces[2] = toServerFilename(pathPieces[2], jsonPath).toLowerCase(Locale.ROOT);
+            pathPieces[2] = getFilename(CodegenKeyType.SERVER, pathPieces[2], jsonPath).toLowerCase(Locale.ROOT);
             pathPieces[3] = getSchemaFilename(jsonPath);
         }
-    }
-
-    @Override
-    public String toServerFilename(String basename, String jsonPath) {
-        return getPascalCase(CodegenKeyType.SERVER, basename, jsonPath);
     }
 
     @Override
@@ -2574,6 +2569,8 @@ public class JavaClientGenerator extends DefaultGenerator implements Generator {
     public String getFilename(CodegenKeyType type, String lastJsonPathFragment, String jsonPath) {
         String[] pathPieces = jsonPath.split("/");
         switch(type) {
+            case SERVER:
+                return getPascalCase(CodegenKeyType.SERVER, lastJsonPathFragment, jsonPath);
             case SECURITY_SCHEME:
                 return toModelName(lastJsonPathFragment, jsonPath);
             case OPERATION:

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -145,7 +145,7 @@ public class JavaClientGenerator extends DefaultGenerator implements Generator {
         } else {
             // #/servers/0/variables
             pathPieces[2] = getFilename(CodegenKeyType.SERVER, pathPieces[2], jsonPath).toLowerCase(Locale.ROOT);
-            pathPieces[3] = getSchemaFilename(jsonPath);
+            pathPieces[3] = getFilename(CodegenKeyType.SCHEMA, pathPieces[pathPieces.length-1], jsonPath);
         }
     }
 
@@ -1293,16 +1293,6 @@ public class JavaClientGenerator extends DefaultGenerator implements Generator {
         return usedKey;
     }
 
-    @Override
-    public String getSchemaFilename(String jsonPath) {
-        String modelName = schemaJsonPathToModelName.get(jsonPath);
-        if (modelName != null) {
-            return modelName;
-        }
-        String[] pathPieces = jsonPath.split("/");
-        return getSchemaPascalCaseName(pathPieces[pathPieces.length-1], jsonPath, false);
-    }
-
     protected CodegenKey getContainerJsonPathPiece(String expectedComponentType, String currentJsonPath, String sourceJsonPath) {
         return getJsonPathPiece(expectedComponentType, currentJsonPath, sourceJsonPath);
     }
@@ -1337,7 +1327,7 @@ public class JavaClientGenerator extends DefaultGenerator implements Generator {
         if (ref.equals(sourceJsonPath)) {
             // self reference, no import needed
             if (ref.startsWith("#/components/schemas/") && refPieces.length == 4) {
-                return getSchemaFilename(ref)+schemaSuffix;
+                return getFilename(CodegenKeyType.SCHEMA, refPieces[refPieces.length-1], ref)+schemaSuffix;
             }
             Set<String> httpMethods = new HashSet<>(Arrays.asList("post", "put", "patch", "get", "delete", "trace", "options"));
             boolean requestBodyCase = (
@@ -1364,7 +1354,7 @@ public class JavaClientGenerator extends DefaultGenerator implements Generator {
                 return null;
             }
         }
-        return getSchemaFilename(ref)+schemaSuffix;
+        return getFilename(CodegenKeyType.SCHEMA, refPieces[refPieces.length-1], ref)+schemaSuffix;
     }
 
     private String toRequestBodyRefClass(String ref) {
@@ -2569,6 +2559,12 @@ public class JavaClientGenerator extends DefaultGenerator implements Generator {
     public String getFilename(CodegenKeyType type, String lastJsonPathFragment, String jsonPath) {
         String[] pathPieces = jsonPath.split("/");
         switch(type) {
+            case SCHEMA:
+                String modelName = schemaJsonPathToModelName.get(jsonPath);
+                if (modelName != null) {
+                    return modelName;
+                }
+                return getSchemaPascalCaseName(pathPieces[pathPieces.length-1], jsonPath, false);
             case SERVER:
                 return getPascalCase(CodegenKeyType.SERVER, lastJsonPathFragment, jsonPath);
             case SECURITY_SCHEME:

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -1097,37 +1097,6 @@ public class JavaClientGenerator extends DefaultGenerator implements Generator {
         return toModelName(basename, jsonPath);
     }
 
-    public String toHeaderFilename(String componentName, String jsonPath) {
-        String[] pathPieces = jsonPath.split("/");
-        if (jsonPath.startsWith("#/components/headers/")) {
-            if (pathPieces.length == 4) {
-                // #/components/headers/SomeHeader
-                return toModelName(componentName, null);
-            }
-            // deeper paths
-            return toModuleFilename(componentName, jsonPath);
-        } else if (jsonPath.startsWith("#/components/responses/")) {
-            if (pathPieces.length == 5) {
-                // #/components/responses/SomeResponse/headers
-                return "Headers";
-            } else if (pathPieces.length == 6) {
-                // #/components/responses/SomeResponse/headers/SomeHeader
-                return toModelName(componentName, null);
-            }
-            // deeper paths
-            return toModuleFilename(componentName, jsonPath);
-        }
-        if (pathPieces.length == 7) {
-            // #/paths/somePath/verb/responses/200/headers
-            return "Headers";
-        } else if (pathPieces.length == 8) {
-            // #/paths/somePath/verb/responses/200/headers/SomeHeader
-            return toModelName(componentName, null);
-        }
-        // deeper paths
-        return toModuleFilename(componentName, jsonPath);
-    }
-
     @Override
     public String toResponseModuleName(String componentName, String jsonPath) {
         String[] pathPieces = jsonPath.split("/");
@@ -3187,6 +3156,34 @@ public class JavaClientGenerator extends DefaultGenerator implements Generator {
     public String getFilename(CodegenKeyType type, String lastJsonPathFragment, String jsonPath) {
         String[] pathPieces = jsonPath.split("/");
         switch(type) {
+            case HEADER:
+                if (jsonPath.startsWith("#/components/headers/")) {
+                    if (pathPieces.length == 4) {
+                        // #/components/headers/SomeHeader
+                        return toModelName(lastJsonPathFragment, null);
+                    }
+                    // deeper paths
+                    return toModuleFilename(lastJsonPathFragment, jsonPath);
+                } else if (jsonPath.startsWith("#/components/responses/")) {
+                    if (pathPieces.length == 5) {
+                        // #/components/responses/SomeResponse/headers
+                        return "Headers";
+                    } else if (pathPieces.length == 6) {
+                        // #/components/responses/SomeResponse/headers/SomeHeader
+                        return toModelName(lastJsonPathFragment, null);
+                    }
+                    // deeper paths
+                    return toModuleFilename(lastJsonPathFragment, jsonPath);
+                }
+                if (pathPieces.length == 7) {
+                    // #/paths/somePath/verb/responses/200/headers
+                    return "Headers";
+                } else if (pathPieces.length == 8) {
+                    // #/paths/somePath/verb/responses/200/headers/SomeHeader
+                    return toModelName(lastJsonPathFragment, null);
+                }
+                // deeper paths
+                return toModuleFilename(lastJsonPathFragment, jsonPath);
             case REQUEST_BODY:
                 if (pathPieces[2].equals("requestbodies") || pathPieces[2].equals("requestBodies")) {
                     if (pathPieces.length == 4) {

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -2696,7 +2696,7 @@ public class JavaClientGenerator extends DefaultGenerator implements Generator {
                 // #/paths/somePath/get/servers/0
                 return prefix + "Server" + pathPieces[5];
             case SECURITY:
-                return toSecurityFilename(lastJsonPathFragment, jsonPath);
+                return getFilename(CodegenKeyType.SECURITY, lastJsonPathFragment, jsonPath);
             default:
                 return null;
         }
@@ -3229,24 +3229,28 @@ public class JavaClientGenerator extends DefaultGenerator implements Generator {
     }
 
     @Override
-    public String toSecurityFilename(String basename, String jsonPath) {
+    public String getFilename(CodegenKeyType type, String lastJsonPathFragment, String jsonPath) {
         String[] pathPieces = jsonPath.split("/");
-        if (pathPieces.length == 2) {
-            // #/security
-            return "SecurityInfo";
-        } else if (pathPieces.length == 3) {
-            // #/security/0
-            return "SecurityRequirementObject"+pathPieces[pathPieces.length-1];
-        } else if (pathPieces.length == 5) {
-            // #/paths/somePath/verb/security
-            String prefix = getPathClassNamePrefix(jsonPath);
-            return prefix + "SecurityInfo";
-        } else if (pathPieces.length == 6) {
-            // #/paths/somePath/verb/security/0
-            String prefix = getPathClassNamePrefix(jsonPath);
-            return prefix + "SecurityRequirementObject"+pathPieces[pathPieces.length-1];
+        switch(type) {
+            case SECURITY:
+                if (pathPieces.length == 2) {
+                    // #/security
+                    return "SecurityInfo";
+                } else if (pathPieces.length == 3) {
+                    // #/security/0
+                    return "SecurityRequirementObject"+pathPieces[pathPieces.length-1];
+                } else if (pathPieces.length == 5) {
+                    // #/paths/somePath/verb/security
+                    String prefix = getPathClassNamePrefix(jsonPath);
+                    return prefix + "SecurityInfo";
+                }
+                // pathPieces.length == 6
+                // #/paths/somePath/verb/security/0
+                String prefix = getPathClassNamePrefix(jsonPath);
+                return prefix + "SecurityRequirementObject"+pathPieces[pathPieces.length-1];
+            default:
+                return null;
         }
-        return null;
     }
 
     @Override

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -2509,15 +2509,6 @@ public class JavaClientGenerator extends DefaultGenerator implements Generator {
     }
 
     @Override
-    public String toOperationFilename(String name, String jsonPath) {
-        String[] pathPieces = jsonPath.split("/");
-        String pathJsonPath = "#/paths/"+pathPieces[2];
-        String pathClassName = getFilename(CodegenKeyType.PATH, ModelUtils.decodeSlashes(pathPieces[2]), pathJsonPath);
-        String operationFileName = pathClassName + StringUtils.capitalize(name);
-        return operationFileName;
-    }
-
-    @Override
     public String getPascalCase(CodegenKeyType type, String lastJsonPathFragment, String jsonPath) {
         switch (type) {
             case SCHEMA:
@@ -2536,7 +2527,7 @@ public class JavaClientGenerator extends DefaultGenerator implements Generator {
             case SECURITY_SCHEME:
                 return toModelName(lastJsonPathFragment, jsonPath);
             case OPERATION:
-                return toOperationFilename(lastJsonPathFragment, jsonPath);
+                return getFilename(CodegenKeyType.OPERATION, lastJsonPathFragment, jsonPath);
             case PARAMETER:
                 return getFilename(CodegenKeyType.PARAMETER, lastJsonPathFragment, jsonPath);
             case RESPONSE:
@@ -2588,6 +2579,11 @@ public class JavaClientGenerator extends DefaultGenerator implements Generator {
     public String getFilename(CodegenKeyType type, String lastJsonPathFragment, String jsonPath) {
         String[] pathPieces = jsonPath.split("/");
         switch(type) {
+            case OPERATION:
+                String pathJsonPath = "#/paths/"+pathPieces[2];
+                String pthClassName = getFilename(CodegenKeyType.PATH, ModelUtils.decodeSlashes(pathPieces[2]), pathJsonPath);
+                String operationFileName = pthClassName + StringUtils.capitalize(lastJsonPathFragment);
+                return operationFileName;
             case PARAMETER:
                 if (jsonPath.startsWith("#/components/parameters/")) {
                     if (pathPieces.length == 4) {

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -1088,11 +1088,6 @@ public class JavaClientGenerator extends DefaultGenerator implements Generator {
     }
 
     @Override
-    public String toContentTypeFilename(String name) {
-        return toModuleFilename(name, null);
-    }
-
-    @Override
     public String toModelFilename(String name, String jsonPath) {
         return toModelName(name, jsonPath);
     }
@@ -2628,6 +2623,7 @@ public class JavaClientGenerator extends DefaultGenerator implements Generator {
                 return toModelName(lastJsonPathFragment, jsonPath);
             case MISC:
             case HEADER:
+            case CONTENT_TYPE:
             case SECURITY_SCHEME:
                 return toModelName(lastJsonPathFragment, jsonPath);
             case OPERATION:
@@ -3209,6 +3205,8 @@ public class JavaClientGenerator extends DefaultGenerator implements Generator {
     public String getFilename(CodegenKeyType type, String lastJsonPathFragment, String jsonPath) {
         String[] pathPieces = jsonPath.split("/");
         switch(type) {
+            case CONTENT_TYPE:
+                return toModuleFilename(lastJsonPathFragment, null);
             case SECURITY:
                 if (pathPieces.length == 2) {
                     // #/security

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -149,12 +149,6 @@ public class JavaClientGenerator extends DefaultGenerator implements Generator {
         }
     }
 
-    @Deprecated
-    @Override
-    public String getPascalCaseServer(String basename, String jsonPath) {
-        return getPascalCase(CodegenKeyType.SERVER, basename, jsonPath);
-    }
-
     @Override
     public String toServerFilename(String basename, String jsonPath) {
         return getPascalCase(CodegenKeyType.SERVER, basename, jsonPath);
@@ -1157,11 +1151,6 @@ public class JavaClientGenerator extends DefaultGenerator implements Generator {
         return toModuleFilename(componentName, jsonPath);
     }
 
-    @Deprecated
-    public String getPascalCaseResponse(String componentName, String jsonPath) {
-        return getPascalCase(CodegenKeyType.RESPONSE, componentName, jsonPath);
-    }
-
     @Override
     public String toResponseModuleName(String componentName, String jsonPath) {
         String[] pathPieces = jsonPath.split("/");
@@ -1197,12 +1186,6 @@ public class JavaClientGenerator extends DefaultGenerator implements Generator {
             return false;
         }
         return name.matches("^[a-zA-Z]\\w*$");
-    }
-
-    @Deprecated
-    @Override
-    public String getSchemaPascalCaseName(String name, @NotNull String sourceJsonPath) {
-        return getPascalCase(CodegenKeyType.SCHEMA, name, sourceJsonPath);
     }
 
     protected String getCamelCaseName(String key) {
@@ -1312,7 +1295,7 @@ public class JavaClientGenerator extends DefaultGenerator implements Generator {
             // #/paths/path/verb/responses/200/HeadersSchema
             String responseJsonPath = String.join("/", Arrays.copyOfRange(pathPieces, 0, pathPieces.length-1));
             String responseFragment = pathPieces[pathPieces.length-2];
-            String pascalCaseResponse = getPascalCaseResponse(responseFragment, responseJsonPath);
+            String pascalCaseResponse = getPascalCase(CodegenKeyType.RESPONSE, responseFragment, responseJsonPath);
             usedKey =  pascalCaseResponse + camelize(usedKey);
         } else if (operationParametersSchema) {
             String prefix = getPathClassNamePrefix(sourceJsonPath);
@@ -1410,12 +1393,6 @@ public class JavaClientGenerator extends DefaultGenerator implements Generator {
             }
         }
         return true;
-    }
-
-    @Deprecated
-    @Override
-    public String getPascalCaseParameter(String basename, String jsonPath) {
-        return getPascalCase(CodegenKeyType.PARAMETER, basename, jsonPath);
     }
 
     public String toPathFilename(String name, String jsonPath) {

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -1097,24 +1097,6 @@ public class JavaClientGenerator extends DefaultGenerator implements Generator {
         return toModelName(basename, jsonPath);
     }
 
-    @Override
-    public String toRequestBodyFilename(String componentName, String jsonPath) {
-        String[] pathPieces = jsonPath.split("/");
-        if (pathPieces[2].equals("requestbodies") || pathPieces[2].equals("requestBodies")) {
-            if (pathPieces.length == 4) {
-                // #/components/requestBodies/Pet
-                return toModelName( componentName, null);
-            }
-            return toModuleFilename(componentName, null);
-        }
-        if (pathPieces.length == 5) {
-            // #/paths/somePath/verb/requestBody
-            String pathClassName = getPathClassNamePrefix(jsonPath);
-            return pathClassName + "RequestBody";
-        }
-        return toModuleFilename(componentName, null);
-    }
-
     public String toHeaderFilename(String componentName, String jsonPath) {
         String[] pathPieces = jsonPath.split("/");
         if (jsonPath.startsWith("#/components/headers/")) {
@@ -3205,6 +3187,20 @@ public class JavaClientGenerator extends DefaultGenerator implements Generator {
     public String getFilename(CodegenKeyType type, String lastJsonPathFragment, String jsonPath) {
         String[] pathPieces = jsonPath.split("/");
         switch(type) {
+            case REQUEST_BODY:
+                if (pathPieces[2].equals("requestbodies") || pathPieces[2].equals("requestBodies")) {
+                    if (pathPieces.length == 4) {
+                        // #/components/requestBodies/Pet
+                        return toModelName(lastJsonPathFragment, null);
+                    }
+                    return toModuleFilename(lastJsonPathFragment, null);
+                }
+                if (pathPieces.length == 5) {
+                    // #/paths/somePath/verb/requestBody
+                    String pathClassName = getPathClassNamePrefix(jsonPath);
+                    return pathClassName + "RequestBody";
+                }
+                return toModuleFilename(lastJsonPathFragment, null);
             case CONTENT_TYPE:
                 return toModuleFilename(lastJsonPathFragment, null);
             case SECURITY:

--- a/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/JavaClientGenerator.java
@@ -1093,11 +1093,6 @@ public class JavaClientGenerator extends DefaultGenerator implements Generator {
     }
 
     @Override
-    public String toSecuritySchemeFilename(String basename, String jsonPath) {
-        return toModelName(basename, jsonPath);
-    }
-
-    @Override
     public String toResponseModuleName(String componentName, String jsonPath) {
         String[] pathPieces = jsonPath.split("/");
         if (jsonPath.startsWith("#/components/responses/")) {
@@ -2579,6 +2574,8 @@ public class JavaClientGenerator extends DefaultGenerator implements Generator {
     public String getFilename(CodegenKeyType type, String lastJsonPathFragment, String jsonPath) {
         String[] pathPieces = jsonPath.split("/");
         switch(type) {
+            case SECURITY_SCHEME:
+                return toModelName(lastJsonPathFragment, jsonPath);
             case OPERATION:
                 String pathJsonPath = "#/paths/"+pathPieces[2];
                 String pthClassName = getFilename(CodegenKeyType.PATH, ModelUtils.decodeSlashes(pathPieces[2]), pathJsonPath);

--- a/src/main/java/org/openapijsonschematools/codegen/generators/PythonClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/PythonClientGenerator.java
@@ -1837,11 +1837,6 @@ public class PythonClientGenerator extends DefaultGenerator implements Generator
     }
 
     @Override
-    public String toSecuritySchemeFilename(String basename, String jsonPath) {
-        return "security_scheme_" + toModuleFilename(basename, null);
-    }
-
-    @Override
     public String toServerFilename(String basename, String jsonPath) {
         if (jsonPath.endsWith("/servers")) {
             return "servers";
@@ -1852,6 +1847,8 @@ public class PythonClientGenerator extends DefaultGenerator implements Generator
     @Override
     public String getFilename(CodegenKeyType type, String lastJsonPathFragment, String jsonPath) {
         switch(type) {
+            case SECURITY_SCHEME:
+                return "security_scheme_" + toModuleFilename(lastJsonPathFragment, null);
             case OPERATION:
                 return lastJsonPathFragment;
             case PARAMETER:

--- a/src/main/java/org/openapijsonschematools/codegen/generators/PythonClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/PythonClientGenerator.java
@@ -827,11 +827,6 @@ public class PythonClientGenerator extends DefaultGenerator implements Generator
         return underscore(dropDots(toModelName(name, jsonPath)));
     }
 
-    @Deprecated
-    protected String toSecurityPascalCase(String basename, String jsonPath) {
-        return getPascalCase(CodegenKeyType.SECURITY, basename, jsonPath);
-    }
-
     @Override
     public String toContentTypeFilename(String name) {
         return toModuleFilename(name, null);
@@ -1908,17 +1903,6 @@ public class PythonClientGenerator extends DefaultGenerator implements Generator
         }
     }
 
-    @Deprecated
-    @Override
-    public String getPascalCaseParameter(String name, String jsonPath) {
-        return getPascalCase(CodegenKeyType.PARAMETER, name, jsonPath);
-    }
-
-    @Deprecated
-    public String getPascalCaseResponse(String name, String jsonPath) {
-        return getPascalCase(CodegenKeyType.RESPONSE, name, jsonPath);
-    }
-
     @Override
     public String toParamName(String basename) {
         return toParameterFilename(basename, null);
@@ -2124,12 +2108,6 @@ public class PythonClientGenerator extends DefaultGenerator implements Generator
         LOGGER.info("# This generator was written by Justin Black (https://github.com/spacether)    #");
         LOGGER.info("# Please support his work directly via https://github.com/sponsors/spacether \uD83D\uDE4F#");
         LOGGER.info("################################################################################");
-    }
-
-    @Deprecated
-    @Override
-    public String getSchemaPascalCaseName(String name, @NotNull String sourceJsonPath) {
-        return getPascalCase(CodegenKeyType.SCHEMA, name, sourceJsonPath);
     }
 
     @Override

--- a/src/main/java/org/openapijsonschematools/codegen/generators/PythonClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/PythonClientGenerator.java
@@ -1837,24 +1837,6 @@ public class PythonClientGenerator extends DefaultGenerator implements Generator
     }
 
     @Override
-    public String toParameterFilename(String name, String jsonPath) {
-        String[] pathPieces = jsonPath.split("/");
-        if (operationVerbs.contains(pathPieces[3]) && pathPieces.length == 5) {
-            // #/paths/somePath/verb/parameters
-            return "parameters";
-        }
-        // adds prefix parameter_ onto the result so modules do not start with _
-        try {
-            Integer.parseInt(name);
-            // for parameters in path, or an endpoint
-            return "parameter_" + name;
-        } catch (NumberFormatException nfe) {
-            // for header parameters in responses
-            return "parameter_" + toModuleFilename(name, null);
-        }
-    }
-
-    @Override
     public String toSecuritySchemeFilename(String basename, String jsonPath) {
         return "security_scheme_" + toModuleFilename(basename, null);
     }
@@ -1870,6 +1852,21 @@ public class PythonClientGenerator extends DefaultGenerator implements Generator
     @Override
     public String getFilename(CodegenKeyType type, String lastJsonPathFragment, String jsonPath) {
         switch(type) {
+            case PARAMETER:
+                String[] paramPathPieces = jsonPath.split("/");
+                if (operationVerbs.contains(paramPathPieces[3]) && paramPathPieces.length == 5) {
+                    // #/paths/somePath/verb/parameters
+                    return "parameters";
+                }
+                // adds prefix parameter_ onto the result so modules do not start with _
+                try {
+                    Integer.parseInt(lastJsonPathFragment);
+                    // for parameters in path, or an endpoint
+                    return "parameter_" + lastJsonPathFragment;
+                } catch (NumberFormatException nfe) {
+                    // for header parameters in responses
+                    return "parameter_" + toModuleFilename(lastJsonPathFragment, null);
+                }
             case PATH:
                 return toModuleFilename(lastJsonPathFragment, jsonPath);
             case HEADER:
@@ -1899,7 +1896,7 @@ public class PythonClientGenerator extends DefaultGenerator implements Generator
 
     @Override
     public String toParamName(String basename) {
-        return toParameterFilename(basename, null);
+        return getFilename(CodegenKeyType.PARAMETER, basename, null);
     }
 
     private String toSchemaRefClass(String ref, String sourceJsonPath) {

--- a/src/main/java/org/openapijsonschematools/codegen/generators/PythonClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/PythonClientGenerator.java
@@ -1779,16 +1779,6 @@ public class PythonClientGenerator extends DefaultGenerator implements Generator
         return "response_" + componentName.toLowerCase(Locale.ROOT);
     }
 
-    public String toHeaderFilename(String componentName, String jsonPath) {
-        String[] pathPieces = jsonPath.split("/");
-        if ((pathPieces.length == 5 || pathPieces.length == 7) && componentName.equals("headers")) {
-            // #/components/responses/SomeResponse/headers
-            // #/paths/somePath/verb/responses/200/headers
-            return "headers";
-        }
-        return toModuleFilename("header_" + componentName, null);
-    }
-
     public void setUseNose(String val) {
         this.useNose = Boolean.parseBoolean(val);
     }
@@ -1880,6 +1870,14 @@ public class PythonClientGenerator extends DefaultGenerator implements Generator
     @Override
     public String getFilename(CodegenKeyType type, String lastJsonPathFragment, String jsonPath) {
         switch(type) {
+            case HEADER:
+                String[] pathPieces = jsonPath.split("/");
+                if ((pathPieces.length == 5 || pathPieces.length == 7) && lastJsonPathFragment.equals("headers")) {
+                    // #/components/responses/SomeResponse/headers
+                    // #/paths/somePath/verb/responses/200/headers
+                    return "headers";
+                }
+                return toModuleFilename("header_" + lastJsonPathFragment, null);
             case REQUEST_BODY:
                 if (jsonPath.startsWith("#/components")) {
                     return toModuleFilename("request_body_" + lastJsonPathFragment, null);

--- a/src/main/java/org/openapijsonschematools/codegen/generators/PythonClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/PythonClientGenerator.java
@@ -1779,14 +1779,6 @@ public class PythonClientGenerator extends DefaultGenerator implements Generator
         return "response_" + componentName.toLowerCase(Locale.ROOT);
     }
 
-    @Override
-    public String toRequestBodyFilename(String componentName, String jsonPath) {
-        if (jsonPath.startsWith("#/components")) {
-            return toModuleFilename("request_body_" + componentName, null);
-        }
-        return toModuleFilename("request_body", null);
-    }
-
     public String toHeaderFilename(String componentName, String jsonPath) {
         String[] pathPieces = jsonPath.split("/");
         if ((pathPieces.length == 5 || pathPieces.length == 7) && componentName.equals("headers")) {
@@ -1888,6 +1880,11 @@ public class PythonClientGenerator extends DefaultGenerator implements Generator
     @Override
     public String getFilename(CodegenKeyType type, String lastJsonPathFragment, String jsonPath) {
         switch(type) {
+            case REQUEST_BODY:
+                if (jsonPath.startsWith("#/components")) {
+                    return toModuleFilename("request_body_" + lastJsonPathFragment, null);
+                }
+                return toModuleFilename("request_body", null);
             case CONTENT_TYPE:
                 return toModuleFilename(lastJsonPathFragment, null);
             case SECURITY:

--- a/src/main/java/org/openapijsonschematools/codegen/generators/PythonClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/PythonClientGenerator.java
@@ -1852,6 +1852,8 @@ public class PythonClientGenerator extends DefaultGenerator implements Generator
     @Override
     public String getFilename(CodegenKeyType type, String lastJsonPathFragment, String jsonPath) {
         switch(type) {
+            case OPERATION:
+                return lastJsonPathFragment;
             case PARAMETER:
                 String[] paramPathPieces = jsonPath.split("/");
                 if (operationVerbs.contains(paramPathPieces[3]) && paramPathPieces.length == 5) {

--- a/src/main/java/org/openapijsonschematools/codegen/generators/PythonClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/PythonClientGenerator.java
@@ -1870,6 +1870,8 @@ public class PythonClientGenerator extends DefaultGenerator implements Generator
     @Override
     public String getFilename(CodegenKeyType type, String lastJsonPathFragment, String jsonPath) {
         switch(type) {
+            case PATH:
+                return toModuleFilename(lastJsonPathFragment, jsonPath);
             case HEADER:
                 String[] pathPieces = jsonPath.split("/");
                 if ((pathPieces.length == 5 || pathPieces.length == 7) && lastJsonPathFragment.equals("headers")) {
@@ -2120,7 +2122,7 @@ public class PythonClientGenerator extends DefaultGenerator implements Generator
                 }
                 return toModelName(usedKey + suffix, jsonPath);
             case PATH:
-                return camelize(toPathFilename(lastJsonPathFragment, jsonPath));
+                return camelize(getFilename(CodegenKeyType.PATH, lastJsonPathFragment, jsonPath));
             case MISC:
             case OPERATION:
             case REQUEST_BODY:

--- a/src/main/java/org/openapijsonschematools/codegen/generators/PythonClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/PythonClientGenerator.java
@@ -1837,16 +1837,13 @@ public class PythonClientGenerator extends DefaultGenerator implements Generator
     }
 
     @Override
-    public String toServerFilename(String basename, String jsonPath) {
-        if (jsonPath.endsWith("/servers")) {
-            return "servers";
-        }
-        return "server_" + basename;
-    }
-
-    @Override
     public String getFilename(CodegenKeyType type, String lastJsonPathFragment, String jsonPath) {
         switch(type) {
+            case SERVER:
+                if (jsonPath.endsWith("/servers")) {
+                    return "servers";
+                }
+                return "server_" + lastJsonPathFragment;
             case SECURITY_SCHEME:
                 return "security_scheme_" + toModuleFilename(lastJsonPathFragment, null);
             case OPERATION:

--- a/src/main/java/org/openapijsonschematools/codegen/generators/PythonClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/PythonClientGenerator.java
@@ -1839,6 +1839,14 @@ public class PythonClientGenerator extends DefaultGenerator implements Generator
     @Override
     public String getFilename(CodegenKeyType type, String lastJsonPathFragment, String jsonPath) {
         switch(type) {
+            case SCHEMA:
+                String[] pieces = jsonPath.split("/");
+                String name = pieces[pieces.length - 1];
+                if (name.equals("Headers") && jsonPath.contains("/responses/")) {
+                    // synthetic response headers jsonPath
+                    return "header_parameters";
+                }
+                return toModelFilename(name, jsonPath);
             case SERVER:
                 if (jsonPath.endsWith("/servers")) {
                     return "servers";
@@ -2145,17 +2153,6 @@ public class PythonClientGenerator extends DefaultGenerator implements Generator
             default:
                 return null;
         }
-    }
-
-    @Override
-    public String getSchemaFilename(String jsonPath) {
-        String[] pieces = jsonPath.split("/");
-        String name = pieces[pieces.length - 1];
-        if (name.equals("Headers") && jsonPath.contains("/responses/")) {
-            // synthetic response headers jsonPath
-            return "header_parameters";
-        }
-        return toModelFilename(name, jsonPath);
     }
 
     @Override

--- a/src/main/java/org/openapijsonschematools/codegen/generators/PythonClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/PythonClientGenerator.java
@@ -827,11 +827,6 @@ public class PythonClientGenerator extends DefaultGenerator implements Generator
         return underscore(dropDots(toModelName(name, jsonPath)));
     }
 
-    @Override
-    public String toContentTypeFilename(String name) {
-        return toModuleFilename(name, null);
-    }
-
     /*
     This method requires jsonPath to be passed in
     It handles responses and schemas
@@ -1893,6 +1888,8 @@ public class PythonClientGenerator extends DefaultGenerator implements Generator
     @Override
     public String getFilename(CodegenKeyType type, String lastJsonPathFragment, String jsonPath) {
         switch(type) {
+            case CONTENT_TYPE:
+                return toModuleFilename(lastJsonPathFragment, null);
             case SECURITY:
                 if (jsonPath.endsWith("/security")) {
                     return "security";
@@ -2133,6 +2130,7 @@ public class PythonClientGenerator extends DefaultGenerator implements Generator
             case OPERATION:
             case REQUEST_BODY:
             case HEADER:
+            case CONTENT_TYPE:
             case SECURITY_SCHEME:
                 return toModelName(lastJsonPathFragment, jsonPath);
             case PARAMETER:

--- a/src/main/java/org/openapijsonschematools/codegen/generators/PythonClientGenerator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/PythonClientGenerator.java
@@ -1896,11 +1896,16 @@ public class PythonClientGenerator extends DefaultGenerator implements Generator
     }
 
     @Override
-    public String toSecurityFilename(String basename, String jsonPath) {
-        if (jsonPath.endsWith("/security")) {
-            return "security";
+    public String getFilename(CodegenKeyType type, String lastJsonPathFragment, String jsonPath) {
+        switch(type) {
+            case SECURITY:
+                if (jsonPath.endsWith("/security")) {
+                    return "security";
+                }
+                return "security_requirement_object_" + lastJsonPathFragment;
+            default:
+                return null;
         }
-        return "security_requirement_object_" + basename;
     }
 
     @Deprecated

--- a/src/main/java/org/openapijsonschematools/codegen/generators/openapimodels/CodegenKeyType.java
+++ b/src/main/java/org/openapijsonschematools/codegen/generators/openapimodels/CodegenKeyType.java
@@ -4,6 +4,7 @@ public enum CodegenKeyType {
     SCHEMA,
     PATH,
     MISC, // content-type, operation method
+    CONTENT_TYPE,
     OPERATION,
     PARAMETER,
     REQUEST_BODY,


### PR DESCRIPTION
Generator layer, refactors filename methods
- old methods are deprecated

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/generate_samples_configs/python*`
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
