### PR TITLE
Allows generators to ingest integers when type is number and format is float/double

### DIFF
--- a/src/main/java/org/openapijsonschematools/codegen/clicommands/Generate.java
+++ b/src/main/java/org/openapijsonschematools/codegen/clicommands/Generate.java
@@ -177,6 +177,10 @@ public class Generate extends AbstractCommand {
             description = CodegenConstants.SKIP_OPERATION_EXAMPLE_DESC)
     private Boolean skipOperationExample;
 
+    @Option(name = {"--inst-allowed-for-float-double-formats"}, title = "allow int payloads when type is number and format is double/float",
+        description = CodegenConstants.INTS_ALLOWED_FOR_FLOAT_DOUBLE_FORMATS_DESC)
+    private Boolean intsAllowedForFloatDoubleFormats;
+
     @Option(name = {"--skip-validate-spec"},
             title = "skip spec validation",
             description = "Skips the default behavior of validating an input specification.")
@@ -325,6 +329,10 @@ public class Generate extends AbstractCommand {
 
         if (removeEnumValuePrefix != null) {
             configurator.setRemoveEnumValuePrefix(removeEnumValuePrefix);
+        }
+
+        if (intsAllowedForFloatDoubleFormats != null) {
+            configurator.setIntsAllowedForFloatDoubleFormats(intsAllowedForFloatDoubleFormats);
         }
 
         if (hideGenerationTimestamp != null) {

--- a/src/main/java/org/openapijsonschematools/codegen/common/CodegenConstants.java
+++ b/src/main/java/org/openapijsonschematools/codegen/common/CodegenConstants.java
@@ -364,6 +364,10 @@ public class CodegenConstants {
     public static final String INIT_REQUIRED_VARS = "initRequiredVars";
     public static final String INIT_REQUIRED_VARS_DESC = "If set to true then the required variables are included as positional arguments in __init__ and _from_openapi_data methods. Note: this can break some composition use cases. To learn more read PR #8802.";
 
+    public static final String INTS_ALLOWED_FOR_FLOAT_DOUBLE_FORMATS = "intsAllowedForFloatDoubleFormats";
+
+    public static final String INTS_ALLOWED_FOR_FLOAT_DOUBLE_FORMATS_DESC = "Integers are allowed in for type: number format:float/double payloads";
+
     public static final String NON_COMPLIANT_USE_DISCR_IF_COMPOSITION_FAILS = "nonCompliantUseDiscriminatorIfCompositionFails";
 
     public static final String NON_COMPLIANT_USE_DISCR_IF_COMPOSITION_FAILS_DESC =

--- a/src/main/java/org/openapijsonschematools/codegen/config/CodegenConfigurator.java
+++ b/src/main/java/org/openapijsonschematools/codegen/config/CodegenConfigurator.java
@@ -326,6 +326,11 @@ public class CodegenConfigurator {
         return this;
     }
 
+    public CodegenConfigurator setIntsAllowedForFloatDoubleFormats(boolean intsAllowedForFloatDoubleFormats) {
+        workflowSettingsBuilder.withIntsAllowedForFloatDoubleFormats(intsAllowedForFloatDoubleFormats);
+        return this;
+    }
+
     public CodegenConfigurator setHideGenerationTimestamp(boolean hideGenerationTimestamp) {
         workflowSettingsBuilder.withHideGenerationTimestamp(hideGenerationTimestamp);
         return this;

--- a/src/main/java/org/openapijsonschematools/codegen/config/WorkflowSettings.java
+++ b/src/main/java/org/openapijsonschematools/codegen/config/WorkflowSettings.java
@@ -49,6 +49,7 @@ public class WorkflowSettings {
     public static final String DEFAULT_TEMPLATING_ENGINE_NAME = "handlebars";
 
     public static final boolean DEFAULT_HIDE_GENERATION_TIMESTAMP = true;
+    public static final boolean DEFAULT_INTS_ALLOWED_FOR_FLOAT_DOUBLE_FORMATS = false; // TODO in version 5.0.0 release change this to true
     public static final Map<String, String> DEFAULT_GLOBAL_PROPERTIES = Collections.unmodifiableMap(new HashMap<>());
 
     private String inputSpec;
@@ -68,6 +69,7 @@ public class WorkflowSettings {
     private Map<String, ?> globalProperties = DEFAULT_GLOBAL_PROPERTIES;
     private boolean removeEnumValuePrefix = DEFAULT_REMOVE_ENUM_VALUE_PREFIX;
     private Boolean hideGenerationTimestamp = DEFAULT_HIDE_GENERATION_TIMESTAMP;
+    private Boolean intsAllowedForFloatDoubleFormats = DEFAULT_INTS_ALLOWED_FOR_FLOAT_DOUBLE_FORMATS;
 
     private WorkflowSettings(Builder builder) {
         this.inputSpec = builder.inputSpec;
@@ -87,6 +89,7 @@ public class WorkflowSettings {
         this.globalProperties = Collections.unmodifiableMap(builder.globalProperties);
         this.removeEnumValuePrefix = builder.removeEnumValuePrefix;
         this.hideGenerationTimestamp = builder.hideGenerationTimestamp;
+        this.intsAllowedForFloatDoubleFormats = builder.intsAllowedForFloatDoubleFormats;
     }
 
     /**
@@ -121,6 +124,7 @@ public class WorkflowSettings {
         builder.globalProperties = new HashMap<>(copy.getGlobalProperties());
         builder.removeEnumValuePrefix = copy.isRemoveEnumValuePrefix();
         builder.hideGenerationTimestamp = copy.isHideGenerationTimestamp();
+        builder.intsAllowedForFloatDoubleFormats = copy.isIntsAllowedForFloatDoubleFormats();
 
         // force builder "with" methods to invoke side effects
         builder.withTemplateDir(copy.getTemplateDir());
@@ -180,6 +184,9 @@ public class WorkflowSettings {
     }
 
     public boolean isHideGenerationTimestamp() { return hideGenerationTimestamp; }
+
+    public boolean isIntsAllowedForFloatDoubleFormats() { return intsAllowedForFloatDoubleFormats; }
+
     /**
      * Indicates whether or not to skip examples defined in the operation.
      *
@@ -314,7 +321,8 @@ public class WorkflowSettings {
         private String templateDir;
         private String templatingEngineName = DEFAULT_TEMPLATING_ENGINE_NAME;
         private String ignoreFileOverride;
-        private boolean hideGenerationTimestamp = DEFAULT_HIDE_GENERATION_TIMESTAMP;
+        private Boolean hideGenerationTimestamp = DEFAULT_HIDE_GENERATION_TIMESTAMP;
+        private Boolean intsAllowedForFloatDoubleFormats = DEFAULT_INTS_ALLOWED_FOR_FLOAT_DOUBLE_FORMATS;
 
         // NOTE: All collections must be mutable in the builder, and copied to a new immutable collection in .build()
         private Map<String, String> globalProperties = new HashMap<>();
@@ -322,6 +330,12 @@ public class WorkflowSettings {
         private Builder() {
         }
 
+        public Builder withIntsAllowedForFloatDoubleFormats(Boolean intsAllowedForFloatDoubleFormats) {
+            if (intsAllowedForFloatDoubleFormats != null) {
+                this.intsAllowedForFloatDoubleFormats = intsAllowedForFloatDoubleFormats;
+            }
+            return this;
+        }
 
         /**
          * Sets the {@code inputSpec} and returns a reference to this Builder so that the methods can be chained together.


### PR DESCRIPTION
Allows generators to ingest integers when type is number and format is float/double
A new command line arg was added:
`--ints-allowed-for-float-double-formats`

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/generate_samples_configs/python*`
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
