### PR TITLE
Kotlin: schema docs improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,15 +143,8 @@ jobs:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     steps:
-      - restore_cache:
-          keys:
-            - kotlinClientGradleCache
       - command_build_and_test:
           jobId: "testKotlinClientSamples"
-      - save_cache:
-          key: kotlinClientGradleCache
-          paths:
-            - ~/build
 workflows:
   version: 2
   build:

--- a/.circleci/testKotlinClientSamples.sh
+++ b/.circleci/testKotlinClientSamples.sh
@@ -1,2 +1,2 @@
-  (cd samples/client/3_0_3_unit_test/kotlin && gradle wrapper && ./gradlew cleanTest test -info --no-daemon)
-  (cd samples/client/3_1_0_unit_test/kotlin && gradle wrapper && ./gradlew cleanTest test -info --no-daemon)
+  (cd samples/client/3_0_3_unit_test/kotlin && gradle wrapper && ./gradlew cleanTest test --no-daemon)
+  (cd samples/client/3_1_0_unit_test/kotlin && gradle wrapper && ./gradlew cleanTest test --no-daemon)

--- a/.circleci/testKotlinClientSamples.sh
+++ b/.circleci/testKotlinClientSamples.sh
@@ -1,2 +1,2 @@
-  (cd samples/client/3_0_3_unit_test/kotlin && gradle wrapper && ./gradlew cleanTest test -info)
-  (cd samples/client/3_1_0_unit_test/kotlin && gradle wrapper && ./gradlew cleanTest test -info)
+  (cd samples/client/3_0_3_unit_test/kotlin && gradle wrapper && ./gradlew cleanTest test -info --no-daemon)
+  (cd samples/client/3_1_0_unit_test/kotlin && gradle wrapper && ./gradlew cleanTest test -info --no-daemon)

--- a/samples/client/3_0_3_unit_test/kotlin/build.gradle.kts
+++ b/samples/client/3_0_3_unit_test/kotlin/build.gradle.kts
@@ -21,10 +21,8 @@ group = "org.openapijsonschematools"
 version = "0.0.1"
 description = "OpenAPI Kotlin"
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
-    }
+kotlin {
+    jvmToolchain(17)
 }
 
 tasks.wrapper {

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesAllowsASchemaWhichShouldValidate.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesAllowsASchemaWhichShouldValidate.md
@@ -13,29 +13,29 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.AdditionalpropertiesAllowsASchemaWhichShouldValidate1Boxed](#additionalpropertiesallowsaschemawhichshouldvalidate1boxed)<br> sealed interface for validated payloads |
-| record | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.AdditionalpropertiesAllowsASchemaWhichShouldValidate1BoxedMap](#additionalpropertiesallowsaschemawhichshouldvalidate1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.AdditionalpropertiesAllowsASchemaWhichShouldValidate1](#additionalpropertiesallowsaschemawhichshouldvalidate1)<br> schema class |
-| static class | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.AdditionalpropertiesAllowsASchemaWhichShouldValidateMapBuilder](#additionalpropertiesallowsaschemawhichshouldvalidatemapbuilder)<br> builder for Map payloads |
-| static class | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.AdditionalpropertiesAllowsASchemaWhichShouldValidateMap](#additionalpropertiesallowsaschemawhichshouldvalidatemap)<br> output class for Map payloads |
+| data class | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.AdditionalpropertiesAllowsASchemaWhichShouldValidate1BoxedMap](#additionalpropertiesallowsaschemawhichshouldvalidate1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.AdditionalpropertiesAllowsASchemaWhichShouldValidate1](#additionalpropertiesallowsaschemawhichshouldvalidate1)<br> schema class |
+| class | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.AdditionalpropertiesAllowsASchemaWhichShouldValidateMapBuilder](#additionalpropertiesallowsaschemawhichshouldvalidatemapbuilder)<br> builder for Map payloads |
+| class | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.AdditionalpropertiesAllowsASchemaWhichShouldValidateMap](#additionalpropertiesallowsaschemawhichshouldvalidatemap)<br> output class for Map payloads |
 | sealed interface | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.BarBoxed](#barboxed)<br> sealed interface for validated payloads |
-| record | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.BarBoxedVoid](#barboxedvoid)<br> boxed class to store validated null payloads |
-| record | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.BarBoxedBoolean](#barboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.BarBoxedNumber](#barboxednumber)<br> boxed class to store validated Number payloads |
-| record | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.BarBoxedString](#barboxedstring)<br> boxed class to store validated String payloads |
-| record | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.BarBoxedList](#barboxedlist)<br> boxed class to store validated List payloads |
-| record | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.BarBoxedMap](#barboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.Bar](#bar)<br> schema class |
+| data class | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.BarBoxedVoid](#barboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.BarBoxedBoolean](#barboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.BarBoxedNumber](#barboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.BarBoxedString](#barboxedstring)<br> boxed class to store validated String payloads |
+| data class | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.BarBoxedList](#barboxedlist)<br> boxed class to store validated List payloads |
+| data class | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.BarBoxedMap](#barboxedmap)<br> boxed class to store validated Map payloads |
+| class | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.Bar](#bar)<br> schema class |
 | sealed interface | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.FooBoxedVoid](#fooboxedvoid)<br> boxed class to store validated null payloads |
-| record | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.FooBoxedBoolean](#fooboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
-| record | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
-| record | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.FooBoxedList](#fooboxedlist)<br> boxed class to store validated List payloads |
-| record | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.FooBoxedMap](#fooboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.Foo](#foo)<br> schema class |
+| data class | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.FooBoxedVoid](#fooboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.FooBoxedBoolean](#fooboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
+| data class | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.FooBoxedList](#fooboxedlist)<br> boxed class to store validated List payloads |
+| data class | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.FooBoxedMap](#fooboxedmap)<br> boxed class to store validated Map payloads |
+| class | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.Foo](#foo)<br> schema class |
 | sealed interface | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.AdditionalPropertiesBoxed](#additionalpropertiesboxed)<br> sealed interface for validated payloads |
-| record | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.AdditionalPropertiesBoxedBoolean](#additionalpropertiesboxedboolean)<br> boxed class to store validated boolean payloads |
-| static class | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.AdditionalProperties](#additionalproperties)<br> schema class |
+| data class | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.AdditionalPropertiesBoxedBoolean](#additionalpropertiesboxedboolean)<br> boxed class to store validated boolean payloads |
+| class | [AdditionalpropertiesAllowsASchemaWhichShouldValidate.AdditionalProperties](#additionalproperties)<br> schema class |
 
 ## AdditionalpropertiesAllowsASchemaWhichShouldValidate1Boxed
 sealed interface AdditionalpropertiesAllowsASchemaWhichShouldValidate1Boxed<br>
@@ -187,7 +187,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class BarBoxedBoolean<br>
 implements [BarBoxed](#barboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -312,7 +312,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class FooBoxedBoolean<br>
 implements [FooBoxed](#fooboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -415,7 +415,7 @@ sealed interface that stores validated payloads using boxed classes
 data class AdditionalPropertiesBoxedBoolean<br>
 implements [AdditionalPropertiesBoxed](#additionalpropertiesboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesAllowsASchemaWhichShouldValidate.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesAllowsASchemaWhichShouldValidate.md
@@ -69,29 +69,25 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.AdditionalpropertiesAllowsASchemaWhichShouldValidate;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.AdditionalpropertiesAllowsASchemaWhichShouldValidate
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // Map validation
-AdditionalpropertiesAllowsASchemaWhichShouldValidate.AdditionalpropertiesAllowsASchemaWhichShouldValidateMap validatedPayload =
+val validatedPayload: AdditionalpropertiesAllowsASchemaWhichShouldValidate.AdditionalpropertiesAllowsASchemaWhichShouldValidateMap =
     AdditionalpropertiesAllowsASchemaWhichShouldValidate.AdditionalpropertiesAllowsASchemaWhichShouldValidate1.validate(
-    new AdditionalpropertiesAllowsASchemaWhichShouldValidate.AdditionalpropertiesAllowsASchemaWhichShouldValidateMapBuilder()
+    AdditionalpropertiesAllowsASchemaWhichShouldValidate.AdditionalpropertiesAllowsASchemaWhichShouldValidateMapBuilder()
         .additionalProperty("someAdditionalProperty", true)
 
     .build(),
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -104,8 +100,8 @@ AdditionalpropertiesAllowsASchemaWhichShouldValidate.AdditionalpropertiesAllowsA
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| [AdditionalpropertiesAllowsASchemaWhichShouldValidateMap](#additionalpropertiesallowsaschemawhichshouldvalidatemap) | validate(arg: [Map&lt;?, ?&gt;](#additionalpropertiesallowsaschemawhichshouldvalidatemapbuilder), configuration: SchemaConfiguration) |
-| [AdditionalpropertiesAllowsASchemaWhichShouldValidate1BoxedMap](#additionalpropertiesallowsaschemawhichshouldvalidate1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#additionalpropertiesallowsaschemawhichshouldvalidatemapbuilder), configuration: SchemaConfiguration) |
+| [AdditionalpropertiesAllowsASchemaWhichShouldValidateMap](#additionalpropertiesallowsaschemawhichshouldvalidatemap) | validate(arg: [Map&lt;*, *&gt;](#additionalpropertiesallowsaschemawhichshouldvalidatemapbuilder), configuration: SchemaConfiguration) |
+| [AdditionalpropertiesAllowsASchemaWhichShouldValidate1BoxedMap](#additionalpropertiesallowsaschemawhichshouldvalidate1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#additionalpropertiesallowsaschemawhichshouldvalidatemapbuilder), configuration: SchemaConfiguration) |
 | [AdditionalpropertiesAllowsASchemaWhichShouldValidate1Boxed](#additionalpropertiesallowsaschemawhichshouldvalidate1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
 

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesAreAllowedByDefault.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesAreAllowedByDefault.md
@@ -13,31 +13,31 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefault1Boxed](#additionalpropertiesareallowedbydefault1boxed)<br> sealed interface for validated payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefault1BoxedVoid](#additionalpropertiesareallowedbydefault1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefault1BoxedBoolean](#additionalpropertiesareallowedbydefault1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefault1BoxedNumber](#additionalpropertiesareallowedbydefault1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefault1BoxedString](#additionalpropertiesareallowedbydefault1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefault1BoxedList](#additionalpropertiesareallowedbydefault1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefault1BoxedMap](#additionalpropertiesareallowedbydefault1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefault1](#additionalpropertiesareallowedbydefault1)<br> schema class |
-| static class | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefaultMapBuilder](#additionalpropertiesareallowedbydefaultmapbuilder)<br> builder for Map payloads |
-| static class | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefaultMap](#additionalpropertiesareallowedbydefaultmap)<br> output class for Map payloads |
+| data class | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefault1BoxedVoid](#additionalpropertiesareallowedbydefault1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefault1BoxedBoolean](#additionalpropertiesareallowedbydefault1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefault1BoxedNumber](#additionalpropertiesareallowedbydefault1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefault1BoxedString](#additionalpropertiesareallowedbydefault1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefault1BoxedList](#additionalpropertiesareallowedbydefault1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefault1BoxedMap](#additionalpropertiesareallowedbydefault1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefault1](#additionalpropertiesareallowedbydefault1)<br> schema class |
+| class | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefaultMapBuilder](#additionalpropertiesareallowedbydefaultmapbuilder)<br> builder for Map payloads |
+| class | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefaultMap](#additionalpropertiesareallowedbydefaultmap)<br> output class for Map payloads |
 | sealed interface | [AdditionalpropertiesAreAllowedByDefault.BarBoxed](#barboxed)<br> sealed interface for validated payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.BarBoxedVoid](#barboxedvoid)<br> boxed class to store validated null payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.BarBoxedBoolean](#barboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.BarBoxedNumber](#barboxednumber)<br> boxed class to store validated Number payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.BarBoxedString](#barboxedstring)<br> boxed class to store validated String payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.BarBoxedList](#barboxedlist)<br> boxed class to store validated List payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.BarBoxedMap](#barboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AdditionalpropertiesAreAllowedByDefault.Bar](#bar)<br> schema class |
+| data class | [AdditionalpropertiesAreAllowedByDefault.BarBoxedVoid](#barboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AdditionalpropertiesAreAllowedByDefault.BarBoxedBoolean](#barboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AdditionalpropertiesAreAllowedByDefault.BarBoxedNumber](#barboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AdditionalpropertiesAreAllowedByDefault.BarBoxedString](#barboxedstring)<br> boxed class to store validated String payloads |
+| data class | [AdditionalpropertiesAreAllowedByDefault.BarBoxedList](#barboxedlist)<br> boxed class to store validated List payloads |
+| data class | [AdditionalpropertiesAreAllowedByDefault.BarBoxedMap](#barboxedmap)<br> boxed class to store validated Map payloads |
+| class | [AdditionalpropertiesAreAllowedByDefault.Bar](#bar)<br> schema class |
 | sealed interface | [AdditionalpropertiesAreAllowedByDefault.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.FooBoxedVoid](#fooboxedvoid)<br> boxed class to store validated null payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.FooBoxedBoolean](#fooboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.FooBoxedList](#fooboxedlist)<br> boxed class to store validated List payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.FooBoxedMap](#fooboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AdditionalpropertiesAreAllowedByDefault.Foo](#foo)<br> schema class |
+| data class | [AdditionalpropertiesAreAllowedByDefault.FooBoxedVoid](#fooboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AdditionalpropertiesAreAllowedByDefault.FooBoxedBoolean](#fooboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AdditionalpropertiesAreAllowedByDefault.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AdditionalpropertiesAreAllowedByDefault.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
+| data class | [AdditionalpropertiesAreAllowedByDefault.FooBoxedList](#fooboxedlist)<br> boxed class to store validated List payloads |
+| data class | [AdditionalpropertiesAreAllowedByDefault.FooBoxedMap](#fooboxedmap)<br> boxed class to store validated Map payloads |
+| class | [AdditionalpropertiesAreAllowedByDefault.Foo](#foo)<br> schema class |
 
 ## AdditionalpropertiesAreAllowedByDefault1Boxed
 sealed interface AdditionalpropertiesAreAllowedByDefault1Boxed<br>
@@ -72,7 +72,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class AdditionalpropertiesAreAllowedByDefault1BoxedBoolean<br>
 implements [AdditionalpropertiesAreAllowedByDefault1Boxed](#additionalpropertiesareallowedbydefault1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -276,7 +276,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class BarBoxedBoolean<br>
 implements [BarBoxed](#barboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -401,7 +401,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class FooBoxedBoolean<br>
 implements [FooBoxed](#fooboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesAreAllowedByDefault.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesAreAllowedByDefault.md
@@ -169,19 +169,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [AdditionalpropertiesAreAllowedByDefaultMap](#additionalpropertiesareallowedbydefaultmap) | validate(arg: [Map&lt;?, ?&gt;](#additionalpropertiesareallowedbydefaultmapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [AdditionalpropertiesAreAllowedByDefaultMap](#additionalpropertiesareallowedbydefaultmap) | validate(arg: [Map&lt;*, *&gt;](#additionalpropertiesareallowedbydefaultmapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [AdditionalpropertiesAreAllowedByDefault1BoxedString](#additionalpropertiesareallowedbydefault1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [AdditionalpropertiesAreAllowedByDefault1BoxedVoid](#additionalpropertiesareallowedbydefault1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [AdditionalpropertiesAreAllowedByDefault1BoxedNumber](#additionalpropertiesareallowedbydefault1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [AdditionalpropertiesAreAllowedByDefault1BoxedBoolean](#additionalpropertiesareallowedbydefault1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [AdditionalpropertiesAreAllowedByDefault1BoxedMap](#additionalpropertiesareallowedbydefault1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#additionalpropertiesareallowedbydefaultmapbuilder), configuration: SchemaConfiguration) |
+| [AdditionalpropertiesAreAllowedByDefault1BoxedBoolean](#additionalpropertiesareallowedbydefault1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [AdditionalpropertiesAreAllowedByDefault1BoxedMap](#additionalpropertiesareallowedbydefault1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#additionalpropertiesareallowedbydefaultmapbuilder), configuration: SchemaConfiguration) |
 | [AdditionalpropertiesAreAllowedByDefault1BoxedList](#additionalpropertiesareallowedbydefault1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [AdditionalpropertiesAreAllowedByDefault1Boxed](#additionalpropertiesareallowedbydefault1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesCanExistByItself.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesCanExistByItself.md
@@ -13,13 +13,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [AdditionalpropertiesCanExistByItself.AdditionalpropertiesCanExistByItself1Boxed](#additionalpropertiescanexistbyitself1boxed)<br> sealed interface for validated payloads |
-| record | [AdditionalpropertiesCanExistByItself.AdditionalpropertiesCanExistByItself1BoxedMap](#additionalpropertiescanexistbyitself1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AdditionalpropertiesCanExistByItself.AdditionalpropertiesCanExistByItself1](#additionalpropertiescanexistbyitself1)<br> schema class |
-| static class | [AdditionalpropertiesCanExistByItself.AdditionalpropertiesCanExistByItselfMapBuilder](#additionalpropertiescanexistbyitselfmapbuilder)<br> builder for Map payloads |
-| static class | [AdditionalpropertiesCanExistByItself.AdditionalpropertiesCanExistByItselfMap](#additionalpropertiescanexistbyitselfmap)<br> output class for Map payloads |
+| data class | [AdditionalpropertiesCanExistByItself.AdditionalpropertiesCanExistByItself1BoxedMap](#additionalpropertiescanexistbyitself1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AdditionalpropertiesCanExistByItself.AdditionalpropertiesCanExistByItself1](#additionalpropertiescanexistbyitself1)<br> schema class |
+| class | [AdditionalpropertiesCanExistByItself.AdditionalpropertiesCanExistByItselfMapBuilder](#additionalpropertiescanexistbyitselfmapbuilder)<br> builder for Map payloads |
+| class | [AdditionalpropertiesCanExistByItself.AdditionalpropertiesCanExistByItselfMap](#additionalpropertiescanexistbyitselfmap)<br> output class for Map payloads |
 | sealed interface | [AdditionalpropertiesCanExistByItself.AdditionalPropertiesBoxed](#additionalpropertiesboxed)<br> sealed interface for validated payloads |
-| record | [AdditionalpropertiesCanExistByItself.AdditionalPropertiesBoxedBoolean](#additionalpropertiesboxedboolean)<br> boxed class to store validated boolean payloads |
-| static class | [AdditionalpropertiesCanExistByItself.AdditionalProperties](#additionalproperties)<br> schema class |
+| data class | [AdditionalpropertiesCanExistByItself.AdditionalPropertiesBoxedBoolean](#additionalpropertiesboxedboolean)<br> boxed class to store validated boolean payloads |
+| class | [AdditionalpropertiesCanExistByItself.AdditionalProperties](#additionalproperties)<br> schema class |
 
 ## AdditionalpropertiesCanExistByItself1Boxed
 sealed interface AdditionalpropertiesCanExistByItself1Boxed<br>
@@ -128,7 +128,7 @@ sealed interface that stores validated payloads using boxed classes
 data class AdditionalPropertiesBoxedBoolean<br>
 implements [AdditionalPropertiesBoxed](#additionalpropertiesboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesCanExistByItself.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesCanExistByItself.md
@@ -53,29 +53,25 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.AdditionalpropertiesCanExistByItself;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.AdditionalpropertiesCanExistByItself
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // Map validation
-AdditionalpropertiesCanExistByItself.AdditionalpropertiesCanExistByItselfMap validatedPayload =
+val validatedPayload: AdditionalpropertiesCanExistByItself.AdditionalpropertiesCanExistByItselfMap =
     AdditionalpropertiesCanExistByItself.AdditionalpropertiesCanExistByItself1.validate(
-    new AdditionalpropertiesCanExistByItself.AdditionalpropertiesCanExistByItselfMapBuilder()
+    AdditionalpropertiesCanExistByItself.AdditionalpropertiesCanExistByItselfMapBuilder()
         .additionalProperty("someAdditionalProperty", true)
 
     .build(),
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -87,8 +83,8 @@ AdditionalpropertiesCanExistByItself.AdditionalpropertiesCanExistByItselfMap val
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| [AdditionalpropertiesCanExistByItselfMap](#additionalpropertiescanexistbyitselfmap) | validate(arg: [Map&lt;?, ?&gt;](#additionalpropertiescanexistbyitselfmapbuilder), configuration: SchemaConfiguration) |
-| [AdditionalpropertiesCanExistByItself1BoxedMap](#additionalpropertiescanexistbyitself1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#additionalpropertiescanexistbyitselfmapbuilder), configuration: SchemaConfiguration) |
+| [AdditionalpropertiesCanExistByItselfMap](#additionalpropertiescanexistbyitselfmap) | validate(arg: [Map&lt;*, *&gt;](#additionalpropertiescanexistbyitselfmapbuilder), configuration: SchemaConfiguration) |
+| [AdditionalpropertiesCanExistByItself1BoxedMap](#additionalpropertiescanexistbyitself1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#additionalpropertiescanexistbyitselfmapbuilder), configuration: SchemaConfiguration) |
 | [AdditionalpropertiesCanExistByItself1Boxed](#additionalpropertiescanexistbyitself1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
 

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesShouldNotLookInApplicators.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesShouldNotLookInApplicators.md
@@ -175,19 +175,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [AdditionalpropertiesShouldNotLookInApplicatorsMap](#additionalpropertiesshouldnotlookinapplicatorsmap) | validate(arg: [Map&lt;?, ?&gt;](#additionalpropertiesshouldnotlookinapplicatorsmapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [AdditionalpropertiesShouldNotLookInApplicatorsMap](#additionalpropertiesshouldnotlookinapplicatorsmap) | validate(arg: [Map&lt;*, *&gt;](#additionalpropertiesshouldnotlookinapplicatorsmapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [AdditionalpropertiesShouldNotLookInApplicators1BoxedString](#additionalpropertiesshouldnotlookinapplicators1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [AdditionalpropertiesShouldNotLookInApplicators1BoxedVoid](#additionalpropertiesshouldnotlookinapplicators1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [AdditionalpropertiesShouldNotLookInApplicators1BoxedNumber](#additionalpropertiesshouldnotlookinapplicators1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [AdditionalpropertiesShouldNotLookInApplicators1BoxedBoolean](#additionalpropertiesshouldnotlookinapplicators1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [AdditionalpropertiesShouldNotLookInApplicators1BoxedMap](#additionalpropertiesshouldnotlookinapplicators1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#additionalpropertiesshouldnotlookinapplicatorsmapbuilder), configuration: SchemaConfiguration) |
+| [AdditionalpropertiesShouldNotLookInApplicators1BoxedBoolean](#additionalpropertiesshouldnotlookinapplicators1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [AdditionalpropertiesShouldNotLookInApplicators1BoxedMap](#additionalpropertiesshouldnotlookinapplicators1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#additionalpropertiesshouldnotlookinapplicatorsmapbuilder), configuration: SchemaConfiguration) |
 | [AdditionalpropertiesShouldNotLookInApplicators1BoxedList](#additionalpropertiesshouldnotlookinapplicators1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [AdditionalpropertiesShouldNotLookInApplicators1Boxed](#additionalpropertiesshouldnotlookinapplicators1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -351,19 +351,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [Schema0Map](#schema0map) | validate(arg: [Map&lt;?, ?&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [Schema0Map](#schema0map) | validate(arg: [Map&lt;*, *&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema0BoxedString](#schema0boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema0BoxedVoid](#schema0boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema0BoxedNumber](#schema0boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
+| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox([Map&lt;*, *&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
 | [Schema0BoxedList](#schema0boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema0Boxed](#schema0boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesShouldNotLookInApplicators.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesShouldNotLookInApplicators.md
@@ -13,36 +13,36 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [AdditionalpropertiesShouldNotLookInApplicators.AdditionalpropertiesShouldNotLookInApplicators1Boxed](#additionalpropertiesshouldnotlookinapplicators1boxed)<br> sealed interface for validated payloads |
-| record | [AdditionalpropertiesShouldNotLookInApplicators.AdditionalpropertiesShouldNotLookInApplicators1BoxedVoid](#additionalpropertiesshouldnotlookinapplicators1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AdditionalpropertiesShouldNotLookInApplicators.AdditionalpropertiesShouldNotLookInApplicators1BoxedBoolean](#additionalpropertiesshouldnotlookinapplicators1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AdditionalpropertiesShouldNotLookInApplicators.AdditionalpropertiesShouldNotLookInApplicators1BoxedNumber](#additionalpropertiesshouldnotlookinapplicators1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AdditionalpropertiesShouldNotLookInApplicators.AdditionalpropertiesShouldNotLookInApplicators1BoxedString](#additionalpropertiesshouldnotlookinapplicators1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AdditionalpropertiesShouldNotLookInApplicators.AdditionalpropertiesShouldNotLookInApplicators1BoxedList](#additionalpropertiesshouldnotlookinapplicators1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AdditionalpropertiesShouldNotLookInApplicators.AdditionalpropertiesShouldNotLookInApplicators1BoxedMap](#additionalpropertiesshouldnotlookinapplicators1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AdditionalpropertiesShouldNotLookInApplicators.AdditionalpropertiesShouldNotLookInApplicators1](#additionalpropertiesshouldnotlookinapplicators1)<br> schema class |
-| static class | [AdditionalpropertiesShouldNotLookInApplicators.AdditionalpropertiesShouldNotLookInApplicatorsMapBuilder](#additionalpropertiesshouldnotlookinapplicatorsmapbuilder)<br> builder for Map payloads |
-| static class | [AdditionalpropertiesShouldNotLookInApplicators.AdditionalpropertiesShouldNotLookInApplicatorsMap](#additionalpropertiesshouldnotlookinapplicatorsmap)<br> output class for Map payloads |
+| data class | [AdditionalpropertiesShouldNotLookInApplicators.AdditionalpropertiesShouldNotLookInApplicators1BoxedVoid](#additionalpropertiesshouldnotlookinapplicators1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AdditionalpropertiesShouldNotLookInApplicators.AdditionalpropertiesShouldNotLookInApplicators1BoxedBoolean](#additionalpropertiesshouldnotlookinapplicators1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AdditionalpropertiesShouldNotLookInApplicators.AdditionalpropertiesShouldNotLookInApplicators1BoxedNumber](#additionalpropertiesshouldnotlookinapplicators1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AdditionalpropertiesShouldNotLookInApplicators.AdditionalpropertiesShouldNotLookInApplicators1BoxedString](#additionalpropertiesshouldnotlookinapplicators1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AdditionalpropertiesShouldNotLookInApplicators.AdditionalpropertiesShouldNotLookInApplicators1BoxedList](#additionalpropertiesshouldnotlookinapplicators1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AdditionalpropertiesShouldNotLookInApplicators.AdditionalpropertiesShouldNotLookInApplicators1BoxedMap](#additionalpropertiesshouldnotlookinapplicators1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AdditionalpropertiesShouldNotLookInApplicators.AdditionalpropertiesShouldNotLookInApplicators1](#additionalpropertiesshouldnotlookinapplicators1)<br> schema class |
+| class | [AdditionalpropertiesShouldNotLookInApplicators.AdditionalpropertiesShouldNotLookInApplicatorsMapBuilder](#additionalpropertiesshouldnotlookinapplicatorsmapbuilder)<br> builder for Map payloads |
+| class | [AdditionalpropertiesShouldNotLookInApplicators.AdditionalpropertiesShouldNotLookInApplicatorsMap](#additionalpropertiesshouldnotlookinapplicatorsmap)<br> output class for Map payloads |
 | sealed interface | [AdditionalpropertiesShouldNotLookInApplicators.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [AdditionalpropertiesShouldNotLookInApplicators.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AdditionalpropertiesShouldNotLookInApplicators.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AdditionalpropertiesShouldNotLookInApplicators.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AdditionalpropertiesShouldNotLookInApplicators.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [AdditionalpropertiesShouldNotLookInApplicators.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [AdditionalpropertiesShouldNotLookInApplicators.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AdditionalpropertiesShouldNotLookInApplicators.Schema0](#schema0)<br> schema class |
-| static class | [AdditionalpropertiesShouldNotLookInApplicators.Schema0MapBuilder](#schema0mapbuilder)<br> builder for Map payloads |
-| static class | [AdditionalpropertiesShouldNotLookInApplicators.Schema0Map](#schema0map)<br> output class for Map payloads |
+| data class | [AdditionalpropertiesShouldNotLookInApplicators.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AdditionalpropertiesShouldNotLookInApplicators.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AdditionalpropertiesShouldNotLookInApplicators.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AdditionalpropertiesShouldNotLookInApplicators.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AdditionalpropertiesShouldNotLookInApplicators.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AdditionalpropertiesShouldNotLookInApplicators.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AdditionalpropertiesShouldNotLookInApplicators.Schema0](#schema0)<br> schema class |
+| class | [AdditionalpropertiesShouldNotLookInApplicators.Schema0MapBuilder](#schema0mapbuilder)<br> builder for Map payloads |
+| class | [AdditionalpropertiesShouldNotLookInApplicators.Schema0Map](#schema0map)<br> output class for Map payloads |
 | sealed interface | [AdditionalpropertiesShouldNotLookInApplicators.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [AdditionalpropertiesShouldNotLookInApplicators.FooBoxedVoid](#fooboxedvoid)<br> boxed class to store validated null payloads |
-| record | [AdditionalpropertiesShouldNotLookInApplicators.FooBoxedBoolean](#fooboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AdditionalpropertiesShouldNotLookInApplicators.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
-| record | [AdditionalpropertiesShouldNotLookInApplicators.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
-| record | [AdditionalpropertiesShouldNotLookInApplicators.FooBoxedList](#fooboxedlist)<br> boxed class to store validated List payloads |
-| record | [AdditionalpropertiesShouldNotLookInApplicators.FooBoxedMap](#fooboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AdditionalpropertiesShouldNotLookInApplicators.Foo](#foo)<br> schema class |
+| data class | [AdditionalpropertiesShouldNotLookInApplicators.FooBoxedVoid](#fooboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AdditionalpropertiesShouldNotLookInApplicators.FooBoxedBoolean](#fooboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AdditionalpropertiesShouldNotLookInApplicators.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AdditionalpropertiesShouldNotLookInApplicators.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
+| data class | [AdditionalpropertiesShouldNotLookInApplicators.FooBoxedList](#fooboxedlist)<br> boxed class to store validated List payloads |
+| data class | [AdditionalpropertiesShouldNotLookInApplicators.FooBoxedMap](#fooboxedmap)<br> boxed class to store validated Map payloads |
+| class | [AdditionalpropertiesShouldNotLookInApplicators.Foo](#foo)<br> schema class |
 | sealed interface | [AdditionalpropertiesShouldNotLookInApplicators.AdditionalPropertiesBoxed](#additionalpropertiesboxed)<br> sealed interface for validated payloads |
-| record | [AdditionalpropertiesShouldNotLookInApplicators.AdditionalPropertiesBoxedBoolean](#additionalpropertiesboxedboolean)<br> boxed class to store validated boolean payloads |
-| static class | [AdditionalpropertiesShouldNotLookInApplicators.AdditionalProperties](#additionalproperties)<br> schema class |
+| data class | [AdditionalpropertiesShouldNotLookInApplicators.AdditionalPropertiesBoxedBoolean](#additionalpropertiesboxedboolean)<br> boxed class to store validated boolean payloads |
+| class | [AdditionalpropertiesShouldNotLookInApplicators.AdditionalProperties](#additionalproperties)<br> schema class |
 
 ## AdditionalpropertiesShouldNotLookInApplicators1Boxed
 sealed interface AdditionalpropertiesShouldNotLookInApplicators1Boxed<br>
@@ -77,7 +77,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class AdditionalpropertiesShouldNotLookInApplicators1BoxedBoolean<br>
 implements [AdditionalpropertiesShouldNotLookInApplicators1Boxed](#additionalpropertiesshouldnotlookinapplicators1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -254,7 +254,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -448,7 +448,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class FooBoxedBoolean<br>
 implements [FooBoxed](#fooboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -551,7 +551,7 @@ sealed interface that stores validated payloads using boxed classes
 data class AdditionalPropertiesBoxedBoolean<br>
 implements [AdditionalPropertiesBoxed](#additionalpropertiesboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/Allof.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/Allof.md
@@ -177,19 +177,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Allof1BoxedString](#allof1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Allof1BoxedVoid](#allof1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Allof1BoxedNumber](#allof1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Allof1BoxedBoolean](#allof1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Allof1BoxedMap](#allof1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Allof1BoxedBoolean](#allof1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Allof1BoxedMap](#allof1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Allof1BoxedList](#allof1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Allof1Boxed](#allof1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -325,19 +325,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [Schema1Map](#schema1map) | validate(arg: [Map&lt;?, ?&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [Schema1Map](#schema1map) | validate(arg: [Map&lt;*, *&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema1BoxedString](#schema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema1BoxedVoid](#schema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema1BoxedNumber](#schema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
+| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
 | [Schema1BoxedList](#schema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema1Boxed](#schema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -562,19 +562,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [Schema0Map](#schema0map) | validate(arg: [Map&lt;?, ?&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [Schema0Map](#schema0map) | validate(arg: [Map&lt;*, *&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema0BoxedString](#schema0boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema0BoxedVoid](#schema0boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema0BoxedNumber](#schema0boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
+| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox([Map&lt;*, *&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
 | [Schema0BoxedList](#schema0boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema0Boxed](#schema0boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/Allof.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/Allof.md
@@ -13,39 +13,39 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [Allof.Allof1Boxed](#allof1boxed)<br> sealed interface for validated payloads |
-| record | [Allof.Allof1BoxedVoid](#allof1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [Allof.Allof1BoxedBoolean](#allof1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [Allof.Allof1BoxedNumber](#allof1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [Allof.Allof1BoxedString](#allof1boxedstring)<br> boxed class to store validated String payloads |
-| record | [Allof.Allof1BoxedList](#allof1boxedlist)<br> boxed class to store validated List payloads |
-| record | [Allof.Allof1BoxedMap](#allof1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [Allof.Allof1](#allof1)<br> schema class |
+| data class | [Allof.Allof1BoxedVoid](#allof1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [Allof.Allof1BoxedBoolean](#allof1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [Allof.Allof1BoxedNumber](#allof1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [Allof.Allof1BoxedString](#allof1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [Allof.Allof1BoxedList](#allof1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [Allof.Allof1BoxedMap](#allof1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [Allof.Allof1](#allof1)<br> schema class |
 | sealed interface | [Allof.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [Allof.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [Allof.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [Allof.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [Allof.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [Allof.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [Allof.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [Allof.Schema1](#schema1)<br> schema class |
-| static class | [Allof.Schema1MapBuilder](#schema1mapbuilder)<br> builder for Map payloads |
-| static class | [Allof.Schema1Map](#schema1map)<br> output class for Map payloads |
+| data class | [Allof.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [Allof.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [Allof.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [Allof.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [Allof.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [Allof.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [Allof.Schema1](#schema1)<br> schema class |
+| class | [Allof.Schema1MapBuilder](#schema1mapbuilder)<br> builder for Map payloads |
+| class | [Allof.Schema1Map](#schema1map)<br> output class for Map payloads |
 | sealed interface | [Allof.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [Allof.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
-| static class | [Allof.Foo](#foo)<br> schema class |
+| data class | [Allof.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
+| class | [Allof.Foo](#foo)<br> schema class |
 | sealed interface | [Allof.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [Allof.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [Allof.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [Allof.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [Allof.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [Allof.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [Allof.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [Allof.Schema0](#schema0)<br> schema class |
-| static class | [Allof.Schema0MapBuilder](#schema0mapbuilder)<br> builder for Map payloads |
-| static class | [Allof.Schema0Map](#schema0map)<br> output class for Map payloads |
+| data class | [Allof.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [Allof.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [Allof.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [Allof.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [Allof.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [Allof.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [Allof.Schema0](#schema0)<br> schema class |
+| class | [Allof.Schema0MapBuilder](#schema0mapbuilder)<br> builder for Map payloads |
+| class | [Allof.Schema0Map](#schema0map)<br> output class for Map payloads |
 | sealed interface | [Allof.BarBoxed](#barboxed)<br> sealed interface for validated payloads |
-| record | [Allof.BarBoxedNumber](#barboxednumber)<br> boxed class to store validated Number payloads |
-| static class | [Allof.Bar](#bar)<br> schema class |
+| data class | [Allof.BarBoxedNumber](#barboxednumber)<br> boxed class to store validated Number payloads |
+| class | [Allof.Bar](#bar)<br> schema class |
 
 ## Allof1Boxed
 sealed interface Allof1Boxed<br>
@@ -80,7 +80,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Allof1BoxedBoolean<br>
 implements [Allof1Boxed](#allof1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -227,7 +227,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema1BoxedBoolean<br>
 implements [Schema1Boxed](#schema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -464,7 +464,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AllofCombinedWithAnyofOneof.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AllofCombinedWithAnyofOneof.md
@@ -175,19 +175,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [AllofCombinedWithAnyofOneof1BoxedString](#allofcombinedwithanyofoneof1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [AllofCombinedWithAnyofOneof1BoxedVoid](#allofcombinedwithanyofoneof1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [AllofCombinedWithAnyofOneof1BoxedNumber](#allofcombinedwithanyofoneof1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [AllofCombinedWithAnyofOneof1BoxedBoolean](#allofcombinedwithanyofoneof1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [AllofCombinedWithAnyofOneof1BoxedMap](#allofcombinedwithanyofoneof1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [AllofCombinedWithAnyofOneof1BoxedBoolean](#allofcombinedwithanyofoneof1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [AllofCombinedWithAnyofOneof1BoxedMap](#allofcombinedwithanyofoneof1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [AllofCombinedWithAnyofOneof1BoxedList](#allofcombinedwithanyofoneof1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [AllofCombinedWithAnyofOneof1Boxed](#allofcombinedwithanyofoneof1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -322,19 +322,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema0BoxedString](#schema0boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema0BoxedVoid](#schema0boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema0BoxedNumber](#schema0boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema0BoxedList](#schema0boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema0Boxed](#schema0boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -469,19 +469,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema01BoxedString](#schema01boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema01BoxedVoid](#schema01boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema01BoxedNumber](#schema01boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema01BoxedBoolean](#schema01boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema01BoxedMap](#schema01boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema01BoxedBoolean](#schema01boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema01BoxedMap](#schema01boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema01BoxedList](#schema01boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema01Boxed](#schema01boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -616,19 +616,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema02BoxedString](#schema02boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema02BoxedVoid](#schema02boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema02BoxedNumber](#schema02boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema02BoxedBoolean](#schema02boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema02BoxedMap](#schema02boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema02BoxedBoolean](#schema02boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema02BoxedMap](#schema02boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema02BoxedList](#schema02boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema02Boxed](#schema02boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AllofCombinedWithAnyofOneof.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AllofCombinedWithAnyofOneof.md
@@ -11,37 +11,37 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [AllofCombinedWithAnyofOneof.AllofCombinedWithAnyofOneof1Boxed](#allofcombinedwithanyofoneof1boxed)<br> sealed interface for validated payloads |
-| record | [AllofCombinedWithAnyofOneof.AllofCombinedWithAnyofOneof1BoxedVoid](#allofcombinedwithanyofoneof1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofCombinedWithAnyofOneof.AllofCombinedWithAnyofOneof1BoxedBoolean](#allofcombinedwithanyofoneof1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofCombinedWithAnyofOneof.AllofCombinedWithAnyofOneof1BoxedNumber](#allofcombinedwithanyofoneof1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofCombinedWithAnyofOneof.AllofCombinedWithAnyofOneof1BoxedString](#allofcombinedwithanyofoneof1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofCombinedWithAnyofOneof.AllofCombinedWithAnyofOneof1BoxedList](#allofcombinedwithanyofoneof1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofCombinedWithAnyofOneof.AllofCombinedWithAnyofOneof1BoxedMap](#allofcombinedwithanyofoneof1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofCombinedWithAnyofOneof.AllofCombinedWithAnyofOneof1](#allofcombinedwithanyofoneof1)<br> schema class |
+| data class | [AllofCombinedWithAnyofOneof.AllofCombinedWithAnyofOneof1BoxedVoid](#allofcombinedwithanyofoneof1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofCombinedWithAnyofOneof.AllofCombinedWithAnyofOneof1BoxedBoolean](#allofcombinedwithanyofoneof1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofCombinedWithAnyofOneof.AllofCombinedWithAnyofOneof1BoxedNumber](#allofcombinedwithanyofoneof1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofCombinedWithAnyofOneof.AllofCombinedWithAnyofOneof1BoxedString](#allofcombinedwithanyofoneof1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofCombinedWithAnyofOneof.AllofCombinedWithAnyofOneof1BoxedList](#allofcombinedwithanyofoneof1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofCombinedWithAnyofOneof.AllofCombinedWithAnyofOneof1BoxedMap](#allofcombinedwithanyofoneof1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofCombinedWithAnyofOneof.AllofCombinedWithAnyofOneof1](#allofcombinedwithanyofoneof1)<br> schema class |
 | sealed interface | [AllofCombinedWithAnyofOneof.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofCombinedWithAnyofOneof.Schema0](#schema0)<br> schema class |
+| data class | [AllofCombinedWithAnyofOneof.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofCombinedWithAnyofOneof.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofCombinedWithAnyofOneof.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofCombinedWithAnyofOneof.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofCombinedWithAnyofOneof.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofCombinedWithAnyofOneof.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofCombinedWithAnyofOneof.Schema0](#schema0)<br> schema class |
 | sealed interface | [AllofCombinedWithAnyofOneof.Schema01Boxed](#schema01boxed)<br> sealed interface for validated payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema01BoxedVoid](#schema01boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema01BoxedBoolean](#schema01boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema01BoxedNumber](#schema01boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema01BoxedString](#schema01boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema01BoxedList](#schema01boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema01BoxedMap](#schema01boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofCombinedWithAnyofOneof.Schema01](#schema01)<br> schema class |
+| data class | [AllofCombinedWithAnyofOneof.Schema01BoxedVoid](#schema01boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofCombinedWithAnyofOneof.Schema01BoxedBoolean](#schema01boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofCombinedWithAnyofOneof.Schema01BoxedNumber](#schema01boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofCombinedWithAnyofOneof.Schema01BoxedString](#schema01boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofCombinedWithAnyofOneof.Schema01BoxedList](#schema01boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofCombinedWithAnyofOneof.Schema01BoxedMap](#schema01boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofCombinedWithAnyofOneof.Schema01](#schema01)<br> schema class |
 | sealed interface | [AllofCombinedWithAnyofOneof.Schema02Boxed](#schema02boxed)<br> sealed interface for validated payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema02BoxedVoid](#schema02boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema02BoxedBoolean](#schema02boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema02BoxedNumber](#schema02boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema02BoxedString](#schema02boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema02BoxedList](#schema02boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema02BoxedMap](#schema02boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofCombinedWithAnyofOneof.Schema02](#schema02)<br> schema class |
+| data class | [AllofCombinedWithAnyofOneof.Schema02BoxedVoid](#schema02boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofCombinedWithAnyofOneof.Schema02BoxedBoolean](#schema02boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofCombinedWithAnyofOneof.Schema02BoxedNumber](#schema02boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofCombinedWithAnyofOneof.Schema02BoxedString](#schema02boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofCombinedWithAnyofOneof.Schema02BoxedList](#schema02boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofCombinedWithAnyofOneof.Schema02BoxedMap](#schema02boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofCombinedWithAnyofOneof.Schema02](#schema02)<br> schema class |
 
 ## AllofCombinedWithAnyofOneof1Boxed
 sealed interface AllofCombinedWithAnyofOneof1Boxed<br>
@@ -76,7 +76,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class AllofCombinedWithAnyofOneof1BoxedBoolean<br>
 implements [AllofCombinedWithAnyofOneof1Boxed](#allofcombinedwithanyofoneof1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -225,7 +225,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -372,7 +372,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema01BoxedBoolean<br>
 implements [Schema01Boxed](#schema01boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -519,7 +519,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema02BoxedBoolean<br>
 implements [Schema02Boxed](#schema02boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AllofSimpleTypes.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AllofSimpleTypes.md
@@ -165,19 +165,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [AllofSimpleTypes1BoxedString](#allofsimpletypes1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [AllofSimpleTypes1BoxedVoid](#allofsimpletypes1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [AllofSimpleTypes1BoxedNumber](#allofsimpletypes1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [AllofSimpleTypes1BoxedBoolean](#allofsimpletypes1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [AllofSimpleTypes1BoxedMap](#allofsimpletypes1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [AllofSimpleTypes1BoxedBoolean](#allofsimpletypes1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [AllofSimpleTypes1BoxedMap](#allofsimpletypes1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [AllofSimpleTypes1BoxedList](#allofsimpletypes1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [AllofSimpleTypes1Boxed](#allofsimpletypes1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -312,19 +312,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema1BoxedString](#schema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema1BoxedVoid](#schema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema1BoxedNumber](#schema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema1BoxedList](#schema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema1Boxed](#schema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -459,19 +459,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema0BoxedString](#schema0boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema0BoxedVoid](#schema0boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema0BoxedNumber](#schema0boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema0BoxedList](#schema0boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema0Boxed](#schema0boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AllofSimpleTypes.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AllofSimpleTypes.md
@@ -11,29 +11,29 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [AllofSimpleTypes.AllofSimpleTypes1Boxed](#allofsimpletypes1boxed)<br> sealed interface for validated payloads |
-| record | [AllofSimpleTypes.AllofSimpleTypes1BoxedVoid](#allofsimpletypes1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofSimpleTypes.AllofSimpleTypes1BoxedBoolean](#allofsimpletypes1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofSimpleTypes.AllofSimpleTypes1BoxedNumber](#allofsimpletypes1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofSimpleTypes.AllofSimpleTypes1BoxedString](#allofsimpletypes1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofSimpleTypes.AllofSimpleTypes1BoxedList](#allofsimpletypes1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofSimpleTypes.AllofSimpleTypes1BoxedMap](#allofsimpletypes1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofSimpleTypes.AllofSimpleTypes1](#allofsimpletypes1)<br> schema class |
+| data class | [AllofSimpleTypes.AllofSimpleTypes1BoxedVoid](#allofsimpletypes1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofSimpleTypes.AllofSimpleTypes1BoxedBoolean](#allofsimpletypes1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofSimpleTypes.AllofSimpleTypes1BoxedNumber](#allofsimpletypes1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofSimpleTypes.AllofSimpleTypes1BoxedString](#allofsimpletypes1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofSimpleTypes.AllofSimpleTypes1BoxedList](#allofsimpletypes1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofSimpleTypes.AllofSimpleTypes1BoxedMap](#allofsimpletypes1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofSimpleTypes.AllofSimpleTypes1](#allofsimpletypes1)<br> schema class |
 | sealed interface | [AllofSimpleTypes.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [AllofSimpleTypes.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofSimpleTypes.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofSimpleTypes.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofSimpleTypes.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofSimpleTypes.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofSimpleTypes.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofSimpleTypes.Schema1](#schema1)<br> schema class |
+| data class | [AllofSimpleTypes.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofSimpleTypes.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofSimpleTypes.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofSimpleTypes.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofSimpleTypes.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofSimpleTypes.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofSimpleTypes.Schema1](#schema1)<br> schema class |
 | sealed interface | [AllofSimpleTypes.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [AllofSimpleTypes.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofSimpleTypes.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofSimpleTypes.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofSimpleTypes.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofSimpleTypes.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofSimpleTypes.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofSimpleTypes.Schema0](#schema0)<br> schema class |
+| data class | [AllofSimpleTypes.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofSimpleTypes.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofSimpleTypes.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofSimpleTypes.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofSimpleTypes.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofSimpleTypes.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofSimpleTypes.Schema0](#schema0)<br> schema class |
 
 ## AllofSimpleTypes1Boxed
 sealed interface AllofSimpleTypes1Boxed<br>
@@ -68,7 +68,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class AllofSimpleTypes1BoxedBoolean<br>
 implements [AllofSimpleTypes1Boxed](#allofsimpletypes1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -215,7 +215,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema1BoxedBoolean<br>
 implements [Schema1Boxed](#schema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -362,7 +362,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AllofWithBaseSchema.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AllofWithBaseSchema.md
@@ -184,19 +184,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [AllofWithBaseSchemaMap](#allofwithbaseschemamap) | validate(arg: [Map&lt;?, ?&gt;](#allofwithbaseschemamapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [AllofWithBaseSchemaMap](#allofwithbaseschemamap) | validate(arg: [Map&lt;*, *&gt;](#allofwithbaseschemamapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [AllofWithBaseSchema1BoxedString](#allofwithbaseschema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [AllofWithBaseSchema1BoxedVoid](#allofwithbaseschema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [AllofWithBaseSchema1BoxedNumber](#allofwithbaseschema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [AllofWithBaseSchema1BoxedBoolean](#allofwithbaseschema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [AllofWithBaseSchema1BoxedMap](#allofwithbaseschema1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#allofwithbaseschemamapbuilder), configuration: SchemaConfiguration) |
+| [AllofWithBaseSchema1BoxedBoolean](#allofwithbaseschema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [AllofWithBaseSchema1BoxedMap](#allofwithbaseschema1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#allofwithbaseschemamapbuilder), configuration: SchemaConfiguration) |
 | [AllofWithBaseSchema1BoxedList](#allofwithbaseschema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [AllofWithBaseSchema1Boxed](#allofwithbaseschema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -424,19 +424,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [Schema1Map](#schema1map) | validate(arg: [Map&lt;?, ?&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [Schema1Map](#schema1map) | validate(arg: [Map&lt;*, *&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema1BoxedString](#schema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema1BoxedVoid](#schema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema1BoxedNumber](#schema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
+| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
 | [Schema1BoxedList](#schema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema1Boxed](#schema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -661,19 +661,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [Schema0Map](#schema0map) | validate(arg: [Map&lt;?, ?&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [Schema0Map](#schema0map) | validate(arg: [Map&lt;*, *&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema0BoxedString](#schema0boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema0BoxedVoid](#schema0boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema0BoxedNumber](#schema0boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
+| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox([Map&lt;*, *&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
 | [Schema0BoxedList](#schema0boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema0Boxed](#schema0boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AllofWithBaseSchema.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AllofWithBaseSchema.md
@@ -13,44 +13,44 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [AllofWithBaseSchema.AllofWithBaseSchema1Boxed](#allofwithbaseschema1boxed)<br> sealed interface for validated payloads |
-| record | [AllofWithBaseSchema.AllofWithBaseSchema1BoxedVoid](#allofwithbaseschema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofWithBaseSchema.AllofWithBaseSchema1BoxedBoolean](#allofwithbaseschema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofWithBaseSchema.AllofWithBaseSchema1BoxedNumber](#allofwithbaseschema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofWithBaseSchema.AllofWithBaseSchema1BoxedString](#allofwithbaseschema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofWithBaseSchema.AllofWithBaseSchema1BoxedList](#allofwithbaseschema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofWithBaseSchema.AllofWithBaseSchema1BoxedMap](#allofwithbaseschema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofWithBaseSchema.AllofWithBaseSchema1](#allofwithbaseschema1)<br> schema class |
-| static class | [AllofWithBaseSchema.AllofWithBaseSchemaMapBuilder](#allofwithbaseschemamapbuilder)<br> builder for Map payloads |
-| static class | [AllofWithBaseSchema.AllofWithBaseSchemaMap](#allofwithbaseschemamap)<br> output class for Map payloads |
+| data class | [AllofWithBaseSchema.AllofWithBaseSchema1BoxedVoid](#allofwithbaseschema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofWithBaseSchema.AllofWithBaseSchema1BoxedBoolean](#allofwithbaseschema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofWithBaseSchema.AllofWithBaseSchema1BoxedNumber](#allofwithbaseschema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofWithBaseSchema.AllofWithBaseSchema1BoxedString](#allofwithbaseschema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofWithBaseSchema.AllofWithBaseSchema1BoxedList](#allofwithbaseschema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofWithBaseSchema.AllofWithBaseSchema1BoxedMap](#allofwithbaseschema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofWithBaseSchema.AllofWithBaseSchema1](#allofwithbaseschema1)<br> schema class |
+| class | [AllofWithBaseSchema.AllofWithBaseSchemaMapBuilder](#allofwithbaseschemamapbuilder)<br> builder for Map payloads |
+| class | [AllofWithBaseSchema.AllofWithBaseSchemaMap](#allofwithbaseschemamap)<br> output class for Map payloads |
 | sealed interface | [AllofWithBaseSchema.BarBoxed](#barboxed)<br> sealed interface for validated payloads |
-| record | [AllofWithBaseSchema.BarBoxedNumber](#barboxednumber)<br> boxed class to store validated Number payloads |
-| static class | [AllofWithBaseSchema.Bar](#bar)<br> schema class |
+| data class | [AllofWithBaseSchema.BarBoxedNumber](#barboxednumber)<br> boxed class to store validated Number payloads |
+| class | [AllofWithBaseSchema.Bar](#bar)<br> schema class |
 | sealed interface | [AllofWithBaseSchema.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [AllofWithBaseSchema.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofWithBaseSchema.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofWithBaseSchema.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofWithBaseSchema.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofWithBaseSchema.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofWithBaseSchema.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofWithBaseSchema.Schema1](#schema1)<br> schema class |
-| static class | [AllofWithBaseSchema.Schema1MapBuilder](#schema1mapbuilder)<br> builder for Map payloads |
-| static class | [AllofWithBaseSchema.Schema1Map](#schema1map)<br> output class for Map payloads |
+| data class | [AllofWithBaseSchema.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofWithBaseSchema.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofWithBaseSchema.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofWithBaseSchema.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofWithBaseSchema.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofWithBaseSchema.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofWithBaseSchema.Schema1](#schema1)<br> schema class |
+| class | [AllofWithBaseSchema.Schema1MapBuilder](#schema1mapbuilder)<br> builder for Map payloads |
+| class | [AllofWithBaseSchema.Schema1Map](#schema1map)<br> output class for Map payloads |
 | sealed interface | [AllofWithBaseSchema.BazBoxed](#bazboxed)<br> sealed interface for validated payloads |
-| record | [AllofWithBaseSchema.BazBoxedVoid](#bazboxedvoid)<br> boxed class to store validated null payloads |
-| static class | [AllofWithBaseSchema.Baz](#baz)<br> schema class |
+| data class | [AllofWithBaseSchema.BazBoxedVoid](#bazboxedvoid)<br> boxed class to store validated null payloads |
+| class | [AllofWithBaseSchema.Baz](#baz)<br> schema class |
 | sealed interface | [AllofWithBaseSchema.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [AllofWithBaseSchema.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofWithBaseSchema.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofWithBaseSchema.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofWithBaseSchema.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofWithBaseSchema.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofWithBaseSchema.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofWithBaseSchema.Schema0](#schema0)<br> schema class |
-| static class | [AllofWithBaseSchema.Schema0MapBuilder](#schema0mapbuilder)<br> builder for Map payloads |
-| static class | [AllofWithBaseSchema.Schema0Map](#schema0map)<br> output class for Map payloads |
+| data class | [AllofWithBaseSchema.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofWithBaseSchema.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofWithBaseSchema.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofWithBaseSchema.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofWithBaseSchema.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofWithBaseSchema.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofWithBaseSchema.Schema0](#schema0)<br> schema class |
+| class | [AllofWithBaseSchema.Schema0MapBuilder](#schema0mapbuilder)<br> builder for Map payloads |
+| class | [AllofWithBaseSchema.Schema0Map](#schema0map)<br> output class for Map payloads |
 | sealed interface | [AllofWithBaseSchema.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [AllofWithBaseSchema.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
-| static class | [AllofWithBaseSchema.Foo](#foo)<br> schema class |
+| data class | [AllofWithBaseSchema.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
+| class | [AllofWithBaseSchema.Foo](#foo)<br> schema class |
 
 ## AllofWithBaseSchema1Boxed
 sealed interface AllofWithBaseSchema1Boxed<br>
@@ -85,7 +85,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class AllofWithBaseSchema1BoxedBoolean<br>
 implements [AllofWithBaseSchema1Boxed](#allofwithbaseschema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -326,7 +326,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema1BoxedBoolean<br>
 implements [Schema1Boxed](#schema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -563,7 +563,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AllofWithOneEmptySchema.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AllofWithOneEmptySchema.md
@@ -11,21 +11,21 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [AllofWithOneEmptySchema.AllofWithOneEmptySchema1Boxed](#allofwithoneemptyschema1boxed)<br> sealed interface for validated payloads |
-| record | [AllofWithOneEmptySchema.AllofWithOneEmptySchema1BoxedVoid](#allofwithoneemptyschema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofWithOneEmptySchema.AllofWithOneEmptySchema1BoxedBoolean](#allofwithoneemptyschema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofWithOneEmptySchema.AllofWithOneEmptySchema1BoxedNumber](#allofwithoneemptyschema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofWithOneEmptySchema.AllofWithOneEmptySchema1BoxedString](#allofwithoneemptyschema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofWithOneEmptySchema.AllofWithOneEmptySchema1BoxedList](#allofwithoneemptyschema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofWithOneEmptySchema.AllofWithOneEmptySchema1BoxedMap](#allofwithoneemptyschema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofWithOneEmptySchema.AllofWithOneEmptySchema1](#allofwithoneemptyschema1)<br> schema class |
+| data class | [AllofWithOneEmptySchema.AllofWithOneEmptySchema1BoxedVoid](#allofwithoneemptyschema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofWithOneEmptySchema.AllofWithOneEmptySchema1BoxedBoolean](#allofwithoneemptyschema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofWithOneEmptySchema.AllofWithOneEmptySchema1BoxedNumber](#allofwithoneemptyschema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofWithOneEmptySchema.AllofWithOneEmptySchema1BoxedString](#allofwithoneemptyschema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofWithOneEmptySchema.AllofWithOneEmptySchema1BoxedList](#allofwithoneemptyschema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofWithOneEmptySchema.AllofWithOneEmptySchema1BoxedMap](#allofwithoneemptyschema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofWithOneEmptySchema.AllofWithOneEmptySchema1](#allofwithoneemptyschema1)<br> schema class |
 | sealed interface | [AllofWithOneEmptySchema.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [AllofWithOneEmptySchema.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofWithOneEmptySchema.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofWithOneEmptySchema.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofWithOneEmptySchema.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofWithOneEmptySchema.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofWithOneEmptySchema.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofWithOneEmptySchema.Schema0](#schema0)<br> schema class |
+| data class | [AllofWithOneEmptySchema.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofWithOneEmptySchema.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofWithOneEmptySchema.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofWithOneEmptySchema.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofWithOneEmptySchema.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofWithOneEmptySchema.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofWithOneEmptySchema.Schema0](#schema0)<br> schema class |
 
 ## AllofWithOneEmptySchema1Boxed
 sealed interface AllofWithOneEmptySchema1Boxed<br>
@@ -60,7 +60,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class AllofWithOneEmptySchema1BoxedBoolean<br>
 implements [AllofWithOneEmptySchema1Boxed](#allofwithoneemptyschema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -207,7 +207,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AllofWithOneEmptySchema.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AllofWithOneEmptySchema.md
@@ -157,19 +157,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [AllofWithOneEmptySchema1BoxedString](#allofwithoneemptyschema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [AllofWithOneEmptySchema1BoxedVoid](#allofwithoneemptyschema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [AllofWithOneEmptySchema1BoxedNumber](#allofwithoneemptyschema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [AllofWithOneEmptySchema1BoxedBoolean](#allofwithoneemptyschema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [AllofWithOneEmptySchema1BoxedMap](#allofwithoneemptyschema1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [AllofWithOneEmptySchema1BoxedBoolean](#allofwithoneemptyschema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [AllofWithOneEmptySchema1BoxedMap](#allofwithoneemptyschema1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [AllofWithOneEmptySchema1BoxedList](#allofwithoneemptyschema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [AllofWithOneEmptySchema1Boxed](#allofwithoneemptyschema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AllofWithTheFirstEmptySchema.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AllofWithTheFirstEmptySchema.md
@@ -11,24 +11,24 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [AllofWithTheFirstEmptySchema.AllofWithTheFirstEmptySchema1Boxed](#allofwiththefirstemptyschema1boxed)<br> sealed interface for validated payloads |
-| record | [AllofWithTheFirstEmptySchema.AllofWithTheFirstEmptySchema1BoxedVoid](#allofwiththefirstemptyschema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofWithTheFirstEmptySchema.AllofWithTheFirstEmptySchema1BoxedBoolean](#allofwiththefirstemptyschema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofWithTheFirstEmptySchema.AllofWithTheFirstEmptySchema1BoxedNumber](#allofwiththefirstemptyschema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofWithTheFirstEmptySchema.AllofWithTheFirstEmptySchema1BoxedString](#allofwiththefirstemptyschema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofWithTheFirstEmptySchema.AllofWithTheFirstEmptySchema1BoxedList](#allofwiththefirstemptyschema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofWithTheFirstEmptySchema.AllofWithTheFirstEmptySchema1BoxedMap](#allofwiththefirstemptyschema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofWithTheFirstEmptySchema.AllofWithTheFirstEmptySchema1](#allofwiththefirstemptyschema1)<br> schema class |
+| data class | [AllofWithTheFirstEmptySchema.AllofWithTheFirstEmptySchema1BoxedVoid](#allofwiththefirstemptyschema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofWithTheFirstEmptySchema.AllofWithTheFirstEmptySchema1BoxedBoolean](#allofwiththefirstemptyschema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofWithTheFirstEmptySchema.AllofWithTheFirstEmptySchema1BoxedNumber](#allofwiththefirstemptyschema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofWithTheFirstEmptySchema.AllofWithTheFirstEmptySchema1BoxedString](#allofwiththefirstemptyschema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofWithTheFirstEmptySchema.AllofWithTheFirstEmptySchema1BoxedList](#allofwiththefirstemptyschema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofWithTheFirstEmptySchema.AllofWithTheFirstEmptySchema1BoxedMap](#allofwiththefirstemptyschema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofWithTheFirstEmptySchema.AllofWithTheFirstEmptySchema1](#allofwiththefirstemptyschema1)<br> schema class |
 | sealed interface | [AllofWithTheFirstEmptySchema.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [AllofWithTheFirstEmptySchema.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [AllofWithTheFirstEmptySchema.Schema1](#schema1)<br> schema class |
+| data class | [AllofWithTheFirstEmptySchema.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
+| class | [AllofWithTheFirstEmptySchema.Schema1](#schema1)<br> schema class |
 | sealed interface | [AllofWithTheFirstEmptySchema.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [AllofWithTheFirstEmptySchema.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofWithTheFirstEmptySchema.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofWithTheFirstEmptySchema.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofWithTheFirstEmptySchema.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofWithTheFirstEmptySchema.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofWithTheFirstEmptySchema.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofWithTheFirstEmptySchema.Schema0](#schema0)<br> schema class |
+| data class | [AllofWithTheFirstEmptySchema.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofWithTheFirstEmptySchema.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofWithTheFirstEmptySchema.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofWithTheFirstEmptySchema.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofWithTheFirstEmptySchema.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofWithTheFirstEmptySchema.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofWithTheFirstEmptySchema.Schema0](#schema0)<br> schema class |
 
 ## AllofWithTheFirstEmptySchema1Boxed
 sealed interface AllofWithTheFirstEmptySchema1Boxed<br>
@@ -63,7 +63,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class AllofWithTheFirstEmptySchema1BoxedBoolean<br>
 implements [AllofWithTheFirstEmptySchema1Boxed](#allofwiththefirstemptyschema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -245,7 +245,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AllofWithTheFirstEmptySchema.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AllofWithTheFirstEmptySchema.md
@@ -160,19 +160,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [AllofWithTheFirstEmptySchema1BoxedString](#allofwiththefirstemptyschema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [AllofWithTheFirstEmptySchema1BoxedVoid](#allofwiththefirstemptyschema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [AllofWithTheFirstEmptySchema1BoxedNumber](#allofwiththefirstemptyschema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [AllofWithTheFirstEmptySchema1BoxedBoolean](#allofwiththefirstemptyschema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [AllofWithTheFirstEmptySchema1BoxedMap](#allofwiththefirstemptyschema1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [AllofWithTheFirstEmptySchema1BoxedBoolean](#allofwiththefirstemptyschema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [AllofWithTheFirstEmptySchema1BoxedMap](#allofwiththefirstemptyschema1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [AllofWithTheFirstEmptySchema1BoxedList](#allofwiththefirstemptyschema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [AllofWithTheFirstEmptySchema1Boxed](#allofwiththefirstemptyschema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AllofWithTheLastEmptySchema.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AllofWithTheLastEmptySchema.md
@@ -160,19 +160,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [AllofWithTheLastEmptySchema1BoxedString](#allofwiththelastemptyschema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [AllofWithTheLastEmptySchema1BoxedVoid](#allofwiththelastemptyschema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [AllofWithTheLastEmptySchema1BoxedNumber](#allofwiththelastemptyschema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [AllofWithTheLastEmptySchema1BoxedBoolean](#allofwiththelastemptyschema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [AllofWithTheLastEmptySchema1BoxedMap](#allofwiththelastemptyschema1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [AllofWithTheLastEmptySchema1BoxedBoolean](#allofwiththelastemptyschema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [AllofWithTheLastEmptySchema1BoxedMap](#allofwiththelastemptyschema1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [AllofWithTheLastEmptySchema1BoxedList](#allofwiththelastemptyschema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [AllofWithTheLastEmptySchema1Boxed](#allofwiththelastemptyschema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AllofWithTheLastEmptySchema.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AllofWithTheLastEmptySchema.md
@@ -11,24 +11,24 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [AllofWithTheLastEmptySchema.AllofWithTheLastEmptySchema1Boxed](#allofwiththelastemptyschema1boxed)<br> sealed interface for validated payloads |
-| record | [AllofWithTheLastEmptySchema.AllofWithTheLastEmptySchema1BoxedVoid](#allofwiththelastemptyschema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofWithTheLastEmptySchema.AllofWithTheLastEmptySchema1BoxedBoolean](#allofwiththelastemptyschema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofWithTheLastEmptySchema.AllofWithTheLastEmptySchema1BoxedNumber](#allofwiththelastemptyschema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofWithTheLastEmptySchema.AllofWithTheLastEmptySchema1BoxedString](#allofwiththelastemptyschema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofWithTheLastEmptySchema.AllofWithTheLastEmptySchema1BoxedList](#allofwiththelastemptyschema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofWithTheLastEmptySchema.AllofWithTheLastEmptySchema1BoxedMap](#allofwiththelastemptyschema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofWithTheLastEmptySchema.AllofWithTheLastEmptySchema1](#allofwiththelastemptyschema1)<br> schema class |
+| data class | [AllofWithTheLastEmptySchema.AllofWithTheLastEmptySchema1BoxedVoid](#allofwiththelastemptyschema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofWithTheLastEmptySchema.AllofWithTheLastEmptySchema1BoxedBoolean](#allofwiththelastemptyschema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofWithTheLastEmptySchema.AllofWithTheLastEmptySchema1BoxedNumber](#allofwiththelastemptyschema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofWithTheLastEmptySchema.AllofWithTheLastEmptySchema1BoxedString](#allofwiththelastemptyschema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofWithTheLastEmptySchema.AllofWithTheLastEmptySchema1BoxedList](#allofwiththelastemptyschema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofWithTheLastEmptySchema.AllofWithTheLastEmptySchema1BoxedMap](#allofwiththelastemptyschema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofWithTheLastEmptySchema.AllofWithTheLastEmptySchema1](#allofwiththelastemptyschema1)<br> schema class |
 | sealed interface | [AllofWithTheLastEmptySchema.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [AllofWithTheLastEmptySchema.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofWithTheLastEmptySchema.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofWithTheLastEmptySchema.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofWithTheLastEmptySchema.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofWithTheLastEmptySchema.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofWithTheLastEmptySchema.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofWithTheLastEmptySchema.Schema1](#schema1)<br> schema class |
+| data class | [AllofWithTheLastEmptySchema.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofWithTheLastEmptySchema.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofWithTheLastEmptySchema.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofWithTheLastEmptySchema.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofWithTheLastEmptySchema.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofWithTheLastEmptySchema.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofWithTheLastEmptySchema.Schema1](#schema1)<br> schema class |
 | sealed interface | [AllofWithTheLastEmptySchema.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [AllofWithTheLastEmptySchema.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [AllofWithTheLastEmptySchema.Schema0](#schema0)<br> schema class |
+| data class | [AllofWithTheLastEmptySchema.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| class | [AllofWithTheLastEmptySchema.Schema0](#schema0)<br> schema class |
 
 ## AllofWithTheLastEmptySchema1Boxed
 sealed interface AllofWithTheLastEmptySchema1Boxed<br>
@@ -63,7 +63,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class AllofWithTheLastEmptySchema1BoxedBoolean<br>
 implements [AllofWithTheLastEmptySchema1Boxed](#allofwiththelastemptyschema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -210,7 +210,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema1BoxedBoolean<br>
 implements [Schema1Boxed](#schema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AllofWithTwoEmptySchemas.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AllofWithTwoEmptySchemas.md
@@ -165,19 +165,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [AllofWithTwoEmptySchemas1BoxedString](#allofwithtwoemptyschemas1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [AllofWithTwoEmptySchemas1BoxedVoid](#allofwithtwoemptyschemas1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [AllofWithTwoEmptySchemas1BoxedNumber](#allofwithtwoemptyschemas1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [AllofWithTwoEmptySchemas1BoxedBoolean](#allofwithtwoemptyschemas1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [AllofWithTwoEmptySchemas1BoxedMap](#allofwithtwoemptyschemas1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [AllofWithTwoEmptySchemas1BoxedBoolean](#allofwithtwoemptyschemas1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [AllofWithTwoEmptySchemas1BoxedMap](#allofwithtwoemptyschemas1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [AllofWithTwoEmptySchemas1BoxedList](#allofwithtwoemptyschemas1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [AllofWithTwoEmptySchemas1Boxed](#allofwithtwoemptyschemas1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AllofWithTwoEmptySchemas.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AllofWithTwoEmptySchemas.md
@@ -11,29 +11,29 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [AllofWithTwoEmptySchemas.AllofWithTwoEmptySchemas1Boxed](#allofwithtwoemptyschemas1boxed)<br> sealed interface for validated payloads |
-| record | [AllofWithTwoEmptySchemas.AllofWithTwoEmptySchemas1BoxedVoid](#allofwithtwoemptyschemas1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofWithTwoEmptySchemas.AllofWithTwoEmptySchemas1BoxedBoolean](#allofwithtwoemptyschemas1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofWithTwoEmptySchemas.AllofWithTwoEmptySchemas1BoxedNumber](#allofwithtwoemptyschemas1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofWithTwoEmptySchemas.AllofWithTwoEmptySchemas1BoxedString](#allofwithtwoemptyschemas1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofWithTwoEmptySchemas.AllofWithTwoEmptySchemas1BoxedList](#allofwithtwoemptyschemas1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofWithTwoEmptySchemas.AllofWithTwoEmptySchemas1BoxedMap](#allofwithtwoemptyschemas1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofWithTwoEmptySchemas.AllofWithTwoEmptySchemas1](#allofwithtwoemptyschemas1)<br> schema class |
+| data class | [AllofWithTwoEmptySchemas.AllofWithTwoEmptySchemas1BoxedVoid](#allofwithtwoemptyschemas1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofWithTwoEmptySchemas.AllofWithTwoEmptySchemas1BoxedBoolean](#allofwithtwoemptyschemas1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofWithTwoEmptySchemas.AllofWithTwoEmptySchemas1BoxedNumber](#allofwithtwoemptyschemas1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofWithTwoEmptySchemas.AllofWithTwoEmptySchemas1BoxedString](#allofwithtwoemptyschemas1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofWithTwoEmptySchemas.AllofWithTwoEmptySchemas1BoxedList](#allofwithtwoemptyschemas1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofWithTwoEmptySchemas.AllofWithTwoEmptySchemas1BoxedMap](#allofwithtwoemptyschemas1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofWithTwoEmptySchemas.AllofWithTwoEmptySchemas1](#allofwithtwoemptyschemas1)<br> schema class |
 | sealed interface | [AllofWithTwoEmptySchemas.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [AllofWithTwoEmptySchemas.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofWithTwoEmptySchemas.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofWithTwoEmptySchemas.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofWithTwoEmptySchemas.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofWithTwoEmptySchemas.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofWithTwoEmptySchemas.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofWithTwoEmptySchemas.Schema1](#schema1)<br> schema class |
+| data class | [AllofWithTwoEmptySchemas.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofWithTwoEmptySchemas.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofWithTwoEmptySchemas.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofWithTwoEmptySchemas.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofWithTwoEmptySchemas.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofWithTwoEmptySchemas.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofWithTwoEmptySchemas.Schema1](#schema1)<br> schema class |
 | sealed interface | [AllofWithTwoEmptySchemas.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [AllofWithTwoEmptySchemas.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofWithTwoEmptySchemas.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofWithTwoEmptySchemas.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofWithTwoEmptySchemas.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofWithTwoEmptySchemas.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofWithTwoEmptySchemas.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofWithTwoEmptySchemas.Schema0](#schema0)<br> schema class |
+| data class | [AllofWithTwoEmptySchemas.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofWithTwoEmptySchemas.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofWithTwoEmptySchemas.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofWithTwoEmptySchemas.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofWithTwoEmptySchemas.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofWithTwoEmptySchemas.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofWithTwoEmptySchemas.Schema0](#schema0)<br> schema class |
 
 ## AllofWithTwoEmptySchemas1Boxed
 sealed interface AllofWithTwoEmptySchemas1Boxed<br>
@@ -68,7 +68,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class AllofWithTwoEmptySchemas1BoxedBoolean<br>
 implements [AllofWithTwoEmptySchemas1Boxed](#allofwithtwoemptyschemas1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -215,7 +215,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema1BoxedBoolean<br>
 implements [Schema1Boxed](#schema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -340,7 +340,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/Anyof.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/Anyof.md
@@ -11,24 +11,24 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [Anyof.Anyof1Boxed](#anyof1boxed)<br> sealed interface for validated payloads |
-| record | [Anyof.Anyof1BoxedVoid](#anyof1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [Anyof.Anyof1BoxedBoolean](#anyof1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [Anyof.Anyof1BoxedNumber](#anyof1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [Anyof.Anyof1BoxedString](#anyof1boxedstring)<br> boxed class to store validated String payloads |
-| record | [Anyof.Anyof1BoxedList](#anyof1boxedlist)<br> boxed class to store validated List payloads |
-| record | [Anyof.Anyof1BoxedMap](#anyof1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [Anyof.Anyof1](#anyof1)<br> schema class |
+| data class | [Anyof.Anyof1BoxedVoid](#anyof1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [Anyof.Anyof1BoxedBoolean](#anyof1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [Anyof.Anyof1BoxedNumber](#anyof1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [Anyof.Anyof1BoxedString](#anyof1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [Anyof.Anyof1BoxedList](#anyof1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [Anyof.Anyof1BoxedMap](#anyof1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [Anyof.Anyof1](#anyof1)<br> schema class |
 | sealed interface | [Anyof.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [Anyof.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [Anyof.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [Anyof.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [Anyof.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [Anyof.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [Anyof.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [Anyof.Schema1](#schema1)<br> schema class |
+| data class | [Anyof.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [Anyof.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [Anyof.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [Anyof.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [Anyof.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [Anyof.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [Anyof.Schema1](#schema1)<br> schema class |
 | sealed interface | [Anyof.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [Anyof.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [Anyof.Schema0](#schema0)<br> schema class |
+| data class | [Anyof.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| class | [Anyof.Schema0](#schema0)<br> schema class |
 
 ## Anyof1Boxed
 sealed interface Anyof1Boxed<br>
@@ -63,7 +63,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Anyof1BoxedBoolean<br>
 implements [Anyof1Boxed](#anyof1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -210,7 +210,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema1BoxedBoolean<br>
 implements [Schema1Boxed](#schema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/Anyof.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/Anyof.md
@@ -160,19 +160,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Anyof1BoxedString](#anyof1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Anyof1BoxedVoid](#anyof1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Anyof1BoxedNumber](#anyof1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Anyof1BoxedBoolean](#anyof1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Anyof1BoxedMap](#anyof1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Anyof1BoxedBoolean](#anyof1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Anyof1BoxedMap](#anyof1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Anyof1BoxedList](#anyof1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Anyof1Boxed](#anyof1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -307,19 +307,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema1BoxedString](#schema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema1BoxedVoid](#schema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema1BoxedNumber](#schema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema1BoxedList](#schema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema1Boxed](#schema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AnyofComplexTypes.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AnyofComplexTypes.md
@@ -13,39 +13,39 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [AnyofComplexTypes.AnyofComplexTypes1Boxed](#anyofcomplextypes1boxed)<br> sealed interface for validated payloads |
-| record | [AnyofComplexTypes.AnyofComplexTypes1BoxedVoid](#anyofcomplextypes1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AnyofComplexTypes.AnyofComplexTypes1BoxedBoolean](#anyofcomplextypes1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AnyofComplexTypes.AnyofComplexTypes1BoxedNumber](#anyofcomplextypes1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AnyofComplexTypes.AnyofComplexTypes1BoxedString](#anyofcomplextypes1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AnyofComplexTypes.AnyofComplexTypes1BoxedList](#anyofcomplextypes1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AnyofComplexTypes.AnyofComplexTypes1BoxedMap](#anyofcomplextypes1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AnyofComplexTypes.AnyofComplexTypes1](#anyofcomplextypes1)<br> schema class |
+| data class | [AnyofComplexTypes.AnyofComplexTypes1BoxedVoid](#anyofcomplextypes1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AnyofComplexTypes.AnyofComplexTypes1BoxedBoolean](#anyofcomplextypes1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AnyofComplexTypes.AnyofComplexTypes1BoxedNumber](#anyofcomplextypes1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AnyofComplexTypes.AnyofComplexTypes1BoxedString](#anyofcomplextypes1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AnyofComplexTypes.AnyofComplexTypes1BoxedList](#anyofcomplextypes1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AnyofComplexTypes.AnyofComplexTypes1BoxedMap](#anyofcomplextypes1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AnyofComplexTypes.AnyofComplexTypes1](#anyofcomplextypes1)<br> schema class |
 | sealed interface | [AnyofComplexTypes.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [AnyofComplexTypes.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AnyofComplexTypes.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AnyofComplexTypes.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AnyofComplexTypes.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AnyofComplexTypes.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AnyofComplexTypes.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AnyofComplexTypes.Schema1](#schema1)<br> schema class |
-| static class | [AnyofComplexTypes.Schema1MapBuilder](#schema1mapbuilder)<br> builder for Map payloads |
-| static class | [AnyofComplexTypes.Schema1Map](#schema1map)<br> output class for Map payloads |
+| data class | [AnyofComplexTypes.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AnyofComplexTypes.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AnyofComplexTypes.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AnyofComplexTypes.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AnyofComplexTypes.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AnyofComplexTypes.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AnyofComplexTypes.Schema1](#schema1)<br> schema class |
+| class | [AnyofComplexTypes.Schema1MapBuilder](#schema1mapbuilder)<br> builder for Map payloads |
+| class | [AnyofComplexTypes.Schema1Map](#schema1map)<br> output class for Map payloads |
 | sealed interface | [AnyofComplexTypes.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [AnyofComplexTypes.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
-| static class | [AnyofComplexTypes.Foo](#foo)<br> schema class |
+| data class | [AnyofComplexTypes.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
+| class | [AnyofComplexTypes.Foo](#foo)<br> schema class |
 | sealed interface | [AnyofComplexTypes.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [AnyofComplexTypes.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AnyofComplexTypes.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AnyofComplexTypes.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AnyofComplexTypes.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [AnyofComplexTypes.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [AnyofComplexTypes.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AnyofComplexTypes.Schema0](#schema0)<br> schema class |
-| static class | [AnyofComplexTypes.Schema0MapBuilder](#schema0mapbuilder)<br> builder for Map payloads |
-| static class | [AnyofComplexTypes.Schema0Map](#schema0map)<br> output class for Map payloads |
+| data class | [AnyofComplexTypes.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AnyofComplexTypes.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AnyofComplexTypes.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AnyofComplexTypes.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AnyofComplexTypes.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AnyofComplexTypes.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AnyofComplexTypes.Schema0](#schema0)<br> schema class |
+| class | [AnyofComplexTypes.Schema0MapBuilder](#schema0mapbuilder)<br> builder for Map payloads |
+| class | [AnyofComplexTypes.Schema0Map](#schema0map)<br> output class for Map payloads |
 | sealed interface | [AnyofComplexTypes.BarBoxed](#barboxed)<br> sealed interface for validated payloads |
-| record | [AnyofComplexTypes.BarBoxedNumber](#barboxednumber)<br> boxed class to store validated Number payloads |
-| static class | [AnyofComplexTypes.Bar](#bar)<br> schema class |
+| data class | [AnyofComplexTypes.BarBoxedNumber](#barboxednumber)<br> boxed class to store validated Number payloads |
+| class | [AnyofComplexTypes.Bar](#bar)<br> schema class |
 
 ## AnyofComplexTypes1Boxed
 sealed interface AnyofComplexTypes1Boxed<br>
@@ -80,7 +80,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class AnyofComplexTypes1BoxedBoolean<br>
 implements [AnyofComplexTypes1Boxed](#anyofcomplextypes1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -227,7 +227,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema1BoxedBoolean<br>
 implements [Schema1Boxed](#schema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -464,7 +464,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AnyofComplexTypes.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AnyofComplexTypes.md
@@ -177,19 +177,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [AnyofComplexTypes1BoxedString](#anyofcomplextypes1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [AnyofComplexTypes1BoxedVoid](#anyofcomplextypes1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [AnyofComplexTypes1BoxedNumber](#anyofcomplextypes1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [AnyofComplexTypes1BoxedBoolean](#anyofcomplextypes1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [AnyofComplexTypes1BoxedMap](#anyofcomplextypes1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [AnyofComplexTypes1BoxedBoolean](#anyofcomplextypes1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [AnyofComplexTypes1BoxedMap](#anyofcomplextypes1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [AnyofComplexTypes1BoxedList](#anyofcomplextypes1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [AnyofComplexTypes1Boxed](#anyofcomplextypes1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -325,19 +325,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [Schema1Map](#schema1map) | validate(arg: [Map&lt;?, ?&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [Schema1Map](#schema1map) | validate(arg: [Map&lt;*, *&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema1BoxedString](#schema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema1BoxedVoid](#schema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema1BoxedNumber](#schema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
+| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
 | [Schema1BoxedList](#schema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema1Boxed](#schema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -562,19 +562,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [Schema0Map](#schema0map) | validate(arg: [Map&lt;?, ?&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [Schema0Map](#schema0map) | validate(arg: [Map&lt;*, *&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema0BoxedString](#schema0boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema0BoxedVoid](#schema0boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema0BoxedNumber](#schema0boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
+| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox([Map&lt;*, *&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
 | [Schema0BoxedList](#schema0boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema0Boxed](#schema0boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AnyofWithBaseSchema.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AnyofWithBaseSchema.md
@@ -62,25 +62,21 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.AnyofWithBaseSchema;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.AnyofWithBaseSchema
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // String validation
-String validatedPayload = AnyofWithBaseSchema.AnyofWithBaseSchema1.validate(
+val validatedPayload: String = AnyofWithBaseSchema.AnyofWithBaseSchema1.validate(
     "a",
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -220,26 +216,26 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| Integer | minLength = 4 |
+| Int | minLength = 4 |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema1BoxedString](#schema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema1BoxedVoid](#schema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema1BoxedNumber](#schema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema1BoxedList](#schema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema1Boxed](#schema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -367,26 +363,26 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| Integer | maxLength = 2 |
+| Int | maxLength = 2 |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema0BoxedString](#schema0boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema0BoxedVoid](#schema0boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema0BoxedNumber](#schema0boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema0BoxedList](#schema0boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema0Boxed](#schema0boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AnyofWithBaseSchema.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AnyofWithBaseSchema.md
@@ -11,24 +11,24 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [AnyofWithBaseSchema.AnyofWithBaseSchema1Boxed](#anyofwithbaseschema1boxed)<br> sealed interface for validated payloads |
-| record | [AnyofWithBaseSchema.AnyofWithBaseSchema1BoxedString](#anyofwithbaseschema1boxedstring)<br> boxed class to store validated String payloads |
-| static class | [AnyofWithBaseSchema.AnyofWithBaseSchema1](#anyofwithbaseschema1)<br> schema class |
+| data class | [AnyofWithBaseSchema.AnyofWithBaseSchema1BoxedString](#anyofwithbaseschema1boxedstring)<br> boxed class to store validated String payloads |
+| class | [AnyofWithBaseSchema.AnyofWithBaseSchema1](#anyofwithbaseschema1)<br> schema class |
 | sealed interface | [AnyofWithBaseSchema.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [AnyofWithBaseSchema.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AnyofWithBaseSchema.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AnyofWithBaseSchema.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AnyofWithBaseSchema.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AnyofWithBaseSchema.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AnyofWithBaseSchema.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AnyofWithBaseSchema.Schema1](#schema1)<br> schema class |
+| data class | [AnyofWithBaseSchema.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AnyofWithBaseSchema.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AnyofWithBaseSchema.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AnyofWithBaseSchema.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AnyofWithBaseSchema.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AnyofWithBaseSchema.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AnyofWithBaseSchema.Schema1](#schema1)<br> schema class |
 | sealed interface | [AnyofWithBaseSchema.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [AnyofWithBaseSchema.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AnyofWithBaseSchema.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AnyofWithBaseSchema.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AnyofWithBaseSchema.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [AnyofWithBaseSchema.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [AnyofWithBaseSchema.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AnyofWithBaseSchema.Schema0](#schema0)<br> schema class |
+| data class | [AnyofWithBaseSchema.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AnyofWithBaseSchema.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AnyofWithBaseSchema.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AnyofWithBaseSchema.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AnyofWithBaseSchema.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AnyofWithBaseSchema.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AnyofWithBaseSchema.Schema0](#schema0)<br> schema class |
 
 ## AnyofWithBaseSchema1Boxed
 sealed interface AnyofWithBaseSchema1Boxed<br>
@@ -126,7 +126,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema1BoxedBoolean<br>
 implements [Schema1Boxed](#schema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -273,7 +273,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AnyofWithOneEmptySchema.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AnyofWithOneEmptySchema.md
@@ -11,24 +11,24 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [AnyofWithOneEmptySchema.AnyofWithOneEmptySchema1Boxed](#anyofwithoneemptyschema1boxed)<br> sealed interface for validated payloads |
-| record | [AnyofWithOneEmptySchema.AnyofWithOneEmptySchema1BoxedVoid](#anyofwithoneemptyschema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AnyofWithOneEmptySchema.AnyofWithOneEmptySchema1BoxedBoolean](#anyofwithoneemptyschema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AnyofWithOneEmptySchema.AnyofWithOneEmptySchema1BoxedNumber](#anyofwithoneemptyschema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AnyofWithOneEmptySchema.AnyofWithOneEmptySchema1BoxedString](#anyofwithoneemptyschema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AnyofWithOneEmptySchema.AnyofWithOneEmptySchema1BoxedList](#anyofwithoneemptyschema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AnyofWithOneEmptySchema.AnyofWithOneEmptySchema1BoxedMap](#anyofwithoneemptyschema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AnyofWithOneEmptySchema.AnyofWithOneEmptySchema1](#anyofwithoneemptyschema1)<br> schema class |
+| data class | [AnyofWithOneEmptySchema.AnyofWithOneEmptySchema1BoxedVoid](#anyofwithoneemptyschema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AnyofWithOneEmptySchema.AnyofWithOneEmptySchema1BoxedBoolean](#anyofwithoneemptyschema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AnyofWithOneEmptySchema.AnyofWithOneEmptySchema1BoxedNumber](#anyofwithoneemptyschema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AnyofWithOneEmptySchema.AnyofWithOneEmptySchema1BoxedString](#anyofwithoneemptyschema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AnyofWithOneEmptySchema.AnyofWithOneEmptySchema1BoxedList](#anyofwithoneemptyschema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AnyofWithOneEmptySchema.AnyofWithOneEmptySchema1BoxedMap](#anyofwithoneemptyschema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AnyofWithOneEmptySchema.AnyofWithOneEmptySchema1](#anyofwithoneemptyschema1)<br> schema class |
 | sealed interface | [AnyofWithOneEmptySchema.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [AnyofWithOneEmptySchema.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AnyofWithOneEmptySchema.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AnyofWithOneEmptySchema.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AnyofWithOneEmptySchema.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AnyofWithOneEmptySchema.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AnyofWithOneEmptySchema.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AnyofWithOneEmptySchema.Schema1](#schema1)<br> schema class |
+| data class | [AnyofWithOneEmptySchema.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AnyofWithOneEmptySchema.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AnyofWithOneEmptySchema.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AnyofWithOneEmptySchema.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AnyofWithOneEmptySchema.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AnyofWithOneEmptySchema.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AnyofWithOneEmptySchema.Schema1](#schema1)<br> schema class |
 | sealed interface | [AnyofWithOneEmptySchema.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [AnyofWithOneEmptySchema.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [AnyofWithOneEmptySchema.Schema0](#schema0)<br> schema class |
+| data class | [AnyofWithOneEmptySchema.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| class | [AnyofWithOneEmptySchema.Schema0](#schema0)<br> schema class |
 
 ## AnyofWithOneEmptySchema1Boxed
 sealed interface AnyofWithOneEmptySchema1Boxed<br>
@@ -63,7 +63,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class AnyofWithOneEmptySchema1BoxedBoolean<br>
 implements [AnyofWithOneEmptySchema1Boxed](#anyofwithoneemptyschema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -210,7 +210,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema1BoxedBoolean<br>
 implements [Schema1Boxed](#schema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AnyofWithOneEmptySchema.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/AnyofWithOneEmptySchema.md
@@ -160,19 +160,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [AnyofWithOneEmptySchema1BoxedString](#anyofwithoneemptyschema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [AnyofWithOneEmptySchema1BoxedVoid](#anyofwithoneemptyschema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [AnyofWithOneEmptySchema1BoxedNumber](#anyofwithoneemptyschema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [AnyofWithOneEmptySchema1BoxedBoolean](#anyofwithoneemptyschema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [AnyofWithOneEmptySchema1BoxedMap](#anyofwithoneemptyschema1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [AnyofWithOneEmptySchema1BoxedBoolean](#anyofwithoneemptyschema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [AnyofWithOneEmptySchema1BoxedMap](#anyofwithoneemptyschema1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [AnyofWithOneEmptySchema1BoxedList](#anyofwithoneemptyschema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [AnyofWithOneEmptySchema1Boxed](#anyofwithoneemptyschema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/ArrayTypeMatchesArrays.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/ArrayTypeMatchesArrays.md
@@ -58,27 +58,23 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.ArrayTypeMatchesArrays;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.ArrayTypeMatchesArrays
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // List validation
-ArrayTypeMatchesArrays.ArrayTypeMatchesArraysList validatedPayload =
+val validatedPayload: ArrayTypeMatchesArrays.ArrayTypeMatchesArraysList =
     ArrayTypeMatchesArrays.ArrayTypeMatchesArrays1.validate(
-    new ArrayTypeMatchesArrays.ArrayTypeMatchesArraysListBuilder()
+    ArrayTypeMatchesArrays.ArrayTypeMatchesArraysListBuilder()
     .build(),
     configuration
-);
+)
 ```
 
 ### Field Summary

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/ArrayTypeMatchesArrays.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/ArrayTypeMatchesArrays.md
@@ -13,18 +13,18 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [ArrayTypeMatchesArrays.ArrayTypeMatchesArrays1Boxed](#arraytypematchesarrays1boxed)<br> sealed interface for validated payloads |
-| record | [ArrayTypeMatchesArrays.ArrayTypeMatchesArrays1BoxedList](#arraytypematchesarrays1boxedlist)<br> boxed class to store validated List payloads |
-| static class | [ArrayTypeMatchesArrays.ArrayTypeMatchesArrays1](#arraytypematchesarrays1)<br> schema class |
-| static class | [ArrayTypeMatchesArrays.ArrayTypeMatchesArraysListBuilder](#arraytypematchesarrayslistbuilder)<br> builder for List payloads |
-| static class | [ArrayTypeMatchesArrays.ArrayTypeMatchesArraysList](#arraytypematchesarrayslist)<br> output class for List payloads |
+| data class | [ArrayTypeMatchesArrays.ArrayTypeMatchesArrays1BoxedList](#arraytypematchesarrays1boxedlist)<br> boxed class to store validated List payloads |
+| class | [ArrayTypeMatchesArrays.ArrayTypeMatchesArrays1](#arraytypematchesarrays1)<br> schema class |
+| class | [ArrayTypeMatchesArrays.ArrayTypeMatchesArraysListBuilder](#arraytypematchesarrayslistbuilder)<br> builder for List payloads |
+| class | [ArrayTypeMatchesArrays.ArrayTypeMatchesArraysList](#arraytypematchesarrayslist)<br> output class for List payloads |
 | sealed interface | [ArrayTypeMatchesArrays.ItemsBoxed](#itemsboxed)<br> sealed interface for validated payloads |
-| record | [ArrayTypeMatchesArrays.ItemsBoxedVoid](#itemsboxedvoid)<br> boxed class to store validated null payloads |
-| record | [ArrayTypeMatchesArrays.ItemsBoxedBoolean](#itemsboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [ArrayTypeMatchesArrays.ItemsBoxedNumber](#itemsboxednumber)<br> boxed class to store validated Number payloads |
-| record | [ArrayTypeMatchesArrays.ItemsBoxedString](#itemsboxedstring)<br> boxed class to store validated String payloads |
-| record | [ArrayTypeMatchesArrays.ItemsBoxedList](#itemsboxedlist)<br> boxed class to store validated List payloads |
-| record | [ArrayTypeMatchesArrays.ItemsBoxedMap](#itemsboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [ArrayTypeMatchesArrays.Items](#items)<br> schema class |
+| data class | [ArrayTypeMatchesArrays.ItemsBoxedVoid](#itemsboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [ArrayTypeMatchesArrays.ItemsBoxedBoolean](#itemsboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [ArrayTypeMatchesArrays.ItemsBoxedNumber](#itemsboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [ArrayTypeMatchesArrays.ItemsBoxedString](#itemsboxedstring)<br> boxed class to store validated String payloads |
+| data class | [ArrayTypeMatchesArrays.ItemsBoxedList](#itemsboxedlist)<br> boxed class to store validated List payloads |
+| data class | [ArrayTypeMatchesArrays.ItemsBoxedMap](#itemsboxedmap)<br> boxed class to store validated Map payloads |
+| class | [ArrayTypeMatchesArrays.Items](#items)<br> schema class |
 
 ## ArrayTypeMatchesArrays1Boxed
 sealed interface ArrayTypeMatchesArrays1Boxed<br>
@@ -161,7 +161,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class ItemsBoxedBoolean<br>
 implements [ItemsBoxed](#itemsboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/BooleanTypeMatchesBooleans.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/BooleanTypeMatchesBooleans.md
@@ -11,8 +11,8 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [BooleanTypeMatchesBooleans.BooleanTypeMatchesBooleans1Boxed](#booleantypematchesbooleans1boxed)<br> sealed interface for validated payloads |
-| record | [BooleanTypeMatchesBooleans.BooleanTypeMatchesBooleans1BoxedBoolean](#booleantypematchesbooleans1boxedboolean)<br> boxed class to store validated boolean payloads |
-| static class | [BooleanTypeMatchesBooleans.BooleanTypeMatchesBooleans1](#booleantypematchesbooleans1)<br> schema class |
+| data class | [BooleanTypeMatchesBooleans.BooleanTypeMatchesBooleans1BoxedBoolean](#booleantypematchesbooleans1boxedboolean)<br> boxed class to store validated boolean payloads |
+| class | [BooleanTypeMatchesBooleans.BooleanTypeMatchesBooleans1](#booleantypematchesbooleans1)<br> schema class |
 
 ## BooleanTypeMatchesBooleans1Boxed
 sealed interface BooleanTypeMatchesBooleans1Boxed<br>
@@ -25,7 +25,7 @@ sealed interface that stores validated payloads using boxed classes
 data class BooleanTypeMatchesBooleans1BoxedBoolean<br>
 implements [BooleanTypeMatchesBooleans1Boxed](#booleantypematchesbooleans1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/ByInt.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/ByInt.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [ByInt.ByInt1Boxed](#byint1boxed)<br> sealed interface for validated payloads |
-| record | [ByInt.ByInt1BoxedVoid](#byint1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [ByInt.ByInt1BoxedBoolean](#byint1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [ByInt.ByInt1BoxedNumber](#byint1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [ByInt.ByInt1BoxedString](#byint1boxedstring)<br> boxed class to store validated String payloads |
-| record | [ByInt.ByInt1BoxedList](#byint1boxedlist)<br> boxed class to store validated List payloads |
-| record | [ByInt.ByInt1BoxedMap](#byint1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [ByInt.ByInt1](#byint1)<br> schema class |
+| data class | [ByInt.ByInt1BoxedVoid](#byint1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [ByInt.ByInt1BoxedBoolean](#byint1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [ByInt.ByInt1BoxedNumber](#byint1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [ByInt.ByInt1BoxedString](#byint1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [ByInt.ByInt1BoxedList](#byint1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [ByInt.ByInt1BoxedMap](#byint1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [ByInt.ByInt1](#byint1)<br> schema class |
 
 ## ByInt1Boxed
 sealed interface ByInt1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class ByInt1BoxedBoolean<br>
 implements [ByInt1Boxed](#byint1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/ByInt.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/ByInt.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [ByInt1BoxedString](#byint1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [ByInt1BoxedVoid](#byint1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [ByInt1BoxedNumber](#byint1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [ByInt1BoxedBoolean](#byint1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [ByInt1BoxedMap](#byint1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [ByInt1BoxedBoolean](#byint1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [ByInt1BoxedMap](#byint1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [ByInt1BoxedList](#byint1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [ByInt1Boxed](#byint1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/ByNumber.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/ByNumber.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [ByNumber1BoxedString](#bynumber1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [ByNumber1BoxedVoid](#bynumber1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [ByNumber1BoxedNumber](#bynumber1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [ByNumber1BoxedBoolean](#bynumber1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [ByNumber1BoxedMap](#bynumber1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [ByNumber1BoxedBoolean](#bynumber1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [ByNumber1BoxedMap](#bynumber1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [ByNumber1BoxedList](#bynumber1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [ByNumber1Boxed](#bynumber1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/ByNumber.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/ByNumber.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [ByNumber.ByNumber1Boxed](#bynumber1boxed)<br> sealed interface for validated payloads |
-| record | [ByNumber.ByNumber1BoxedVoid](#bynumber1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [ByNumber.ByNumber1BoxedBoolean](#bynumber1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [ByNumber.ByNumber1BoxedNumber](#bynumber1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [ByNumber.ByNumber1BoxedString](#bynumber1boxedstring)<br> boxed class to store validated String payloads |
-| record | [ByNumber.ByNumber1BoxedList](#bynumber1boxedlist)<br> boxed class to store validated List payloads |
-| record | [ByNumber.ByNumber1BoxedMap](#bynumber1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [ByNumber.ByNumber1](#bynumber1)<br> schema class |
+| data class | [ByNumber.ByNumber1BoxedVoid](#bynumber1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [ByNumber.ByNumber1BoxedBoolean](#bynumber1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [ByNumber.ByNumber1BoxedNumber](#bynumber1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [ByNumber.ByNumber1BoxedString](#bynumber1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [ByNumber.ByNumber1BoxedList](#bynumber1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [ByNumber.ByNumber1BoxedMap](#bynumber1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [ByNumber.ByNumber1](#bynumber1)<br> schema class |
 
 ## ByNumber1Boxed
 sealed interface ByNumber1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class ByNumber1BoxedBoolean<br>
 implements [ByNumber1Boxed](#bynumber1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/BySmallNumber.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/BySmallNumber.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [BySmallNumber1BoxedString](#bysmallnumber1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [BySmallNumber1BoxedVoid](#bysmallnumber1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [BySmallNumber1BoxedNumber](#bysmallnumber1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [BySmallNumber1BoxedBoolean](#bysmallnumber1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [BySmallNumber1BoxedMap](#bysmallnumber1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [BySmallNumber1BoxedBoolean](#bysmallnumber1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [BySmallNumber1BoxedMap](#bysmallnumber1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [BySmallNumber1BoxedList](#bysmallnumber1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [BySmallNumber1Boxed](#bysmallnumber1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/BySmallNumber.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/BySmallNumber.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [BySmallNumber.BySmallNumber1Boxed](#bysmallnumber1boxed)<br> sealed interface for validated payloads |
-| record | [BySmallNumber.BySmallNumber1BoxedVoid](#bysmallnumber1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [BySmallNumber.BySmallNumber1BoxedBoolean](#bysmallnumber1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [BySmallNumber.BySmallNumber1BoxedNumber](#bysmallnumber1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [BySmallNumber.BySmallNumber1BoxedString](#bysmallnumber1boxedstring)<br> boxed class to store validated String payloads |
-| record | [BySmallNumber.BySmallNumber1BoxedList](#bysmallnumber1boxedlist)<br> boxed class to store validated List payloads |
-| record | [BySmallNumber.BySmallNumber1BoxedMap](#bysmallnumber1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [BySmallNumber.BySmallNumber1](#bysmallnumber1)<br> schema class |
+| data class | [BySmallNumber.BySmallNumber1BoxedVoid](#bysmallnumber1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [BySmallNumber.BySmallNumber1BoxedBoolean](#bysmallnumber1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [BySmallNumber.BySmallNumber1BoxedNumber](#bysmallnumber1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [BySmallNumber.BySmallNumber1BoxedString](#bysmallnumber1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [BySmallNumber.BySmallNumber1BoxedList](#bysmallnumber1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [BySmallNumber.BySmallNumber1BoxedMap](#bysmallnumber1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [BySmallNumber.BySmallNumber1](#bysmallnumber1)<br> schema class |
 
 ## BySmallNumber1Boxed
 sealed interface BySmallNumber1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class BySmallNumber1BoxedBoolean<br>
 implements [BySmallNumber1Boxed](#bysmallnumber1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/DateTimeFormat.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/DateTimeFormat.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [DateTimeFormat.DateTimeFormat1Boxed](#datetimeformat1boxed)<br> sealed interface for validated payloads |
-| record | [DateTimeFormat.DateTimeFormat1BoxedVoid](#datetimeformat1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [DateTimeFormat.DateTimeFormat1BoxedBoolean](#datetimeformat1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [DateTimeFormat.DateTimeFormat1BoxedNumber](#datetimeformat1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [DateTimeFormat.DateTimeFormat1BoxedString](#datetimeformat1boxedstring)<br> boxed class to store validated String payloads |
-| record | [DateTimeFormat.DateTimeFormat1BoxedList](#datetimeformat1boxedlist)<br> boxed class to store validated List payloads |
-| record | [DateTimeFormat.DateTimeFormat1BoxedMap](#datetimeformat1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [DateTimeFormat.DateTimeFormat1](#datetimeformat1)<br> schema class |
+| data class | [DateTimeFormat.DateTimeFormat1BoxedVoid](#datetimeformat1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [DateTimeFormat.DateTimeFormat1BoxedBoolean](#datetimeformat1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [DateTimeFormat.DateTimeFormat1BoxedNumber](#datetimeformat1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [DateTimeFormat.DateTimeFormat1BoxedString](#datetimeformat1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [DateTimeFormat.DateTimeFormat1BoxedList](#datetimeformat1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [DateTimeFormat.DateTimeFormat1BoxedMap](#datetimeformat1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [DateTimeFormat.DateTimeFormat1](#datetimeformat1)<br> schema class |
 
 ## DateTimeFormat1Boxed
 sealed interface DateTimeFormat1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class DateTimeFormat1BoxedBoolean<br>
 implements [DateTimeFormat1Boxed](#datetimeformat1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/DateTimeFormat.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/DateTimeFormat.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [DateTimeFormat1BoxedString](#datetimeformat1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [DateTimeFormat1BoxedVoid](#datetimeformat1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [DateTimeFormat1BoxedNumber](#datetimeformat1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [DateTimeFormat1BoxedBoolean](#datetimeformat1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [DateTimeFormat1BoxedMap](#datetimeformat1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [DateTimeFormat1BoxedBoolean](#datetimeformat1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [DateTimeFormat1BoxedMap](#datetimeformat1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [DateTimeFormat1BoxedList](#datetimeformat1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [DateTimeFormat1Boxed](#datetimeformat1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/EmailFormat.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/EmailFormat.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [EmailFormat1BoxedString](#emailformat1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [EmailFormat1BoxedVoid](#emailformat1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [EmailFormat1BoxedNumber](#emailformat1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [EmailFormat1BoxedBoolean](#emailformat1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [EmailFormat1BoxedMap](#emailformat1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [EmailFormat1BoxedBoolean](#emailformat1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [EmailFormat1BoxedMap](#emailformat1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [EmailFormat1BoxedList](#emailformat1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [EmailFormat1Boxed](#emailformat1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/EmailFormat.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/EmailFormat.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [EmailFormat.EmailFormat1Boxed](#emailformat1boxed)<br> sealed interface for validated payloads |
-| record | [EmailFormat.EmailFormat1BoxedVoid](#emailformat1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [EmailFormat.EmailFormat1BoxedBoolean](#emailformat1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [EmailFormat.EmailFormat1BoxedNumber](#emailformat1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [EmailFormat.EmailFormat1BoxedString](#emailformat1boxedstring)<br> boxed class to store validated String payloads |
-| record | [EmailFormat.EmailFormat1BoxedList](#emailformat1boxedlist)<br> boxed class to store validated List payloads |
-| record | [EmailFormat.EmailFormat1BoxedMap](#emailformat1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [EmailFormat.EmailFormat1](#emailformat1)<br> schema class |
+| data class | [EmailFormat.EmailFormat1BoxedVoid](#emailformat1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [EmailFormat.EmailFormat1BoxedBoolean](#emailformat1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [EmailFormat.EmailFormat1BoxedNumber](#emailformat1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [EmailFormat.EmailFormat1BoxedString](#emailformat1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [EmailFormat.EmailFormat1BoxedList](#emailformat1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [EmailFormat.EmailFormat1BoxedMap](#emailformat1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [EmailFormat.EmailFormat1](#emailformat1)<br> schema class |
 
 ## EmailFormat1Boxed
 sealed interface EmailFormat1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class EmailFormat1BoxedBoolean<br>
 implements [EmailFormat1Boxed](#emailformat1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/EnumWith0DoesNotMatchFalse.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/EnumWith0DoesNotMatchFalse.md
@@ -51,25 +51,21 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.EnumWith0DoesNotMatchFalse;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.EnumWith0DoesNotMatchFalse
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // int validation
-int validatedPayload = EnumWith0DoesNotMatchFalse.EnumWith0DoesNotMatchFalse1.validate(
+val validatedPayload: Int = EnumWith0DoesNotMatchFalse.EnumWith0DoesNotMatchFalse1.validate(
     1,
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -90,7 +86,7 @@ int validatedPayload = EnumWith0DoesNotMatchFalse.EnumWith0DoesNotMatchFalse1.va
 public enum IntegerEnumWith0DoesNotMatchFalseEnums<br>
 extends `Enum<IntegerEnumWith0DoesNotMatchFalseEnums>`
 
-A class that stores Integer enum values
+A class that stores Int enum values
 
 ### Enum Constant Summary
 | Enum Constant | Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/EnumWith0DoesNotMatchFalse.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/EnumWith0DoesNotMatchFalse.md
@@ -12,8 +12,8 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [EnumWith0DoesNotMatchFalse.EnumWith0DoesNotMatchFalse1Boxed](#enumwith0doesnotmatchfalse1boxed)<br> sealed interface for validated payloads |
-| record | [EnumWith0DoesNotMatchFalse.EnumWith0DoesNotMatchFalse1BoxedNumber](#enumwith0doesnotmatchfalse1boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [EnumWith0DoesNotMatchFalse.EnumWith0DoesNotMatchFalse1](#enumwith0doesnotmatchfalse1)<br> schema class |
+| data class | [EnumWith0DoesNotMatchFalse.EnumWith0DoesNotMatchFalse1BoxedNumber](#enumwith0doesnotmatchfalse1boxednumber)<br> boxed class to store validated Number payloads |
+| class | [EnumWith0DoesNotMatchFalse.EnumWith0DoesNotMatchFalse1](#enumwith0doesnotmatchfalse1)<br> schema class |
 | enum | [EnumWith0DoesNotMatchFalse.IntegerEnumWith0DoesNotMatchFalseEnums](#integerenumwith0doesnotmatchfalseenums)<br>Integer enum |
 | enum | [EnumWith0DoesNotMatchFalse.LongEnumWith0DoesNotMatchFalseEnums](#longenumwith0doesnotmatchfalseenums)<br>Long enum |
 | enum | [EnumWith0DoesNotMatchFalse.FloatEnumWith0DoesNotMatchFalseEnums](#floatenumwith0doesnotmatchfalseenums)<br>Float enum |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/EnumWith1DoesNotMatchTrue.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/EnumWith1DoesNotMatchTrue.md
@@ -51,25 +51,21 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.EnumWith1DoesNotMatchTrue;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.EnumWith1DoesNotMatchTrue
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // int validation
-int validatedPayload = EnumWith1DoesNotMatchTrue.EnumWith1DoesNotMatchTrue1.validate(
+val validatedPayload: Int = EnumWith1DoesNotMatchTrue.EnumWith1DoesNotMatchTrue1.validate(
     1,
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -90,7 +86,7 @@ int validatedPayload = EnumWith1DoesNotMatchTrue.EnumWith1DoesNotMatchTrue1.vali
 public enum IntegerEnumWith1DoesNotMatchTrueEnums<br>
 extends `Enum<IntegerEnumWith1DoesNotMatchTrueEnums>`
 
-A class that stores Integer enum values
+A class that stores Int enum values
 
 ### Enum Constant Summary
 | Enum Constant | Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/EnumWith1DoesNotMatchTrue.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/EnumWith1DoesNotMatchTrue.md
@@ -12,8 +12,8 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [EnumWith1DoesNotMatchTrue.EnumWith1DoesNotMatchTrue1Boxed](#enumwith1doesnotmatchtrue1boxed)<br> sealed interface for validated payloads |
-| record | [EnumWith1DoesNotMatchTrue.EnumWith1DoesNotMatchTrue1BoxedNumber](#enumwith1doesnotmatchtrue1boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [EnumWith1DoesNotMatchTrue.EnumWith1DoesNotMatchTrue1](#enumwith1doesnotmatchtrue1)<br> schema class |
+| data class | [EnumWith1DoesNotMatchTrue.EnumWith1DoesNotMatchTrue1BoxedNumber](#enumwith1doesnotmatchtrue1boxednumber)<br> boxed class to store validated Number payloads |
+| class | [EnumWith1DoesNotMatchTrue.EnumWith1DoesNotMatchTrue1](#enumwith1doesnotmatchtrue1)<br> schema class |
 | enum | [EnumWith1DoesNotMatchTrue.IntegerEnumWith1DoesNotMatchTrueEnums](#integerenumwith1doesnotmatchtrueenums)<br>Integer enum |
 | enum | [EnumWith1DoesNotMatchTrue.LongEnumWith1DoesNotMatchTrueEnums](#longenumwith1doesnotmatchtrueenums)<br>Long enum |
 | enum | [EnumWith1DoesNotMatchTrue.FloatEnumWith1DoesNotMatchTrueEnums](#floatenumwith1doesnotmatchtrueenums)<br>Float enum |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/EnumWithEscapedCharacters.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/EnumWithEscapedCharacters.md
@@ -12,8 +12,8 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [EnumWithEscapedCharacters.EnumWithEscapedCharacters1Boxed](#enumwithescapedcharacters1boxed)<br> sealed interface for validated payloads |
-| record | [EnumWithEscapedCharacters.EnumWithEscapedCharacters1BoxedString](#enumwithescapedcharacters1boxedstring)<br> boxed class to store validated String payloads |
-| static class | [EnumWithEscapedCharacters.EnumWithEscapedCharacters1](#enumwithescapedcharacters1)<br> schema class |
+| data class | [EnumWithEscapedCharacters.EnumWithEscapedCharacters1BoxedString](#enumwithescapedcharacters1boxedstring)<br> boxed class to store validated String payloads |
+| class | [EnumWithEscapedCharacters.EnumWithEscapedCharacters1](#enumwithescapedcharacters1)<br> schema class |
 | enum | [EnumWithEscapedCharacters.StringEnumWithEscapedCharactersEnums](#stringenumwithescapedcharactersenums)<br>String enum |
 
 ## EnumWithEscapedCharacters1Boxed

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/EnumWithEscapedCharacters.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/EnumWithEscapedCharacters.md
@@ -48,25 +48,21 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.EnumWithEscapedCharacters;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.EnumWithEscapedCharacters
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // String validation
-String validatedPayload = EnumWithEscapedCharacters.EnumWithEscapedCharacters1.validate(
+val validatedPayload: String = EnumWithEscapedCharacters.EnumWithEscapedCharacters1.validate(
     "foo\nbar",
     configuration
-);
+)
 ```
 
 ### Field Summary

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/EnumWithFalseDoesNotMatch0.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/EnumWithFalseDoesNotMatch0.md
@@ -48,25 +48,21 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.EnumWithFalseDoesNotMatch0;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.EnumWithFalseDoesNotMatch0
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // boolean validation
-boolean validatedPayload = EnumWithFalseDoesNotMatch0.EnumWithFalseDoesNotMatch01.validate(
+val validatedPayload: Boolean = EnumWithFalseDoesNotMatch0.EnumWithFalseDoesNotMatch01.validate(
     false,
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -78,9 +74,9 @@ boolean validatedPayload = EnumWithFalseDoesNotMatch0.EnumWithFalseDoesNotMatch0
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| boolean | validate(arg: [BooleanEnumWithFalseDoesNotMatch0Enums](#booleanenumwithfalsedoesnotmatch0enums), configuration: SchemaConfiguration) |
-| [EnumWithFalseDoesNotMatch01BoxedBoolean](#enumwithfalsedoesnotmatch01boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: [BooleanEnumWithFalseDoesNotMatch0Enums](#booleanenumwithfalsedoesnotmatch0enums), configuration: SchemaConfiguration) |
+| [EnumWithFalseDoesNotMatch01BoxedBoolean](#enumwithfalsedoesnotmatch01boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
 | [EnumWithFalseDoesNotMatch01Boxed](#enumwithfalsedoesnotmatch01boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
 

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/EnumWithFalseDoesNotMatch0.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/EnumWithFalseDoesNotMatch0.md
@@ -12,8 +12,8 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [EnumWithFalseDoesNotMatch0.EnumWithFalseDoesNotMatch01Boxed](#enumwithfalsedoesnotmatch01boxed)<br> sealed interface for validated payloads |
-| record | [EnumWithFalseDoesNotMatch0.EnumWithFalseDoesNotMatch01BoxedBoolean](#enumwithfalsedoesnotmatch01boxedboolean)<br> boxed class to store validated boolean payloads |
-| static class | [EnumWithFalseDoesNotMatch0.EnumWithFalseDoesNotMatch01](#enumwithfalsedoesnotmatch01)<br> schema class |
+| data class | [EnumWithFalseDoesNotMatch0.EnumWithFalseDoesNotMatch01BoxedBoolean](#enumwithfalsedoesnotmatch01boxedboolean)<br> boxed class to store validated boolean payloads |
+| class | [EnumWithFalseDoesNotMatch0.EnumWithFalseDoesNotMatch01](#enumwithfalsedoesnotmatch01)<br> schema class |
 | enum | [EnumWithFalseDoesNotMatch0.BooleanEnumWithFalseDoesNotMatch0Enums](#booleanenumwithfalsedoesnotmatch0enums)<br>boolean enum |
 
 ## EnumWithFalseDoesNotMatch01Boxed
@@ -27,7 +27,7 @@ sealed interface that stores validated payloads using boxed classes
 data class EnumWithFalseDoesNotMatch01BoxedBoolean<br>
 implements [EnumWithFalseDoesNotMatch01Boxed](#enumwithfalsedoesnotmatch01boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/EnumWithTrueDoesNotMatch1.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/EnumWithTrueDoesNotMatch1.md
@@ -12,8 +12,8 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [EnumWithTrueDoesNotMatch1.EnumWithTrueDoesNotMatch11Boxed](#enumwithtruedoesnotmatch11boxed)<br> sealed interface for validated payloads |
-| record | [EnumWithTrueDoesNotMatch1.EnumWithTrueDoesNotMatch11BoxedBoolean](#enumwithtruedoesnotmatch11boxedboolean)<br> boxed class to store validated boolean payloads |
-| static class | [EnumWithTrueDoesNotMatch1.EnumWithTrueDoesNotMatch11](#enumwithtruedoesnotmatch11)<br> schema class |
+| data class | [EnumWithTrueDoesNotMatch1.EnumWithTrueDoesNotMatch11BoxedBoolean](#enumwithtruedoesnotmatch11boxedboolean)<br> boxed class to store validated boolean payloads |
+| class | [EnumWithTrueDoesNotMatch1.EnumWithTrueDoesNotMatch11](#enumwithtruedoesnotmatch11)<br> schema class |
 | enum | [EnumWithTrueDoesNotMatch1.BooleanEnumWithTrueDoesNotMatch1Enums](#booleanenumwithtruedoesnotmatch1enums)<br>boolean enum |
 
 ## EnumWithTrueDoesNotMatch11Boxed
@@ -27,7 +27,7 @@ sealed interface that stores validated payloads using boxed classes
 data class EnumWithTrueDoesNotMatch11BoxedBoolean<br>
 implements [EnumWithTrueDoesNotMatch11Boxed](#enumwithtruedoesnotmatch11boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/EnumWithTrueDoesNotMatch1.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/EnumWithTrueDoesNotMatch1.md
@@ -48,25 +48,21 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.EnumWithTrueDoesNotMatch1;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.EnumWithTrueDoesNotMatch1
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // boolean validation
-boolean validatedPayload = EnumWithTrueDoesNotMatch1.EnumWithTrueDoesNotMatch11.validate(
+val validatedPayload: Boolean = EnumWithTrueDoesNotMatch1.EnumWithTrueDoesNotMatch11.validate(
     true,
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -78,9 +74,9 @@ boolean validatedPayload = EnumWithTrueDoesNotMatch1.EnumWithTrueDoesNotMatch11.
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| boolean | validate(arg: [BooleanEnumWithTrueDoesNotMatch1Enums](#booleanenumwithtruedoesnotmatch1enums), configuration: SchemaConfiguration) |
-| [EnumWithTrueDoesNotMatch11BoxedBoolean](#enumwithtruedoesnotmatch11boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: [BooleanEnumWithTrueDoesNotMatch1Enums](#booleanenumwithtruedoesnotmatch1enums), configuration: SchemaConfiguration) |
+| [EnumWithTrueDoesNotMatch11BoxedBoolean](#enumwithtruedoesnotmatch11boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
 | [EnumWithTrueDoesNotMatch11Boxed](#enumwithtruedoesnotmatch11boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
 

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/EnumsInProperties.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/EnumsInProperties.md
@@ -14,17 +14,17 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [EnumsInProperties.EnumsInProperties1Boxed](#enumsinproperties1boxed)<br> sealed interface for validated payloads |
-| record | [EnumsInProperties.EnumsInProperties1BoxedMap](#enumsinproperties1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [EnumsInProperties.EnumsInProperties1](#enumsinproperties1)<br> schema class |
-| static class | [EnumsInProperties.EnumsInPropertiesMapBuilder](#enumsinpropertiesmapbuilder)<br> builder for Map payloads |
-| static class | [EnumsInProperties.EnumsInPropertiesMap](#enumsinpropertiesmap)<br> output class for Map payloads |
+| data class | [EnumsInProperties.EnumsInProperties1BoxedMap](#enumsinproperties1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [EnumsInProperties.EnumsInProperties1](#enumsinproperties1)<br> schema class |
+| class | [EnumsInProperties.EnumsInPropertiesMapBuilder](#enumsinpropertiesmapbuilder)<br> builder for Map payloads |
+| class | [EnumsInProperties.EnumsInPropertiesMap](#enumsinpropertiesmap)<br> output class for Map payloads |
 | sealed interface | [EnumsInProperties.BarBoxed](#barboxed)<br> sealed interface for validated payloads |
-| record | [EnumsInProperties.BarBoxedString](#barboxedstring)<br> boxed class to store validated String payloads |
-| static class | [EnumsInProperties.Bar](#bar)<br> schema class |
+| data class | [EnumsInProperties.BarBoxedString](#barboxedstring)<br> boxed class to store validated String payloads |
+| class | [EnumsInProperties.Bar](#bar)<br> schema class |
 | enum | [EnumsInProperties.StringBarEnums](#stringbarenums)<br>String enum |
 | sealed interface | [EnumsInProperties.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [EnumsInProperties.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
-| static class | [EnumsInProperties.Foo](#foo)<br> schema class |
+| data class | [EnumsInProperties.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
+| class | [EnumsInProperties.Foo](#foo)<br> schema class |
 | enum | [EnumsInProperties.StringFooEnums](#stringfooenums)<br>String enum |
 
 ## EnumsInProperties1Boxed

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/EnumsInProperties.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/EnumsInProperties.md
@@ -59,31 +59,27 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.EnumsInProperties;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.EnumsInProperties
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // Map validation
-EnumsInProperties.EnumsInPropertiesMap validatedPayload =
+val validatedPayload: EnumsInProperties.EnumsInPropertiesMap =
     EnumsInProperties.EnumsInProperties1.validate(
-    new EnumsInProperties.EnumsInPropertiesMapBuilder()
+    EnumsInProperties.EnumsInPropertiesMapBuilder()
         .bar("bar")
 
         .foo("foo")
 
     .build(),
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -96,8 +92,8 @@ EnumsInProperties.EnumsInPropertiesMap validatedPayload =
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| [EnumsInPropertiesMap](#enumsinpropertiesmap) | validate(arg: [Map&lt;?, ?&gt;](#enumsinpropertiesmapbuilder), configuration: SchemaConfiguration) |
-| [EnumsInProperties1BoxedMap](#enumsinproperties1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#enumsinpropertiesmapbuilder), configuration: SchemaConfiguration) |
+| [EnumsInPropertiesMap](#enumsinpropertiesmap) | validate(arg: [Map&lt;*, *&gt;](#enumsinpropertiesmapbuilder), configuration: SchemaConfiguration) |
+| [EnumsInProperties1BoxedMap](#enumsinproperties1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#enumsinpropertiesmapbuilder), configuration: SchemaConfiguration) |
 | [EnumsInProperties1Boxed](#enumsinproperties1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
 
@@ -191,25 +187,21 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.EnumsInProperties;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.EnumsInProperties
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // String validation
-String validatedPayload = EnumsInProperties.Bar.validate(
+val validatedPayload: String = EnumsInProperties.Bar.validate(
     "bar",
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -270,25 +262,21 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.EnumsInProperties;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.EnumsInProperties
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // String validation
-String validatedPayload = EnumsInProperties.Foo.validate(
+val validatedPayload: String = EnumsInProperties.Foo.validate(
     "foo",
     configuration
-);
+)
 ```
 
 ### Field Summary

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/ForbiddenProperty.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/ForbiddenProperty.md
@@ -161,19 +161,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [ForbiddenPropertyMap](#forbiddenpropertymap) | validate(arg: [Map&lt;?, ?&gt;](#forbiddenpropertymapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [ForbiddenPropertyMap](#forbiddenpropertymap) | validate(arg: [Map&lt;*, *&gt;](#forbiddenpropertymapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [ForbiddenProperty1BoxedString](#forbiddenproperty1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [ForbiddenProperty1BoxedVoid](#forbiddenproperty1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [ForbiddenProperty1BoxedNumber](#forbiddenproperty1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [ForbiddenProperty1BoxedBoolean](#forbiddenproperty1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [ForbiddenProperty1BoxedMap](#forbiddenproperty1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#forbiddenpropertymapbuilder), configuration: SchemaConfiguration) |
+| [ForbiddenProperty1BoxedBoolean](#forbiddenproperty1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [ForbiddenProperty1BoxedMap](#forbiddenproperty1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#forbiddenpropertymapbuilder), configuration: SchemaConfiguration) |
 | [ForbiddenProperty1BoxedList](#forbiddenproperty1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [ForbiddenProperty1Boxed](#forbiddenproperty1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/ForbiddenProperty.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/ForbiddenProperty.md
@@ -13,23 +13,23 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [ForbiddenProperty.ForbiddenProperty1Boxed](#forbiddenproperty1boxed)<br> sealed interface for validated payloads |
-| record | [ForbiddenProperty.ForbiddenProperty1BoxedVoid](#forbiddenproperty1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [ForbiddenProperty.ForbiddenProperty1BoxedBoolean](#forbiddenproperty1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [ForbiddenProperty.ForbiddenProperty1BoxedNumber](#forbiddenproperty1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [ForbiddenProperty.ForbiddenProperty1BoxedString](#forbiddenproperty1boxedstring)<br> boxed class to store validated String payloads |
-| record | [ForbiddenProperty.ForbiddenProperty1BoxedList](#forbiddenproperty1boxedlist)<br> boxed class to store validated List payloads |
-| record | [ForbiddenProperty.ForbiddenProperty1BoxedMap](#forbiddenproperty1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [ForbiddenProperty.ForbiddenProperty1](#forbiddenproperty1)<br> schema class |
-| static class | [ForbiddenProperty.ForbiddenPropertyMapBuilder](#forbiddenpropertymapbuilder)<br> builder for Map payloads |
-| static class | [ForbiddenProperty.ForbiddenPropertyMap](#forbiddenpropertymap)<br> output class for Map payloads |
+| data class | [ForbiddenProperty.ForbiddenProperty1BoxedVoid](#forbiddenproperty1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [ForbiddenProperty.ForbiddenProperty1BoxedBoolean](#forbiddenproperty1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [ForbiddenProperty.ForbiddenProperty1BoxedNumber](#forbiddenproperty1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [ForbiddenProperty.ForbiddenProperty1BoxedString](#forbiddenproperty1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [ForbiddenProperty.ForbiddenProperty1BoxedList](#forbiddenproperty1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [ForbiddenProperty.ForbiddenProperty1BoxedMap](#forbiddenproperty1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [ForbiddenProperty.ForbiddenProperty1](#forbiddenproperty1)<br> schema class |
+| class | [ForbiddenProperty.ForbiddenPropertyMapBuilder](#forbiddenpropertymapbuilder)<br> builder for Map payloads |
+| class | [ForbiddenProperty.ForbiddenPropertyMap](#forbiddenpropertymap)<br> output class for Map payloads |
 | sealed interface | [ForbiddenProperty.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [ForbiddenProperty.FooBoxedVoid](#fooboxedvoid)<br> boxed class to store validated null payloads |
-| record | [ForbiddenProperty.FooBoxedBoolean](#fooboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [ForbiddenProperty.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
-| record | [ForbiddenProperty.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
-| record | [ForbiddenProperty.FooBoxedList](#fooboxedlist)<br> boxed class to store validated List payloads |
-| record | [ForbiddenProperty.FooBoxedMap](#fooboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [ForbiddenProperty.Foo](#foo)<br> schema class |
+| data class | [ForbiddenProperty.FooBoxedVoid](#fooboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [ForbiddenProperty.FooBoxedBoolean](#fooboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [ForbiddenProperty.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [ForbiddenProperty.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
+| data class | [ForbiddenProperty.FooBoxedList](#fooboxedlist)<br> boxed class to store validated List payloads |
+| data class | [ForbiddenProperty.FooBoxedMap](#fooboxedmap)<br> boxed class to store validated Map payloads |
+| class | [ForbiddenProperty.Foo](#foo)<br> schema class |
 
 ## ForbiddenProperty1Boxed
 sealed interface ForbiddenProperty1Boxed<br>
@@ -64,7 +64,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class ForbiddenProperty1BoxedBoolean<br>
 implements [ForbiddenProperty1Boxed](#forbiddenproperty1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -258,7 +258,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class FooBoxedBoolean<br>
 implements [FooBoxed](#fooboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/HostnameFormat.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/HostnameFormat.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [HostnameFormat1BoxedString](#hostnameformat1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [HostnameFormat1BoxedVoid](#hostnameformat1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [HostnameFormat1BoxedNumber](#hostnameformat1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [HostnameFormat1BoxedBoolean](#hostnameformat1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [HostnameFormat1BoxedMap](#hostnameformat1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [HostnameFormat1BoxedBoolean](#hostnameformat1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [HostnameFormat1BoxedMap](#hostnameformat1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [HostnameFormat1BoxedList](#hostnameformat1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [HostnameFormat1Boxed](#hostnameformat1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/HostnameFormat.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/HostnameFormat.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [HostnameFormat.HostnameFormat1Boxed](#hostnameformat1boxed)<br> sealed interface for validated payloads |
-| record | [HostnameFormat.HostnameFormat1BoxedVoid](#hostnameformat1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [HostnameFormat.HostnameFormat1BoxedBoolean](#hostnameformat1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [HostnameFormat.HostnameFormat1BoxedNumber](#hostnameformat1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [HostnameFormat.HostnameFormat1BoxedString](#hostnameformat1boxedstring)<br> boxed class to store validated String payloads |
-| record | [HostnameFormat.HostnameFormat1BoxedList](#hostnameformat1boxedlist)<br> boxed class to store validated List payloads |
-| record | [HostnameFormat.HostnameFormat1BoxedMap](#hostnameformat1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [HostnameFormat.HostnameFormat1](#hostnameformat1)<br> schema class |
+| data class | [HostnameFormat.HostnameFormat1BoxedVoid](#hostnameformat1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [HostnameFormat.HostnameFormat1BoxedBoolean](#hostnameformat1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [HostnameFormat.HostnameFormat1BoxedNumber](#hostnameformat1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [HostnameFormat.HostnameFormat1BoxedString](#hostnameformat1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [HostnameFormat.HostnameFormat1BoxedList](#hostnameformat1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [HostnameFormat.HostnameFormat1BoxedMap](#hostnameformat1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [HostnameFormat.HostnameFormat1](#hostnameformat1)<br> schema class |
 
 ## HostnameFormat1Boxed
 sealed interface HostnameFormat1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class HostnameFormat1BoxedBoolean<br>
 implements [HostnameFormat1Boxed](#hostnameformat1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/IntegerTypeMatchesIntegers.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/IntegerTypeMatchesIntegers.md
@@ -11,8 +11,8 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [IntegerTypeMatchesIntegers.IntegerTypeMatchesIntegers1Boxed](#integertypematchesintegers1boxed)<br> sealed interface for validated payloads |
-| record | [IntegerTypeMatchesIntegers.IntegerTypeMatchesIntegers1BoxedNumber](#integertypematchesintegers1boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [IntegerTypeMatchesIntegers.IntegerTypeMatchesIntegers1](#integertypematchesintegers1)<br> schema class |
+| data class | [IntegerTypeMatchesIntegers.IntegerTypeMatchesIntegers1BoxedNumber](#integertypematchesintegers1boxednumber)<br> boxed class to store validated Number payloads |
+| class | [IntegerTypeMatchesIntegers.IntegerTypeMatchesIntegers1](#integertypematchesintegers1)<br> schema class |
 
 ## IntegerTypeMatchesIntegers1Boxed
 sealed interface IntegerTypeMatchesIntegers1Boxed<br>

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf.md
@@ -11,8 +11,8 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf.InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf1Boxed](#invalidinstanceshouldnotraiseerrorwhenfloatdivisioninf1boxed)<br> sealed interface for validated payloads |
-| record | [InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf.InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf1BoxedNumber](#invalidinstanceshouldnotraiseerrorwhenfloatdivisioninf1boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf.InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf1](#invalidinstanceshouldnotraiseerrorwhenfloatdivisioninf1)<br> schema class |
+| data class | [InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf.InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf1BoxedNumber](#invalidinstanceshouldnotraiseerrorwhenfloatdivisioninf1boxednumber)<br> boxed class to store validated Number payloads |
+| class | [InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf.InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf1](#invalidinstanceshouldnotraiseerrorwhenfloatdivisioninf1)<br> schema class |
 
 ## InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf1Boxed
 sealed interface InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf1Boxed<br>

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf.md
@@ -46,25 +46,21 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // int validation
-int validatedPayload = InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf.InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf1.validate(
+val validatedPayload: Int = InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf.InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf1.validate(
     1L,
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -77,7 +73,7 @@ int validatedPayload = InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf.In
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
 | [InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf1BoxedNumber](#invalidinstanceshouldnotraiseerrorwhenfloatdivisioninf1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
 | [InvalidInstanceShouldNotRaiseErrorWhenFloatDivisionInf1Boxed](#invalidinstanceshouldnotraiseerrorwhenfloatdivisioninf1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/InvalidStringValueForDefault.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/InvalidStringValueForDefault.md
@@ -156,19 +156,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [InvalidStringValueForDefaultMap](#invalidstringvaluefordefaultmap) | validate(arg: [Map&lt;?, ?&gt;](#invalidstringvaluefordefaultmapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [InvalidStringValueForDefaultMap](#invalidstringvaluefordefaultmap) | validate(arg: [Map&lt;*, *&gt;](#invalidstringvaluefordefaultmapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [InvalidStringValueForDefault1BoxedString](#invalidstringvaluefordefault1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [InvalidStringValueForDefault1BoxedVoid](#invalidstringvaluefordefault1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [InvalidStringValueForDefault1BoxedNumber](#invalidstringvaluefordefault1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [InvalidStringValueForDefault1BoxedBoolean](#invalidstringvaluefordefault1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [InvalidStringValueForDefault1BoxedMap](#invalidstringvaluefordefault1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#invalidstringvaluefordefaultmapbuilder), configuration: SchemaConfiguration) |
+| [InvalidStringValueForDefault1BoxedBoolean](#invalidstringvaluefordefault1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [InvalidStringValueForDefault1BoxedMap](#invalidstringvaluefordefault1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#invalidstringvaluefordefaultmapbuilder), configuration: SchemaConfiguration) |
 | [InvalidStringValueForDefault1BoxedList](#invalidstringvaluefordefault1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [InvalidStringValueForDefault1Boxed](#invalidstringvaluefordefault1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -244,32 +244,28 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.InvalidStringValueForDefault;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.InvalidStringValueForDefault
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // String validation
-String validatedPayload = InvalidStringValueForDefault.Bar.validate(
+val validatedPayload: String = InvalidStringValueForDefault.Bar.validate(
     "a",
     configuration
-);
+)
 ```
 
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
 | Set<Class<?>> | type = setOf(<br/>&nbsp;&nbsp;&nbsp;&nbsp;String::class.java<br/>)<br/> |
-| Integer | minLength = 4 |
+| Int | minLength = 4 |
 | Any? | defaultValue = "bad" |
 
 ### Method Summary

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/InvalidStringValueForDefault.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/InvalidStringValueForDefault.md
@@ -13,18 +13,18 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [InvalidStringValueForDefault.InvalidStringValueForDefault1Boxed](#invalidstringvaluefordefault1boxed)<br> sealed interface for validated payloads |
-| record | [InvalidStringValueForDefault.InvalidStringValueForDefault1BoxedVoid](#invalidstringvaluefordefault1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [InvalidStringValueForDefault.InvalidStringValueForDefault1BoxedBoolean](#invalidstringvaluefordefault1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [InvalidStringValueForDefault.InvalidStringValueForDefault1BoxedNumber](#invalidstringvaluefordefault1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [InvalidStringValueForDefault.InvalidStringValueForDefault1BoxedString](#invalidstringvaluefordefault1boxedstring)<br> boxed class to store validated String payloads |
-| record | [InvalidStringValueForDefault.InvalidStringValueForDefault1BoxedList](#invalidstringvaluefordefault1boxedlist)<br> boxed class to store validated List payloads |
-| record | [InvalidStringValueForDefault.InvalidStringValueForDefault1BoxedMap](#invalidstringvaluefordefault1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [InvalidStringValueForDefault.InvalidStringValueForDefault1](#invalidstringvaluefordefault1)<br> schema class |
-| static class | [InvalidStringValueForDefault.InvalidStringValueForDefaultMapBuilder](#invalidstringvaluefordefaultmapbuilder)<br> builder for Map payloads |
-| static class | [InvalidStringValueForDefault.InvalidStringValueForDefaultMap](#invalidstringvaluefordefaultmap)<br> output class for Map payloads |
+| data class | [InvalidStringValueForDefault.InvalidStringValueForDefault1BoxedVoid](#invalidstringvaluefordefault1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [InvalidStringValueForDefault.InvalidStringValueForDefault1BoxedBoolean](#invalidstringvaluefordefault1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [InvalidStringValueForDefault.InvalidStringValueForDefault1BoxedNumber](#invalidstringvaluefordefault1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [InvalidStringValueForDefault.InvalidStringValueForDefault1BoxedString](#invalidstringvaluefordefault1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [InvalidStringValueForDefault.InvalidStringValueForDefault1BoxedList](#invalidstringvaluefordefault1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [InvalidStringValueForDefault.InvalidStringValueForDefault1BoxedMap](#invalidstringvaluefordefault1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [InvalidStringValueForDefault.InvalidStringValueForDefault1](#invalidstringvaluefordefault1)<br> schema class |
+| class | [InvalidStringValueForDefault.InvalidStringValueForDefaultMapBuilder](#invalidstringvaluefordefaultmapbuilder)<br> builder for Map payloads |
+| class | [InvalidStringValueForDefault.InvalidStringValueForDefaultMap](#invalidstringvaluefordefaultmap)<br> output class for Map payloads |
 | sealed interface | [InvalidStringValueForDefault.BarBoxed](#barboxed)<br> sealed interface for validated payloads |
-| record | [InvalidStringValueForDefault.BarBoxedString](#barboxedstring)<br> boxed class to store validated String payloads |
-| static class | [InvalidStringValueForDefault.Bar](#bar)<br> schema class |
+| data class | [InvalidStringValueForDefault.BarBoxedString](#barboxedstring)<br> boxed class to store validated String payloads |
+| class | [InvalidStringValueForDefault.Bar](#bar)<br> schema class |
 
 ## InvalidStringValueForDefault1Boxed
 sealed interface InvalidStringValueForDefault1Boxed<br>
@@ -59,7 +59,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class InvalidStringValueForDefault1BoxedBoolean<br>
 implements [InvalidStringValueForDefault1Boxed](#invalidstringvaluefordefault1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/Ipv4Format.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/Ipv4Format.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Ipv4Format1BoxedString](#ipv4format1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Ipv4Format1BoxedVoid](#ipv4format1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Ipv4Format1BoxedNumber](#ipv4format1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Ipv4Format1BoxedBoolean](#ipv4format1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Ipv4Format1BoxedMap](#ipv4format1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Ipv4Format1BoxedBoolean](#ipv4format1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Ipv4Format1BoxedMap](#ipv4format1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Ipv4Format1BoxedList](#ipv4format1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Ipv4Format1Boxed](#ipv4format1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/Ipv4Format.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/Ipv4Format.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [Ipv4Format.Ipv4Format1Boxed](#ipv4format1boxed)<br> sealed interface for validated payloads |
-| record | [Ipv4Format.Ipv4Format1BoxedVoid](#ipv4format1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [Ipv4Format.Ipv4Format1BoxedBoolean](#ipv4format1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [Ipv4Format.Ipv4Format1BoxedNumber](#ipv4format1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [Ipv4Format.Ipv4Format1BoxedString](#ipv4format1boxedstring)<br> boxed class to store validated String payloads |
-| record | [Ipv4Format.Ipv4Format1BoxedList](#ipv4format1boxedlist)<br> boxed class to store validated List payloads |
-| record | [Ipv4Format.Ipv4Format1BoxedMap](#ipv4format1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [Ipv4Format.Ipv4Format1](#ipv4format1)<br> schema class |
+| data class | [Ipv4Format.Ipv4Format1BoxedVoid](#ipv4format1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [Ipv4Format.Ipv4Format1BoxedBoolean](#ipv4format1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [Ipv4Format.Ipv4Format1BoxedNumber](#ipv4format1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [Ipv4Format.Ipv4Format1BoxedString](#ipv4format1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [Ipv4Format.Ipv4Format1BoxedList](#ipv4format1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [Ipv4Format.Ipv4Format1BoxedMap](#ipv4format1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [Ipv4Format.Ipv4Format1](#ipv4format1)<br> schema class |
 
 ## Ipv4Format1Boxed
 sealed interface Ipv4Format1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Ipv4Format1BoxedBoolean<br>
 implements [Ipv4Format1Boxed](#ipv4format1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/Ipv6Format.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/Ipv6Format.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Ipv6Format1BoxedString](#ipv6format1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Ipv6Format1BoxedVoid](#ipv6format1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Ipv6Format1BoxedNumber](#ipv6format1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Ipv6Format1BoxedBoolean](#ipv6format1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Ipv6Format1BoxedMap](#ipv6format1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Ipv6Format1BoxedBoolean](#ipv6format1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Ipv6Format1BoxedMap](#ipv6format1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Ipv6Format1BoxedList](#ipv6format1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Ipv6Format1Boxed](#ipv6format1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/Ipv6Format.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/Ipv6Format.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [Ipv6Format.Ipv6Format1Boxed](#ipv6format1boxed)<br> sealed interface for validated payloads |
-| record | [Ipv6Format.Ipv6Format1BoxedVoid](#ipv6format1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [Ipv6Format.Ipv6Format1BoxedBoolean](#ipv6format1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [Ipv6Format.Ipv6Format1BoxedNumber](#ipv6format1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [Ipv6Format.Ipv6Format1BoxedString](#ipv6format1boxedstring)<br> boxed class to store validated String payloads |
-| record | [Ipv6Format.Ipv6Format1BoxedList](#ipv6format1boxedlist)<br> boxed class to store validated List payloads |
-| record | [Ipv6Format.Ipv6Format1BoxedMap](#ipv6format1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [Ipv6Format.Ipv6Format1](#ipv6format1)<br> schema class |
+| data class | [Ipv6Format.Ipv6Format1BoxedVoid](#ipv6format1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [Ipv6Format.Ipv6Format1BoxedBoolean](#ipv6format1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [Ipv6Format.Ipv6Format1BoxedNumber](#ipv6format1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [Ipv6Format.Ipv6Format1BoxedString](#ipv6format1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [Ipv6Format.Ipv6Format1BoxedList](#ipv6format1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [Ipv6Format.Ipv6Format1BoxedMap](#ipv6format1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [Ipv6Format.Ipv6Format1](#ipv6format1)<br> schema class |
 
 ## Ipv6Format1Boxed
 sealed interface Ipv6Format1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Ipv6Format1BoxedBoolean<br>
 implements [Ipv6Format1Boxed](#ipv6format1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/JsonPointerFormat.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/JsonPointerFormat.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [JsonPointerFormat.JsonPointerFormat1Boxed](#jsonpointerformat1boxed)<br> sealed interface for validated payloads |
-| record | [JsonPointerFormat.JsonPointerFormat1BoxedVoid](#jsonpointerformat1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [JsonPointerFormat.JsonPointerFormat1BoxedBoolean](#jsonpointerformat1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [JsonPointerFormat.JsonPointerFormat1BoxedNumber](#jsonpointerformat1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [JsonPointerFormat.JsonPointerFormat1BoxedString](#jsonpointerformat1boxedstring)<br> boxed class to store validated String payloads |
-| record | [JsonPointerFormat.JsonPointerFormat1BoxedList](#jsonpointerformat1boxedlist)<br> boxed class to store validated List payloads |
-| record | [JsonPointerFormat.JsonPointerFormat1BoxedMap](#jsonpointerformat1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [JsonPointerFormat.JsonPointerFormat1](#jsonpointerformat1)<br> schema class |
+| data class | [JsonPointerFormat.JsonPointerFormat1BoxedVoid](#jsonpointerformat1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [JsonPointerFormat.JsonPointerFormat1BoxedBoolean](#jsonpointerformat1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [JsonPointerFormat.JsonPointerFormat1BoxedNumber](#jsonpointerformat1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [JsonPointerFormat.JsonPointerFormat1BoxedString](#jsonpointerformat1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [JsonPointerFormat.JsonPointerFormat1BoxedList](#jsonpointerformat1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [JsonPointerFormat.JsonPointerFormat1BoxedMap](#jsonpointerformat1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [JsonPointerFormat.JsonPointerFormat1](#jsonpointerformat1)<br> schema class |
 
 ## JsonPointerFormat1Boxed
 sealed interface JsonPointerFormat1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class JsonPointerFormat1BoxedBoolean<br>
 implements [JsonPointerFormat1Boxed](#jsonpointerformat1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/JsonPointerFormat.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/JsonPointerFormat.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [JsonPointerFormat1BoxedString](#jsonpointerformat1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [JsonPointerFormat1BoxedVoid](#jsonpointerformat1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [JsonPointerFormat1BoxedNumber](#jsonpointerformat1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [JsonPointerFormat1BoxedBoolean](#jsonpointerformat1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [JsonPointerFormat1BoxedMap](#jsonpointerformat1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [JsonPointerFormat1BoxedBoolean](#jsonpointerformat1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [JsonPointerFormat1BoxedMap](#jsonpointerformat1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [JsonPointerFormat1BoxedList](#jsonpointerformat1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [JsonPointerFormat1Boxed](#jsonpointerformat1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MaximumValidation.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MaximumValidation.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [MaximumValidation.MaximumValidation1Boxed](#maximumvalidation1boxed)<br> sealed interface for validated payloads |
-| record | [MaximumValidation.MaximumValidation1BoxedVoid](#maximumvalidation1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [MaximumValidation.MaximumValidation1BoxedBoolean](#maximumvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [MaximumValidation.MaximumValidation1BoxedNumber](#maximumvalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [MaximumValidation.MaximumValidation1BoxedString](#maximumvalidation1boxedstring)<br> boxed class to store validated String payloads |
-| record | [MaximumValidation.MaximumValidation1BoxedList](#maximumvalidation1boxedlist)<br> boxed class to store validated List payloads |
-| record | [MaximumValidation.MaximumValidation1BoxedMap](#maximumvalidation1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [MaximumValidation.MaximumValidation1](#maximumvalidation1)<br> schema class |
+| data class | [MaximumValidation.MaximumValidation1BoxedVoid](#maximumvalidation1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [MaximumValidation.MaximumValidation1BoxedBoolean](#maximumvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [MaximumValidation.MaximumValidation1BoxedNumber](#maximumvalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [MaximumValidation.MaximumValidation1BoxedString](#maximumvalidation1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [MaximumValidation.MaximumValidation1BoxedList](#maximumvalidation1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [MaximumValidation.MaximumValidation1BoxedMap](#maximumvalidation1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [MaximumValidation.MaximumValidation1](#maximumvalidation1)<br> schema class |
 
 ## MaximumValidation1Boxed
 sealed interface MaximumValidation1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class MaximumValidation1BoxedBoolean<br>
 implements [MaximumValidation1Boxed](#maximumvalidation1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MaximumValidation.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MaximumValidation.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [MaximumValidation1BoxedString](#maximumvalidation1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [MaximumValidation1BoxedVoid](#maximumvalidation1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [MaximumValidation1BoxedNumber](#maximumvalidation1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [MaximumValidation1BoxedBoolean](#maximumvalidation1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [MaximumValidation1BoxedMap](#maximumvalidation1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [MaximumValidation1BoxedBoolean](#maximumvalidation1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [MaximumValidation1BoxedMap](#maximumvalidation1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [MaximumValidation1BoxedList](#maximumvalidation1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [MaximumValidation1Boxed](#maximumvalidation1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MaximumValidationWithUnsignedInteger.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MaximumValidationWithUnsignedInteger.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [MaximumValidationWithUnsignedInteger.MaximumValidationWithUnsignedInteger1Boxed](#maximumvalidationwithunsignedinteger1boxed)<br> sealed interface for validated payloads |
-| record | [MaximumValidationWithUnsignedInteger.MaximumValidationWithUnsignedInteger1BoxedVoid](#maximumvalidationwithunsignedinteger1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [MaximumValidationWithUnsignedInteger.MaximumValidationWithUnsignedInteger1BoxedBoolean](#maximumvalidationwithunsignedinteger1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [MaximumValidationWithUnsignedInteger.MaximumValidationWithUnsignedInteger1BoxedNumber](#maximumvalidationwithunsignedinteger1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [MaximumValidationWithUnsignedInteger.MaximumValidationWithUnsignedInteger1BoxedString](#maximumvalidationwithunsignedinteger1boxedstring)<br> boxed class to store validated String payloads |
-| record | [MaximumValidationWithUnsignedInteger.MaximumValidationWithUnsignedInteger1BoxedList](#maximumvalidationwithunsignedinteger1boxedlist)<br> boxed class to store validated List payloads |
-| record | [MaximumValidationWithUnsignedInteger.MaximumValidationWithUnsignedInteger1BoxedMap](#maximumvalidationwithunsignedinteger1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [MaximumValidationWithUnsignedInteger.MaximumValidationWithUnsignedInteger1](#maximumvalidationwithunsignedinteger1)<br> schema class |
+| data class | [MaximumValidationWithUnsignedInteger.MaximumValidationWithUnsignedInteger1BoxedVoid](#maximumvalidationwithunsignedinteger1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [MaximumValidationWithUnsignedInteger.MaximumValidationWithUnsignedInteger1BoxedBoolean](#maximumvalidationwithunsignedinteger1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [MaximumValidationWithUnsignedInteger.MaximumValidationWithUnsignedInteger1BoxedNumber](#maximumvalidationwithunsignedinteger1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [MaximumValidationWithUnsignedInteger.MaximumValidationWithUnsignedInteger1BoxedString](#maximumvalidationwithunsignedinteger1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [MaximumValidationWithUnsignedInteger.MaximumValidationWithUnsignedInteger1BoxedList](#maximumvalidationwithunsignedinteger1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [MaximumValidationWithUnsignedInteger.MaximumValidationWithUnsignedInteger1BoxedMap](#maximumvalidationwithunsignedinteger1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [MaximumValidationWithUnsignedInteger.MaximumValidationWithUnsignedInteger1](#maximumvalidationwithunsignedinteger1)<br> schema class |
 
 ## MaximumValidationWithUnsignedInteger1Boxed
 sealed interface MaximumValidationWithUnsignedInteger1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class MaximumValidationWithUnsignedInteger1BoxedBoolean<br>
 implements [MaximumValidationWithUnsignedInteger1Boxed](#maximumvalidationwithunsignedinteger1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MaximumValidationWithUnsignedInteger.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MaximumValidationWithUnsignedInteger.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [MaximumValidationWithUnsignedInteger1BoxedString](#maximumvalidationwithunsignedinteger1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [MaximumValidationWithUnsignedInteger1BoxedVoid](#maximumvalidationwithunsignedinteger1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [MaximumValidationWithUnsignedInteger1BoxedNumber](#maximumvalidationwithunsignedinteger1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [MaximumValidationWithUnsignedInteger1BoxedBoolean](#maximumvalidationwithunsignedinteger1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [MaximumValidationWithUnsignedInteger1BoxedMap](#maximumvalidationwithunsignedinteger1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [MaximumValidationWithUnsignedInteger1BoxedBoolean](#maximumvalidationwithunsignedinteger1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [MaximumValidationWithUnsignedInteger1BoxedMap](#maximumvalidationwithunsignedinteger1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [MaximumValidationWithUnsignedInteger1BoxedList](#maximumvalidationwithunsignedinteger1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [MaximumValidationWithUnsignedInteger1Boxed](#maximumvalidationwithunsignedinteger1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MaxitemsValidation.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MaxitemsValidation.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [MaxitemsValidation.MaxitemsValidation1Boxed](#maxitemsvalidation1boxed)<br> sealed interface for validated payloads |
-| record | [MaxitemsValidation.MaxitemsValidation1BoxedVoid](#maxitemsvalidation1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [MaxitemsValidation.MaxitemsValidation1BoxedBoolean](#maxitemsvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [MaxitemsValidation.MaxitemsValidation1BoxedNumber](#maxitemsvalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [MaxitemsValidation.MaxitemsValidation1BoxedString](#maxitemsvalidation1boxedstring)<br> boxed class to store validated String payloads |
-| record | [MaxitemsValidation.MaxitemsValidation1BoxedList](#maxitemsvalidation1boxedlist)<br> boxed class to store validated List payloads |
-| record | [MaxitemsValidation.MaxitemsValidation1BoxedMap](#maxitemsvalidation1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [MaxitemsValidation.MaxitemsValidation1](#maxitemsvalidation1)<br> schema class |
+| data class | [MaxitemsValidation.MaxitemsValidation1BoxedVoid](#maxitemsvalidation1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [MaxitemsValidation.MaxitemsValidation1BoxedBoolean](#maxitemsvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [MaxitemsValidation.MaxitemsValidation1BoxedNumber](#maxitemsvalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [MaxitemsValidation.MaxitemsValidation1BoxedString](#maxitemsvalidation1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [MaxitemsValidation.MaxitemsValidation1BoxedList](#maxitemsvalidation1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [MaxitemsValidation.MaxitemsValidation1BoxedMap](#maxitemsvalidation1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [MaxitemsValidation.MaxitemsValidation1](#maxitemsvalidation1)<br> schema class |
 
 ## MaxitemsValidation1Boxed
 sealed interface MaxitemsValidation1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class MaxitemsValidation1BoxedBoolean<br>
 implements [MaxitemsValidation1Boxed](#maxitemsvalidation1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MaxitemsValidation.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MaxitemsValidation.md
@@ -142,26 +142,26 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| Integer | maxItems = 2 |
+| Int | maxItems = 2 |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [MaxitemsValidation1BoxedString](#maxitemsvalidation1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [MaxitemsValidation1BoxedVoid](#maxitemsvalidation1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [MaxitemsValidation1BoxedNumber](#maxitemsvalidation1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [MaxitemsValidation1BoxedBoolean](#maxitemsvalidation1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [MaxitemsValidation1BoxedMap](#maxitemsvalidation1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [MaxitemsValidation1BoxedBoolean](#maxitemsvalidation1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [MaxitemsValidation1BoxedMap](#maxitemsvalidation1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [MaxitemsValidation1BoxedList](#maxitemsvalidation1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [MaxitemsValidation1Boxed](#maxitemsvalidation1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MaxlengthValidation.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MaxlengthValidation.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [MaxlengthValidation.MaxlengthValidation1Boxed](#maxlengthvalidation1boxed)<br> sealed interface for validated payloads |
-| record | [MaxlengthValidation.MaxlengthValidation1BoxedVoid](#maxlengthvalidation1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [MaxlengthValidation.MaxlengthValidation1BoxedBoolean](#maxlengthvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [MaxlengthValidation.MaxlengthValidation1BoxedNumber](#maxlengthvalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [MaxlengthValidation.MaxlengthValidation1BoxedString](#maxlengthvalidation1boxedstring)<br> boxed class to store validated String payloads |
-| record | [MaxlengthValidation.MaxlengthValidation1BoxedList](#maxlengthvalidation1boxedlist)<br> boxed class to store validated List payloads |
-| record | [MaxlengthValidation.MaxlengthValidation1BoxedMap](#maxlengthvalidation1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [MaxlengthValidation.MaxlengthValidation1](#maxlengthvalidation1)<br> schema class |
+| data class | [MaxlengthValidation.MaxlengthValidation1BoxedVoid](#maxlengthvalidation1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [MaxlengthValidation.MaxlengthValidation1BoxedBoolean](#maxlengthvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [MaxlengthValidation.MaxlengthValidation1BoxedNumber](#maxlengthvalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [MaxlengthValidation.MaxlengthValidation1BoxedString](#maxlengthvalidation1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [MaxlengthValidation.MaxlengthValidation1BoxedList](#maxlengthvalidation1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [MaxlengthValidation.MaxlengthValidation1BoxedMap](#maxlengthvalidation1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [MaxlengthValidation.MaxlengthValidation1](#maxlengthvalidation1)<br> schema class |
 
 ## MaxlengthValidation1Boxed
 sealed interface MaxlengthValidation1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class MaxlengthValidation1BoxedBoolean<br>
 implements [MaxlengthValidation1Boxed](#maxlengthvalidation1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MaxlengthValidation.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MaxlengthValidation.md
@@ -142,26 +142,26 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| Integer | maxLength = 2 |
+| Int | maxLength = 2 |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [MaxlengthValidation1BoxedString](#maxlengthvalidation1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [MaxlengthValidation1BoxedVoid](#maxlengthvalidation1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [MaxlengthValidation1BoxedNumber](#maxlengthvalidation1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [MaxlengthValidation1BoxedBoolean](#maxlengthvalidation1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [MaxlengthValidation1BoxedMap](#maxlengthvalidation1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [MaxlengthValidation1BoxedBoolean](#maxlengthvalidation1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [MaxlengthValidation1BoxedMap](#maxlengthvalidation1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [MaxlengthValidation1BoxedList](#maxlengthvalidation1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [MaxlengthValidation1Boxed](#maxlengthvalidation1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/Maxproperties0MeansTheObjectIsEmpty.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/Maxproperties0MeansTheObjectIsEmpty.md
@@ -142,26 +142,26 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| Integer | maxProperties = 0 |
+| Int | maxProperties = 0 |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Maxproperties0MeansTheObjectIsEmpty1BoxedString](#maxproperties0meanstheobjectisempty1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Maxproperties0MeansTheObjectIsEmpty1BoxedVoid](#maxproperties0meanstheobjectisempty1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Maxproperties0MeansTheObjectIsEmpty1BoxedNumber](#maxproperties0meanstheobjectisempty1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Maxproperties0MeansTheObjectIsEmpty1BoxedBoolean](#maxproperties0meanstheobjectisempty1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Maxproperties0MeansTheObjectIsEmpty1BoxedMap](#maxproperties0meanstheobjectisempty1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Maxproperties0MeansTheObjectIsEmpty1BoxedBoolean](#maxproperties0meanstheobjectisempty1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Maxproperties0MeansTheObjectIsEmpty1BoxedMap](#maxproperties0meanstheobjectisempty1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Maxproperties0MeansTheObjectIsEmpty1BoxedList](#maxproperties0meanstheobjectisempty1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Maxproperties0MeansTheObjectIsEmpty1Boxed](#maxproperties0meanstheobjectisempty1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/Maxproperties0MeansTheObjectIsEmpty.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/Maxproperties0MeansTheObjectIsEmpty.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [Maxproperties0MeansTheObjectIsEmpty.Maxproperties0MeansTheObjectIsEmpty1Boxed](#maxproperties0meanstheobjectisempty1boxed)<br> sealed interface for validated payloads |
-| record | [Maxproperties0MeansTheObjectIsEmpty.Maxproperties0MeansTheObjectIsEmpty1BoxedVoid](#maxproperties0meanstheobjectisempty1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [Maxproperties0MeansTheObjectIsEmpty.Maxproperties0MeansTheObjectIsEmpty1BoxedBoolean](#maxproperties0meanstheobjectisempty1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [Maxproperties0MeansTheObjectIsEmpty.Maxproperties0MeansTheObjectIsEmpty1BoxedNumber](#maxproperties0meanstheobjectisempty1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [Maxproperties0MeansTheObjectIsEmpty.Maxproperties0MeansTheObjectIsEmpty1BoxedString](#maxproperties0meanstheobjectisempty1boxedstring)<br> boxed class to store validated String payloads |
-| record | [Maxproperties0MeansTheObjectIsEmpty.Maxproperties0MeansTheObjectIsEmpty1BoxedList](#maxproperties0meanstheobjectisempty1boxedlist)<br> boxed class to store validated List payloads |
-| record | [Maxproperties0MeansTheObjectIsEmpty.Maxproperties0MeansTheObjectIsEmpty1BoxedMap](#maxproperties0meanstheobjectisempty1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [Maxproperties0MeansTheObjectIsEmpty.Maxproperties0MeansTheObjectIsEmpty1](#maxproperties0meanstheobjectisempty1)<br> schema class |
+| data class | [Maxproperties0MeansTheObjectIsEmpty.Maxproperties0MeansTheObjectIsEmpty1BoxedVoid](#maxproperties0meanstheobjectisempty1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [Maxproperties0MeansTheObjectIsEmpty.Maxproperties0MeansTheObjectIsEmpty1BoxedBoolean](#maxproperties0meanstheobjectisempty1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [Maxproperties0MeansTheObjectIsEmpty.Maxproperties0MeansTheObjectIsEmpty1BoxedNumber](#maxproperties0meanstheobjectisempty1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [Maxproperties0MeansTheObjectIsEmpty.Maxproperties0MeansTheObjectIsEmpty1BoxedString](#maxproperties0meanstheobjectisempty1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [Maxproperties0MeansTheObjectIsEmpty.Maxproperties0MeansTheObjectIsEmpty1BoxedList](#maxproperties0meanstheobjectisempty1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [Maxproperties0MeansTheObjectIsEmpty.Maxproperties0MeansTheObjectIsEmpty1BoxedMap](#maxproperties0meanstheobjectisempty1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [Maxproperties0MeansTheObjectIsEmpty.Maxproperties0MeansTheObjectIsEmpty1](#maxproperties0meanstheobjectisempty1)<br> schema class |
 
 ## Maxproperties0MeansTheObjectIsEmpty1Boxed
 sealed interface Maxproperties0MeansTheObjectIsEmpty1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Maxproperties0MeansTheObjectIsEmpty1BoxedBoolean<br>
 implements [Maxproperties0MeansTheObjectIsEmpty1Boxed](#maxproperties0meanstheobjectisempty1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MaxpropertiesValidation.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MaxpropertiesValidation.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [MaxpropertiesValidation.MaxpropertiesValidation1Boxed](#maxpropertiesvalidation1boxed)<br> sealed interface for validated payloads |
-| record | [MaxpropertiesValidation.MaxpropertiesValidation1BoxedVoid](#maxpropertiesvalidation1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [MaxpropertiesValidation.MaxpropertiesValidation1BoxedBoolean](#maxpropertiesvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [MaxpropertiesValidation.MaxpropertiesValidation1BoxedNumber](#maxpropertiesvalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [MaxpropertiesValidation.MaxpropertiesValidation1BoxedString](#maxpropertiesvalidation1boxedstring)<br> boxed class to store validated String payloads |
-| record | [MaxpropertiesValidation.MaxpropertiesValidation1BoxedList](#maxpropertiesvalidation1boxedlist)<br> boxed class to store validated List payloads |
-| record | [MaxpropertiesValidation.MaxpropertiesValidation1BoxedMap](#maxpropertiesvalidation1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [MaxpropertiesValidation.MaxpropertiesValidation1](#maxpropertiesvalidation1)<br> schema class |
+| data class | [MaxpropertiesValidation.MaxpropertiesValidation1BoxedVoid](#maxpropertiesvalidation1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [MaxpropertiesValidation.MaxpropertiesValidation1BoxedBoolean](#maxpropertiesvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [MaxpropertiesValidation.MaxpropertiesValidation1BoxedNumber](#maxpropertiesvalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [MaxpropertiesValidation.MaxpropertiesValidation1BoxedString](#maxpropertiesvalidation1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [MaxpropertiesValidation.MaxpropertiesValidation1BoxedList](#maxpropertiesvalidation1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [MaxpropertiesValidation.MaxpropertiesValidation1BoxedMap](#maxpropertiesvalidation1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [MaxpropertiesValidation.MaxpropertiesValidation1](#maxpropertiesvalidation1)<br> schema class |
 
 ## MaxpropertiesValidation1Boxed
 sealed interface MaxpropertiesValidation1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class MaxpropertiesValidation1BoxedBoolean<br>
 implements [MaxpropertiesValidation1Boxed](#maxpropertiesvalidation1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MaxpropertiesValidation.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MaxpropertiesValidation.md
@@ -142,26 +142,26 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| Integer | maxProperties = 2 |
+| Int | maxProperties = 2 |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [MaxpropertiesValidation1BoxedString](#maxpropertiesvalidation1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [MaxpropertiesValidation1BoxedVoid](#maxpropertiesvalidation1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [MaxpropertiesValidation1BoxedNumber](#maxpropertiesvalidation1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [MaxpropertiesValidation1BoxedBoolean](#maxpropertiesvalidation1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [MaxpropertiesValidation1BoxedMap](#maxpropertiesvalidation1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [MaxpropertiesValidation1BoxedBoolean](#maxpropertiesvalidation1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [MaxpropertiesValidation1BoxedMap](#maxpropertiesvalidation1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [MaxpropertiesValidation1BoxedList](#maxpropertiesvalidation1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [MaxpropertiesValidation1Boxed](#maxpropertiesvalidation1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MinimumValidation.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MinimumValidation.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [MinimumValidation.MinimumValidation1Boxed](#minimumvalidation1boxed)<br> sealed interface for validated payloads |
-| record | [MinimumValidation.MinimumValidation1BoxedVoid](#minimumvalidation1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [MinimumValidation.MinimumValidation1BoxedBoolean](#minimumvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [MinimumValidation.MinimumValidation1BoxedNumber](#minimumvalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [MinimumValidation.MinimumValidation1BoxedString](#minimumvalidation1boxedstring)<br> boxed class to store validated String payloads |
-| record | [MinimumValidation.MinimumValidation1BoxedList](#minimumvalidation1boxedlist)<br> boxed class to store validated List payloads |
-| record | [MinimumValidation.MinimumValidation1BoxedMap](#minimumvalidation1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [MinimumValidation.MinimumValidation1](#minimumvalidation1)<br> schema class |
+| data class | [MinimumValidation.MinimumValidation1BoxedVoid](#minimumvalidation1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [MinimumValidation.MinimumValidation1BoxedBoolean](#minimumvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [MinimumValidation.MinimumValidation1BoxedNumber](#minimumvalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [MinimumValidation.MinimumValidation1BoxedString](#minimumvalidation1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [MinimumValidation.MinimumValidation1BoxedList](#minimumvalidation1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [MinimumValidation.MinimumValidation1BoxedMap](#minimumvalidation1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [MinimumValidation.MinimumValidation1](#minimumvalidation1)<br> schema class |
 
 ## MinimumValidation1Boxed
 sealed interface MinimumValidation1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class MinimumValidation1BoxedBoolean<br>
 implements [MinimumValidation1Boxed](#minimumvalidation1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MinimumValidation.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MinimumValidation.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [MinimumValidation1BoxedString](#minimumvalidation1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [MinimumValidation1BoxedVoid](#minimumvalidation1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [MinimumValidation1BoxedNumber](#minimumvalidation1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [MinimumValidation1BoxedBoolean](#minimumvalidation1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [MinimumValidation1BoxedMap](#minimumvalidation1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [MinimumValidation1BoxedBoolean](#minimumvalidation1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [MinimumValidation1BoxedMap](#minimumvalidation1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [MinimumValidation1BoxedList](#minimumvalidation1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [MinimumValidation1Boxed](#minimumvalidation1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MinimumValidationWithSignedInteger.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MinimumValidationWithSignedInteger.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [MinimumValidationWithSignedInteger1BoxedString](#minimumvalidationwithsignedinteger1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [MinimumValidationWithSignedInteger1BoxedVoid](#minimumvalidationwithsignedinteger1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [MinimumValidationWithSignedInteger1BoxedNumber](#minimumvalidationwithsignedinteger1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [MinimumValidationWithSignedInteger1BoxedBoolean](#minimumvalidationwithsignedinteger1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [MinimumValidationWithSignedInteger1BoxedMap](#minimumvalidationwithsignedinteger1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [MinimumValidationWithSignedInteger1BoxedBoolean](#minimumvalidationwithsignedinteger1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [MinimumValidationWithSignedInteger1BoxedMap](#minimumvalidationwithsignedinteger1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [MinimumValidationWithSignedInteger1BoxedList](#minimumvalidationwithsignedinteger1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [MinimumValidationWithSignedInteger1Boxed](#minimumvalidationwithsignedinteger1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MinimumValidationWithSignedInteger.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MinimumValidationWithSignedInteger.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [MinimumValidationWithSignedInteger.MinimumValidationWithSignedInteger1Boxed](#minimumvalidationwithsignedinteger1boxed)<br> sealed interface for validated payloads |
-| record | [MinimumValidationWithSignedInteger.MinimumValidationWithSignedInteger1BoxedVoid](#minimumvalidationwithsignedinteger1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [MinimumValidationWithSignedInteger.MinimumValidationWithSignedInteger1BoxedBoolean](#minimumvalidationwithsignedinteger1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [MinimumValidationWithSignedInteger.MinimumValidationWithSignedInteger1BoxedNumber](#minimumvalidationwithsignedinteger1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [MinimumValidationWithSignedInteger.MinimumValidationWithSignedInteger1BoxedString](#minimumvalidationwithsignedinteger1boxedstring)<br> boxed class to store validated String payloads |
-| record | [MinimumValidationWithSignedInteger.MinimumValidationWithSignedInteger1BoxedList](#minimumvalidationwithsignedinteger1boxedlist)<br> boxed class to store validated List payloads |
-| record | [MinimumValidationWithSignedInteger.MinimumValidationWithSignedInteger1BoxedMap](#minimumvalidationwithsignedinteger1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [MinimumValidationWithSignedInteger.MinimumValidationWithSignedInteger1](#minimumvalidationwithsignedinteger1)<br> schema class |
+| data class | [MinimumValidationWithSignedInteger.MinimumValidationWithSignedInteger1BoxedVoid](#minimumvalidationwithsignedinteger1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [MinimumValidationWithSignedInteger.MinimumValidationWithSignedInteger1BoxedBoolean](#minimumvalidationwithsignedinteger1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [MinimumValidationWithSignedInteger.MinimumValidationWithSignedInteger1BoxedNumber](#minimumvalidationwithsignedinteger1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [MinimumValidationWithSignedInteger.MinimumValidationWithSignedInteger1BoxedString](#minimumvalidationwithsignedinteger1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [MinimumValidationWithSignedInteger.MinimumValidationWithSignedInteger1BoxedList](#minimumvalidationwithsignedinteger1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [MinimumValidationWithSignedInteger.MinimumValidationWithSignedInteger1BoxedMap](#minimumvalidationwithsignedinteger1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [MinimumValidationWithSignedInteger.MinimumValidationWithSignedInteger1](#minimumvalidationwithsignedinteger1)<br> schema class |
 
 ## MinimumValidationWithSignedInteger1Boxed
 sealed interface MinimumValidationWithSignedInteger1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class MinimumValidationWithSignedInteger1BoxedBoolean<br>
 implements [MinimumValidationWithSignedInteger1Boxed](#minimumvalidationwithsignedinteger1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MinitemsValidation.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MinitemsValidation.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [MinitemsValidation.MinitemsValidation1Boxed](#minitemsvalidation1boxed)<br> sealed interface for validated payloads |
-| record | [MinitemsValidation.MinitemsValidation1BoxedVoid](#minitemsvalidation1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [MinitemsValidation.MinitemsValidation1BoxedBoolean](#minitemsvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [MinitemsValidation.MinitemsValidation1BoxedNumber](#minitemsvalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [MinitemsValidation.MinitemsValidation1BoxedString](#minitemsvalidation1boxedstring)<br> boxed class to store validated String payloads |
-| record | [MinitemsValidation.MinitemsValidation1BoxedList](#minitemsvalidation1boxedlist)<br> boxed class to store validated List payloads |
-| record | [MinitemsValidation.MinitemsValidation1BoxedMap](#minitemsvalidation1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [MinitemsValidation.MinitemsValidation1](#minitemsvalidation1)<br> schema class |
+| data class | [MinitemsValidation.MinitemsValidation1BoxedVoid](#minitemsvalidation1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [MinitemsValidation.MinitemsValidation1BoxedBoolean](#minitemsvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [MinitemsValidation.MinitemsValidation1BoxedNumber](#minitemsvalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [MinitemsValidation.MinitemsValidation1BoxedString](#minitemsvalidation1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [MinitemsValidation.MinitemsValidation1BoxedList](#minitemsvalidation1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [MinitemsValidation.MinitemsValidation1BoxedMap](#minitemsvalidation1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [MinitemsValidation.MinitemsValidation1](#minitemsvalidation1)<br> schema class |
 
 ## MinitemsValidation1Boxed
 sealed interface MinitemsValidation1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class MinitemsValidation1BoxedBoolean<br>
 implements [MinitemsValidation1Boxed](#minitemsvalidation1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MinitemsValidation.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MinitemsValidation.md
@@ -142,26 +142,26 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| Integer | minItems = 1 |
+| Int | minItems = 1 |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [MinitemsValidation1BoxedString](#minitemsvalidation1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [MinitemsValidation1BoxedVoid](#minitemsvalidation1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [MinitemsValidation1BoxedNumber](#minitemsvalidation1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [MinitemsValidation1BoxedBoolean](#minitemsvalidation1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [MinitemsValidation1BoxedMap](#minitemsvalidation1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [MinitemsValidation1BoxedBoolean](#minitemsvalidation1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [MinitemsValidation1BoxedMap](#minitemsvalidation1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [MinitemsValidation1BoxedList](#minitemsvalidation1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [MinitemsValidation1Boxed](#minitemsvalidation1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MinlengthValidation.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MinlengthValidation.md
@@ -142,26 +142,26 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| Integer | minLength = 2 |
+| Int | minLength = 2 |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [MinlengthValidation1BoxedString](#minlengthvalidation1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [MinlengthValidation1BoxedVoid](#minlengthvalidation1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [MinlengthValidation1BoxedNumber](#minlengthvalidation1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [MinlengthValidation1BoxedBoolean](#minlengthvalidation1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [MinlengthValidation1BoxedMap](#minlengthvalidation1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [MinlengthValidation1BoxedBoolean](#minlengthvalidation1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [MinlengthValidation1BoxedMap](#minlengthvalidation1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [MinlengthValidation1BoxedList](#minlengthvalidation1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [MinlengthValidation1Boxed](#minlengthvalidation1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MinlengthValidation.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MinlengthValidation.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [MinlengthValidation.MinlengthValidation1Boxed](#minlengthvalidation1boxed)<br> sealed interface for validated payloads |
-| record | [MinlengthValidation.MinlengthValidation1BoxedVoid](#minlengthvalidation1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [MinlengthValidation.MinlengthValidation1BoxedBoolean](#minlengthvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [MinlengthValidation.MinlengthValidation1BoxedNumber](#minlengthvalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [MinlengthValidation.MinlengthValidation1BoxedString](#minlengthvalidation1boxedstring)<br> boxed class to store validated String payloads |
-| record | [MinlengthValidation.MinlengthValidation1BoxedList](#minlengthvalidation1boxedlist)<br> boxed class to store validated List payloads |
-| record | [MinlengthValidation.MinlengthValidation1BoxedMap](#minlengthvalidation1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [MinlengthValidation.MinlengthValidation1](#minlengthvalidation1)<br> schema class |
+| data class | [MinlengthValidation.MinlengthValidation1BoxedVoid](#minlengthvalidation1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [MinlengthValidation.MinlengthValidation1BoxedBoolean](#minlengthvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [MinlengthValidation.MinlengthValidation1BoxedNumber](#minlengthvalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [MinlengthValidation.MinlengthValidation1BoxedString](#minlengthvalidation1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [MinlengthValidation.MinlengthValidation1BoxedList](#minlengthvalidation1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [MinlengthValidation.MinlengthValidation1BoxedMap](#minlengthvalidation1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [MinlengthValidation.MinlengthValidation1](#minlengthvalidation1)<br> schema class |
 
 ## MinlengthValidation1Boxed
 sealed interface MinlengthValidation1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class MinlengthValidation1BoxedBoolean<br>
 implements [MinlengthValidation1Boxed](#minlengthvalidation1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MinpropertiesValidation.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MinpropertiesValidation.md
@@ -142,26 +142,26 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| Integer | minProperties = 1 |
+| Int | minProperties = 1 |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [MinpropertiesValidation1BoxedString](#minpropertiesvalidation1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [MinpropertiesValidation1BoxedVoid](#minpropertiesvalidation1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [MinpropertiesValidation1BoxedNumber](#minpropertiesvalidation1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [MinpropertiesValidation1BoxedBoolean](#minpropertiesvalidation1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [MinpropertiesValidation1BoxedMap](#minpropertiesvalidation1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [MinpropertiesValidation1BoxedBoolean](#minpropertiesvalidation1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [MinpropertiesValidation1BoxedMap](#minpropertiesvalidation1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [MinpropertiesValidation1BoxedList](#minpropertiesvalidation1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [MinpropertiesValidation1Boxed](#minpropertiesvalidation1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MinpropertiesValidation.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/MinpropertiesValidation.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [MinpropertiesValidation.MinpropertiesValidation1Boxed](#minpropertiesvalidation1boxed)<br> sealed interface for validated payloads |
-| record | [MinpropertiesValidation.MinpropertiesValidation1BoxedVoid](#minpropertiesvalidation1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [MinpropertiesValidation.MinpropertiesValidation1BoxedBoolean](#minpropertiesvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [MinpropertiesValidation.MinpropertiesValidation1BoxedNumber](#minpropertiesvalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [MinpropertiesValidation.MinpropertiesValidation1BoxedString](#minpropertiesvalidation1boxedstring)<br> boxed class to store validated String payloads |
-| record | [MinpropertiesValidation.MinpropertiesValidation1BoxedList](#minpropertiesvalidation1boxedlist)<br> boxed class to store validated List payloads |
-| record | [MinpropertiesValidation.MinpropertiesValidation1BoxedMap](#minpropertiesvalidation1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [MinpropertiesValidation.MinpropertiesValidation1](#minpropertiesvalidation1)<br> schema class |
+| data class | [MinpropertiesValidation.MinpropertiesValidation1BoxedVoid](#minpropertiesvalidation1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [MinpropertiesValidation.MinpropertiesValidation1BoxedBoolean](#minpropertiesvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [MinpropertiesValidation.MinpropertiesValidation1BoxedNumber](#minpropertiesvalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [MinpropertiesValidation.MinpropertiesValidation1BoxedString](#minpropertiesvalidation1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [MinpropertiesValidation.MinpropertiesValidation1BoxedList](#minpropertiesvalidation1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [MinpropertiesValidation.MinpropertiesValidation1BoxedMap](#minpropertiesvalidation1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [MinpropertiesValidation.MinpropertiesValidation1](#minpropertiesvalidation1)<br> schema class |
 
 ## MinpropertiesValidation1Boxed
 sealed interface MinpropertiesValidation1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class MinpropertiesValidation1BoxedBoolean<br>
 implements [MinpropertiesValidation1Boxed](#minpropertiesvalidation1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/NestedAllofToCheckValidationSemantics.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/NestedAllofToCheckValidationSemantics.md
@@ -11,24 +11,24 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [NestedAllofToCheckValidationSemantics.NestedAllofToCheckValidationSemantics1Boxed](#nestedalloftocheckvalidationsemantics1boxed)<br> sealed interface for validated payloads |
-| record | [NestedAllofToCheckValidationSemantics.NestedAllofToCheckValidationSemantics1BoxedVoid](#nestedalloftocheckvalidationsemantics1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [NestedAllofToCheckValidationSemantics.NestedAllofToCheckValidationSemantics1BoxedBoolean](#nestedalloftocheckvalidationsemantics1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [NestedAllofToCheckValidationSemantics.NestedAllofToCheckValidationSemantics1BoxedNumber](#nestedalloftocheckvalidationsemantics1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [NestedAllofToCheckValidationSemantics.NestedAllofToCheckValidationSemantics1BoxedString](#nestedalloftocheckvalidationsemantics1boxedstring)<br> boxed class to store validated String payloads |
-| record | [NestedAllofToCheckValidationSemantics.NestedAllofToCheckValidationSemantics1BoxedList](#nestedalloftocheckvalidationsemantics1boxedlist)<br> boxed class to store validated List payloads |
-| record | [NestedAllofToCheckValidationSemantics.NestedAllofToCheckValidationSemantics1BoxedMap](#nestedalloftocheckvalidationsemantics1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [NestedAllofToCheckValidationSemantics.NestedAllofToCheckValidationSemantics1](#nestedalloftocheckvalidationsemantics1)<br> schema class |
+| data class | [NestedAllofToCheckValidationSemantics.NestedAllofToCheckValidationSemantics1BoxedVoid](#nestedalloftocheckvalidationsemantics1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [NestedAllofToCheckValidationSemantics.NestedAllofToCheckValidationSemantics1BoxedBoolean](#nestedalloftocheckvalidationsemantics1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [NestedAllofToCheckValidationSemantics.NestedAllofToCheckValidationSemantics1BoxedNumber](#nestedalloftocheckvalidationsemantics1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [NestedAllofToCheckValidationSemantics.NestedAllofToCheckValidationSemantics1BoxedString](#nestedalloftocheckvalidationsemantics1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [NestedAllofToCheckValidationSemantics.NestedAllofToCheckValidationSemantics1BoxedList](#nestedalloftocheckvalidationsemantics1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [NestedAllofToCheckValidationSemantics.NestedAllofToCheckValidationSemantics1BoxedMap](#nestedalloftocheckvalidationsemantics1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [NestedAllofToCheckValidationSemantics.NestedAllofToCheckValidationSemantics1](#nestedalloftocheckvalidationsemantics1)<br> schema class |
 | sealed interface | [NestedAllofToCheckValidationSemantics.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [NestedAllofToCheckValidationSemantics.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [NestedAllofToCheckValidationSemantics.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [NestedAllofToCheckValidationSemantics.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [NestedAllofToCheckValidationSemantics.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [NestedAllofToCheckValidationSemantics.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [NestedAllofToCheckValidationSemantics.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [NestedAllofToCheckValidationSemantics.Schema0](#schema0)<br> schema class |
+| data class | [NestedAllofToCheckValidationSemantics.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [NestedAllofToCheckValidationSemantics.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [NestedAllofToCheckValidationSemantics.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [NestedAllofToCheckValidationSemantics.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [NestedAllofToCheckValidationSemantics.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [NestedAllofToCheckValidationSemantics.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [NestedAllofToCheckValidationSemantics.Schema0](#schema0)<br> schema class |
 | sealed interface | [NestedAllofToCheckValidationSemantics.Schema01Boxed](#schema01boxed)<br> sealed interface for validated payloads |
-| record | [NestedAllofToCheckValidationSemantics.Schema01BoxedVoid](#schema01boxedvoid)<br> boxed class to store validated null payloads |
-| static class | [NestedAllofToCheckValidationSemantics.Schema01](#schema01)<br> schema class |
+| data class | [NestedAllofToCheckValidationSemantics.Schema01BoxedVoid](#schema01boxedvoid)<br> boxed class to store validated null payloads |
+| class | [NestedAllofToCheckValidationSemantics.Schema01](#schema01)<br> schema class |
 
 ## NestedAllofToCheckValidationSemantics1Boxed
 sealed interface NestedAllofToCheckValidationSemantics1Boxed<br>
@@ -63,7 +63,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class NestedAllofToCheckValidationSemantics1BoxedBoolean<br>
 implements [NestedAllofToCheckValidationSemantics1Boxed](#nestedalloftocheckvalidationsemantics1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -210,7 +210,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/NestedAllofToCheckValidationSemantics.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/NestedAllofToCheckValidationSemantics.md
@@ -160,19 +160,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [NestedAllofToCheckValidationSemantics1BoxedString](#nestedalloftocheckvalidationsemantics1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [NestedAllofToCheckValidationSemantics1BoxedVoid](#nestedalloftocheckvalidationsemantics1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [NestedAllofToCheckValidationSemantics1BoxedNumber](#nestedalloftocheckvalidationsemantics1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [NestedAllofToCheckValidationSemantics1BoxedBoolean](#nestedalloftocheckvalidationsemantics1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [NestedAllofToCheckValidationSemantics1BoxedMap](#nestedalloftocheckvalidationsemantics1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [NestedAllofToCheckValidationSemantics1BoxedBoolean](#nestedalloftocheckvalidationsemantics1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [NestedAllofToCheckValidationSemantics1BoxedMap](#nestedalloftocheckvalidationsemantics1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [NestedAllofToCheckValidationSemantics1BoxedList](#nestedalloftocheckvalidationsemantics1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [NestedAllofToCheckValidationSemantics1Boxed](#nestedalloftocheckvalidationsemantics1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -307,19 +307,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema0BoxedString](#schema0boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema0BoxedVoid](#schema0boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema0BoxedNumber](#schema0boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema0BoxedList](#schema0boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema0Boxed](#schema0boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/NestedAnyofToCheckValidationSemantics.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/NestedAnyofToCheckValidationSemantics.md
@@ -11,24 +11,24 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [NestedAnyofToCheckValidationSemantics.NestedAnyofToCheckValidationSemantics1Boxed](#nestedanyoftocheckvalidationsemantics1boxed)<br> sealed interface for validated payloads |
-| record | [NestedAnyofToCheckValidationSemantics.NestedAnyofToCheckValidationSemantics1BoxedVoid](#nestedanyoftocheckvalidationsemantics1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [NestedAnyofToCheckValidationSemantics.NestedAnyofToCheckValidationSemantics1BoxedBoolean](#nestedanyoftocheckvalidationsemantics1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [NestedAnyofToCheckValidationSemantics.NestedAnyofToCheckValidationSemantics1BoxedNumber](#nestedanyoftocheckvalidationsemantics1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [NestedAnyofToCheckValidationSemantics.NestedAnyofToCheckValidationSemantics1BoxedString](#nestedanyoftocheckvalidationsemantics1boxedstring)<br> boxed class to store validated String payloads |
-| record | [NestedAnyofToCheckValidationSemantics.NestedAnyofToCheckValidationSemantics1BoxedList](#nestedanyoftocheckvalidationsemantics1boxedlist)<br> boxed class to store validated List payloads |
-| record | [NestedAnyofToCheckValidationSemantics.NestedAnyofToCheckValidationSemantics1BoxedMap](#nestedanyoftocheckvalidationsemantics1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [NestedAnyofToCheckValidationSemantics.NestedAnyofToCheckValidationSemantics1](#nestedanyoftocheckvalidationsemantics1)<br> schema class |
+| data class | [NestedAnyofToCheckValidationSemantics.NestedAnyofToCheckValidationSemantics1BoxedVoid](#nestedanyoftocheckvalidationsemantics1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [NestedAnyofToCheckValidationSemantics.NestedAnyofToCheckValidationSemantics1BoxedBoolean](#nestedanyoftocheckvalidationsemantics1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [NestedAnyofToCheckValidationSemantics.NestedAnyofToCheckValidationSemantics1BoxedNumber](#nestedanyoftocheckvalidationsemantics1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [NestedAnyofToCheckValidationSemantics.NestedAnyofToCheckValidationSemantics1BoxedString](#nestedanyoftocheckvalidationsemantics1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [NestedAnyofToCheckValidationSemantics.NestedAnyofToCheckValidationSemantics1BoxedList](#nestedanyoftocheckvalidationsemantics1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [NestedAnyofToCheckValidationSemantics.NestedAnyofToCheckValidationSemantics1BoxedMap](#nestedanyoftocheckvalidationsemantics1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [NestedAnyofToCheckValidationSemantics.NestedAnyofToCheckValidationSemantics1](#nestedanyoftocheckvalidationsemantics1)<br> schema class |
 | sealed interface | [NestedAnyofToCheckValidationSemantics.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [NestedAnyofToCheckValidationSemantics.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [NestedAnyofToCheckValidationSemantics.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [NestedAnyofToCheckValidationSemantics.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [NestedAnyofToCheckValidationSemantics.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [NestedAnyofToCheckValidationSemantics.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [NestedAnyofToCheckValidationSemantics.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [NestedAnyofToCheckValidationSemantics.Schema0](#schema0)<br> schema class |
+| data class | [NestedAnyofToCheckValidationSemantics.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [NestedAnyofToCheckValidationSemantics.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [NestedAnyofToCheckValidationSemantics.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [NestedAnyofToCheckValidationSemantics.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [NestedAnyofToCheckValidationSemantics.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [NestedAnyofToCheckValidationSemantics.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [NestedAnyofToCheckValidationSemantics.Schema0](#schema0)<br> schema class |
 | sealed interface | [NestedAnyofToCheckValidationSemantics.Schema01Boxed](#schema01boxed)<br> sealed interface for validated payloads |
-| record | [NestedAnyofToCheckValidationSemantics.Schema01BoxedVoid](#schema01boxedvoid)<br> boxed class to store validated null payloads |
-| static class | [NestedAnyofToCheckValidationSemantics.Schema01](#schema01)<br> schema class |
+| data class | [NestedAnyofToCheckValidationSemantics.Schema01BoxedVoid](#schema01boxedvoid)<br> boxed class to store validated null payloads |
+| class | [NestedAnyofToCheckValidationSemantics.Schema01](#schema01)<br> schema class |
 
 ## NestedAnyofToCheckValidationSemantics1Boxed
 sealed interface NestedAnyofToCheckValidationSemantics1Boxed<br>
@@ -63,7 +63,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class NestedAnyofToCheckValidationSemantics1BoxedBoolean<br>
 implements [NestedAnyofToCheckValidationSemantics1Boxed](#nestedanyoftocheckvalidationsemantics1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -210,7 +210,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/NestedAnyofToCheckValidationSemantics.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/NestedAnyofToCheckValidationSemantics.md
@@ -160,19 +160,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [NestedAnyofToCheckValidationSemantics1BoxedString](#nestedanyoftocheckvalidationsemantics1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [NestedAnyofToCheckValidationSemantics1BoxedVoid](#nestedanyoftocheckvalidationsemantics1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [NestedAnyofToCheckValidationSemantics1BoxedNumber](#nestedanyoftocheckvalidationsemantics1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [NestedAnyofToCheckValidationSemantics1BoxedBoolean](#nestedanyoftocheckvalidationsemantics1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [NestedAnyofToCheckValidationSemantics1BoxedMap](#nestedanyoftocheckvalidationsemantics1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [NestedAnyofToCheckValidationSemantics1BoxedBoolean](#nestedanyoftocheckvalidationsemantics1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [NestedAnyofToCheckValidationSemantics1BoxedMap](#nestedanyoftocheckvalidationsemantics1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [NestedAnyofToCheckValidationSemantics1BoxedList](#nestedanyoftocheckvalidationsemantics1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [NestedAnyofToCheckValidationSemantics1Boxed](#nestedanyoftocheckvalidationsemantics1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -307,19 +307,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema0BoxedString](#schema0boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema0BoxedVoid](#schema0boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema0BoxedNumber](#schema0boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema0BoxedList](#schema0boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema0Boxed](#schema0boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/NestedItems.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/NestedItems.md
@@ -68,24 +68,20 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.NestedItems;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.NestedItems
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // List validation
-NestedItems.NestedItemsList validatedPayload =
+val validatedPayload: NestedItems.NestedItemsList =
     NestedItems.NestedItems1.validate(
-    new NestedItems.NestedItemsListBuilder()
+    NestedItems.NestedItemsListBuilder()
         .add(
             listOf(
                 listOf(
@@ -97,7 +93,7 @@ NestedItems.NestedItemsList validatedPayload =
         )
     .build(),
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -175,24 +171,20 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.NestedItems;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.NestedItems
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // List validation
-NestedItems.ItemsList2 validatedPayload =
+val validatedPayload: NestedItems.ItemsList2 =
     NestedItems.Items.validate(
-    new NestedItems.ItemsListBuilder2()
+    NestedItems.ItemsListBuilder2()
         .add(
             listOf(
                 listOf(
@@ -202,7 +194,7 @@ NestedItems.ItemsList2 validatedPayload =
         )
     .build(),
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -280,24 +272,20 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.NestedItems;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.NestedItems
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // List validation
-NestedItems.ItemsList1 validatedPayload =
+val validatedPayload: NestedItems.ItemsList1 =
     NestedItems.Items1.validate(
-    new NestedItems.ItemsListBuilder1()
+    NestedItems.ItemsListBuilder1()
         .add(
             listOf(
                 1
@@ -305,7 +293,7 @@ NestedItems.ItemsList1 validatedPayload =
         )
     .build(),
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -383,29 +371,25 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.NestedItems;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.NestedItems
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // List validation
-NestedItems.ItemsList validatedPayload =
+val validatedPayload: NestedItems.ItemsList =
     NestedItems.Items2.validate(
-    new NestedItems.ItemsListBuilder()
+    NestedItems.ItemsListBuilder()
         .add(1)
 
     .build(),
     configuration
-);
+)
 ```
 
 ### Field Summary

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/NestedItems.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/NestedItems.md
@@ -13,28 +13,28 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [NestedItems.NestedItems1Boxed](#nesteditems1boxed)<br> sealed interface for validated payloads |
-| record | [NestedItems.NestedItems1BoxedList](#nesteditems1boxedlist)<br> boxed class to store validated List payloads |
-| static class | [NestedItems.NestedItems1](#nesteditems1)<br> schema class |
-| static class | [NestedItems.NestedItemsListBuilder](#nesteditemslistbuilder)<br> builder for List payloads |
-| static class | [NestedItems.NestedItemsList](#nesteditemslist)<br> output class for List payloads |
+| data class | [NestedItems.NestedItems1BoxedList](#nesteditems1boxedlist)<br> boxed class to store validated List payloads |
+| class | [NestedItems.NestedItems1](#nesteditems1)<br> schema class |
+| class | [NestedItems.NestedItemsListBuilder](#nesteditemslistbuilder)<br> builder for List payloads |
+| class | [NestedItems.NestedItemsList](#nesteditemslist)<br> output class for List payloads |
 | sealed interface | [NestedItems.ItemsBoxed](#itemsboxed)<br> sealed interface for validated payloads |
-| record | [NestedItems.ItemsBoxedList](#itemsboxedlist)<br> boxed class to store validated List payloads |
-| static class | [NestedItems.Items](#items)<br> schema class |
-| static class | [NestedItems.ItemsListBuilder2](#itemslistbuilder2)<br> builder for List payloads |
-| static class | [NestedItems.ItemsList2](#itemslist2)<br> output class for List payloads |
+| data class | [NestedItems.ItemsBoxedList](#itemsboxedlist)<br> boxed class to store validated List payloads |
+| class | [NestedItems.Items](#items)<br> schema class |
+| class | [NestedItems.ItemsListBuilder2](#itemslistbuilder2)<br> builder for List payloads |
+| class | [NestedItems.ItemsList2](#itemslist2)<br> output class for List payloads |
 | sealed interface | [NestedItems.Items1Boxed](#items1boxed)<br> sealed interface for validated payloads |
-| record | [NestedItems.Items1BoxedList](#items1boxedlist)<br> boxed class to store validated List payloads |
-| static class | [NestedItems.Items1](#items1)<br> schema class |
-| static class | [NestedItems.ItemsListBuilder1](#itemslistbuilder1)<br> builder for List payloads |
-| static class | [NestedItems.ItemsList1](#itemslist1)<br> output class for List payloads |
+| data class | [NestedItems.Items1BoxedList](#items1boxedlist)<br> boxed class to store validated List payloads |
+| class | [NestedItems.Items1](#items1)<br> schema class |
+| class | [NestedItems.ItemsListBuilder1](#itemslistbuilder1)<br> builder for List payloads |
+| class | [NestedItems.ItemsList1](#itemslist1)<br> output class for List payloads |
 | sealed interface | [NestedItems.Items2Boxed](#items2boxed)<br> sealed interface for validated payloads |
-| record | [NestedItems.Items2BoxedList](#items2boxedlist)<br> boxed class to store validated List payloads |
-| static class | [NestedItems.Items2](#items2)<br> schema class |
-| static class | [NestedItems.ItemsListBuilder](#itemslistbuilder)<br> builder for List payloads |
-| static class | [NestedItems.ItemsList](#itemslist)<br> output class for List payloads |
+| data class | [NestedItems.Items2BoxedList](#items2boxedlist)<br> boxed class to store validated List payloads |
+| class | [NestedItems.Items2](#items2)<br> schema class |
+| class | [NestedItems.ItemsListBuilder](#itemslistbuilder)<br> builder for List payloads |
+| class | [NestedItems.ItemsList](#itemslist)<br> output class for List payloads |
 | sealed interface | [NestedItems.Items3Boxed](#items3boxed)<br> sealed interface for validated payloads |
-| record | [NestedItems.Items3BoxedNumber](#items3boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [NestedItems.Items3](#items3)<br> schema class |
+| data class | [NestedItems.Items3BoxedNumber](#items3boxednumber)<br> boxed class to store validated Number payloads |
+| class | [NestedItems.Items3](#items3)<br> schema class |
 
 ## NestedItems1Boxed
 sealed interface NestedItems1Boxed<br>

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/NestedOneofToCheckValidationSemantics.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/NestedOneofToCheckValidationSemantics.md
@@ -160,19 +160,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [NestedOneofToCheckValidationSemantics1BoxedString](#nestedoneoftocheckvalidationsemantics1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [NestedOneofToCheckValidationSemantics1BoxedVoid](#nestedoneoftocheckvalidationsemantics1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [NestedOneofToCheckValidationSemantics1BoxedNumber](#nestedoneoftocheckvalidationsemantics1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [NestedOneofToCheckValidationSemantics1BoxedBoolean](#nestedoneoftocheckvalidationsemantics1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [NestedOneofToCheckValidationSemantics1BoxedMap](#nestedoneoftocheckvalidationsemantics1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [NestedOneofToCheckValidationSemantics1BoxedBoolean](#nestedoneoftocheckvalidationsemantics1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [NestedOneofToCheckValidationSemantics1BoxedMap](#nestedoneoftocheckvalidationsemantics1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [NestedOneofToCheckValidationSemantics1BoxedList](#nestedoneoftocheckvalidationsemantics1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [NestedOneofToCheckValidationSemantics1Boxed](#nestedoneoftocheckvalidationsemantics1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -307,19 +307,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema0BoxedString](#schema0boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema0BoxedVoid](#schema0boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema0BoxedNumber](#schema0boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema0BoxedList](#schema0boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema0Boxed](#schema0boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/NestedOneofToCheckValidationSemantics.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/NestedOneofToCheckValidationSemantics.md
@@ -11,24 +11,24 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [NestedOneofToCheckValidationSemantics.NestedOneofToCheckValidationSemantics1Boxed](#nestedoneoftocheckvalidationsemantics1boxed)<br> sealed interface for validated payloads |
-| record | [NestedOneofToCheckValidationSemantics.NestedOneofToCheckValidationSemantics1BoxedVoid](#nestedoneoftocheckvalidationsemantics1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [NestedOneofToCheckValidationSemantics.NestedOneofToCheckValidationSemantics1BoxedBoolean](#nestedoneoftocheckvalidationsemantics1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [NestedOneofToCheckValidationSemantics.NestedOneofToCheckValidationSemantics1BoxedNumber](#nestedoneoftocheckvalidationsemantics1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [NestedOneofToCheckValidationSemantics.NestedOneofToCheckValidationSemantics1BoxedString](#nestedoneoftocheckvalidationsemantics1boxedstring)<br> boxed class to store validated String payloads |
-| record | [NestedOneofToCheckValidationSemantics.NestedOneofToCheckValidationSemantics1BoxedList](#nestedoneoftocheckvalidationsemantics1boxedlist)<br> boxed class to store validated List payloads |
-| record | [NestedOneofToCheckValidationSemantics.NestedOneofToCheckValidationSemantics1BoxedMap](#nestedoneoftocheckvalidationsemantics1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [NestedOneofToCheckValidationSemantics.NestedOneofToCheckValidationSemantics1](#nestedoneoftocheckvalidationsemantics1)<br> schema class |
+| data class | [NestedOneofToCheckValidationSemantics.NestedOneofToCheckValidationSemantics1BoxedVoid](#nestedoneoftocheckvalidationsemantics1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [NestedOneofToCheckValidationSemantics.NestedOneofToCheckValidationSemantics1BoxedBoolean](#nestedoneoftocheckvalidationsemantics1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [NestedOneofToCheckValidationSemantics.NestedOneofToCheckValidationSemantics1BoxedNumber](#nestedoneoftocheckvalidationsemantics1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [NestedOneofToCheckValidationSemantics.NestedOneofToCheckValidationSemantics1BoxedString](#nestedoneoftocheckvalidationsemantics1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [NestedOneofToCheckValidationSemantics.NestedOneofToCheckValidationSemantics1BoxedList](#nestedoneoftocheckvalidationsemantics1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [NestedOneofToCheckValidationSemantics.NestedOneofToCheckValidationSemantics1BoxedMap](#nestedoneoftocheckvalidationsemantics1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [NestedOneofToCheckValidationSemantics.NestedOneofToCheckValidationSemantics1](#nestedoneoftocheckvalidationsemantics1)<br> schema class |
 | sealed interface | [NestedOneofToCheckValidationSemantics.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [NestedOneofToCheckValidationSemantics.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [NestedOneofToCheckValidationSemantics.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [NestedOneofToCheckValidationSemantics.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [NestedOneofToCheckValidationSemantics.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [NestedOneofToCheckValidationSemantics.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [NestedOneofToCheckValidationSemantics.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [NestedOneofToCheckValidationSemantics.Schema0](#schema0)<br> schema class |
+| data class | [NestedOneofToCheckValidationSemantics.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [NestedOneofToCheckValidationSemantics.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [NestedOneofToCheckValidationSemantics.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [NestedOneofToCheckValidationSemantics.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [NestedOneofToCheckValidationSemantics.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [NestedOneofToCheckValidationSemantics.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [NestedOneofToCheckValidationSemantics.Schema0](#schema0)<br> schema class |
 | sealed interface | [NestedOneofToCheckValidationSemantics.Schema01Boxed](#schema01boxed)<br> sealed interface for validated payloads |
-| record | [NestedOneofToCheckValidationSemantics.Schema01BoxedVoid](#schema01boxedvoid)<br> boxed class to store validated null payloads |
-| static class | [NestedOneofToCheckValidationSemantics.Schema01](#schema01)<br> schema class |
+| data class | [NestedOneofToCheckValidationSemantics.Schema01BoxedVoid](#schema01boxedvoid)<br> boxed class to store validated null payloads |
+| class | [NestedOneofToCheckValidationSemantics.Schema01](#schema01)<br> schema class |
 
 ## NestedOneofToCheckValidationSemantics1Boxed
 sealed interface NestedOneofToCheckValidationSemantics1Boxed<br>
@@ -63,7 +63,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class NestedOneofToCheckValidationSemantics1BoxedBoolean<br>
 implements [NestedOneofToCheckValidationSemantics1Boxed](#nestedoneoftocheckvalidationsemantics1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -210,7 +210,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/Not.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/Not.md
@@ -152,19 +152,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Not1BoxedString](#not1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Not1BoxedVoid](#not1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Not1BoxedNumber](#not1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Not1BoxedBoolean](#not1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Not1BoxedMap](#not1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Not1BoxedBoolean](#not1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Not1BoxedMap](#not1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Not1BoxedList](#not1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Not1Boxed](#not1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/Not.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/Not.md
@@ -11,16 +11,16 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [Not.Not1Boxed](#not1boxed)<br> sealed interface for validated payloads |
-| record | [Not.Not1BoxedVoid](#not1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [Not.Not1BoxedBoolean](#not1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [Not.Not1BoxedNumber](#not1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [Not.Not1BoxedString](#not1boxedstring)<br> boxed class to store validated String payloads |
-| record | [Not.Not1BoxedList](#not1boxedlist)<br> boxed class to store validated List payloads |
-| record | [Not.Not1BoxedMap](#not1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [Not.Not1](#not1)<br> schema class |
+| data class | [Not.Not1BoxedVoid](#not1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [Not.Not1BoxedBoolean](#not1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [Not.Not1BoxedNumber](#not1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [Not.Not1BoxedString](#not1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [Not.Not1BoxedList](#not1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [Not.Not1BoxedMap](#not1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [Not.Not1](#not1)<br> schema class |
 | sealed interface | [Not.Not2Boxed](#not2boxed)<br> sealed interface for validated payloads |
-| record | [Not.Not2BoxedNumber](#not2boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [Not.Not2](#not2)<br> schema class |
+| data class | [Not.Not2BoxedNumber](#not2boxednumber)<br> boxed class to store validated Number payloads |
+| class | [Not.Not2](#not2)<br> schema class |
 
 ## Not1Boxed
 sealed interface Not1Boxed<br>
@@ -55,7 +55,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Not1BoxedBoolean<br>
 implements [Not1Boxed](#not1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/NotMoreComplexSchema.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/NotMoreComplexSchema.md
@@ -159,19 +159,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [NotMoreComplexSchema1BoxedString](#notmorecomplexschema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [NotMoreComplexSchema1BoxedVoid](#notmorecomplexschema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [NotMoreComplexSchema1BoxedNumber](#notmorecomplexschema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [NotMoreComplexSchema1BoxedBoolean](#notmorecomplexschema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [NotMoreComplexSchema1BoxedMap](#notmorecomplexschema1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [NotMoreComplexSchema1BoxedBoolean](#notmorecomplexschema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [NotMoreComplexSchema1BoxedMap](#notmorecomplexschema1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [NotMoreComplexSchema1BoxedList](#notmorecomplexschema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [NotMoreComplexSchema1Boxed](#notmorecomplexschema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -208,29 +208,25 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.NotMoreComplexSchema;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.NotMoreComplexSchema
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // Map validation
-NotMoreComplexSchema.NotMap validatedPayload =
+val validatedPayload: NotMoreComplexSchema.NotMap =
     NotMoreComplexSchema.Not.validate(
-    new NotMoreComplexSchema.NotMapBuilder()
+    NotMoreComplexSchema.NotMapBuilder()
         .foo("a")
 
     .build(),
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -242,8 +238,8 @@ NotMoreComplexSchema.NotMap validatedPayload =
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| [NotMap](#notmap) | validate(arg: [Map&lt;?, ?&gt;](#notmapbuilder), configuration: SchemaConfiguration) |
-| [NotBoxedMap](#notboxedmap) | validateAndBox([Map&lt;?, ?&gt;](#notmapbuilder), configuration: SchemaConfiguration) |
+| [NotMap](#notmap) | validate(arg: [Map&lt;*, *&gt;](#notmapbuilder), configuration: SchemaConfiguration) |
+| [NotBoxedMap](#notboxedmap) | validateAndBox([Map&lt;*, *&gt;](#notmapbuilder), configuration: SchemaConfiguration) |
 | [NotBoxed](#notboxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
 

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/NotMoreComplexSchema.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/NotMoreComplexSchema.md
@@ -13,21 +13,21 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [NotMoreComplexSchema.NotMoreComplexSchema1Boxed](#notmorecomplexschema1boxed)<br> sealed interface for validated payloads |
-| record | [NotMoreComplexSchema.NotMoreComplexSchema1BoxedVoid](#notmorecomplexschema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [NotMoreComplexSchema.NotMoreComplexSchema1BoxedBoolean](#notmorecomplexschema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [NotMoreComplexSchema.NotMoreComplexSchema1BoxedNumber](#notmorecomplexschema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [NotMoreComplexSchema.NotMoreComplexSchema1BoxedString](#notmorecomplexschema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [NotMoreComplexSchema.NotMoreComplexSchema1BoxedList](#notmorecomplexschema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [NotMoreComplexSchema.NotMoreComplexSchema1BoxedMap](#notmorecomplexschema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [NotMoreComplexSchema.NotMoreComplexSchema1](#notmorecomplexschema1)<br> schema class |
+| data class | [NotMoreComplexSchema.NotMoreComplexSchema1BoxedVoid](#notmorecomplexschema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [NotMoreComplexSchema.NotMoreComplexSchema1BoxedBoolean](#notmorecomplexschema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [NotMoreComplexSchema.NotMoreComplexSchema1BoxedNumber](#notmorecomplexschema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [NotMoreComplexSchema.NotMoreComplexSchema1BoxedString](#notmorecomplexschema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [NotMoreComplexSchema.NotMoreComplexSchema1BoxedList](#notmorecomplexschema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [NotMoreComplexSchema.NotMoreComplexSchema1BoxedMap](#notmorecomplexschema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [NotMoreComplexSchema.NotMoreComplexSchema1](#notmorecomplexschema1)<br> schema class |
 | sealed interface | [NotMoreComplexSchema.NotBoxed](#notboxed)<br> sealed interface for validated payloads |
-| record | [NotMoreComplexSchema.NotBoxedMap](#notboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [NotMoreComplexSchema.Not](#not)<br> schema class |
-| static class | [NotMoreComplexSchema.NotMapBuilder](#notmapbuilder)<br> builder for Map payloads |
-| static class | [NotMoreComplexSchema.NotMap](#notmap)<br> output class for Map payloads |
+| data class | [NotMoreComplexSchema.NotBoxedMap](#notboxedmap)<br> boxed class to store validated Map payloads |
+| class | [NotMoreComplexSchema.Not](#not)<br> schema class |
+| class | [NotMoreComplexSchema.NotMapBuilder](#notmapbuilder)<br> builder for Map payloads |
+| class | [NotMoreComplexSchema.NotMap](#notmap)<br> output class for Map payloads |
 | sealed interface | [NotMoreComplexSchema.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [NotMoreComplexSchema.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
-| static class | [NotMoreComplexSchema.Foo](#foo)<br> schema class |
+| data class | [NotMoreComplexSchema.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
+| class | [NotMoreComplexSchema.Foo](#foo)<br> schema class |
 
 ## NotMoreComplexSchema1Boxed
 sealed interface NotMoreComplexSchema1Boxed<br>
@@ -62,7 +62,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class NotMoreComplexSchema1BoxedBoolean<br>
 implements [NotMoreComplexSchema1Boxed](#notmorecomplexschema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/NulCharactersInStrings.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/NulCharactersInStrings.md
@@ -12,8 +12,8 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [NulCharactersInStrings.NulCharactersInStrings1Boxed](#nulcharactersinstrings1boxed)<br> sealed interface for validated payloads |
-| record | [NulCharactersInStrings.NulCharactersInStrings1BoxedString](#nulcharactersinstrings1boxedstring)<br> boxed class to store validated String payloads |
-| static class | [NulCharactersInStrings.NulCharactersInStrings1](#nulcharactersinstrings1)<br> schema class |
+| data class | [NulCharactersInStrings.NulCharactersInStrings1BoxedString](#nulcharactersinstrings1boxedstring)<br> boxed class to store validated String payloads |
+| class | [NulCharactersInStrings.NulCharactersInStrings1](#nulcharactersinstrings1)<br> schema class |
 | enum | [NulCharactersInStrings.StringNulCharactersInStringsEnums](#stringnulcharactersinstringsenums)<br>String enum |
 
 ## NulCharactersInStrings1Boxed

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/NulCharactersInStrings.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/NulCharactersInStrings.md
@@ -48,25 +48,21 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.NulCharactersInStrings;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.NulCharactersInStrings
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // String validation
-String validatedPayload = NulCharactersInStrings.NulCharactersInStrings1.validate(
+val validatedPayload: String = NulCharactersInStrings.NulCharactersInStrings1.validate(
     "hello\u0000there",
     configuration
-);
+)
 ```
 
 ### Field Summary

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/NullTypeMatchesOnlyTheNullObject.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/NullTypeMatchesOnlyTheNullObject.md
@@ -11,8 +11,8 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [NullTypeMatchesOnlyTheNullObject.NullTypeMatchesOnlyTheNullObject1Boxed](#nulltypematchesonlythenullobject1boxed)<br> sealed interface for validated payloads |
-| record | [NullTypeMatchesOnlyTheNullObject.NullTypeMatchesOnlyTheNullObject1BoxedVoid](#nulltypematchesonlythenullobject1boxedvoid)<br> boxed class to store validated null payloads |
-| static class | [NullTypeMatchesOnlyTheNullObject.NullTypeMatchesOnlyTheNullObject1](#nulltypematchesonlythenullobject1)<br> schema class |
+| data class | [NullTypeMatchesOnlyTheNullObject.NullTypeMatchesOnlyTheNullObject1BoxedVoid](#nulltypematchesonlythenullobject1boxedvoid)<br> boxed class to store validated null payloads |
+| class | [NullTypeMatchesOnlyTheNullObject.NullTypeMatchesOnlyTheNullObject1](#nulltypematchesonlythenullobject1)<br> schema class |
 
 ## NullTypeMatchesOnlyTheNullObject1Boxed
 sealed interface NullTypeMatchesOnlyTheNullObject1Boxed<br>

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/NumberTypeMatchesNumbers.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/NumberTypeMatchesNumbers.md
@@ -11,8 +11,8 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [NumberTypeMatchesNumbers.NumberTypeMatchesNumbers1Boxed](#numbertypematchesnumbers1boxed)<br> sealed interface for validated payloads |
-| record | [NumberTypeMatchesNumbers.NumberTypeMatchesNumbers1BoxedNumber](#numbertypematchesnumbers1boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [NumberTypeMatchesNumbers.NumberTypeMatchesNumbers1](#numbertypematchesnumbers1)<br> schema class |
+| data class | [NumberTypeMatchesNumbers.NumberTypeMatchesNumbers1BoxedNumber](#numbertypematchesnumbers1boxednumber)<br> boxed class to store validated Number payloads |
+| class | [NumberTypeMatchesNumbers.NumberTypeMatchesNumbers1](#numbertypematchesnumbers1)<br> schema class |
 
 ## NumberTypeMatchesNumbers1Boxed
 sealed interface NumberTypeMatchesNumbers1Boxed<br>

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/ObjectPropertiesValidation.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/ObjectPropertiesValidation.md
@@ -159,19 +159,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [ObjectPropertiesValidationMap](#objectpropertiesvalidationmap) | validate(arg: [Map&lt;?, ?&gt;](#objectpropertiesvalidationmapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [ObjectPropertiesValidationMap](#objectpropertiesvalidationmap) | validate(arg: [Map&lt;*, *&gt;](#objectpropertiesvalidationmapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [ObjectPropertiesValidation1BoxedString](#objectpropertiesvalidation1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [ObjectPropertiesValidation1BoxedVoid](#objectpropertiesvalidation1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [ObjectPropertiesValidation1BoxedNumber](#objectpropertiesvalidation1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [ObjectPropertiesValidation1BoxedBoolean](#objectpropertiesvalidation1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [ObjectPropertiesValidation1BoxedMap](#objectpropertiesvalidation1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#objectpropertiesvalidationmapbuilder), configuration: SchemaConfiguration) |
+| [ObjectPropertiesValidation1BoxedBoolean](#objectpropertiesvalidation1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [ObjectPropertiesValidation1BoxedMap](#objectpropertiesvalidation1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#objectpropertiesvalidationmapbuilder), configuration: SchemaConfiguration) |
 | [ObjectPropertiesValidation1BoxedList](#objectpropertiesvalidation1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [ObjectPropertiesValidation1Boxed](#objectpropertiesvalidation1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/ObjectPropertiesValidation.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/ObjectPropertiesValidation.md
@@ -13,21 +13,21 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [ObjectPropertiesValidation.ObjectPropertiesValidation1Boxed](#objectpropertiesvalidation1boxed)<br> sealed interface for validated payloads |
-| record | [ObjectPropertiesValidation.ObjectPropertiesValidation1BoxedVoid](#objectpropertiesvalidation1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [ObjectPropertiesValidation.ObjectPropertiesValidation1BoxedBoolean](#objectpropertiesvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [ObjectPropertiesValidation.ObjectPropertiesValidation1BoxedNumber](#objectpropertiesvalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [ObjectPropertiesValidation.ObjectPropertiesValidation1BoxedString](#objectpropertiesvalidation1boxedstring)<br> boxed class to store validated String payloads |
-| record | [ObjectPropertiesValidation.ObjectPropertiesValidation1BoxedList](#objectpropertiesvalidation1boxedlist)<br> boxed class to store validated List payloads |
-| record | [ObjectPropertiesValidation.ObjectPropertiesValidation1BoxedMap](#objectpropertiesvalidation1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [ObjectPropertiesValidation.ObjectPropertiesValidation1](#objectpropertiesvalidation1)<br> schema class |
-| static class | [ObjectPropertiesValidation.ObjectPropertiesValidationMapBuilder](#objectpropertiesvalidationmapbuilder)<br> builder for Map payloads |
-| static class | [ObjectPropertiesValidation.ObjectPropertiesValidationMap](#objectpropertiesvalidationmap)<br> output class for Map payloads |
+| data class | [ObjectPropertiesValidation.ObjectPropertiesValidation1BoxedVoid](#objectpropertiesvalidation1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [ObjectPropertiesValidation.ObjectPropertiesValidation1BoxedBoolean](#objectpropertiesvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [ObjectPropertiesValidation.ObjectPropertiesValidation1BoxedNumber](#objectpropertiesvalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [ObjectPropertiesValidation.ObjectPropertiesValidation1BoxedString](#objectpropertiesvalidation1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [ObjectPropertiesValidation.ObjectPropertiesValidation1BoxedList](#objectpropertiesvalidation1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [ObjectPropertiesValidation.ObjectPropertiesValidation1BoxedMap](#objectpropertiesvalidation1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [ObjectPropertiesValidation.ObjectPropertiesValidation1](#objectpropertiesvalidation1)<br> schema class |
+| class | [ObjectPropertiesValidation.ObjectPropertiesValidationMapBuilder](#objectpropertiesvalidationmapbuilder)<br> builder for Map payloads |
+| class | [ObjectPropertiesValidation.ObjectPropertiesValidationMap](#objectpropertiesvalidationmap)<br> output class for Map payloads |
 | sealed interface | [ObjectPropertiesValidation.BarBoxed](#barboxed)<br> sealed interface for validated payloads |
-| record | [ObjectPropertiesValidation.BarBoxedString](#barboxedstring)<br> boxed class to store validated String payloads |
-| static class | [ObjectPropertiesValidation.Bar](#bar)<br> schema class |
+| data class | [ObjectPropertiesValidation.BarBoxedString](#barboxedstring)<br> boxed class to store validated String payloads |
+| class | [ObjectPropertiesValidation.Bar](#bar)<br> schema class |
 | sealed interface | [ObjectPropertiesValidation.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [ObjectPropertiesValidation.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
-| static class | [ObjectPropertiesValidation.Foo](#foo)<br> schema class |
+| data class | [ObjectPropertiesValidation.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
+| class | [ObjectPropertiesValidation.Foo](#foo)<br> schema class |
 
 ## ObjectPropertiesValidation1Boxed
 sealed interface ObjectPropertiesValidation1Boxed<br>
@@ -62,7 +62,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class ObjectPropertiesValidation1BoxedBoolean<br>
 implements [ObjectPropertiesValidation1Boxed](#objectpropertiesvalidation1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/ObjectTypeMatchesObjects.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/ObjectTypeMatchesObjects.md
@@ -11,8 +11,8 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [ObjectTypeMatchesObjects.ObjectTypeMatchesObjects1Boxed](#objecttypematchesobjects1boxed)<br> sealed interface for validated payloads |
-| record | [ObjectTypeMatchesObjects.ObjectTypeMatchesObjects1BoxedMap](#objecttypematchesobjects1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [ObjectTypeMatchesObjects.ObjectTypeMatchesObjects1](#objecttypematchesobjects1)<br> schema class |
+| data class | [ObjectTypeMatchesObjects.ObjectTypeMatchesObjects1BoxedMap](#objecttypematchesobjects1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [ObjectTypeMatchesObjects.ObjectTypeMatchesObjects1](#objecttypematchesobjects1)<br> schema class |
 
 ## ObjectTypeMatchesObjects1Boxed
 sealed interface ObjectTypeMatchesObjects1Boxed<br>

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/Oneof.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/Oneof.md
@@ -160,19 +160,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Oneof1BoxedString](#oneof1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Oneof1BoxedVoid](#oneof1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Oneof1BoxedNumber](#oneof1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Oneof1BoxedBoolean](#oneof1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Oneof1BoxedMap](#oneof1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Oneof1BoxedBoolean](#oneof1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Oneof1BoxedMap](#oneof1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Oneof1BoxedList](#oneof1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Oneof1Boxed](#oneof1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -307,19 +307,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema1BoxedString](#schema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema1BoxedVoid](#schema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema1BoxedNumber](#schema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema1BoxedList](#schema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema1Boxed](#schema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/Oneof.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/Oneof.md
@@ -11,24 +11,24 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [Oneof.Oneof1Boxed](#oneof1boxed)<br> sealed interface for validated payloads |
-| record | [Oneof.Oneof1BoxedVoid](#oneof1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [Oneof.Oneof1BoxedBoolean](#oneof1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [Oneof.Oneof1BoxedNumber](#oneof1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [Oneof.Oneof1BoxedString](#oneof1boxedstring)<br> boxed class to store validated String payloads |
-| record | [Oneof.Oneof1BoxedList](#oneof1boxedlist)<br> boxed class to store validated List payloads |
-| record | [Oneof.Oneof1BoxedMap](#oneof1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [Oneof.Oneof1](#oneof1)<br> schema class |
+| data class | [Oneof.Oneof1BoxedVoid](#oneof1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [Oneof.Oneof1BoxedBoolean](#oneof1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [Oneof.Oneof1BoxedNumber](#oneof1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [Oneof.Oneof1BoxedString](#oneof1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [Oneof.Oneof1BoxedList](#oneof1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [Oneof.Oneof1BoxedMap](#oneof1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [Oneof.Oneof1](#oneof1)<br> schema class |
 | sealed interface | [Oneof.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [Oneof.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [Oneof.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [Oneof.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [Oneof.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [Oneof.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [Oneof.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [Oneof.Schema1](#schema1)<br> schema class |
+| data class | [Oneof.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [Oneof.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [Oneof.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [Oneof.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [Oneof.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [Oneof.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [Oneof.Schema1](#schema1)<br> schema class |
 | sealed interface | [Oneof.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [Oneof.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [Oneof.Schema0](#schema0)<br> schema class |
+| data class | [Oneof.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| class | [Oneof.Schema0](#schema0)<br> schema class |
 
 ## Oneof1Boxed
 sealed interface Oneof1Boxed<br>
@@ -63,7 +63,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Oneof1BoxedBoolean<br>
 implements [Oneof1Boxed](#oneof1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -210,7 +210,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema1BoxedBoolean<br>
 implements [Schema1Boxed](#schema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/OneofComplexTypes.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/OneofComplexTypes.md
@@ -177,19 +177,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [OneofComplexTypes1BoxedString](#oneofcomplextypes1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [OneofComplexTypes1BoxedVoid](#oneofcomplextypes1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [OneofComplexTypes1BoxedNumber](#oneofcomplextypes1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [OneofComplexTypes1BoxedBoolean](#oneofcomplextypes1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [OneofComplexTypes1BoxedMap](#oneofcomplextypes1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [OneofComplexTypes1BoxedBoolean](#oneofcomplextypes1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [OneofComplexTypes1BoxedMap](#oneofcomplextypes1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [OneofComplexTypes1BoxedList](#oneofcomplextypes1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [OneofComplexTypes1Boxed](#oneofcomplextypes1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -325,19 +325,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [Schema1Map](#schema1map) | validate(arg: [Map&lt;?, ?&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [Schema1Map](#schema1map) | validate(arg: [Map&lt;*, *&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema1BoxedString](#schema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema1BoxedVoid](#schema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema1BoxedNumber](#schema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
+| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
 | [Schema1BoxedList](#schema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema1Boxed](#schema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -562,19 +562,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [Schema0Map](#schema0map) | validate(arg: [Map&lt;?, ?&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [Schema0Map](#schema0map) | validate(arg: [Map&lt;*, *&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema0BoxedString](#schema0boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema0BoxedVoid](#schema0boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema0BoxedNumber](#schema0boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
+| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox([Map&lt;*, *&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
 | [Schema0BoxedList](#schema0boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema0Boxed](#schema0boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/OneofComplexTypes.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/OneofComplexTypes.md
@@ -13,39 +13,39 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [OneofComplexTypes.OneofComplexTypes1Boxed](#oneofcomplextypes1boxed)<br> sealed interface for validated payloads |
-| record | [OneofComplexTypes.OneofComplexTypes1BoxedVoid](#oneofcomplextypes1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [OneofComplexTypes.OneofComplexTypes1BoxedBoolean](#oneofcomplextypes1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [OneofComplexTypes.OneofComplexTypes1BoxedNumber](#oneofcomplextypes1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [OneofComplexTypes.OneofComplexTypes1BoxedString](#oneofcomplextypes1boxedstring)<br> boxed class to store validated String payloads |
-| record | [OneofComplexTypes.OneofComplexTypes1BoxedList](#oneofcomplextypes1boxedlist)<br> boxed class to store validated List payloads |
-| record | [OneofComplexTypes.OneofComplexTypes1BoxedMap](#oneofcomplextypes1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [OneofComplexTypes.OneofComplexTypes1](#oneofcomplextypes1)<br> schema class |
+| data class | [OneofComplexTypes.OneofComplexTypes1BoxedVoid](#oneofcomplextypes1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [OneofComplexTypes.OneofComplexTypes1BoxedBoolean](#oneofcomplextypes1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [OneofComplexTypes.OneofComplexTypes1BoxedNumber](#oneofcomplextypes1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [OneofComplexTypes.OneofComplexTypes1BoxedString](#oneofcomplextypes1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [OneofComplexTypes.OneofComplexTypes1BoxedList](#oneofcomplextypes1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [OneofComplexTypes.OneofComplexTypes1BoxedMap](#oneofcomplextypes1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [OneofComplexTypes.OneofComplexTypes1](#oneofcomplextypes1)<br> schema class |
 | sealed interface | [OneofComplexTypes.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [OneofComplexTypes.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [OneofComplexTypes.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [OneofComplexTypes.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [OneofComplexTypes.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [OneofComplexTypes.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [OneofComplexTypes.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [OneofComplexTypes.Schema1](#schema1)<br> schema class |
-| static class | [OneofComplexTypes.Schema1MapBuilder](#schema1mapbuilder)<br> builder for Map payloads |
-| static class | [OneofComplexTypes.Schema1Map](#schema1map)<br> output class for Map payloads |
+| data class | [OneofComplexTypes.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [OneofComplexTypes.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [OneofComplexTypes.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [OneofComplexTypes.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [OneofComplexTypes.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [OneofComplexTypes.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [OneofComplexTypes.Schema1](#schema1)<br> schema class |
+| class | [OneofComplexTypes.Schema1MapBuilder](#schema1mapbuilder)<br> builder for Map payloads |
+| class | [OneofComplexTypes.Schema1Map](#schema1map)<br> output class for Map payloads |
 | sealed interface | [OneofComplexTypes.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [OneofComplexTypes.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
-| static class | [OneofComplexTypes.Foo](#foo)<br> schema class |
+| data class | [OneofComplexTypes.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
+| class | [OneofComplexTypes.Foo](#foo)<br> schema class |
 | sealed interface | [OneofComplexTypes.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [OneofComplexTypes.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [OneofComplexTypes.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [OneofComplexTypes.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [OneofComplexTypes.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [OneofComplexTypes.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [OneofComplexTypes.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [OneofComplexTypes.Schema0](#schema0)<br> schema class |
-| static class | [OneofComplexTypes.Schema0MapBuilder](#schema0mapbuilder)<br> builder for Map payloads |
-| static class | [OneofComplexTypes.Schema0Map](#schema0map)<br> output class for Map payloads |
+| data class | [OneofComplexTypes.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [OneofComplexTypes.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [OneofComplexTypes.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [OneofComplexTypes.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [OneofComplexTypes.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [OneofComplexTypes.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [OneofComplexTypes.Schema0](#schema0)<br> schema class |
+| class | [OneofComplexTypes.Schema0MapBuilder](#schema0mapbuilder)<br> builder for Map payloads |
+| class | [OneofComplexTypes.Schema0Map](#schema0map)<br> output class for Map payloads |
 | sealed interface | [OneofComplexTypes.BarBoxed](#barboxed)<br> sealed interface for validated payloads |
-| record | [OneofComplexTypes.BarBoxedNumber](#barboxednumber)<br> boxed class to store validated Number payloads |
-| static class | [OneofComplexTypes.Bar](#bar)<br> schema class |
+| data class | [OneofComplexTypes.BarBoxedNumber](#barboxednumber)<br> boxed class to store validated Number payloads |
+| class | [OneofComplexTypes.Bar](#bar)<br> schema class |
 
 ## OneofComplexTypes1Boxed
 sealed interface OneofComplexTypes1Boxed<br>
@@ -80,7 +80,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class OneofComplexTypes1BoxedBoolean<br>
 implements [OneofComplexTypes1Boxed](#oneofcomplextypes1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -227,7 +227,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema1BoxedBoolean<br>
 implements [Schema1Boxed](#schema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -464,7 +464,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/OneofWithBaseSchema.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/OneofWithBaseSchema.md
@@ -62,25 +62,21 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.OneofWithBaseSchema;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.OneofWithBaseSchema
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // String validation
-String validatedPayload = OneofWithBaseSchema.OneofWithBaseSchema1.validate(
+val validatedPayload: String = OneofWithBaseSchema.OneofWithBaseSchema1.validate(
     "a",
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -220,26 +216,26 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| Integer | maxLength = 4 |
+| Int | maxLength = 4 |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema1BoxedString](#schema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema1BoxedVoid](#schema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema1BoxedNumber](#schema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema1BoxedList](#schema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema1Boxed](#schema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -367,26 +363,26 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| Integer | minLength = 2 |
+| Int | minLength = 2 |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema0BoxedString](#schema0boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema0BoxedVoid](#schema0boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema0BoxedNumber](#schema0boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema0BoxedList](#schema0boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema0Boxed](#schema0boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/OneofWithBaseSchema.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/OneofWithBaseSchema.md
@@ -11,24 +11,24 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [OneofWithBaseSchema.OneofWithBaseSchema1Boxed](#oneofwithbaseschema1boxed)<br> sealed interface for validated payloads |
-| record | [OneofWithBaseSchema.OneofWithBaseSchema1BoxedString](#oneofwithbaseschema1boxedstring)<br> boxed class to store validated String payloads |
-| static class | [OneofWithBaseSchema.OneofWithBaseSchema1](#oneofwithbaseschema1)<br> schema class |
+| data class | [OneofWithBaseSchema.OneofWithBaseSchema1BoxedString](#oneofwithbaseschema1boxedstring)<br> boxed class to store validated String payloads |
+| class | [OneofWithBaseSchema.OneofWithBaseSchema1](#oneofwithbaseschema1)<br> schema class |
 | sealed interface | [OneofWithBaseSchema.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [OneofWithBaseSchema.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [OneofWithBaseSchema.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [OneofWithBaseSchema.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [OneofWithBaseSchema.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [OneofWithBaseSchema.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [OneofWithBaseSchema.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [OneofWithBaseSchema.Schema1](#schema1)<br> schema class |
+| data class | [OneofWithBaseSchema.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [OneofWithBaseSchema.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [OneofWithBaseSchema.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [OneofWithBaseSchema.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [OneofWithBaseSchema.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [OneofWithBaseSchema.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [OneofWithBaseSchema.Schema1](#schema1)<br> schema class |
 | sealed interface | [OneofWithBaseSchema.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [OneofWithBaseSchema.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [OneofWithBaseSchema.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [OneofWithBaseSchema.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [OneofWithBaseSchema.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [OneofWithBaseSchema.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [OneofWithBaseSchema.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [OneofWithBaseSchema.Schema0](#schema0)<br> schema class |
+| data class | [OneofWithBaseSchema.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [OneofWithBaseSchema.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [OneofWithBaseSchema.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [OneofWithBaseSchema.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [OneofWithBaseSchema.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [OneofWithBaseSchema.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [OneofWithBaseSchema.Schema0](#schema0)<br> schema class |
 
 ## OneofWithBaseSchema1Boxed
 sealed interface OneofWithBaseSchema1Boxed<br>
@@ -126,7 +126,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema1BoxedBoolean<br>
 implements [Schema1Boxed](#schema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -273,7 +273,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/OneofWithEmptySchema.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/OneofWithEmptySchema.md
@@ -160,19 +160,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [OneofWithEmptySchema1BoxedString](#oneofwithemptyschema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [OneofWithEmptySchema1BoxedVoid](#oneofwithemptyschema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [OneofWithEmptySchema1BoxedNumber](#oneofwithemptyschema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [OneofWithEmptySchema1BoxedBoolean](#oneofwithemptyschema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [OneofWithEmptySchema1BoxedMap](#oneofwithemptyschema1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [OneofWithEmptySchema1BoxedBoolean](#oneofwithemptyschema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [OneofWithEmptySchema1BoxedMap](#oneofwithemptyschema1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [OneofWithEmptySchema1BoxedList](#oneofwithemptyschema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [OneofWithEmptySchema1Boxed](#oneofwithemptyschema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/OneofWithEmptySchema.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/OneofWithEmptySchema.md
@@ -11,24 +11,24 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [OneofWithEmptySchema.OneofWithEmptySchema1Boxed](#oneofwithemptyschema1boxed)<br> sealed interface for validated payloads |
-| record | [OneofWithEmptySchema.OneofWithEmptySchema1BoxedVoid](#oneofwithemptyschema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [OneofWithEmptySchema.OneofWithEmptySchema1BoxedBoolean](#oneofwithemptyschema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [OneofWithEmptySchema.OneofWithEmptySchema1BoxedNumber](#oneofwithemptyschema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [OneofWithEmptySchema.OneofWithEmptySchema1BoxedString](#oneofwithemptyschema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [OneofWithEmptySchema.OneofWithEmptySchema1BoxedList](#oneofwithemptyschema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [OneofWithEmptySchema.OneofWithEmptySchema1BoxedMap](#oneofwithemptyschema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [OneofWithEmptySchema.OneofWithEmptySchema1](#oneofwithemptyschema1)<br> schema class |
+| data class | [OneofWithEmptySchema.OneofWithEmptySchema1BoxedVoid](#oneofwithemptyschema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [OneofWithEmptySchema.OneofWithEmptySchema1BoxedBoolean](#oneofwithemptyschema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [OneofWithEmptySchema.OneofWithEmptySchema1BoxedNumber](#oneofwithemptyschema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [OneofWithEmptySchema.OneofWithEmptySchema1BoxedString](#oneofwithemptyschema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [OneofWithEmptySchema.OneofWithEmptySchema1BoxedList](#oneofwithemptyschema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [OneofWithEmptySchema.OneofWithEmptySchema1BoxedMap](#oneofwithemptyschema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [OneofWithEmptySchema.OneofWithEmptySchema1](#oneofwithemptyschema1)<br> schema class |
 | sealed interface | [OneofWithEmptySchema.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [OneofWithEmptySchema.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [OneofWithEmptySchema.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [OneofWithEmptySchema.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [OneofWithEmptySchema.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [OneofWithEmptySchema.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [OneofWithEmptySchema.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [OneofWithEmptySchema.Schema1](#schema1)<br> schema class |
+| data class | [OneofWithEmptySchema.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [OneofWithEmptySchema.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [OneofWithEmptySchema.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [OneofWithEmptySchema.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [OneofWithEmptySchema.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [OneofWithEmptySchema.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [OneofWithEmptySchema.Schema1](#schema1)<br> schema class |
 | sealed interface | [OneofWithEmptySchema.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [OneofWithEmptySchema.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [OneofWithEmptySchema.Schema0](#schema0)<br> schema class |
+| data class | [OneofWithEmptySchema.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| class | [OneofWithEmptySchema.Schema0](#schema0)<br> schema class |
 
 ## OneofWithEmptySchema1Boxed
 sealed interface OneofWithEmptySchema1Boxed<br>
@@ -63,7 +63,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class OneofWithEmptySchema1BoxedBoolean<br>
 implements [OneofWithEmptySchema1Boxed](#oneofwithemptyschema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -210,7 +210,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema1BoxedBoolean<br>
 implements [Schema1Boxed](#schema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/OneofWithRequired.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/OneofWithRequired.md
@@ -13,28 +13,28 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [OneofWithRequired.OneofWithRequired1Boxed](#oneofwithrequired1boxed)<br> sealed interface for validated payloads |
-| record | [OneofWithRequired.OneofWithRequired1BoxedMap](#oneofwithrequired1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [OneofWithRequired.OneofWithRequired1](#oneofwithrequired1)<br> schema class |
+| data class | [OneofWithRequired.OneofWithRequired1BoxedMap](#oneofwithrequired1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [OneofWithRequired.OneofWithRequired1](#oneofwithrequired1)<br> schema class |
 | sealed interface | [OneofWithRequired.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [OneofWithRequired.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [OneofWithRequired.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [OneofWithRequired.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [OneofWithRequired.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [OneofWithRequired.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [OneofWithRequired.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [OneofWithRequired.Schema1](#schema1)<br> schema class |
-| static class | [OneofWithRequired.Schema1MapBuilder](#schema1mapbuilder)<br> builder for Map payloads |
-| static class | [OneofWithRequired.Schema1Map](#schema1map)<br> output class for Map payloads |
+| data class | [OneofWithRequired.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [OneofWithRequired.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [OneofWithRequired.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [OneofWithRequired.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [OneofWithRequired.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [OneofWithRequired.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [OneofWithRequired.Schema1](#schema1)<br> schema class |
+| class | [OneofWithRequired.Schema1MapBuilder](#schema1mapbuilder)<br> builder for Map payloads |
+| class | [OneofWithRequired.Schema1Map](#schema1map)<br> output class for Map payloads |
 | sealed interface | [OneofWithRequired.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [OneofWithRequired.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [OneofWithRequired.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [OneofWithRequired.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [OneofWithRequired.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [OneofWithRequired.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [OneofWithRequired.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [OneofWithRequired.Schema0](#schema0)<br> schema class |
-| static class | [OneofWithRequired.Schema0MapBuilder](#schema0mapbuilder)<br> builder for Map payloads |
-| static class | [OneofWithRequired.Schema0Map](#schema0map)<br> output class for Map payloads |
+| data class | [OneofWithRequired.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [OneofWithRequired.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [OneofWithRequired.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [OneofWithRequired.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [OneofWithRequired.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [OneofWithRequired.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [OneofWithRequired.Schema0](#schema0)<br> schema class |
+| class | [OneofWithRequired.Schema0MapBuilder](#schema0mapbuilder)<br> builder for Map payloads |
+| class | [OneofWithRequired.Schema0Map](#schema0map)<br> output class for Map payloads |
 
 ## OneofWithRequired1Boxed
 sealed interface OneofWithRequired1Boxed<br>
@@ -113,7 +113,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema1BoxedBoolean<br>
 implements [Schema1Boxed](#schema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -380,7 +380,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/OneofWithRequired.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/OneofWithRequired.md
@@ -75,8 +75,8 @@ A schema class that validates payloads
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| FrozenMap<String, Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
-| [OneofWithRequired1BoxedMap](#oneofwithrequired1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| FrozenMap<String, Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
+| [OneofWithRequired1BoxedMap](#oneofwithrequired1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [OneofWithRequired1Boxed](#oneofwithrequired1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
 
@@ -210,19 +210,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [Schema1Map](#schema1map) | validate(arg: [Map&lt;?, ?&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [Schema1Map](#schema1map) | validate(arg: [Map&lt;*, *&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema1BoxedString](#schema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema1BoxedVoid](#schema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema1BoxedNumber](#schema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
+| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
 | [Schema1BoxedList](#schema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema1Boxed](#schema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -477,19 +477,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [Schema0Map](#schema0map) | validate(arg: [Map&lt;?, ?&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [Schema0Map](#schema0map) | validate(arg: [Map&lt;*, *&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema0BoxedString](#schema0boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema0BoxedVoid](#schema0boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema0BoxedNumber](#schema0boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
+| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox([Map&lt;*, *&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
 | [Schema0BoxedList](#schema0boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema0Boxed](#schema0boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/PatternIsNotAnchored.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/PatternIsNotAnchored.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [PatternIsNotAnchored1BoxedString](#patternisnotanchored1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [PatternIsNotAnchored1BoxedVoid](#patternisnotanchored1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [PatternIsNotAnchored1BoxedNumber](#patternisnotanchored1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [PatternIsNotAnchored1BoxedBoolean](#patternisnotanchored1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [PatternIsNotAnchored1BoxedMap](#patternisnotanchored1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [PatternIsNotAnchored1BoxedBoolean](#patternisnotanchored1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [PatternIsNotAnchored1BoxedMap](#patternisnotanchored1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [PatternIsNotAnchored1BoxedList](#patternisnotanchored1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [PatternIsNotAnchored1Boxed](#patternisnotanchored1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/PatternIsNotAnchored.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/PatternIsNotAnchored.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [PatternIsNotAnchored.PatternIsNotAnchored1Boxed](#patternisnotanchored1boxed)<br> sealed interface for validated payloads |
-| record | [PatternIsNotAnchored.PatternIsNotAnchored1BoxedVoid](#patternisnotanchored1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [PatternIsNotAnchored.PatternIsNotAnchored1BoxedBoolean](#patternisnotanchored1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [PatternIsNotAnchored.PatternIsNotAnchored1BoxedNumber](#patternisnotanchored1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [PatternIsNotAnchored.PatternIsNotAnchored1BoxedString](#patternisnotanchored1boxedstring)<br> boxed class to store validated String payloads |
-| record | [PatternIsNotAnchored.PatternIsNotAnchored1BoxedList](#patternisnotanchored1boxedlist)<br> boxed class to store validated List payloads |
-| record | [PatternIsNotAnchored.PatternIsNotAnchored1BoxedMap](#patternisnotanchored1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [PatternIsNotAnchored.PatternIsNotAnchored1](#patternisnotanchored1)<br> schema class |
+| data class | [PatternIsNotAnchored.PatternIsNotAnchored1BoxedVoid](#patternisnotanchored1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [PatternIsNotAnchored.PatternIsNotAnchored1BoxedBoolean](#patternisnotanchored1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [PatternIsNotAnchored.PatternIsNotAnchored1BoxedNumber](#patternisnotanchored1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [PatternIsNotAnchored.PatternIsNotAnchored1BoxedString](#patternisnotanchored1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [PatternIsNotAnchored.PatternIsNotAnchored1BoxedList](#patternisnotanchored1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [PatternIsNotAnchored.PatternIsNotAnchored1BoxedMap](#patternisnotanchored1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [PatternIsNotAnchored.PatternIsNotAnchored1](#patternisnotanchored1)<br> schema class |
 
 ## PatternIsNotAnchored1Boxed
 sealed interface PatternIsNotAnchored1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class PatternIsNotAnchored1BoxedBoolean<br>
 implements [PatternIsNotAnchored1Boxed](#patternisnotanchored1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/PatternValidation.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/PatternValidation.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [PatternValidation1BoxedString](#patternvalidation1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [PatternValidation1BoxedVoid](#patternvalidation1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [PatternValidation1BoxedNumber](#patternvalidation1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [PatternValidation1BoxedBoolean](#patternvalidation1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [PatternValidation1BoxedMap](#patternvalidation1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [PatternValidation1BoxedBoolean](#patternvalidation1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [PatternValidation1BoxedMap](#patternvalidation1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [PatternValidation1BoxedList](#patternvalidation1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [PatternValidation1Boxed](#patternvalidation1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/PatternValidation.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/PatternValidation.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [PatternValidation.PatternValidation1Boxed](#patternvalidation1boxed)<br> sealed interface for validated payloads |
-| record | [PatternValidation.PatternValidation1BoxedVoid](#patternvalidation1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [PatternValidation.PatternValidation1BoxedBoolean](#patternvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [PatternValidation.PatternValidation1BoxedNumber](#patternvalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [PatternValidation.PatternValidation1BoxedString](#patternvalidation1boxedstring)<br> boxed class to store validated String payloads |
-| record | [PatternValidation.PatternValidation1BoxedList](#patternvalidation1boxedlist)<br> boxed class to store validated List payloads |
-| record | [PatternValidation.PatternValidation1BoxedMap](#patternvalidation1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [PatternValidation.PatternValidation1](#patternvalidation1)<br> schema class |
+| data class | [PatternValidation.PatternValidation1BoxedVoid](#patternvalidation1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [PatternValidation.PatternValidation1BoxedBoolean](#patternvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [PatternValidation.PatternValidation1BoxedNumber](#patternvalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [PatternValidation.PatternValidation1BoxedString](#patternvalidation1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [PatternValidation.PatternValidation1BoxedList](#patternvalidation1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [PatternValidation.PatternValidation1BoxedMap](#patternvalidation1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [PatternValidation.PatternValidation1](#patternvalidation1)<br> schema class |
 
 ## PatternValidation1Boxed
 sealed interface PatternValidation1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class PatternValidation1BoxedBoolean<br>
 implements [PatternValidation1Boxed](#patternvalidation1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/PropertiesWithEscapedCharacters.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/PropertiesWithEscapedCharacters.md
@@ -13,33 +13,33 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharacters1Boxed](#propertieswithescapedcharacters1boxed)<br> sealed interface for validated payloads |
-| record | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharacters1BoxedVoid](#propertieswithescapedcharacters1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharacters1BoxedBoolean](#propertieswithescapedcharacters1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharacters1BoxedNumber](#propertieswithescapedcharacters1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharacters1BoxedString](#propertieswithescapedcharacters1boxedstring)<br> boxed class to store validated String payloads |
-| record | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharacters1BoxedList](#propertieswithescapedcharacters1boxedlist)<br> boxed class to store validated List payloads |
-| record | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharacters1BoxedMap](#propertieswithescapedcharacters1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharacters1](#propertieswithescapedcharacters1)<br> schema class |
-| static class | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharactersMapBuilder](#propertieswithescapedcharactersmapbuilder)<br> builder for Map payloads |
-| static class | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharactersMap](#propertieswithescapedcharactersmap)<br> output class for Map payloads |
+| data class | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharacters1BoxedVoid](#propertieswithescapedcharacters1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharacters1BoxedBoolean](#propertieswithescapedcharacters1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharacters1BoxedNumber](#propertieswithescapedcharacters1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharacters1BoxedString](#propertieswithescapedcharacters1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharacters1BoxedList](#propertieswithescapedcharacters1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharacters1BoxedMap](#propertieswithescapedcharacters1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharacters1](#propertieswithescapedcharacters1)<br> schema class |
+| class | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharactersMapBuilder](#propertieswithescapedcharactersmapbuilder)<br> builder for Map payloads |
+| class | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharactersMap](#propertieswithescapedcharactersmap)<br> output class for Map payloads |
 | sealed interface | [PropertiesWithEscapedCharacters.Foou000CbarBoxed](#foou000cbarboxed)<br> sealed interface for validated payloads |
-| record | [PropertiesWithEscapedCharacters.Foou000CbarBoxedNumber](#foou000cbarboxednumber)<br> boxed class to store validated Number payloads |
-| static class | [PropertiesWithEscapedCharacters.Foou000Cbar](#foou000cbar)<br> schema class |
+| data class | [PropertiesWithEscapedCharacters.Foou000CbarBoxedNumber](#foou000cbarboxednumber)<br> boxed class to store validated Number payloads |
+| class | [PropertiesWithEscapedCharacters.Foou000Cbar](#foou000cbar)<br> schema class |
 | sealed interface | [PropertiesWithEscapedCharacters.FootbarBoxed](#footbarboxed)<br> sealed interface for validated payloads |
-| record | [PropertiesWithEscapedCharacters.FootbarBoxedNumber](#footbarboxednumber)<br> boxed class to store validated Number payloads |
-| static class | [PropertiesWithEscapedCharacters.Footbar](#footbar)<br> schema class |
+| data class | [PropertiesWithEscapedCharacters.FootbarBoxedNumber](#footbarboxednumber)<br> boxed class to store validated Number payloads |
+| class | [PropertiesWithEscapedCharacters.Footbar](#footbar)<br> schema class |
 | sealed interface | [PropertiesWithEscapedCharacters.FoorbarBoxed](#foorbarboxed)<br> sealed interface for validated payloads |
-| record | [PropertiesWithEscapedCharacters.FoorbarBoxedNumber](#foorbarboxednumber)<br> boxed class to store validated Number payloads |
-| static class | [PropertiesWithEscapedCharacters.Foorbar](#foorbar)<br> schema class |
+| data class | [PropertiesWithEscapedCharacters.FoorbarBoxedNumber](#foorbarboxednumber)<br> boxed class to store validated Number payloads |
+| class | [PropertiesWithEscapedCharacters.Foorbar](#foorbar)<br> schema class |
 | sealed interface | [PropertiesWithEscapedCharacters.Foobar1Boxed](#foobar1boxed)<br> sealed interface for validated payloads |
-| record | [PropertiesWithEscapedCharacters.Foobar1BoxedNumber](#foobar1boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [PropertiesWithEscapedCharacters.Foobar1](#foobar1)<br> schema class |
+| data class | [PropertiesWithEscapedCharacters.Foobar1BoxedNumber](#foobar1boxednumber)<br> boxed class to store validated Number payloads |
+| class | [PropertiesWithEscapedCharacters.Foobar1](#foobar1)<br> schema class |
 | sealed interface | [PropertiesWithEscapedCharacters.FoobarBoxed](#foobarboxed)<br> sealed interface for validated payloads |
-| record | [PropertiesWithEscapedCharacters.FoobarBoxedNumber](#foobarboxednumber)<br> boxed class to store validated Number payloads |
-| static class | [PropertiesWithEscapedCharacters.Foobar](#foobar)<br> schema class |
+| data class | [PropertiesWithEscapedCharacters.FoobarBoxedNumber](#foobarboxednumber)<br> boxed class to store validated Number payloads |
+| class | [PropertiesWithEscapedCharacters.Foobar](#foobar)<br> schema class |
 | sealed interface | [PropertiesWithEscapedCharacters.FoonbarBoxed](#foonbarboxed)<br> sealed interface for validated payloads |
-| record | [PropertiesWithEscapedCharacters.FoonbarBoxedNumber](#foonbarboxednumber)<br> boxed class to store validated Number payloads |
-| static class | [PropertiesWithEscapedCharacters.Foonbar](#foonbar)<br> schema class |
+| data class | [PropertiesWithEscapedCharacters.FoonbarBoxedNumber](#foonbarboxednumber)<br> boxed class to store validated Number payloads |
+| class | [PropertiesWithEscapedCharacters.Foonbar](#foonbar)<br> schema class |
 
 ## PropertiesWithEscapedCharacters1Boxed
 sealed interface PropertiesWithEscapedCharacters1Boxed<br>
@@ -74,7 +74,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class PropertiesWithEscapedCharacters1BoxedBoolean<br>
 implements [PropertiesWithEscapedCharacters1Boxed](#propertieswithescapedcharacters1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/PropertiesWithEscapedCharacters.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/PropertiesWithEscapedCharacters.md
@@ -171,19 +171,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [PropertiesWithEscapedCharactersMap](#propertieswithescapedcharactersmap) | validate(arg: [Map&lt;?, ?&gt;](#propertieswithescapedcharactersmapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [PropertiesWithEscapedCharactersMap](#propertieswithescapedcharactersmap) | validate(arg: [Map&lt;*, *&gt;](#propertieswithescapedcharactersmapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [PropertiesWithEscapedCharacters1BoxedString](#propertieswithescapedcharacters1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [PropertiesWithEscapedCharacters1BoxedVoid](#propertieswithescapedcharacters1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [PropertiesWithEscapedCharacters1BoxedNumber](#propertieswithescapedcharacters1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [PropertiesWithEscapedCharacters1BoxedBoolean](#propertieswithescapedcharacters1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [PropertiesWithEscapedCharacters1BoxedMap](#propertieswithescapedcharacters1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#propertieswithescapedcharactersmapbuilder), configuration: SchemaConfiguration) |
+| [PropertiesWithEscapedCharacters1BoxedBoolean](#propertieswithescapedcharacters1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [PropertiesWithEscapedCharacters1BoxedMap](#propertieswithescapedcharacters1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#propertieswithescapedcharactersmapbuilder), configuration: SchemaConfiguration) |
 | [PropertiesWithEscapedCharacters1BoxedList](#propertieswithescapedcharacters1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [PropertiesWithEscapedCharacters1Boxed](#propertieswithescapedcharacters1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/PropertyNamedRefThatIsNotAReference.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/PropertyNamedRefThatIsNotAReference.md
@@ -13,18 +13,18 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReference1Boxed](#propertynamedrefthatisnotareference1boxed)<br> sealed interface for validated payloads |
-| record | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReference1BoxedVoid](#propertynamedrefthatisnotareference1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReference1BoxedBoolean](#propertynamedrefthatisnotareference1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReference1BoxedNumber](#propertynamedrefthatisnotareference1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReference1BoxedString](#propertynamedrefthatisnotareference1boxedstring)<br> boxed class to store validated String payloads |
-| record | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReference1BoxedList](#propertynamedrefthatisnotareference1boxedlist)<br> boxed class to store validated List payloads |
-| record | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReference1BoxedMap](#propertynamedrefthatisnotareference1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReference1](#propertynamedrefthatisnotareference1)<br> schema class |
-| static class | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReferenceMapBuilder](#propertynamedrefthatisnotareferencemapbuilder)<br> builder for Map payloads |
-| static class | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReferenceMap](#propertynamedrefthatisnotareferencemap)<br> output class for Map payloads |
+| data class | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReference1BoxedVoid](#propertynamedrefthatisnotareference1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReference1BoxedBoolean](#propertynamedrefthatisnotareference1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReference1BoxedNumber](#propertynamedrefthatisnotareference1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReference1BoxedString](#propertynamedrefthatisnotareference1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReference1BoxedList](#propertynamedrefthatisnotareference1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReference1BoxedMap](#propertynamedrefthatisnotareference1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReference1](#propertynamedrefthatisnotareference1)<br> schema class |
+| class | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReferenceMapBuilder](#propertynamedrefthatisnotareferencemapbuilder)<br> builder for Map payloads |
+| class | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReferenceMap](#propertynamedrefthatisnotareferencemap)<br> output class for Map payloads |
 | sealed interface | [PropertyNamedRefThatIsNotAReference.RefBoxed](#refboxed)<br> sealed interface for validated payloads |
-| record | [PropertyNamedRefThatIsNotAReference.RefBoxedString](#refboxedstring)<br> boxed class to store validated String payloads |
-| static class | [PropertyNamedRefThatIsNotAReference.Ref](#ref)<br> schema class |
+| data class | [PropertyNamedRefThatIsNotAReference.RefBoxedString](#refboxedstring)<br> boxed class to store validated String payloads |
+| class | [PropertyNamedRefThatIsNotAReference.Ref](#ref)<br> schema class |
 
 ## PropertyNamedRefThatIsNotAReference1Boxed
 sealed interface PropertyNamedRefThatIsNotAReference1Boxed<br>
@@ -59,7 +59,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class PropertyNamedRefThatIsNotAReference1BoxedBoolean<br>
 implements [PropertyNamedRefThatIsNotAReference1Boxed](#propertynamedrefthatisnotareference1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/PropertyNamedRefThatIsNotAReference.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/PropertyNamedRefThatIsNotAReference.md
@@ -156,19 +156,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [PropertyNamedRefThatIsNotAReferenceMap](#propertynamedrefthatisnotareferencemap) | validate(arg: [Map&lt;?, ?&gt;](#propertynamedrefthatisnotareferencemapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [PropertyNamedRefThatIsNotAReferenceMap](#propertynamedrefthatisnotareferencemap) | validate(arg: [Map&lt;*, *&gt;](#propertynamedrefthatisnotareferencemapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [PropertyNamedRefThatIsNotAReference1BoxedString](#propertynamedrefthatisnotareference1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [PropertyNamedRefThatIsNotAReference1BoxedVoid](#propertynamedrefthatisnotareference1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [PropertyNamedRefThatIsNotAReference1BoxedNumber](#propertynamedrefthatisnotareference1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [PropertyNamedRefThatIsNotAReference1BoxedBoolean](#propertynamedrefthatisnotareference1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [PropertyNamedRefThatIsNotAReference1BoxedMap](#propertynamedrefthatisnotareference1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#propertynamedrefthatisnotareferencemapbuilder), configuration: SchemaConfiguration) |
+| [PropertyNamedRefThatIsNotAReference1BoxedBoolean](#propertynamedrefthatisnotareference1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [PropertyNamedRefThatIsNotAReference1BoxedMap](#propertynamedrefthatisnotareference1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#propertynamedrefthatisnotareferencemapbuilder), configuration: SchemaConfiguration) |
 | [PropertyNamedRefThatIsNotAReference1BoxedList](#propertynamedrefthatisnotareference1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [PropertyNamedRefThatIsNotAReference1Boxed](#propertynamedrefthatisnotareference1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RefInAdditionalproperties.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RefInAdditionalproperties.md
@@ -13,10 +13,10 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [RefInAdditionalproperties.RefInAdditionalproperties1Boxed](#refinadditionalproperties1boxed)<br> sealed interface for validated payloads |
-| record | [RefInAdditionalproperties.RefInAdditionalproperties1BoxedMap](#refinadditionalproperties1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [RefInAdditionalproperties.RefInAdditionalproperties1](#refinadditionalproperties1)<br> schema class |
-| static class | [RefInAdditionalproperties.RefInAdditionalpropertiesMapBuilder](#refinadditionalpropertiesmapbuilder)<br> builder for Map payloads |
-| static class | [RefInAdditionalproperties.RefInAdditionalpropertiesMap](#refinadditionalpropertiesmap)<br> output class for Map payloads |
+| data class | [RefInAdditionalproperties.RefInAdditionalproperties1BoxedMap](#refinadditionalproperties1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [RefInAdditionalproperties.RefInAdditionalproperties1](#refinadditionalproperties1)<br> schema class |
+| class | [RefInAdditionalproperties.RefInAdditionalpropertiesMapBuilder](#refinadditionalpropertiesmapbuilder)<br> builder for Map payloads |
+| class | [RefInAdditionalproperties.RefInAdditionalpropertiesMap](#refinadditionalpropertiesmap)<br> output class for Map payloads |
 
 ## RefInAdditionalproperties1Boxed
 sealed interface RefInAdditionalproperties1Boxed<br>

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RefInAdditionalproperties.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RefInAdditionalproperties.md
@@ -50,27 +50,23 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.RefInAdditionalproperties;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.RefInAdditionalproperties
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // Map validation
-RefInAdditionalproperties.RefInAdditionalpropertiesMap validatedPayload =
+val validatedPayload: RefInAdditionalproperties.RefInAdditionalpropertiesMap =
     RefInAdditionalproperties.RefInAdditionalproperties1.validate(
-    new RefInAdditionalproperties.RefInAdditionalpropertiesMapBuilder()
+    RefInAdditionalproperties.RefInAdditionalpropertiesMapBuilder()
     .build(),
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -82,8 +78,8 @@ RefInAdditionalproperties.RefInAdditionalpropertiesMap validatedPayload =
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| [RefInAdditionalpropertiesMap](#refinadditionalpropertiesmap) | validate(arg: [Map&lt;?, ?&gt;](#refinadditionalpropertiesmapbuilder), configuration: SchemaConfiguration) |
-| [RefInAdditionalproperties1BoxedMap](#refinadditionalproperties1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#refinadditionalpropertiesmapbuilder), configuration: SchemaConfiguration) |
+| [RefInAdditionalpropertiesMap](#refinadditionalpropertiesmap) | validate(arg: [Map&lt;*, *&gt;](#refinadditionalpropertiesmapbuilder), configuration: SchemaConfiguration) |
+| [RefInAdditionalproperties1BoxedMap](#refinadditionalproperties1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#refinadditionalpropertiesmapbuilder), configuration: SchemaConfiguration) |
 | [RefInAdditionalproperties1Boxed](#refinadditionalproperties1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
 

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RefInAllof.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RefInAllof.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [RefInAllof1BoxedString](#refinallof1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [RefInAllof1BoxedVoid](#refinallof1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [RefInAllof1BoxedNumber](#refinallof1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [RefInAllof1BoxedBoolean](#refinallof1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [RefInAllof1BoxedMap](#refinallof1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [RefInAllof1BoxedBoolean](#refinallof1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [RefInAllof1BoxedMap](#refinallof1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [RefInAllof1BoxedList](#refinallof1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [RefInAllof1Boxed](#refinallof1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RefInAllof.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RefInAllof.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [RefInAllof.RefInAllof1Boxed](#refinallof1boxed)<br> sealed interface for validated payloads |
-| record | [RefInAllof.RefInAllof1BoxedVoid](#refinallof1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [RefInAllof.RefInAllof1BoxedBoolean](#refinallof1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [RefInAllof.RefInAllof1BoxedNumber](#refinallof1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [RefInAllof.RefInAllof1BoxedString](#refinallof1boxedstring)<br> boxed class to store validated String payloads |
-| record | [RefInAllof.RefInAllof1BoxedList](#refinallof1boxedlist)<br> boxed class to store validated List payloads |
-| record | [RefInAllof.RefInAllof1BoxedMap](#refinallof1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [RefInAllof.RefInAllof1](#refinallof1)<br> schema class |
+| data class | [RefInAllof.RefInAllof1BoxedVoid](#refinallof1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [RefInAllof.RefInAllof1BoxedBoolean](#refinallof1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [RefInAllof.RefInAllof1BoxedNumber](#refinallof1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [RefInAllof.RefInAllof1BoxedString](#refinallof1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [RefInAllof.RefInAllof1BoxedList](#refinallof1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [RefInAllof.RefInAllof1BoxedMap](#refinallof1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [RefInAllof.RefInAllof1](#refinallof1)<br> schema class |
 
 ## RefInAllof1Boxed
 sealed interface RefInAllof1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class RefInAllof1BoxedBoolean<br>
 implements [RefInAllof1Boxed](#refinallof1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RefInAnyof.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RefInAnyof.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [RefInAnyof1BoxedString](#refinanyof1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [RefInAnyof1BoxedVoid](#refinanyof1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [RefInAnyof1BoxedNumber](#refinanyof1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [RefInAnyof1BoxedBoolean](#refinanyof1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [RefInAnyof1BoxedMap](#refinanyof1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [RefInAnyof1BoxedBoolean](#refinanyof1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [RefInAnyof1BoxedMap](#refinanyof1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [RefInAnyof1BoxedList](#refinanyof1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [RefInAnyof1Boxed](#refinanyof1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RefInAnyof.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RefInAnyof.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [RefInAnyof.RefInAnyof1Boxed](#refinanyof1boxed)<br> sealed interface for validated payloads |
-| record | [RefInAnyof.RefInAnyof1BoxedVoid](#refinanyof1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [RefInAnyof.RefInAnyof1BoxedBoolean](#refinanyof1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [RefInAnyof.RefInAnyof1BoxedNumber](#refinanyof1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [RefInAnyof.RefInAnyof1BoxedString](#refinanyof1boxedstring)<br> boxed class to store validated String payloads |
-| record | [RefInAnyof.RefInAnyof1BoxedList](#refinanyof1boxedlist)<br> boxed class to store validated List payloads |
-| record | [RefInAnyof.RefInAnyof1BoxedMap](#refinanyof1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [RefInAnyof.RefInAnyof1](#refinanyof1)<br> schema class |
+| data class | [RefInAnyof.RefInAnyof1BoxedVoid](#refinanyof1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [RefInAnyof.RefInAnyof1BoxedBoolean](#refinanyof1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [RefInAnyof.RefInAnyof1BoxedNumber](#refinanyof1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [RefInAnyof.RefInAnyof1BoxedString](#refinanyof1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [RefInAnyof.RefInAnyof1BoxedList](#refinanyof1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [RefInAnyof.RefInAnyof1BoxedMap](#refinanyof1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [RefInAnyof.RefInAnyof1](#refinanyof1)<br> schema class |
 
 ## RefInAnyof1Boxed
 sealed interface RefInAnyof1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class RefInAnyof1BoxedBoolean<br>
 implements [RefInAnyof1Boxed](#refinanyof1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RefInItems.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RefInItems.md
@@ -50,27 +50,23 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.RefInItems;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.RefInItems
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // List validation
-RefInItems.RefInItemsList validatedPayload =
+val validatedPayload: RefInItems.RefInItemsList =
     RefInItems.RefInItems1.validate(
-    new RefInItems.RefInItemsListBuilder()
+    RefInItems.RefInItemsListBuilder()
     .build(),
     configuration
-);
+)
 ```
 
 ### Field Summary

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RefInItems.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RefInItems.md
@@ -13,10 +13,10 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [RefInItems.RefInItems1Boxed](#refinitems1boxed)<br> sealed interface for validated payloads |
-| record | [RefInItems.RefInItems1BoxedList](#refinitems1boxedlist)<br> boxed class to store validated List payloads |
-| static class | [RefInItems.RefInItems1](#refinitems1)<br> schema class |
-| static class | [RefInItems.RefInItemsListBuilder](#refinitemslistbuilder)<br> builder for List payloads |
-| static class | [RefInItems.RefInItemsList](#refinitemslist)<br> output class for List payloads |
+| data class | [RefInItems.RefInItems1BoxedList](#refinitems1boxedlist)<br> boxed class to store validated List payloads |
+| class | [RefInItems.RefInItems1](#refinitems1)<br> schema class |
+| class | [RefInItems.RefInItemsListBuilder](#refinitemslistbuilder)<br> builder for List payloads |
+| class | [RefInItems.RefInItemsList](#refinitemslist)<br> output class for List payloads |
 
 ## RefInItems1Boxed
 sealed interface RefInItems1Boxed<br>

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RefInNot.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RefInNot.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [RefInNot1BoxedString](#refinnot1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [RefInNot1BoxedVoid](#refinnot1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [RefInNot1BoxedNumber](#refinnot1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [RefInNot1BoxedBoolean](#refinnot1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [RefInNot1BoxedMap](#refinnot1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [RefInNot1BoxedBoolean](#refinnot1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [RefInNot1BoxedMap](#refinnot1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [RefInNot1BoxedList](#refinnot1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [RefInNot1Boxed](#refinnot1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RefInNot.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RefInNot.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [RefInNot.RefInNot1Boxed](#refinnot1boxed)<br> sealed interface for validated payloads |
-| record | [RefInNot.RefInNot1BoxedVoid](#refinnot1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [RefInNot.RefInNot1BoxedBoolean](#refinnot1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [RefInNot.RefInNot1BoxedNumber](#refinnot1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [RefInNot.RefInNot1BoxedString](#refinnot1boxedstring)<br> boxed class to store validated String payloads |
-| record | [RefInNot.RefInNot1BoxedList](#refinnot1boxedlist)<br> boxed class to store validated List payloads |
-| record | [RefInNot.RefInNot1BoxedMap](#refinnot1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [RefInNot.RefInNot1](#refinnot1)<br> schema class |
+| data class | [RefInNot.RefInNot1BoxedVoid](#refinnot1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [RefInNot.RefInNot1BoxedBoolean](#refinnot1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [RefInNot.RefInNot1BoxedNumber](#refinnot1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [RefInNot.RefInNot1BoxedString](#refinnot1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [RefInNot.RefInNot1BoxedList](#refinnot1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [RefInNot.RefInNot1BoxedMap](#refinnot1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [RefInNot.RefInNot1](#refinnot1)<br> schema class |
 
 ## RefInNot1Boxed
 sealed interface RefInNot1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class RefInNot1BoxedBoolean<br>
 implements [RefInNot1Boxed](#refinnot1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RefInOneof.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RefInOneof.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [RefInOneof1BoxedString](#refinoneof1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [RefInOneof1BoxedVoid](#refinoneof1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [RefInOneof1BoxedNumber](#refinoneof1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [RefInOneof1BoxedBoolean](#refinoneof1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [RefInOneof1BoxedMap](#refinoneof1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [RefInOneof1BoxedBoolean](#refinoneof1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [RefInOneof1BoxedMap](#refinoneof1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [RefInOneof1BoxedList](#refinoneof1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [RefInOneof1Boxed](#refinoneof1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RefInOneof.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RefInOneof.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [RefInOneof.RefInOneof1Boxed](#refinoneof1boxed)<br> sealed interface for validated payloads |
-| record | [RefInOneof.RefInOneof1BoxedVoid](#refinoneof1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [RefInOneof.RefInOneof1BoxedBoolean](#refinoneof1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [RefInOneof.RefInOneof1BoxedNumber](#refinoneof1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [RefInOneof.RefInOneof1BoxedString](#refinoneof1boxedstring)<br> boxed class to store validated String payloads |
-| record | [RefInOneof.RefInOneof1BoxedList](#refinoneof1boxedlist)<br> boxed class to store validated List payloads |
-| record | [RefInOneof.RefInOneof1BoxedMap](#refinoneof1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [RefInOneof.RefInOneof1](#refinoneof1)<br> schema class |
+| data class | [RefInOneof.RefInOneof1BoxedVoid](#refinoneof1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [RefInOneof.RefInOneof1BoxedBoolean](#refinoneof1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [RefInOneof.RefInOneof1BoxedNumber](#refinoneof1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [RefInOneof.RefInOneof1BoxedString](#refinoneof1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [RefInOneof.RefInOneof1BoxedList](#refinoneof1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [RefInOneof.RefInOneof1BoxedMap](#refinoneof1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [RefInOneof.RefInOneof1](#refinoneof1)<br> schema class |
 
 ## RefInOneof1Boxed
 sealed interface RefInOneof1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class RefInOneof1BoxedBoolean<br>
 implements [RefInOneof1Boxed](#refinoneof1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RefInProperty.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RefInProperty.md
@@ -13,15 +13,15 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [RefInProperty.RefInProperty1Boxed](#refinproperty1boxed)<br> sealed interface for validated payloads |
-| record | [RefInProperty.RefInProperty1BoxedVoid](#refinproperty1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [RefInProperty.RefInProperty1BoxedBoolean](#refinproperty1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [RefInProperty.RefInProperty1BoxedNumber](#refinproperty1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [RefInProperty.RefInProperty1BoxedString](#refinproperty1boxedstring)<br> boxed class to store validated String payloads |
-| record | [RefInProperty.RefInProperty1BoxedList](#refinproperty1boxedlist)<br> boxed class to store validated List payloads |
-| record | [RefInProperty.RefInProperty1BoxedMap](#refinproperty1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [RefInProperty.RefInProperty1](#refinproperty1)<br> schema class |
-| static class | [RefInProperty.RefInPropertyMapBuilder](#refinpropertymapbuilder)<br> builder for Map payloads |
-| static class | [RefInProperty.RefInPropertyMap](#refinpropertymap)<br> output class for Map payloads |
+| data class | [RefInProperty.RefInProperty1BoxedVoid](#refinproperty1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [RefInProperty.RefInProperty1BoxedBoolean](#refinproperty1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [RefInProperty.RefInProperty1BoxedNumber](#refinproperty1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [RefInProperty.RefInProperty1BoxedString](#refinproperty1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [RefInProperty.RefInProperty1BoxedList](#refinproperty1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [RefInProperty.RefInProperty1BoxedMap](#refinproperty1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [RefInProperty.RefInProperty1](#refinproperty1)<br> schema class |
+| class | [RefInProperty.RefInPropertyMapBuilder](#refinpropertymapbuilder)<br> builder for Map payloads |
+| class | [RefInProperty.RefInPropertyMap](#refinpropertymap)<br> output class for Map payloads |
 
 ## RefInProperty1Boxed
 sealed interface RefInProperty1Boxed<br>
@@ -56,7 +56,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class RefInProperty1BoxedBoolean<br>
 implements [RefInProperty1Boxed](#refinproperty1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RefInProperty.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RefInProperty.md
@@ -153,19 +153,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [RefInPropertyMap](#refinpropertymap) | validate(arg: [Map&lt;?, ?&gt;](#refinpropertymapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [RefInPropertyMap](#refinpropertymap) | validate(arg: [Map&lt;*, *&gt;](#refinpropertymapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [RefInProperty1BoxedString](#refinproperty1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [RefInProperty1BoxedVoid](#refinproperty1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [RefInProperty1BoxedNumber](#refinproperty1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [RefInProperty1BoxedBoolean](#refinproperty1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [RefInProperty1BoxedMap](#refinproperty1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#refinpropertymapbuilder), configuration: SchemaConfiguration) |
+| [RefInProperty1BoxedBoolean](#refinproperty1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [RefInProperty1BoxedMap](#refinproperty1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#refinpropertymapbuilder), configuration: SchemaConfiguration) |
 | [RefInProperty1BoxedList](#refinproperty1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [RefInProperty1Boxed](#refinproperty1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RequiredDefaultValidation.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RequiredDefaultValidation.md
@@ -13,23 +13,23 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [RequiredDefaultValidation.RequiredDefaultValidation1Boxed](#requireddefaultvalidation1boxed)<br> sealed interface for validated payloads |
-| record | [RequiredDefaultValidation.RequiredDefaultValidation1BoxedVoid](#requireddefaultvalidation1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [RequiredDefaultValidation.RequiredDefaultValidation1BoxedBoolean](#requireddefaultvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [RequiredDefaultValidation.RequiredDefaultValidation1BoxedNumber](#requireddefaultvalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [RequiredDefaultValidation.RequiredDefaultValidation1BoxedString](#requireddefaultvalidation1boxedstring)<br> boxed class to store validated String payloads |
-| record | [RequiredDefaultValidation.RequiredDefaultValidation1BoxedList](#requireddefaultvalidation1boxedlist)<br> boxed class to store validated List payloads |
-| record | [RequiredDefaultValidation.RequiredDefaultValidation1BoxedMap](#requireddefaultvalidation1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [RequiredDefaultValidation.RequiredDefaultValidation1](#requireddefaultvalidation1)<br> schema class |
-| static class | [RequiredDefaultValidation.RequiredDefaultValidationMapBuilder](#requireddefaultvalidationmapbuilder)<br> builder for Map payloads |
-| static class | [RequiredDefaultValidation.RequiredDefaultValidationMap](#requireddefaultvalidationmap)<br> output class for Map payloads |
+| data class | [RequiredDefaultValidation.RequiredDefaultValidation1BoxedVoid](#requireddefaultvalidation1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [RequiredDefaultValidation.RequiredDefaultValidation1BoxedBoolean](#requireddefaultvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [RequiredDefaultValidation.RequiredDefaultValidation1BoxedNumber](#requireddefaultvalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [RequiredDefaultValidation.RequiredDefaultValidation1BoxedString](#requireddefaultvalidation1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [RequiredDefaultValidation.RequiredDefaultValidation1BoxedList](#requireddefaultvalidation1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [RequiredDefaultValidation.RequiredDefaultValidation1BoxedMap](#requireddefaultvalidation1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [RequiredDefaultValidation.RequiredDefaultValidation1](#requireddefaultvalidation1)<br> schema class |
+| class | [RequiredDefaultValidation.RequiredDefaultValidationMapBuilder](#requireddefaultvalidationmapbuilder)<br> builder for Map payloads |
+| class | [RequiredDefaultValidation.RequiredDefaultValidationMap](#requireddefaultvalidationmap)<br> output class for Map payloads |
 | sealed interface | [RequiredDefaultValidation.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [RequiredDefaultValidation.FooBoxedVoid](#fooboxedvoid)<br> boxed class to store validated null payloads |
-| record | [RequiredDefaultValidation.FooBoxedBoolean](#fooboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [RequiredDefaultValidation.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
-| record | [RequiredDefaultValidation.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
-| record | [RequiredDefaultValidation.FooBoxedList](#fooboxedlist)<br> boxed class to store validated List payloads |
-| record | [RequiredDefaultValidation.FooBoxedMap](#fooboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [RequiredDefaultValidation.Foo](#foo)<br> schema class |
+| data class | [RequiredDefaultValidation.FooBoxedVoid](#fooboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [RequiredDefaultValidation.FooBoxedBoolean](#fooboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [RequiredDefaultValidation.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [RequiredDefaultValidation.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
+| data class | [RequiredDefaultValidation.FooBoxedList](#fooboxedlist)<br> boxed class to store validated List payloads |
+| data class | [RequiredDefaultValidation.FooBoxedMap](#fooboxedmap)<br> boxed class to store validated Map payloads |
+| class | [RequiredDefaultValidation.Foo](#foo)<br> schema class |
 
 ## RequiredDefaultValidation1Boxed
 sealed interface RequiredDefaultValidation1Boxed<br>
@@ -64,7 +64,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class RequiredDefaultValidation1BoxedBoolean<br>
 implements [RequiredDefaultValidation1Boxed](#requireddefaultvalidation1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -258,7 +258,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class FooBoxedBoolean<br>
 implements [FooBoxed](#fooboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RequiredDefaultValidation.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RequiredDefaultValidation.md
@@ -161,19 +161,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [RequiredDefaultValidationMap](#requireddefaultvalidationmap) | validate(arg: [Map&lt;?, ?&gt;](#requireddefaultvalidationmapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [RequiredDefaultValidationMap](#requireddefaultvalidationmap) | validate(arg: [Map&lt;*, *&gt;](#requireddefaultvalidationmapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [RequiredDefaultValidation1BoxedString](#requireddefaultvalidation1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [RequiredDefaultValidation1BoxedVoid](#requireddefaultvalidation1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [RequiredDefaultValidation1BoxedNumber](#requireddefaultvalidation1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [RequiredDefaultValidation1BoxedBoolean](#requireddefaultvalidation1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [RequiredDefaultValidation1BoxedMap](#requireddefaultvalidation1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#requireddefaultvalidationmapbuilder), configuration: SchemaConfiguration) |
+| [RequiredDefaultValidation1BoxedBoolean](#requireddefaultvalidation1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [RequiredDefaultValidation1BoxedMap](#requireddefaultvalidation1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#requireddefaultvalidationmapbuilder), configuration: SchemaConfiguration) |
 | [RequiredDefaultValidation1BoxedList](#requireddefaultvalidation1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [RequiredDefaultValidation1Boxed](#requireddefaultvalidation1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RequiredValidation.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RequiredValidation.md
@@ -13,31 +13,31 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [RequiredValidation.RequiredValidation1Boxed](#requiredvalidation1boxed)<br> sealed interface for validated payloads |
-| record | [RequiredValidation.RequiredValidation1BoxedVoid](#requiredvalidation1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [RequiredValidation.RequiredValidation1BoxedBoolean](#requiredvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [RequiredValidation.RequiredValidation1BoxedNumber](#requiredvalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [RequiredValidation.RequiredValidation1BoxedString](#requiredvalidation1boxedstring)<br> boxed class to store validated String payloads |
-| record | [RequiredValidation.RequiredValidation1BoxedList](#requiredvalidation1boxedlist)<br> boxed class to store validated List payloads |
-| record | [RequiredValidation.RequiredValidation1BoxedMap](#requiredvalidation1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [RequiredValidation.RequiredValidation1](#requiredvalidation1)<br> schema class |
-| static class | [RequiredValidation.RequiredValidationMapBuilder](#requiredvalidationmapbuilder)<br> builder for Map payloads |
-| static class | [RequiredValidation.RequiredValidationMap](#requiredvalidationmap)<br> output class for Map payloads |
+| data class | [RequiredValidation.RequiredValidation1BoxedVoid](#requiredvalidation1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [RequiredValidation.RequiredValidation1BoxedBoolean](#requiredvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [RequiredValidation.RequiredValidation1BoxedNumber](#requiredvalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [RequiredValidation.RequiredValidation1BoxedString](#requiredvalidation1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [RequiredValidation.RequiredValidation1BoxedList](#requiredvalidation1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [RequiredValidation.RequiredValidation1BoxedMap](#requiredvalidation1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [RequiredValidation.RequiredValidation1](#requiredvalidation1)<br> schema class |
+| class | [RequiredValidation.RequiredValidationMapBuilder](#requiredvalidationmapbuilder)<br> builder for Map payloads |
+| class | [RequiredValidation.RequiredValidationMap](#requiredvalidationmap)<br> output class for Map payloads |
 | sealed interface | [RequiredValidation.BarBoxed](#barboxed)<br> sealed interface for validated payloads |
-| record | [RequiredValidation.BarBoxedVoid](#barboxedvoid)<br> boxed class to store validated null payloads |
-| record | [RequiredValidation.BarBoxedBoolean](#barboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [RequiredValidation.BarBoxedNumber](#barboxednumber)<br> boxed class to store validated Number payloads |
-| record | [RequiredValidation.BarBoxedString](#barboxedstring)<br> boxed class to store validated String payloads |
-| record | [RequiredValidation.BarBoxedList](#barboxedlist)<br> boxed class to store validated List payloads |
-| record | [RequiredValidation.BarBoxedMap](#barboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [RequiredValidation.Bar](#bar)<br> schema class |
+| data class | [RequiredValidation.BarBoxedVoid](#barboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [RequiredValidation.BarBoxedBoolean](#barboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [RequiredValidation.BarBoxedNumber](#barboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [RequiredValidation.BarBoxedString](#barboxedstring)<br> boxed class to store validated String payloads |
+| data class | [RequiredValidation.BarBoxedList](#barboxedlist)<br> boxed class to store validated List payloads |
+| data class | [RequiredValidation.BarBoxedMap](#barboxedmap)<br> boxed class to store validated Map payloads |
+| class | [RequiredValidation.Bar](#bar)<br> schema class |
 | sealed interface | [RequiredValidation.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [RequiredValidation.FooBoxedVoid](#fooboxedvoid)<br> boxed class to store validated null payloads |
-| record | [RequiredValidation.FooBoxedBoolean](#fooboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [RequiredValidation.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
-| record | [RequiredValidation.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
-| record | [RequiredValidation.FooBoxedList](#fooboxedlist)<br> boxed class to store validated List payloads |
-| record | [RequiredValidation.FooBoxedMap](#fooboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [RequiredValidation.Foo](#foo)<br> schema class |
+| data class | [RequiredValidation.FooBoxedVoid](#fooboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [RequiredValidation.FooBoxedBoolean](#fooboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [RequiredValidation.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [RequiredValidation.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
+| data class | [RequiredValidation.FooBoxedList](#fooboxedlist)<br> boxed class to store validated List payloads |
+| data class | [RequiredValidation.FooBoxedMap](#fooboxedmap)<br> boxed class to store validated Map payloads |
+| class | [RequiredValidation.Foo](#foo)<br> schema class |
 
 ## RequiredValidation1Boxed
 sealed interface RequiredValidation1Boxed<br>
@@ -72,7 +72,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class RequiredValidation1BoxedBoolean<br>
 implements [RequiredValidation1Boxed](#requiredvalidation1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -292,7 +292,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class BarBoxedBoolean<br>
 implements [BarBoxed](#barboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -417,7 +417,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class FooBoxedBoolean<br>
 implements [FooBoxed](#fooboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RequiredValidation.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RequiredValidation.md
@@ -170,19 +170,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [RequiredValidationMap](#requiredvalidationmap) | validate(arg: [Map&lt;?, ?&gt;](#requiredvalidationmapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [RequiredValidationMap](#requiredvalidationmap) | validate(arg: [Map&lt;*, *&gt;](#requiredvalidationmapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [RequiredValidation1BoxedString](#requiredvalidation1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [RequiredValidation1BoxedVoid](#requiredvalidation1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [RequiredValidation1BoxedNumber](#requiredvalidation1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [RequiredValidation1BoxedBoolean](#requiredvalidation1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [RequiredValidation1BoxedMap](#requiredvalidation1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#requiredvalidationmapbuilder), configuration: SchemaConfiguration) |
+| [RequiredValidation1BoxedBoolean](#requiredvalidation1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [RequiredValidation1BoxedMap](#requiredvalidation1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#requiredvalidationmapbuilder), configuration: SchemaConfiguration) |
 | [RequiredValidation1BoxedList](#requiredvalidation1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [RequiredValidation1Boxed](#requiredvalidation1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RequiredWithEmptyArray.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RequiredWithEmptyArray.md
@@ -161,19 +161,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [RequiredWithEmptyArrayMap](#requiredwithemptyarraymap) | validate(arg: [Map&lt;?, ?&gt;](#requiredwithemptyarraymapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [RequiredWithEmptyArrayMap](#requiredwithemptyarraymap) | validate(arg: [Map&lt;*, *&gt;](#requiredwithemptyarraymapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [RequiredWithEmptyArray1BoxedString](#requiredwithemptyarray1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [RequiredWithEmptyArray1BoxedVoid](#requiredwithemptyarray1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [RequiredWithEmptyArray1BoxedNumber](#requiredwithemptyarray1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [RequiredWithEmptyArray1BoxedBoolean](#requiredwithemptyarray1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [RequiredWithEmptyArray1BoxedMap](#requiredwithemptyarray1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#requiredwithemptyarraymapbuilder), configuration: SchemaConfiguration) |
+| [RequiredWithEmptyArray1BoxedBoolean](#requiredwithemptyarray1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [RequiredWithEmptyArray1BoxedMap](#requiredwithemptyarray1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#requiredwithemptyarraymapbuilder), configuration: SchemaConfiguration) |
 | [RequiredWithEmptyArray1BoxedList](#requiredwithemptyarray1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [RequiredWithEmptyArray1Boxed](#requiredwithemptyarray1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RequiredWithEmptyArray.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RequiredWithEmptyArray.md
@@ -13,23 +13,23 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [RequiredWithEmptyArray.RequiredWithEmptyArray1Boxed](#requiredwithemptyarray1boxed)<br> sealed interface for validated payloads |
-| record | [RequiredWithEmptyArray.RequiredWithEmptyArray1BoxedVoid](#requiredwithemptyarray1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [RequiredWithEmptyArray.RequiredWithEmptyArray1BoxedBoolean](#requiredwithemptyarray1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [RequiredWithEmptyArray.RequiredWithEmptyArray1BoxedNumber](#requiredwithemptyarray1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [RequiredWithEmptyArray.RequiredWithEmptyArray1BoxedString](#requiredwithemptyarray1boxedstring)<br> boxed class to store validated String payloads |
-| record | [RequiredWithEmptyArray.RequiredWithEmptyArray1BoxedList](#requiredwithemptyarray1boxedlist)<br> boxed class to store validated List payloads |
-| record | [RequiredWithEmptyArray.RequiredWithEmptyArray1BoxedMap](#requiredwithemptyarray1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [RequiredWithEmptyArray.RequiredWithEmptyArray1](#requiredwithemptyarray1)<br> schema class |
-| static class | [RequiredWithEmptyArray.RequiredWithEmptyArrayMapBuilder](#requiredwithemptyarraymapbuilder)<br> builder for Map payloads |
-| static class | [RequiredWithEmptyArray.RequiredWithEmptyArrayMap](#requiredwithemptyarraymap)<br> output class for Map payloads |
+| data class | [RequiredWithEmptyArray.RequiredWithEmptyArray1BoxedVoid](#requiredwithemptyarray1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [RequiredWithEmptyArray.RequiredWithEmptyArray1BoxedBoolean](#requiredwithemptyarray1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [RequiredWithEmptyArray.RequiredWithEmptyArray1BoxedNumber](#requiredwithemptyarray1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [RequiredWithEmptyArray.RequiredWithEmptyArray1BoxedString](#requiredwithemptyarray1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [RequiredWithEmptyArray.RequiredWithEmptyArray1BoxedList](#requiredwithemptyarray1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [RequiredWithEmptyArray.RequiredWithEmptyArray1BoxedMap](#requiredwithemptyarray1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [RequiredWithEmptyArray.RequiredWithEmptyArray1](#requiredwithemptyarray1)<br> schema class |
+| class | [RequiredWithEmptyArray.RequiredWithEmptyArrayMapBuilder](#requiredwithemptyarraymapbuilder)<br> builder for Map payloads |
+| class | [RequiredWithEmptyArray.RequiredWithEmptyArrayMap](#requiredwithemptyarraymap)<br> output class for Map payloads |
 | sealed interface | [RequiredWithEmptyArray.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [RequiredWithEmptyArray.FooBoxedVoid](#fooboxedvoid)<br> boxed class to store validated null payloads |
-| record | [RequiredWithEmptyArray.FooBoxedBoolean](#fooboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [RequiredWithEmptyArray.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
-| record | [RequiredWithEmptyArray.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
-| record | [RequiredWithEmptyArray.FooBoxedList](#fooboxedlist)<br> boxed class to store validated List payloads |
-| record | [RequiredWithEmptyArray.FooBoxedMap](#fooboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [RequiredWithEmptyArray.Foo](#foo)<br> schema class |
+| data class | [RequiredWithEmptyArray.FooBoxedVoid](#fooboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [RequiredWithEmptyArray.FooBoxedBoolean](#fooboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [RequiredWithEmptyArray.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [RequiredWithEmptyArray.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
+| data class | [RequiredWithEmptyArray.FooBoxedList](#fooboxedlist)<br> boxed class to store validated List payloads |
+| data class | [RequiredWithEmptyArray.FooBoxedMap](#fooboxedmap)<br> boxed class to store validated Map payloads |
+| class | [RequiredWithEmptyArray.Foo](#foo)<br> schema class |
 
 ## RequiredWithEmptyArray1Boxed
 sealed interface RequiredWithEmptyArray1Boxed<br>
@@ -64,7 +64,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class RequiredWithEmptyArray1BoxedBoolean<br>
 implements [RequiredWithEmptyArray1Boxed](#requiredwithemptyarray1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -258,7 +258,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class FooBoxedBoolean<br>
 implements [FooBoxed](#fooboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RequiredWithEscapedCharacters.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RequiredWithEscapedCharacters.md
@@ -13,15 +13,15 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [RequiredWithEscapedCharacters.RequiredWithEscapedCharacters1Boxed](#requiredwithescapedcharacters1boxed)<br> sealed interface for validated payloads |
-| record | [RequiredWithEscapedCharacters.RequiredWithEscapedCharacters1BoxedVoid](#requiredwithescapedcharacters1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [RequiredWithEscapedCharacters.RequiredWithEscapedCharacters1BoxedBoolean](#requiredwithescapedcharacters1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [RequiredWithEscapedCharacters.RequiredWithEscapedCharacters1BoxedNumber](#requiredwithescapedcharacters1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [RequiredWithEscapedCharacters.RequiredWithEscapedCharacters1BoxedString](#requiredwithescapedcharacters1boxedstring)<br> boxed class to store validated String payloads |
-| record | [RequiredWithEscapedCharacters.RequiredWithEscapedCharacters1BoxedList](#requiredwithescapedcharacters1boxedlist)<br> boxed class to store validated List payloads |
-| record | [RequiredWithEscapedCharacters.RequiredWithEscapedCharacters1BoxedMap](#requiredwithescapedcharacters1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [RequiredWithEscapedCharacters.RequiredWithEscapedCharacters1](#requiredwithescapedcharacters1)<br> schema class |
-| static class | [RequiredWithEscapedCharacters.RequiredWithEscapedCharactersMapBuilder](#requiredwithescapedcharactersmapbuilder)<br> builder for Map payloads |
-| static class | [RequiredWithEscapedCharacters.RequiredWithEscapedCharactersMap](#requiredwithescapedcharactersmap)<br> output class for Map payloads |
+| data class | [RequiredWithEscapedCharacters.RequiredWithEscapedCharacters1BoxedVoid](#requiredwithescapedcharacters1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [RequiredWithEscapedCharacters.RequiredWithEscapedCharacters1BoxedBoolean](#requiredwithescapedcharacters1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [RequiredWithEscapedCharacters.RequiredWithEscapedCharacters1BoxedNumber](#requiredwithescapedcharacters1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [RequiredWithEscapedCharacters.RequiredWithEscapedCharacters1BoxedString](#requiredwithescapedcharacters1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [RequiredWithEscapedCharacters.RequiredWithEscapedCharacters1BoxedList](#requiredwithescapedcharacters1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [RequiredWithEscapedCharacters.RequiredWithEscapedCharacters1BoxedMap](#requiredwithescapedcharacters1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [RequiredWithEscapedCharacters.RequiredWithEscapedCharacters1](#requiredwithescapedcharacters1)<br> schema class |
+| class | [RequiredWithEscapedCharacters.RequiredWithEscapedCharactersMapBuilder](#requiredwithescapedcharactersmapbuilder)<br> builder for Map payloads |
+| class | [RequiredWithEscapedCharacters.RequiredWithEscapedCharactersMap](#requiredwithescapedcharactersmap)<br> output class for Map payloads |
 
 ## RequiredWithEscapedCharacters1Boxed
 sealed interface RequiredWithEscapedCharacters1Boxed<br>
@@ -56,7 +56,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class RequiredWithEscapedCharacters1BoxedBoolean<br>
 implements [RequiredWithEscapedCharacters1Boxed](#requiredwithescapedcharacters1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RequiredWithEscapedCharacters.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/RequiredWithEscapedCharacters.md
@@ -153,19 +153,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [RequiredWithEscapedCharactersMap](#requiredwithescapedcharactersmap) | validate(arg: [Map&lt;?, ?&gt;](#requiredwithescapedcharactersmapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [RequiredWithEscapedCharactersMap](#requiredwithescapedcharactersmap) | validate(arg: [Map&lt;*, *&gt;](#requiredwithescapedcharactersmapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [RequiredWithEscapedCharacters1BoxedString](#requiredwithescapedcharacters1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [RequiredWithEscapedCharacters1BoxedVoid](#requiredwithescapedcharacters1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [RequiredWithEscapedCharacters1BoxedNumber](#requiredwithescapedcharacters1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [RequiredWithEscapedCharacters1BoxedBoolean](#requiredwithescapedcharacters1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [RequiredWithEscapedCharacters1BoxedMap](#requiredwithescapedcharacters1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#requiredwithescapedcharactersmapbuilder), configuration: SchemaConfiguration) |
+| [RequiredWithEscapedCharacters1BoxedBoolean](#requiredwithescapedcharacters1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [RequiredWithEscapedCharacters1BoxedMap](#requiredwithescapedcharacters1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#requiredwithescapedcharactersmapbuilder), configuration: SchemaConfiguration) |
 | [RequiredWithEscapedCharacters1BoxedList](#requiredwithescapedcharacters1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [RequiredWithEscapedCharacters1Boxed](#requiredwithescapedcharacters1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/SimpleEnumValidation.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/SimpleEnumValidation.md
@@ -51,25 +51,21 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.SimpleEnumValidation;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.SimpleEnumValidation
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // int validation
-int validatedPayload = SimpleEnumValidation.SimpleEnumValidation1.validate(
+val validatedPayload: Int = SimpleEnumValidation.SimpleEnumValidation1.validate(
     1,
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -90,7 +86,7 @@ int validatedPayload = SimpleEnumValidation.SimpleEnumValidation1.validate(
 public enum IntegerSimpleEnumValidationEnums<br>
 extends `Enum<IntegerSimpleEnumValidationEnums>`
 
-A class that stores Integer enum values
+A class that stores Int enum values
 
 ### Enum Constant Summary
 | Enum Constant | Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/SimpleEnumValidation.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/SimpleEnumValidation.md
@@ -12,8 +12,8 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [SimpleEnumValidation.SimpleEnumValidation1Boxed](#simpleenumvalidation1boxed)<br> sealed interface for validated payloads |
-| record | [SimpleEnumValidation.SimpleEnumValidation1BoxedNumber](#simpleenumvalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [SimpleEnumValidation.SimpleEnumValidation1](#simpleenumvalidation1)<br> schema class |
+| data class | [SimpleEnumValidation.SimpleEnumValidation1BoxedNumber](#simpleenumvalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| class | [SimpleEnumValidation.SimpleEnumValidation1](#simpleenumvalidation1)<br> schema class |
 | enum | [SimpleEnumValidation.IntegerSimpleEnumValidationEnums](#integersimpleenumvalidationenums)<br>Integer enum |
 | enum | [SimpleEnumValidation.LongSimpleEnumValidationEnums](#longsimpleenumvalidationenums)<br>Long enum |
 | enum | [SimpleEnumValidation.FloatSimpleEnumValidationEnums](#floatsimpleenumvalidationenums)<br>Float enum |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/StringTypeMatchesStrings.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/StringTypeMatchesStrings.md
@@ -11,8 +11,8 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [StringTypeMatchesStrings.StringTypeMatchesStrings1Boxed](#stringtypematchesstrings1boxed)<br> sealed interface for validated payloads |
-| record | [StringTypeMatchesStrings.StringTypeMatchesStrings1BoxedString](#stringtypematchesstrings1boxedstring)<br> boxed class to store validated String payloads |
-| static class | [StringTypeMatchesStrings.StringTypeMatchesStrings1](#stringtypematchesstrings1)<br> schema class |
+| data class | [StringTypeMatchesStrings.StringTypeMatchesStrings1BoxedString](#stringtypematchesstrings1boxedstring)<br> boxed class to store validated String payloads |
+| class | [StringTypeMatchesStrings.StringTypeMatchesStrings1](#stringtypematchesstrings1)<br> schema class |
 
 ## StringTypeMatchesStrings1Boxed
 sealed interface StringTypeMatchesStrings1Boxed<br>

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.md
@@ -13,13 +13,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing1Boxed](#thedefaultkeyworddoesnotdoanythingifthepropertyismissing1boxed)<br> sealed interface for validated payloads |
-| record | [TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing1BoxedMap](#thedefaultkeyworddoesnotdoanythingifthepropertyismissing1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing1](#thedefaultkeyworddoesnotdoanythingifthepropertyismissing1)<br> schema class |
-| static class | [TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissingMapBuilder](#thedefaultkeyworddoesnotdoanythingifthepropertyismissingmapbuilder)<br> builder for Map payloads |
-| static class | [TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissingMap](#thedefaultkeyworddoesnotdoanythingifthepropertyismissingmap)<br> output class for Map payloads |
+| data class | [TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing1BoxedMap](#thedefaultkeyworddoesnotdoanythingifthepropertyismissing1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing1](#thedefaultkeyworddoesnotdoanythingifthepropertyismissing1)<br> schema class |
+| class | [TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissingMapBuilder](#thedefaultkeyworddoesnotdoanythingifthepropertyismissingmapbuilder)<br> builder for Map payloads |
+| class | [TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissingMap](#thedefaultkeyworddoesnotdoanythingifthepropertyismissingmap)<br> output class for Map payloads |
 | sealed interface | [TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.AlphaBoxed](#alphaboxed)<br> sealed interface for validated payloads |
-| record | [TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.AlphaBoxedNumber](#alphaboxednumber)<br> boxed class to store validated Number payloads |
-| static class | [TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.Alpha](#alpha)<br> schema class |
+| data class | [TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.AlphaBoxedNumber](#alphaboxednumber)<br> boxed class to store validated Number payloads |
+| class | [TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.Alpha](#alpha)<br> schema class |
 
 ## TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing1Boxed
 sealed interface TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing1Boxed<br>

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.md
@@ -53,29 +53,25 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // Map validation
-TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissingMap validatedPayload =
+val validatedPayload: TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissingMap =
     TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing1.validate(
-    new TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissingMapBuilder()
+    TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissingMapBuilder()
         .alpha(1)
 
     .build(),
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -87,8 +83,8 @@ TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.TheDefaultKeywordDoesNo
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| [TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissingMap](#thedefaultkeyworddoesnotdoanythingifthepropertyismissingmap) | validate(arg: [Map&lt;?, ?&gt;](#thedefaultkeyworddoesnotdoanythingifthepropertyismissingmapbuilder), configuration: SchemaConfiguration) |
-| [TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing1BoxedMap](#thedefaultkeyworddoesnotdoanythingifthepropertyismissing1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#thedefaultkeyworddoesnotdoanythingifthepropertyismissingmapbuilder), configuration: SchemaConfiguration) |
+| [TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissingMap](#thedefaultkeyworddoesnotdoanythingifthepropertyismissingmap) | validate(arg: [Map&lt;*, *&gt;](#thedefaultkeyworddoesnotdoanythingifthepropertyismissingmapbuilder), configuration: SchemaConfiguration) |
+| [TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing1BoxedMap](#thedefaultkeyworddoesnotdoanythingifthepropertyismissing1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#thedefaultkeyworddoesnotdoanythingifthepropertyismissingmapbuilder), configuration: SchemaConfiguration) |
 | [TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing1Boxed](#thedefaultkeyworddoesnotdoanythingifthepropertyismissing1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
 
@@ -166,25 +162,21 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // int validation
-int validatedPayload = TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.Alpha.validate(
+val validatedPayload: Int = TheDefaultKeywordDoesNotDoAnythingIfThePropertyIsMissing.Alpha.validate(
     1,
     configuration
-);
+)
 ```
 
 ### Field Summary

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/UniqueitemsFalseValidation.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/UniqueitemsFalseValidation.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [UniqueitemsFalseValidation1BoxedString](#uniqueitemsfalsevalidation1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [UniqueitemsFalseValidation1BoxedVoid](#uniqueitemsfalsevalidation1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [UniqueitemsFalseValidation1BoxedNumber](#uniqueitemsfalsevalidation1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [UniqueitemsFalseValidation1BoxedBoolean](#uniqueitemsfalsevalidation1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [UniqueitemsFalseValidation1BoxedMap](#uniqueitemsfalsevalidation1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [UniqueitemsFalseValidation1BoxedBoolean](#uniqueitemsfalsevalidation1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [UniqueitemsFalseValidation1BoxedMap](#uniqueitemsfalsevalidation1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [UniqueitemsFalseValidation1BoxedList](#uniqueitemsfalsevalidation1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [UniqueitemsFalseValidation1Boxed](#uniqueitemsfalsevalidation1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/UniqueitemsFalseValidation.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/UniqueitemsFalseValidation.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [UniqueitemsFalseValidation.UniqueitemsFalseValidation1Boxed](#uniqueitemsfalsevalidation1boxed)<br> sealed interface for validated payloads |
-| record | [UniqueitemsFalseValidation.UniqueitemsFalseValidation1BoxedVoid](#uniqueitemsfalsevalidation1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [UniqueitemsFalseValidation.UniqueitemsFalseValidation1BoxedBoolean](#uniqueitemsfalsevalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [UniqueitemsFalseValidation.UniqueitemsFalseValidation1BoxedNumber](#uniqueitemsfalsevalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [UniqueitemsFalseValidation.UniqueitemsFalseValidation1BoxedString](#uniqueitemsfalsevalidation1boxedstring)<br> boxed class to store validated String payloads |
-| record | [UniqueitemsFalseValidation.UniqueitemsFalseValidation1BoxedList](#uniqueitemsfalsevalidation1boxedlist)<br> boxed class to store validated List payloads |
-| record | [UniqueitemsFalseValidation.UniqueitemsFalseValidation1BoxedMap](#uniqueitemsfalsevalidation1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [UniqueitemsFalseValidation.UniqueitemsFalseValidation1](#uniqueitemsfalsevalidation1)<br> schema class |
+| data class | [UniqueitemsFalseValidation.UniqueitemsFalseValidation1BoxedVoid](#uniqueitemsfalsevalidation1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [UniqueitemsFalseValidation.UniqueitemsFalseValidation1BoxedBoolean](#uniqueitemsfalsevalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [UniqueitemsFalseValidation.UniqueitemsFalseValidation1BoxedNumber](#uniqueitemsfalsevalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [UniqueitemsFalseValidation.UniqueitemsFalseValidation1BoxedString](#uniqueitemsfalsevalidation1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [UniqueitemsFalseValidation.UniqueitemsFalseValidation1BoxedList](#uniqueitemsfalsevalidation1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [UniqueitemsFalseValidation.UniqueitemsFalseValidation1BoxedMap](#uniqueitemsfalsevalidation1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [UniqueitemsFalseValidation.UniqueitemsFalseValidation1](#uniqueitemsfalsevalidation1)<br> schema class |
 
 ## UniqueitemsFalseValidation1Boxed
 sealed interface UniqueitemsFalseValidation1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class UniqueitemsFalseValidation1BoxedBoolean<br>
 implements [UniqueitemsFalseValidation1Boxed](#uniqueitemsfalsevalidation1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/UniqueitemsValidation.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/UniqueitemsValidation.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [UniqueitemsValidation.UniqueitemsValidation1Boxed](#uniqueitemsvalidation1boxed)<br> sealed interface for validated payloads |
-| record | [UniqueitemsValidation.UniqueitemsValidation1BoxedVoid](#uniqueitemsvalidation1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [UniqueitemsValidation.UniqueitemsValidation1BoxedBoolean](#uniqueitemsvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [UniqueitemsValidation.UniqueitemsValidation1BoxedNumber](#uniqueitemsvalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [UniqueitemsValidation.UniqueitemsValidation1BoxedString](#uniqueitemsvalidation1boxedstring)<br> boxed class to store validated String payloads |
-| record | [UniqueitemsValidation.UniqueitemsValidation1BoxedList](#uniqueitemsvalidation1boxedlist)<br> boxed class to store validated List payloads |
-| record | [UniqueitemsValidation.UniqueitemsValidation1BoxedMap](#uniqueitemsvalidation1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [UniqueitemsValidation.UniqueitemsValidation1](#uniqueitemsvalidation1)<br> schema class |
+| data class | [UniqueitemsValidation.UniqueitemsValidation1BoxedVoid](#uniqueitemsvalidation1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [UniqueitemsValidation.UniqueitemsValidation1BoxedBoolean](#uniqueitemsvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [UniqueitemsValidation.UniqueitemsValidation1BoxedNumber](#uniqueitemsvalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [UniqueitemsValidation.UniqueitemsValidation1BoxedString](#uniqueitemsvalidation1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [UniqueitemsValidation.UniqueitemsValidation1BoxedList](#uniqueitemsvalidation1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [UniqueitemsValidation.UniqueitemsValidation1BoxedMap](#uniqueitemsvalidation1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [UniqueitemsValidation.UniqueitemsValidation1](#uniqueitemsvalidation1)<br> schema class |
 
 ## UniqueitemsValidation1Boxed
 sealed interface UniqueitemsValidation1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class UniqueitemsValidation1BoxedBoolean<br>
 implements [UniqueitemsValidation1Boxed](#uniqueitemsvalidation1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/UniqueitemsValidation.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/UniqueitemsValidation.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [UniqueitemsValidation1BoxedString](#uniqueitemsvalidation1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [UniqueitemsValidation1BoxedVoid](#uniqueitemsvalidation1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [UniqueitemsValidation1BoxedNumber](#uniqueitemsvalidation1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [UniqueitemsValidation1BoxedBoolean](#uniqueitemsvalidation1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [UniqueitemsValidation1BoxedMap](#uniqueitemsvalidation1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [UniqueitemsValidation1BoxedBoolean](#uniqueitemsvalidation1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [UniqueitemsValidation1BoxedMap](#uniqueitemsvalidation1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [UniqueitemsValidation1BoxedList](#uniqueitemsvalidation1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [UniqueitemsValidation1Boxed](#uniqueitemsvalidation1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/UriFormat.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/UriFormat.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [UriFormat.UriFormat1Boxed](#uriformat1boxed)<br> sealed interface for validated payloads |
-| record | [UriFormat.UriFormat1BoxedVoid](#uriformat1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [UriFormat.UriFormat1BoxedBoolean](#uriformat1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [UriFormat.UriFormat1BoxedNumber](#uriformat1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [UriFormat.UriFormat1BoxedString](#uriformat1boxedstring)<br> boxed class to store validated String payloads |
-| record | [UriFormat.UriFormat1BoxedList](#uriformat1boxedlist)<br> boxed class to store validated List payloads |
-| record | [UriFormat.UriFormat1BoxedMap](#uriformat1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [UriFormat.UriFormat1](#uriformat1)<br> schema class |
+| data class | [UriFormat.UriFormat1BoxedVoid](#uriformat1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [UriFormat.UriFormat1BoxedBoolean](#uriformat1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [UriFormat.UriFormat1BoxedNumber](#uriformat1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [UriFormat.UriFormat1BoxedString](#uriformat1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [UriFormat.UriFormat1BoxedList](#uriformat1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [UriFormat.UriFormat1BoxedMap](#uriformat1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [UriFormat.UriFormat1](#uriformat1)<br> schema class |
 
 ## UriFormat1Boxed
 sealed interface UriFormat1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class UriFormat1BoxedBoolean<br>
 implements [UriFormat1Boxed](#uriformat1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/UriFormat.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/UriFormat.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [UriFormat1BoxedString](#uriformat1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [UriFormat1BoxedVoid](#uriformat1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [UriFormat1BoxedNumber](#uriformat1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [UriFormat1BoxedBoolean](#uriformat1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [UriFormat1BoxedMap](#uriformat1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [UriFormat1BoxedBoolean](#uriformat1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [UriFormat1BoxedMap](#uriformat1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [UriFormat1BoxedList](#uriformat1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [UriFormat1Boxed](#uriformat1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/UriReferenceFormat.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/UriReferenceFormat.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [UriReferenceFormat1BoxedString](#urireferenceformat1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [UriReferenceFormat1BoxedVoid](#urireferenceformat1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [UriReferenceFormat1BoxedNumber](#urireferenceformat1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [UriReferenceFormat1BoxedBoolean](#urireferenceformat1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [UriReferenceFormat1BoxedMap](#urireferenceformat1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [UriReferenceFormat1BoxedBoolean](#urireferenceformat1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [UriReferenceFormat1BoxedMap](#urireferenceformat1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [UriReferenceFormat1BoxedList](#urireferenceformat1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [UriReferenceFormat1Boxed](#urireferenceformat1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/UriReferenceFormat.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/UriReferenceFormat.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [UriReferenceFormat.UriReferenceFormat1Boxed](#urireferenceformat1boxed)<br> sealed interface for validated payloads |
-| record | [UriReferenceFormat.UriReferenceFormat1BoxedVoid](#urireferenceformat1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [UriReferenceFormat.UriReferenceFormat1BoxedBoolean](#urireferenceformat1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [UriReferenceFormat.UriReferenceFormat1BoxedNumber](#urireferenceformat1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [UriReferenceFormat.UriReferenceFormat1BoxedString](#urireferenceformat1boxedstring)<br> boxed class to store validated String payloads |
-| record | [UriReferenceFormat.UriReferenceFormat1BoxedList](#urireferenceformat1boxedlist)<br> boxed class to store validated List payloads |
-| record | [UriReferenceFormat.UriReferenceFormat1BoxedMap](#urireferenceformat1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [UriReferenceFormat.UriReferenceFormat1](#urireferenceformat1)<br> schema class |
+| data class | [UriReferenceFormat.UriReferenceFormat1BoxedVoid](#urireferenceformat1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [UriReferenceFormat.UriReferenceFormat1BoxedBoolean](#urireferenceformat1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [UriReferenceFormat.UriReferenceFormat1BoxedNumber](#urireferenceformat1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [UriReferenceFormat.UriReferenceFormat1BoxedString](#urireferenceformat1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [UriReferenceFormat.UriReferenceFormat1BoxedList](#urireferenceformat1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [UriReferenceFormat.UriReferenceFormat1BoxedMap](#urireferenceformat1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [UriReferenceFormat.UriReferenceFormat1](#urireferenceformat1)<br> schema class |
 
 ## UriReferenceFormat1Boxed
 sealed interface UriReferenceFormat1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class UriReferenceFormat1BoxedBoolean<br>
 implements [UriReferenceFormat1Boxed](#urireferenceformat1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/UriTemplateFormat.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/UriTemplateFormat.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [UriTemplateFormat1BoxedString](#uritemplateformat1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [UriTemplateFormat1BoxedVoid](#uritemplateformat1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [UriTemplateFormat1BoxedNumber](#uritemplateformat1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [UriTemplateFormat1BoxedBoolean](#uritemplateformat1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [UriTemplateFormat1BoxedMap](#uritemplateformat1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [UriTemplateFormat1BoxedBoolean](#uritemplateformat1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [UriTemplateFormat1BoxedMap](#uritemplateformat1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [UriTemplateFormat1BoxedList](#uritemplateformat1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [UriTemplateFormat1Boxed](#uritemplateformat1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/UriTemplateFormat.md
+++ b/samples/client/3_0_3_unit_test/kotlin/docs/components/schemas/UriTemplateFormat.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [UriTemplateFormat.UriTemplateFormat1Boxed](#uritemplateformat1boxed)<br> sealed interface for validated payloads |
-| record | [UriTemplateFormat.UriTemplateFormat1BoxedVoid](#uritemplateformat1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [UriTemplateFormat.UriTemplateFormat1BoxedBoolean](#uritemplateformat1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [UriTemplateFormat.UriTemplateFormat1BoxedNumber](#uritemplateformat1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [UriTemplateFormat.UriTemplateFormat1BoxedString](#uritemplateformat1boxedstring)<br> boxed class to store validated String payloads |
-| record | [UriTemplateFormat.UriTemplateFormat1BoxedList](#uritemplateformat1boxedlist)<br> boxed class to store validated List payloads |
-| record | [UriTemplateFormat.UriTemplateFormat1BoxedMap](#uritemplateformat1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [UriTemplateFormat.UriTemplateFormat1](#uritemplateformat1)<br> schema class |
+| data class | [UriTemplateFormat.UriTemplateFormat1BoxedVoid](#uritemplateformat1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [UriTemplateFormat.UriTemplateFormat1BoxedBoolean](#uritemplateformat1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [UriTemplateFormat.UriTemplateFormat1BoxedNumber](#uritemplateformat1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [UriTemplateFormat.UriTemplateFormat1BoxedString](#uritemplateformat1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [UriTemplateFormat.UriTemplateFormat1BoxedList](#uritemplateformat1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [UriTemplateFormat.UriTemplateFormat1BoxedMap](#uritemplateformat1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [UriTemplateFormat.UriTemplateFormat1](#uritemplateformat1)<br> schema class |
 
 ## UriTemplateFormat1Boxed
 sealed interface UriTemplateFormat1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class UriTemplateFormat1BoxedBoolean<br>
 implements [UriTemplateFormat1Boxed](#uritemplateformat1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/build.gradle.kts
+++ b/samples/client/3_1_0_unit_test/kotlin/build.gradle.kts
@@ -21,10 +21,8 @@ group = "org.openapijsonschematools"
 version = "0.0.1"
 description = "OpenAPI Kotlin"
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
-    }
+kotlin {
+    jvmToolchain(17)
 }
 
 tasks.wrapper {

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ASchemaGivenForPrefixitems.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ASchemaGivenForPrefixitems.md
@@ -159,19 +159,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [ASchemaGivenForPrefixitemsList](#aschemagivenforprefixitemslist) | validate(arg: [List<*>](#aschemagivenforprefixitemslistbuilder), configuration: SchemaConfiguration) |
 | [ASchemaGivenForPrefixitems1BoxedString](#aschemagivenforprefixitems1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [ASchemaGivenForPrefixitems1BoxedVoid](#aschemagivenforprefixitems1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [ASchemaGivenForPrefixitems1BoxedNumber](#aschemagivenforprefixitems1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [ASchemaGivenForPrefixitems1BoxedBoolean](#aschemagivenforprefixitems1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [ASchemaGivenForPrefixitems1BoxedMap](#aschemagivenforprefixitems1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [ASchemaGivenForPrefixitems1BoxedBoolean](#aschemagivenforprefixitems1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [ASchemaGivenForPrefixitems1BoxedMap](#aschemagivenforprefixitems1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [ASchemaGivenForPrefixitems1BoxedList](#aschemagivenforprefixitems1boxedlist) | validateAndBox([List<*>](#aschemagivenforprefixitemslistbuilder), configuration: SchemaConfiguration) |
 | [ASchemaGivenForPrefixitems1Boxed](#aschemagivenforprefixitems1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ASchemaGivenForPrefixitems.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ASchemaGivenForPrefixitems.md
@@ -13,21 +13,21 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [ASchemaGivenForPrefixitems.ASchemaGivenForPrefixitems1Boxed](#aschemagivenforprefixitems1boxed)<br> sealed interface for validated payloads |
-| record | [ASchemaGivenForPrefixitems.ASchemaGivenForPrefixitems1BoxedVoid](#aschemagivenforprefixitems1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [ASchemaGivenForPrefixitems.ASchemaGivenForPrefixitems1BoxedBoolean](#aschemagivenforprefixitems1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [ASchemaGivenForPrefixitems.ASchemaGivenForPrefixitems1BoxedNumber](#aschemagivenforprefixitems1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [ASchemaGivenForPrefixitems.ASchemaGivenForPrefixitems1BoxedString](#aschemagivenforprefixitems1boxedstring)<br> boxed class to store validated String payloads |
-| record | [ASchemaGivenForPrefixitems.ASchemaGivenForPrefixitems1BoxedList](#aschemagivenforprefixitems1boxedlist)<br> boxed class to store validated List payloads |
-| record | [ASchemaGivenForPrefixitems.ASchemaGivenForPrefixitems1BoxedMap](#aschemagivenforprefixitems1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [ASchemaGivenForPrefixitems.ASchemaGivenForPrefixitems1](#aschemagivenforprefixitems1)<br> schema class |
+| data class | [ASchemaGivenForPrefixitems.ASchemaGivenForPrefixitems1BoxedVoid](#aschemagivenforprefixitems1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [ASchemaGivenForPrefixitems.ASchemaGivenForPrefixitems1BoxedBoolean](#aschemagivenforprefixitems1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [ASchemaGivenForPrefixitems.ASchemaGivenForPrefixitems1BoxedNumber](#aschemagivenforprefixitems1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [ASchemaGivenForPrefixitems.ASchemaGivenForPrefixitems1BoxedString](#aschemagivenforprefixitems1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [ASchemaGivenForPrefixitems.ASchemaGivenForPrefixitems1BoxedList](#aschemagivenforprefixitems1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [ASchemaGivenForPrefixitems.ASchemaGivenForPrefixitems1BoxedMap](#aschemagivenforprefixitems1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [ASchemaGivenForPrefixitems.ASchemaGivenForPrefixitems1](#aschemagivenforprefixitems1)<br> schema class |
 | sealed interface | [ASchemaGivenForPrefixitems.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [ASchemaGivenForPrefixitems.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
-| static class | [ASchemaGivenForPrefixitems.Schema1](#schema1)<br> schema class |
+| data class | [ASchemaGivenForPrefixitems.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
+| class | [ASchemaGivenForPrefixitems.Schema1](#schema1)<br> schema class |
 | sealed interface | [ASchemaGivenForPrefixitems.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [ASchemaGivenForPrefixitems.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [ASchemaGivenForPrefixitems.Schema0](#schema0)<br> schema class |
-| static class | [ASchemaGivenForPrefixitems.ASchemaGivenForPrefixitemsListBuilder](#aschemagivenforprefixitemslistbuilder)<br> builder for List payloads |
-| static class | [ASchemaGivenForPrefixitems.ASchemaGivenForPrefixitemsList](#aschemagivenforprefixitemslist)<br> output class for List payloads |
+| data class | [ASchemaGivenForPrefixitems.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| class | [ASchemaGivenForPrefixitems.Schema0](#schema0)<br> schema class |
+| class | [ASchemaGivenForPrefixitems.ASchemaGivenForPrefixitemsListBuilder](#aschemagivenforprefixitemslistbuilder)<br> builder for List payloads |
+| class | [ASchemaGivenForPrefixitems.ASchemaGivenForPrefixitemsList](#aschemagivenforprefixitemslist)<br> output class for List payloads |
 
 ## ASchemaGivenForPrefixitems1Boxed
 sealed interface ASchemaGivenForPrefixitems1Boxed<br>
@@ -62,7 +62,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class ASchemaGivenForPrefixitems1BoxedBoolean<br>
 implements [ASchemaGivenForPrefixitems1Boxed](#aschemagivenforprefixitems1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AdditionalItemsAreAllowedByDefault.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AdditionalItemsAreAllowedByDefault.md
@@ -13,18 +13,18 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [AdditionalItemsAreAllowedByDefault.AdditionalItemsAreAllowedByDefault1Boxed](#additionalitemsareallowedbydefault1boxed)<br> sealed interface for validated payloads |
-| record | [AdditionalItemsAreAllowedByDefault.AdditionalItemsAreAllowedByDefault1BoxedVoid](#additionalitemsareallowedbydefault1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AdditionalItemsAreAllowedByDefault.AdditionalItemsAreAllowedByDefault1BoxedBoolean](#additionalitemsareallowedbydefault1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AdditionalItemsAreAllowedByDefault.AdditionalItemsAreAllowedByDefault1BoxedNumber](#additionalitemsareallowedbydefault1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AdditionalItemsAreAllowedByDefault.AdditionalItemsAreAllowedByDefault1BoxedString](#additionalitemsareallowedbydefault1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AdditionalItemsAreAllowedByDefault.AdditionalItemsAreAllowedByDefault1BoxedList](#additionalitemsareallowedbydefault1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AdditionalItemsAreAllowedByDefault.AdditionalItemsAreAllowedByDefault1BoxedMap](#additionalitemsareallowedbydefault1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AdditionalItemsAreAllowedByDefault.AdditionalItemsAreAllowedByDefault1](#additionalitemsareallowedbydefault1)<br> schema class |
+| data class | [AdditionalItemsAreAllowedByDefault.AdditionalItemsAreAllowedByDefault1BoxedVoid](#additionalitemsareallowedbydefault1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AdditionalItemsAreAllowedByDefault.AdditionalItemsAreAllowedByDefault1BoxedBoolean](#additionalitemsareallowedbydefault1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AdditionalItemsAreAllowedByDefault.AdditionalItemsAreAllowedByDefault1BoxedNumber](#additionalitemsareallowedbydefault1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AdditionalItemsAreAllowedByDefault.AdditionalItemsAreAllowedByDefault1BoxedString](#additionalitemsareallowedbydefault1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AdditionalItemsAreAllowedByDefault.AdditionalItemsAreAllowedByDefault1BoxedList](#additionalitemsareallowedbydefault1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AdditionalItemsAreAllowedByDefault.AdditionalItemsAreAllowedByDefault1BoxedMap](#additionalitemsareallowedbydefault1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AdditionalItemsAreAllowedByDefault.AdditionalItemsAreAllowedByDefault1](#additionalitemsareallowedbydefault1)<br> schema class |
 | sealed interface | [AdditionalItemsAreAllowedByDefault.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [AdditionalItemsAreAllowedByDefault.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [AdditionalItemsAreAllowedByDefault.Schema0](#schema0)<br> schema class |
-| static class | [AdditionalItemsAreAllowedByDefault.AdditionalItemsAreAllowedByDefaultListBuilder](#additionalitemsareallowedbydefaultlistbuilder)<br> builder for List payloads |
-| static class | [AdditionalItemsAreAllowedByDefault.AdditionalItemsAreAllowedByDefaultList](#additionalitemsareallowedbydefaultlist)<br> output class for List payloads |
+| data class | [AdditionalItemsAreAllowedByDefault.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| class | [AdditionalItemsAreAllowedByDefault.Schema0](#schema0)<br> schema class |
+| class | [AdditionalItemsAreAllowedByDefault.AdditionalItemsAreAllowedByDefaultListBuilder](#additionalitemsareallowedbydefaultlistbuilder)<br> builder for List payloads |
+| class | [AdditionalItemsAreAllowedByDefault.AdditionalItemsAreAllowedByDefaultList](#additionalitemsareallowedbydefaultlist)<br> output class for List payloads |
 
 ## AdditionalItemsAreAllowedByDefault1Boxed
 sealed interface AdditionalItemsAreAllowedByDefault1Boxed<br>
@@ -59,7 +59,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class AdditionalItemsAreAllowedByDefault1BoxedBoolean<br>
 implements [AdditionalItemsAreAllowedByDefault1Boxed](#additionalitemsareallowedbydefault1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AdditionalItemsAreAllowedByDefault.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AdditionalItemsAreAllowedByDefault.md
@@ -156,19 +156,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [AdditionalItemsAreAllowedByDefaultList](#additionalitemsareallowedbydefaultlist) | validate(arg: [List<*>](#additionalitemsareallowedbydefaultlistbuilder), configuration: SchemaConfiguration) |
 | [AdditionalItemsAreAllowedByDefault1BoxedString](#additionalitemsareallowedbydefault1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [AdditionalItemsAreAllowedByDefault1BoxedVoid](#additionalitemsareallowedbydefault1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [AdditionalItemsAreAllowedByDefault1BoxedNumber](#additionalitemsareallowedbydefault1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [AdditionalItemsAreAllowedByDefault1BoxedBoolean](#additionalitemsareallowedbydefault1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [AdditionalItemsAreAllowedByDefault1BoxedMap](#additionalitemsareallowedbydefault1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [AdditionalItemsAreAllowedByDefault1BoxedBoolean](#additionalitemsareallowedbydefault1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [AdditionalItemsAreAllowedByDefault1BoxedMap](#additionalitemsareallowedbydefault1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [AdditionalItemsAreAllowedByDefault1BoxedList](#additionalitemsareallowedbydefault1boxedlist) | validateAndBox([List<*>](#additionalitemsareallowedbydefaultlistbuilder), configuration: SchemaConfiguration) |
 | [AdditionalItemsAreAllowedByDefault1Boxed](#additionalitemsareallowedbydefault1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesAreAllowedByDefault.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesAreAllowedByDefault.md
@@ -13,31 +13,31 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefault1Boxed](#additionalpropertiesareallowedbydefault1boxed)<br> sealed interface for validated payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefault1BoxedVoid](#additionalpropertiesareallowedbydefault1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefault1BoxedBoolean](#additionalpropertiesareallowedbydefault1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefault1BoxedNumber](#additionalpropertiesareallowedbydefault1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefault1BoxedString](#additionalpropertiesareallowedbydefault1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefault1BoxedList](#additionalpropertiesareallowedbydefault1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefault1BoxedMap](#additionalpropertiesareallowedbydefault1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefault1](#additionalpropertiesareallowedbydefault1)<br> schema class |
-| static class | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefaultMapBuilder](#additionalpropertiesareallowedbydefaultmapbuilder)<br> builder for Map payloads |
-| static class | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefaultMap](#additionalpropertiesareallowedbydefaultmap)<br> output class for Map payloads |
+| data class | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefault1BoxedVoid](#additionalpropertiesareallowedbydefault1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefault1BoxedBoolean](#additionalpropertiesareallowedbydefault1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefault1BoxedNumber](#additionalpropertiesareallowedbydefault1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefault1BoxedString](#additionalpropertiesareallowedbydefault1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefault1BoxedList](#additionalpropertiesareallowedbydefault1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefault1BoxedMap](#additionalpropertiesareallowedbydefault1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefault1](#additionalpropertiesareallowedbydefault1)<br> schema class |
+| class | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefaultMapBuilder](#additionalpropertiesareallowedbydefaultmapbuilder)<br> builder for Map payloads |
+| class | [AdditionalpropertiesAreAllowedByDefault.AdditionalpropertiesAreAllowedByDefaultMap](#additionalpropertiesareallowedbydefaultmap)<br> output class for Map payloads |
 | sealed interface | [AdditionalpropertiesAreAllowedByDefault.BarBoxed](#barboxed)<br> sealed interface for validated payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.BarBoxedVoid](#barboxedvoid)<br> boxed class to store validated null payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.BarBoxedBoolean](#barboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.BarBoxedNumber](#barboxednumber)<br> boxed class to store validated Number payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.BarBoxedString](#barboxedstring)<br> boxed class to store validated String payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.BarBoxedList](#barboxedlist)<br> boxed class to store validated List payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.BarBoxedMap](#barboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AdditionalpropertiesAreAllowedByDefault.Bar](#bar)<br> schema class |
+| data class | [AdditionalpropertiesAreAllowedByDefault.BarBoxedVoid](#barboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AdditionalpropertiesAreAllowedByDefault.BarBoxedBoolean](#barboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AdditionalpropertiesAreAllowedByDefault.BarBoxedNumber](#barboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AdditionalpropertiesAreAllowedByDefault.BarBoxedString](#barboxedstring)<br> boxed class to store validated String payloads |
+| data class | [AdditionalpropertiesAreAllowedByDefault.BarBoxedList](#barboxedlist)<br> boxed class to store validated List payloads |
+| data class | [AdditionalpropertiesAreAllowedByDefault.BarBoxedMap](#barboxedmap)<br> boxed class to store validated Map payloads |
+| class | [AdditionalpropertiesAreAllowedByDefault.Bar](#bar)<br> schema class |
 | sealed interface | [AdditionalpropertiesAreAllowedByDefault.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.FooBoxedVoid](#fooboxedvoid)<br> boxed class to store validated null payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.FooBoxedBoolean](#fooboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.FooBoxedList](#fooboxedlist)<br> boxed class to store validated List payloads |
-| record | [AdditionalpropertiesAreAllowedByDefault.FooBoxedMap](#fooboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AdditionalpropertiesAreAllowedByDefault.Foo](#foo)<br> schema class |
+| data class | [AdditionalpropertiesAreAllowedByDefault.FooBoxedVoid](#fooboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AdditionalpropertiesAreAllowedByDefault.FooBoxedBoolean](#fooboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AdditionalpropertiesAreAllowedByDefault.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AdditionalpropertiesAreAllowedByDefault.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
+| data class | [AdditionalpropertiesAreAllowedByDefault.FooBoxedList](#fooboxedlist)<br> boxed class to store validated List payloads |
+| data class | [AdditionalpropertiesAreAllowedByDefault.FooBoxedMap](#fooboxedmap)<br> boxed class to store validated Map payloads |
+| class | [AdditionalpropertiesAreAllowedByDefault.Foo](#foo)<br> schema class |
 
 ## AdditionalpropertiesAreAllowedByDefault1Boxed
 sealed interface AdditionalpropertiesAreAllowedByDefault1Boxed<br>
@@ -72,7 +72,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class AdditionalpropertiesAreAllowedByDefault1BoxedBoolean<br>
 implements [AdditionalpropertiesAreAllowedByDefault1Boxed](#additionalpropertiesareallowedbydefault1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -276,7 +276,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class BarBoxedBoolean<br>
 implements [BarBoxed](#barboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -401,7 +401,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class FooBoxedBoolean<br>
 implements [FooBoxed](#fooboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesAreAllowedByDefault.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesAreAllowedByDefault.md
@@ -169,19 +169,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [AdditionalpropertiesAreAllowedByDefaultMap](#additionalpropertiesareallowedbydefaultmap) | validate(arg: [Map&lt;?, ?&gt;](#additionalpropertiesareallowedbydefaultmapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [AdditionalpropertiesAreAllowedByDefaultMap](#additionalpropertiesareallowedbydefaultmap) | validate(arg: [Map&lt;*, *&gt;](#additionalpropertiesareallowedbydefaultmapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [AdditionalpropertiesAreAllowedByDefault1BoxedString](#additionalpropertiesareallowedbydefault1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [AdditionalpropertiesAreAllowedByDefault1BoxedVoid](#additionalpropertiesareallowedbydefault1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [AdditionalpropertiesAreAllowedByDefault1BoxedNumber](#additionalpropertiesareallowedbydefault1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [AdditionalpropertiesAreAllowedByDefault1BoxedBoolean](#additionalpropertiesareallowedbydefault1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [AdditionalpropertiesAreAllowedByDefault1BoxedMap](#additionalpropertiesareallowedbydefault1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#additionalpropertiesareallowedbydefaultmapbuilder), configuration: SchemaConfiguration) |
+| [AdditionalpropertiesAreAllowedByDefault1BoxedBoolean](#additionalpropertiesareallowedbydefault1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [AdditionalpropertiesAreAllowedByDefault1BoxedMap](#additionalpropertiesareallowedbydefault1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#additionalpropertiesareallowedbydefaultmapbuilder), configuration: SchemaConfiguration) |
 | [AdditionalpropertiesAreAllowedByDefault1BoxedList](#additionalpropertiesareallowedbydefault1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [AdditionalpropertiesAreAllowedByDefault1Boxed](#additionalpropertiesareallowedbydefault1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesCanExistByItself.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesCanExistByItself.md
@@ -13,13 +13,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [AdditionalpropertiesCanExistByItself.AdditionalpropertiesCanExistByItself1Boxed](#additionalpropertiescanexistbyitself1boxed)<br> sealed interface for validated payloads |
-| record | [AdditionalpropertiesCanExistByItself.AdditionalpropertiesCanExistByItself1BoxedMap](#additionalpropertiescanexistbyitself1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AdditionalpropertiesCanExistByItself.AdditionalpropertiesCanExistByItself1](#additionalpropertiescanexistbyitself1)<br> schema class |
-| static class | [AdditionalpropertiesCanExistByItself.AdditionalpropertiesCanExistByItselfMapBuilder](#additionalpropertiescanexistbyitselfmapbuilder)<br> builder for Map payloads |
-| static class | [AdditionalpropertiesCanExistByItself.AdditionalpropertiesCanExistByItselfMap](#additionalpropertiescanexistbyitselfmap)<br> output class for Map payloads |
+| data class | [AdditionalpropertiesCanExistByItself.AdditionalpropertiesCanExistByItself1BoxedMap](#additionalpropertiescanexistbyitself1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AdditionalpropertiesCanExistByItself.AdditionalpropertiesCanExistByItself1](#additionalpropertiescanexistbyitself1)<br> schema class |
+| class | [AdditionalpropertiesCanExistByItself.AdditionalpropertiesCanExistByItselfMapBuilder](#additionalpropertiescanexistbyitselfmapbuilder)<br> builder for Map payloads |
+| class | [AdditionalpropertiesCanExistByItself.AdditionalpropertiesCanExistByItselfMap](#additionalpropertiescanexistbyitselfmap)<br> output class for Map payloads |
 | sealed interface | [AdditionalpropertiesCanExistByItself.AdditionalPropertiesBoxed](#additionalpropertiesboxed)<br> sealed interface for validated payloads |
-| record | [AdditionalpropertiesCanExistByItself.AdditionalPropertiesBoxedBoolean](#additionalpropertiesboxedboolean)<br> boxed class to store validated boolean payloads |
-| static class | [AdditionalpropertiesCanExistByItself.AdditionalProperties](#additionalproperties)<br> schema class |
+| data class | [AdditionalpropertiesCanExistByItself.AdditionalPropertiesBoxedBoolean](#additionalpropertiesboxedboolean)<br> boxed class to store validated boolean payloads |
+| class | [AdditionalpropertiesCanExistByItself.AdditionalProperties](#additionalproperties)<br> schema class |
 
 ## AdditionalpropertiesCanExistByItself1Boxed
 sealed interface AdditionalpropertiesCanExistByItself1Boxed<br>
@@ -128,7 +128,7 @@ sealed interface that stores validated payloads using boxed classes
 data class AdditionalPropertiesBoxedBoolean<br>
 implements [AdditionalPropertiesBoxed](#additionalpropertiesboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesCanExistByItself.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesCanExistByItself.md
@@ -53,29 +53,25 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.AdditionalpropertiesCanExistByItself;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.AdditionalpropertiesCanExistByItself
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // Map validation
-AdditionalpropertiesCanExistByItself.AdditionalpropertiesCanExistByItselfMap validatedPayload =
+val validatedPayload: AdditionalpropertiesCanExistByItself.AdditionalpropertiesCanExistByItselfMap =
     AdditionalpropertiesCanExistByItself.AdditionalpropertiesCanExistByItself1.validate(
-    new AdditionalpropertiesCanExistByItself.AdditionalpropertiesCanExistByItselfMapBuilder()
+    AdditionalpropertiesCanExistByItself.AdditionalpropertiesCanExistByItselfMapBuilder()
         .additionalProperty("someAdditionalProperty", true)
 
     .build(),
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -87,8 +83,8 @@ AdditionalpropertiesCanExistByItself.AdditionalpropertiesCanExistByItselfMap val
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| [AdditionalpropertiesCanExistByItselfMap](#additionalpropertiescanexistbyitselfmap) | validate(arg: [Map&lt;?, ?&gt;](#additionalpropertiescanexistbyitselfmapbuilder), configuration: SchemaConfiguration) |
-| [AdditionalpropertiesCanExistByItself1BoxedMap](#additionalpropertiescanexistbyitself1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#additionalpropertiescanexistbyitselfmapbuilder), configuration: SchemaConfiguration) |
+| [AdditionalpropertiesCanExistByItselfMap](#additionalpropertiescanexistbyitselfmap) | validate(arg: [Map&lt;*, *&gt;](#additionalpropertiescanexistbyitselfmapbuilder), configuration: SchemaConfiguration) |
+| [AdditionalpropertiesCanExistByItself1BoxedMap](#additionalpropertiescanexistbyitself1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#additionalpropertiescanexistbyitselfmapbuilder), configuration: SchemaConfiguration) |
 | [AdditionalpropertiesCanExistByItself1Boxed](#additionalpropertiescanexistbyitself1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
 

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesDoesNotLookInApplicators.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesDoesNotLookInApplicators.md
@@ -175,19 +175,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [AdditionalpropertiesDoesNotLookInApplicatorsMap](#additionalpropertiesdoesnotlookinapplicatorsmap) | validate(arg: [Map&lt;?, ?&gt;](#additionalpropertiesdoesnotlookinapplicatorsmapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [AdditionalpropertiesDoesNotLookInApplicatorsMap](#additionalpropertiesdoesnotlookinapplicatorsmap) | validate(arg: [Map&lt;*, *&gt;](#additionalpropertiesdoesnotlookinapplicatorsmapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [AdditionalpropertiesDoesNotLookInApplicators1BoxedString](#additionalpropertiesdoesnotlookinapplicators1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [AdditionalpropertiesDoesNotLookInApplicators1BoxedVoid](#additionalpropertiesdoesnotlookinapplicators1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [AdditionalpropertiesDoesNotLookInApplicators1BoxedNumber](#additionalpropertiesdoesnotlookinapplicators1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [AdditionalpropertiesDoesNotLookInApplicators1BoxedBoolean](#additionalpropertiesdoesnotlookinapplicators1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [AdditionalpropertiesDoesNotLookInApplicators1BoxedMap](#additionalpropertiesdoesnotlookinapplicators1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#additionalpropertiesdoesnotlookinapplicatorsmapbuilder), configuration: SchemaConfiguration) |
+| [AdditionalpropertiesDoesNotLookInApplicators1BoxedBoolean](#additionalpropertiesdoesnotlookinapplicators1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [AdditionalpropertiesDoesNotLookInApplicators1BoxedMap](#additionalpropertiesdoesnotlookinapplicators1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#additionalpropertiesdoesnotlookinapplicatorsmapbuilder), configuration: SchemaConfiguration) |
 | [AdditionalpropertiesDoesNotLookInApplicators1BoxedList](#additionalpropertiesdoesnotlookinapplicators1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [AdditionalpropertiesDoesNotLookInApplicators1Boxed](#additionalpropertiesdoesnotlookinapplicators1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -351,19 +351,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [Schema0Map](#schema0map) | validate(arg: [Map&lt;?, ?&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [Schema0Map](#schema0map) | validate(arg: [Map&lt;*, *&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema0BoxedString](#schema0boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema0BoxedVoid](#schema0boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema0BoxedNumber](#schema0boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
+| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox([Map&lt;*, *&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
 | [Schema0BoxedList](#schema0boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema0Boxed](#schema0boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesDoesNotLookInApplicators.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesDoesNotLookInApplicators.md
@@ -13,36 +13,36 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [AdditionalpropertiesDoesNotLookInApplicators.AdditionalpropertiesDoesNotLookInApplicators1Boxed](#additionalpropertiesdoesnotlookinapplicators1boxed)<br> sealed interface for validated payloads |
-| record | [AdditionalpropertiesDoesNotLookInApplicators.AdditionalpropertiesDoesNotLookInApplicators1BoxedVoid](#additionalpropertiesdoesnotlookinapplicators1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AdditionalpropertiesDoesNotLookInApplicators.AdditionalpropertiesDoesNotLookInApplicators1BoxedBoolean](#additionalpropertiesdoesnotlookinapplicators1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AdditionalpropertiesDoesNotLookInApplicators.AdditionalpropertiesDoesNotLookInApplicators1BoxedNumber](#additionalpropertiesdoesnotlookinapplicators1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AdditionalpropertiesDoesNotLookInApplicators.AdditionalpropertiesDoesNotLookInApplicators1BoxedString](#additionalpropertiesdoesnotlookinapplicators1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AdditionalpropertiesDoesNotLookInApplicators.AdditionalpropertiesDoesNotLookInApplicators1BoxedList](#additionalpropertiesdoesnotlookinapplicators1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AdditionalpropertiesDoesNotLookInApplicators.AdditionalpropertiesDoesNotLookInApplicators1BoxedMap](#additionalpropertiesdoesnotlookinapplicators1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AdditionalpropertiesDoesNotLookInApplicators.AdditionalpropertiesDoesNotLookInApplicators1](#additionalpropertiesdoesnotlookinapplicators1)<br> schema class |
-| static class | [AdditionalpropertiesDoesNotLookInApplicators.AdditionalpropertiesDoesNotLookInApplicatorsMapBuilder](#additionalpropertiesdoesnotlookinapplicatorsmapbuilder)<br> builder for Map payloads |
-| static class | [AdditionalpropertiesDoesNotLookInApplicators.AdditionalpropertiesDoesNotLookInApplicatorsMap](#additionalpropertiesdoesnotlookinapplicatorsmap)<br> output class for Map payloads |
+| data class | [AdditionalpropertiesDoesNotLookInApplicators.AdditionalpropertiesDoesNotLookInApplicators1BoxedVoid](#additionalpropertiesdoesnotlookinapplicators1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AdditionalpropertiesDoesNotLookInApplicators.AdditionalpropertiesDoesNotLookInApplicators1BoxedBoolean](#additionalpropertiesdoesnotlookinapplicators1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AdditionalpropertiesDoesNotLookInApplicators.AdditionalpropertiesDoesNotLookInApplicators1BoxedNumber](#additionalpropertiesdoesnotlookinapplicators1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AdditionalpropertiesDoesNotLookInApplicators.AdditionalpropertiesDoesNotLookInApplicators1BoxedString](#additionalpropertiesdoesnotlookinapplicators1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AdditionalpropertiesDoesNotLookInApplicators.AdditionalpropertiesDoesNotLookInApplicators1BoxedList](#additionalpropertiesdoesnotlookinapplicators1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AdditionalpropertiesDoesNotLookInApplicators.AdditionalpropertiesDoesNotLookInApplicators1BoxedMap](#additionalpropertiesdoesnotlookinapplicators1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AdditionalpropertiesDoesNotLookInApplicators.AdditionalpropertiesDoesNotLookInApplicators1](#additionalpropertiesdoesnotlookinapplicators1)<br> schema class |
+| class | [AdditionalpropertiesDoesNotLookInApplicators.AdditionalpropertiesDoesNotLookInApplicatorsMapBuilder](#additionalpropertiesdoesnotlookinapplicatorsmapbuilder)<br> builder for Map payloads |
+| class | [AdditionalpropertiesDoesNotLookInApplicators.AdditionalpropertiesDoesNotLookInApplicatorsMap](#additionalpropertiesdoesnotlookinapplicatorsmap)<br> output class for Map payloads |
 | sealed interface | [AdditionalpropertiesDoesNotLookInApplicators.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [AdditionalpropertiesDoesNotLookInApplicators.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AdditionalpropertiesDoesNotLookInApplicators.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AdditionalpropertiesDoesNotLookInApplicators.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AdditionalpropertiesDoesNotLookInApplicators.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [AdditionalpropertiesDoesNotLookInApplicators.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [AdditionalpropertiesDoesNotLookInApplicators.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AdditionalpropertiesDoesNotLookInApplicators.Schema0](#schema0)<br> schema class |
-| static class | [AdditionalpropertiesDoesNotLookInApplicators.Schema0MapBuilder](#schema0mapbuilder)<br> builder for Map payloads |
-| static class | [AdditionalpropertiesDoesNotLookInApplicators.Schema0Map](#schema0map)<br> output class for Map payloads |
+| data class | [AdditionalpropertiesDoesNotLookInApplicators.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AdditionalpropertiesDoesNotLookInApplicators.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AdditionalpropertiesDoesNotLookInApplicators.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AdditionalpropertiesDoesNotLookInApplicators.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AdditionalpropertiesDoesNotLookInApplicators.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AdditionalpropertiesDoesNotLookInApplicators.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AdditionalpropertiesDoesNotLookInApplicators.Schema0](#schema0)<br> schema class |
+| class | [AdditionalpropertiesDoesNotLookInApplicators.Schema0MapBuilder](#schema0mapbuilder)<br> builder for Map payloads |
+| class | [AdditionalpropertiesDoesNotLookInApplicators.Schema0Map](#schema0map)<br> output class for Map payloads |
 | sealed interface | [AdditionalpropertiesDoesNotLookInApplicators.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [AdditionalpropertiesDoesNotLookInApplicators.FooBoxedVoid](#fooboxedvoid)<br> boxed class to store validated null payloads |
-| record | [AdditionalpropertiesDoesNotLookInApplicators.FooBoxedBoolean](#fooboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AdditionalpropertiesDoesNotLookInApplicators.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
-| record | [AdditionalpropertiesDoesNotLookInApplicators.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
-| record | [AdditionalpropertiesDoesNotLookInApplicators.FooBoxedList](#fooboxedlist)<br> boxed class to store validated List payloads |
-| record | [AdditionalpropertiesDoesNotLookInApplicators.FooBoxedMap](#fooboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AdditionalpropertiesDoesNotLookInApplicators.Foo](#foo)<br> schema class |
+| data class | [AdditionalpropertiesDoesNotLookInApplicators.FooBoxedVoid](#fooboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AdditionalpropertiesDoesNotLookInApplicators.FooBoxedBoolean](#fooboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AdditionalpropertiesDoesNotLookInApplicators.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AdditionalpropertiesDoesNotLookInApplicators.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
+| data class | [AdditionalpropertiesDoesNotLookInApplicators.FooBoxedList](#fooboxedlist)<br> boxed class to store validated List payloads |
+| data class | [AdditionalpropertiesDoesNotLookInApplicators.FooBoxedMap](#fooboxedmap)<br> boxed class to store validated Map payloads |
+| class | [AdditionalpropertiesDoesNotLookInApplicators.Foo](#foo)<br> schema class |
 | sealed interface | [AdditionalpropertiesDoesNotLookInApplicators.AdditionalPropertiesBoxed](#additionalpropertiesboxed)<br> sealed interface for validated payloads |
-| record | [AdditionalpropertiesDoesNotLookInApplicators.AdditionalPropertiesBoxedBoolean](#additionalpropertiesboxedboolean)<br> boxed class to store validated boolean payloads |
-| static class | [AdditionalpropertiesDoesNotLookInApplicators.AdditionalProperties](#additionalproperties)<br> schema class |
+| data class | [AdditionalpropertiesDoesNotLookInApplicators.AdditionalPropertiesBoxedBoolean](#additionalpropertiesboxedboolean)<br> boxed class to store validated boolean payloads |
+| class | [AdditionalpropertiesDoesNotLookInApplicators.AdditionalProperties](#additionalproperties)<br> schema class |
 
 ## AdditionalpropertiesDoesNotLookInApplicators1Boxed
 sealed interface AdditionalpropertiesDoesNotLookInApplicators1Boxed<br>
@@ -77,7 +77,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class AdditionalpropertiesDoesNotLookInApplicators1BoxedBoolean<br>
 implements [AdditionalpropertiesDoesNotLookInApplicators1Boxed](#additionalpropertiesdoesnotlookinapplicators1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -254,7 +254,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -448,7 +448,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class FooBoxedBoolean<br>
 implements [FooBoxed](#fooboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -551,7 +551,7 @@ sealed interface that stores validated payloads using boxed classes
 data class AdditionalPropertiesBoxedBoolean<br>
 implements [AdditionalPropertiesBoxed](#additionalpropertiesboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesWithNullValuedInstanceProperties.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesWithNullValuedInstanceProperties.md
@@ -53,29 +53,25 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.AdditionalpropertiesWithNullValuedInstanceProperties;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.AdditionalpropertiesWithNullValuedInstanceProperties
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // Map validation
-AdditionalpropertiesWithNullValuedInstanceProperties.AdditionalpropertiesWithNullValuedInstancePropertiesMap validatedPayload =
+val validatedPayload: AdditionalpropertiesWithNullValuedInstanceProperties.AdditionalpropertiesWithNullValuedInstancePropertiesMap =
     AdditionalpropertiesWithNullValuedInstanceProperties.AdditionalpropertiesWithNullValuedInstanceProperties1.validate(
-    new AdditionalpropertiesWithNullValuedInstanceProperties.AdditionalpropertiesWithNullValuedInstancePropertiesMapBuilder()
+    AdditionalpropertiesWithNullValuedInstanceProperties.AdditionalpropertiesWithNullValuedInstancePropertiesMapBuilder()
         .additionalProperty("someAdditionalProperty", null)
 
     .build(),
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -87,8 +83,8 @@ AdditionalpropertiesWithNullValuedInstanceProperties.AdditionalpropertiesWithNul
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| [AdditionalpropertiesWithNullValuedInstancePropertiesMap](#additionalpropertieswithnullvaluedinstancepropertiesmap) | validate(arg: [Map&lt;?, ?&gt;](#additionalpropertieswithnullvaluedinstancepropertiesmapbuilder), configuration: SchemaConfiguration) |
-| [AdditionalpropertiesWithNullValuedInstanceProperties1BoxedMap](#additionalpropertieswithnullvaluedinstanceproperties1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#additionalpropertieswithnullvaluedinstancepropertiesmapbuilder), configuration: SchemaConfiguration) |
+| [AdditionalpropertiesWithNullValuedInstancePropertiesMap](#additionalpropertieswithnullvaluedinstancepropertiesmap) | validate(arg: [Map&lt;*, *&gt;](#additionalpropertieswithnullvaluedinstancepropertiesmapbuilder), configuration: SchemaConfiguration) |
+| [AdditionalpropertiesWithNullValuedInstanceProperties1BoxedMap](#additionalpropertieswithnullvaluedinstanceproperties1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#additionalpropertieswithnullvaluedinstancepropertiesmapbuilder), configuration: SchemaConfiguration) |
 | [AdditionalpropertiesWithNullValuedInstanceProperties1Boxed](#additionalpropertieswithnullvaluedinstanceproperties1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
 

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesWithNullValuedInstanceProperties.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesWithNullValuedInstanceProperties.md
@@ -13,13 +13,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [AdditionalpropertiesWithNullValuedInstanceProperties.AdditionalpropertiesWithNullValuedInstanceProperties1Boxed](#additionalpropertieswithnullvaluedinstanceproperties1boxed)<br> sealed interface for validated payloads |
-| record | [AdditionalpropertiesWithNullValuedInstanceProperties.AdditionalpropertiesWithNullValuedInstanceProperties1BoxedMap](#additionalpropertieswithnullvaluedinstanceproperties1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AdditionalpropertiesWithNullValuedInstanceProperties.AdditionalpropertiesWithNullValuedInstanceProperties1](#additionalpropertieswithnullvaluedinstanceproperties1)<br> schema class |
-| static class | [AdditionalpropertiesWithNullValuedInstanceProperties.AdditionalpropertiesWithNullValuedInstancePropertiesMapBuilder](#additionalpropertieswithnullvaluedinstancepropertiesmapbuilder)<br> builder for Map payloads |
-| static class | [AdditionalpropertiesWithNullValuedInstanceProperties.AdditionalpropertiesWithNullValuedInstancePropertiesMap](#additionalpropertieswithnullvaluedinstancepropertiesmap)<br> output class for Map payloads |
+| data class | [AdditionalpropertiesWithNullValuedInstanceProperties.AdditionalpropertiesWithNullValuedInstanceProperties1BoxedMap](#additionalpropertieswithnullvaluedinstanceproperties1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AdditionalpropertiesWithNullValuedInstanceProperties.AdditionalpropertiesWithNullValuedInstanceProperties1](#additionalpropertieswithnullvaluedinstanceproperties1)<br> schema class |
+| class | [AdditionalpropertiesWithNullValuedInstanceProperties.AdditionalpropertiesWithNullValuedInstancePropertiesMapBuilder](#additionalpropertieswithnullvaluedinstancepropertiesmapbuilder)<br> builder for Map payloads |
+| class | [AdditionalpropertiesWithNullValuedInstanceProperties.AdditionalpropertiesWithNullValuedInstancePropertiesMap](#additionalpropertieswithnullvaluedinstancepropertiesmap)<br> output class for Map payloads |
 | sealed interface | [AdditionalpropertiesWithNullValuedInstanceProperties.AdditionalPropertiesBoxed](#additionalpropertiesboxed)<br> sealed interface for validated payloads |
-| record | [AdditionalpropertiesWithNullValuedInstanceProperties.AdditionalPropertiesBoxedVoid](#additionalpropertiesboxedvoid)<br> boxed class to store validated null payloads |
-| static class | [AdditionalpropertiesWithNullValuedInstanceProperties.AdditionalProperties](#additionalproperties)<br> schema class |
+| data class | [AdditionalpropertiesWithNullValuedInstanceProperties.AdditionalPropertiesBoxedVoid](#additionalpropertiesboxedvoid)<br> boxed class to store validated null payloads |
+| class | [AdditionalpropertiesWithNullValuedInstanceProperties.AdditionalProperties](#additionalproperties)<br> schema class |
 
 ## AdditionalpropertiesWithNullValuedInstanceProperties1Boxed
 sealed interface AdditionalpropertiesWithNullValuedInstanceProperties1Boxed<br>

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesWithSchema.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesWithSchema.md
@@ -69,29 +69,25 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.AdditionalpropertiesWithSchema;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.AdditionalpropertiesWithSchema
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // Map validation
-AdditionalpropertiesWithSchema.AdditionalpropertiesWithSchemaMap validatedPayload =
+val validatedPayload: AdditionalpropertiesWithSchema.AdditionalpropertiesWithSchemaMap =
     AdditionalpropertiesWithSchema.AdditionalpropertiesWithSchema1.validate(
-    new AdditionalpropertiesWithSchema.AdditionalpropertiesWithSchemaMapBuilder()
+    AdditionalpropertiesWithSchema.AdditionalpropertiesWithSchemaMapBuilder()
         .additionalProperty("someAdditionalProperty", true)
 
     .build(),
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -104,8 +100,8 @@ AdditionalpropertiesWithSchema.AdditionalpropertiesWithSchemaMap validatedPayloa
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| [AdditionalpropertiesWithSchemaMap](#additionalpropertieswithschemamap) | validate(arg: [Map&lt;?, ?&gt;](#additionalpropertieswithschemamapbuilder), configuration: SchemaConfiguration) |
-| [AdditionalpropertiesWithSchema1BoxedMap](#additionalpropertieswithschema1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#additionalpropertieswithschemamapbuilder), configuration: SchemaConfiguration) |
+| [AdditionalpropertiesWithSchemaMap](#additionalpropertieswithschemamap) | validate(arg: [Map&lt;*, *&gt;](#additionalpropertieswithschemamapbuilder), configuration: SchemaConfiguration) |
+| [AdditionalpropertiesWithSchema1BoxedMap](#additionalpropertieswithschema1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#additionalpropertieswithschemamapbuilder), configuration: SchemaConfiguration) |
 | [AdditionalpropertiesWithSchema1Boxed](#additionalpropertieswithschema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
 

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesWithSchema.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AdditionalpropertiesWithSchema.md
@@ -13,29 +13,29 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [AdditionalpropertiesWithSchema.AdditionalpropertiesWithSchema1Boxed](#additionalpropertieswithschema1boxed)<br> sealed interface for validated payloads |
-| record | [AdditionalpropertiesWithSchema.AdditionalpropertiesWithSchema1BoxedMap](#additionalpropertieswithschema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AdditionalpropertiesWithSchema.AdditionalpropertiesWithSchema1](#additionalpropertieswithschema1)<br> schema class |
-| static class | [AdditionalpropertiesWithSchema.AdditionalpropertiesWithSchemaMapBuilder](#additionalpropertieswithschemamapbuilder)<br> builder for Map payloads |
-| static class | [AdditionalpropertiesWithSchema.AdditionalpropertiesWithSchemaMap](#additionalpropertieswithschemamap)<br> output class for Map payloads |
+| data class | [AdditionalpropertiesWithSchema.AdditionalpropertiesWithSchema1BoxedMap](#additionalpropertieswithschema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AdditionalpropertiesWithSchema.AdditionalpropertiesWithSchema1](#additionalpropertieswithschema1)<br> schema class |
+| class | [AdditionalpropertiesWithSchema.AdditionalpropertiesWithSchemaMapBuilder](#additionalpropertieswithschemamapbuilder)<br> builder for Map payloads |
+| class | [AdditionalpropertiesWithSchema.AdditionalpropertiesWithSchemaMap](#additionalpropertieswithschemamap)<br> output class for Map payloads |
 | sealed interface | [AdditionalpropertiesWithSchema.BarBoxed](#barboxed)<br> sealed interface for validated payloads |
-| record | [AdditionalpropertiesWithSchema.BarBoxedVoid](#barboxedvoid)<br> boxed class to store validated null payloads |
-| record | [AdditionalpropertiesWithSchema.BarBoxedBoolean](#barboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AdditionalpropertiesWithSchema.BarBoxedNumber](#barboxednumber)<br> boxed class to store validated Number payloads |
-| record | [AdditionalpropertiesWithSchema.BarBoxedString](#barboxedstring)<br> boxed class to store validated String payloads |
-| record | [AdditionalpropertiesWithSchema.BarBoxedList](#barboxedlist)<br> boxed class to store validated List payloads |
-| record | [AdditionalpropertiesWithSchema.BarBoxedMap](#barboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AdditionalpropertiesWithSchema.Bar](#bar)<br> schema class |
+| data class | [AdditionalpropertiesWithSchema.BarBoxedVoid](#barboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AdditionalpropertiesWithSchema.BarBoxedBoolean](#barboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AdditionalpropertiesWithSchema.BarBoxedNumber](#barboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AdditionalpropertiesWithSchema.BarBoxedString](#barboxedstring)<br> boxed class to store validated String payloads |
+| data class | [AdditionalpropertiesWithSchema.BarBoxedList](#barboxedlist)<br> boxed class to store validated List payloads |
+| data class | [AdditionalpropertiesWithSchema.BarBoxedMap](#barboxedmap)<br> boxed class to store validated Map payloads |
+| class | [AdditionalpropertiesWithSchema.Bar](#bar)<br> schema class |
 | sealed interface | [AdditionalpropertiesWithSchema.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [AdditionalpropertiesWithSchema.FooBoxedVoid](#fooboxedvoid)<br> boxed class to store validated null payloads |
-| record | [AdditionalpropertiesWithSchema.FooBoxedBoolean](#fooboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AdditionalpropertiesWithSchema.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
-| record | [AdditionalpropertiesWithSchema.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
-| record | [AdditionalpropertiesWithSchema.FooBoxedList](#fooboxedlist)<br> boxed class to store validated List payloads |
-| record | [AdditionalpropertiesWithSchema.FooBoxedMap](#fooboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AdditionalpropertiesWithSchema.Foo](#foo)<br> schema class |
+| data class | [AdditionalpropertiesWithSchema.FooBoxedVoid](#fooboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AdditionalpropertiesWithSchema.FooBoxedBoolean](#fooboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AdditionalpropertiesWithSchema.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AdditionalpropertiesWithSchema.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
+| data class | [AdditionalpropertiesWithSchema.FooBoxedList](#fooboxedlist)<br> boxed class to store validated List payloads |
+| data class | [AdditionalpropertiesWithSchema.FooBoxedMap](#fooboxedmap)<br> boxed class to store validated Map payloads |
+| class | [AdditionalpropertiesWithSchema.Foo](#foo)<br> schema class |
 | sealed interface | [AdditionalpropertiesWithSchema.AdditionalPropertiesBoxed](#additionalpropertiesboxed)<br> sealed interface for validated payloads |
-| record | [AdditionalpropertiesWithSchema.AdditionalPropertiesBoxedBoolean](#additionalpropertiesboxedboolean)<br> boxed class to store validated boolean payloads |
-| static class | [AdditionalpropertiesWithSchema.AdditionalProperties](#additionalproperties)<br> schema class |
+| data class | [AdditionalpropertiesWithSchema.AdditionalPropertiesBoxedBoolean](#additionalpropertiesboxedboolean)<br> boxed class to store validated boolean payloads |
+| class | [AdditionalpropertiesWithSchema.AdditionalProperties](#additionalproperties)<br> schema class |
 
 ## AdditionalpropertiesWithSchema1Boxed
 sealed interface AdditionalpropertiesWithSchema1Boxed<br>
@@ -187,7 +187,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class BarBoxedBoolean<br>
 implements [BarBoxed](#barboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -312,7 +312,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class FooBoxedBoolean<br>
 implements [FooBoxed](#fooboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -415,7 +415,7 @@ sealed interface that stores validated payloads using boxed classes
 data class AdditionalPropertiesBoxedBoolean<br>
 implements [AdditionalPropertiesBoxed](#additionalpropertiesboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/Allof.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/Allof.md
@@ -177,19 +177,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Allof1BoxedString](#allof1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Allof1BoxedVoid](#allof1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Allof1BoxedNumber](#allof1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Allof1BoxedBoolean](#allof1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Allof1BoxedMap](#allof1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Allof1BoxedBoolean](#allof1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Allof1BoxedMap](#allof1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Allof1BoxedList](#allof1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Allof1Boxed](#allof1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -325,19 +325,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [Schema1Map](#schema1map) | validate(arg: [Map&lt;?, ?&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [Schema1Map](#schema1map) | validate(arg: [Map&lt;*, *&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema1BoxedString](#schema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema1BoxedVoid](#schema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema1BoxedNumber](#schema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
+| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
 | [Schema1BoxedList](#schema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema1Boxed](#schema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -562,19 +562,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [Schema0Map](#schema0map) | validate(arg: [Map&lt;?, ?&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [Schema0Map](#schema0map) | validate(arg: [Map&lt;*, *&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema0BoxedString](#schema0boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema0BoxedVoid](#schema0boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema0BoxedNumber](#schema0boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
+| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox([Map&lt;*, *&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
 | [Schema0BoxedList](#schema0boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema0Boxed](#schema0boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/Allof.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/Allof.md
@@ -13,39 +13,39 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [Allof.Allof1Boxed](#allof1boxed)<br> sealed interface for validated payloads |
-| record | [Allof.Allof1BoxedVoid](#allof1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [Allof.Allof1BoxedBoolean](#allof1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [Allof.Allof1BoxedNumber](#allof1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [Allof.Allof1BoxedString](#allof1boxedstring)<br> boxed class to store validated String payloads |
-| record | [Allof.Allof1BoxedList](#allof1boxedlist)<br> boxed class to store validated List payloads |
-| record | [Allof.Allof1BoxedMap](#allof1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [Allof.Allof1](#allof1)<br> schema class |
+| data class | [Allof.Allof1BoxedVoid](#allof1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [Allof.Allof1BoxedBoolean](#allof1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [Allof.Allof1BoxedNumber](#allof1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [Allof.Allof1BoxedString](#allof1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [Allof.Allof1BoxedList](#allof1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [Allof.Allof1BoxedMap](#allof1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [Allof.Allof1](#allof1)<br> schema class |
 | sealed interface | [Allof.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [Allof.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [Allof.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [Allof.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [Allof.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [Allof.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [Allof.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [Allof.Schema1](#schema1)<br> schema class |
-| static class | [Allof.Schema1MapBuilder](#schema1mapbuilder)<br> builder for Map payloads |
-| static class | [Allof.Schema1Map](#schema1map)<br> output class for Map payloads |
+| data class | [Allof.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [Allof.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [Allof.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [Allof.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [Allof.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [Allof.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [Allof.Schema1](#schema1)<br> schema class |
+| class | [Allof.Schema1MapBuilder](#schema1mapbuilder)<br> builder for Map payloads |
+| class | [Allof.Schema1Map](#schema1map)<br> output class for Map payloads |
 | sealed interface | [Allof.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [Allof.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
-| static class | [Allof.Foo](#foo)<br> schema class |
+| data class | [Allof.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
+| class | [Allof.Foo](#foo)<br> schema class |
 | sealed interface | [Allof.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [Allof.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [Allof.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [Allof.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [Allof.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [Allof.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [Allof.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [Allof.Schema0](#schema0)<br> schema class |
-| static class | [Allof.Schema0MapBuilder](#schema0mapbuilder)<br> builder for Map payloads |
-| static class | [Allof.Schema0Map](#schema0map)<br> output class for Map payloads |
+| data class | [Allof.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [Allof.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [Allof.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [Allof.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [Allof.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [Allof.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [Allof.Schema0](#schema0)<br> schema class |
+| class | [Allof.Schema0MapBuilder](#schema0mapbuilder)<br> builder for Map payloads |
+| class | [Allof.Schema0Map](#schema0map)<br> output class for Map payloads |
 | sealed interface | [Allof.BarBoxed](#barboxed)<br> sealed interface for validated payloads |
-| record | [Allof.BarBoxedNumber](#barboxednumber)<br> boxed class to store validated Number payloads |
-| static class | [Allof.Bar](#bar)<br> schema class |
+| data class | [Allof.BarBoxedNumber](#barboxednumber)<br> boxed class to store validated Number payloads |
+| class | [Allof.Bar](#bar)<br> schema class |
 
 ## Allof1Boxed
 sealed interface Allof1Boxed<br>
@@ -80,7 +80,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Allof1BoxedBoolean<br>
 implements [Allof1Boxed](#allof1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -227,7 +227,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema1BoxedBoolean<br>
 implements [Schema1Boxed](#schema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -464,7 +464,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AllofCombinedWithAnyofOneof.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AllofCombinedWithAnyofOneof.md
@@ -175,19 +175,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [AllofCombinedWithAnyofOneof1BoxedString](#allofcombinedwithanyofoneof1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [AllofCombinedWithAnyofOneof1BoxedVoid](#allofcombinedwithanyofoneof1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [AllofCombinedWithAnyofOneof1BoxedNumber](#allofcombinedwithanyofoneof1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [AllofCombinedWithAnyofOneof1BoxedBoolean](#allofcombinedwithanyofoneof1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [AllofCombinedWithAnyofOneof1BoxedMap](#allofcombinedwithanyofoneof1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [AllofCombinedWithAnyofOneof1BoxedBoolean](#allofcombinedwithanyofoneof1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [AllofCombinedWithAnyofOneof1BoxedMap](#allofcombinedwithanyofoneof1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [AllofCombinedWithAnyofOneof1BoxedList](#allofcombinedwithanyofoneof1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [AllofCombinedWithAnyofOneof1Boxed](#allofcombinedwithanyofoneof1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -322,19 +322,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema0BoxedString](#schema0boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema0BoxedVoid](#schema0boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema0BoxedNumber](#schema0boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema0BoxedList](#schema0boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema0Boxed](#schema0boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -469,19 +469,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema01BoxedString](#schema01boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema01BoxedVoid](#schema01boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema01BoxedNumber](#schema01boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema01BoxedBoolean](#schema01boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema01BoxedMap](#schema01boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema01BoxedBoolean](#schema01boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema01BoxedMap](#schema01boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema01BoxedList](#schema01boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema01Boxed](#schema01boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -616,19 +616,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema02BoxedString](#schema02boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema02BoxedVoid](#schema02boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema02BoxedNumber](#schema02boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema02BoxedBoolean](#schema02boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema02BoxedMap](#schema02boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema02BoxedBoolean](#schema02boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema02BoxedMap](#schema02boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema02BoxedList](#schema02boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema02Boxed](#schema02boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AllofCombinedWithAnyofOneof.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AllofCombinedWithAnyofOneof.md
@@ -11,37 +11,37 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [AllofCombinedWithAnyofOneof.AllofCombinedWithAnyofOneof1Boxed](#allofcombinedwithanyofoneof1boxed)<br> sealed interface for validated payloads |
-| record | [AllofCombinedWithAnyofOneof.AllofCombinedWithAnyofOneof1BoxedVoid](#allofcombinedwithanyofoneof1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofCombinedWithAnyofOneof.AllofCombinedWithAnyofOneof1BoxedBoolean](#allofcombinedwithanyofoneof1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofCombinedWithAnyofOneof.AllofCombinedWithAnyofOneof1BoxedNumber](#allofcombinedwithanyofoneof1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofCombinedWithAnyofOneof.AllofCombinedWithAnyofOneof1BoxedString](#allofcombinedwithanyofoneof1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofCombinedWithAnyofOneof.AllofCombinedWithAnyofOneof1BoxedList](#allofcombinedwithanyofoneof1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofCombinedWithAnyofOneof.AllofCombinedWithAnyofOneof1BoxedMap](#allofcombinedwithanyofoneof1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofCombinedWithAnyofOneof.AllofCombinedWithAnyofOneof1](#allofcombinedwithanyofoneof1)<br> schema class |
+| data class | [AllofCombinedWithAnyofOneof.AllofCombinedWithAnyofOneof1BoxedVoid](#allofcombinedwithanyofoneof1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofCombinedWithAnyofOneof.AllofCombinedWithAnyofOneof1BoxedBoolean](#allofcombinedwithanyofoneof1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofCombinedWithAnyofOneof.AllofCombinedWithAnyofOneof1BoxedNumber](#allofcombinedwithanyofoneof1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofCombinedWithAnyofOneof.AllofCombinedWithAnyofOneof1BoxedString](#allofcombinedwithanyofoneof1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofCombinedWithAnyofOneof.AllofCombinedWithAnyofOneof1BoxedList](#allofcombinedwithanyofoneof1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofCombinedWithAnyofOneof.AllofCombinedWithAnyofOneof1BoxedMap](#allofcombinedwithanyofoneof1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofCombinedWithAnyofOneof.AllofCombinedWithAnyofOneof1](#allofcombinedwithanyofoneof1)<br> schema class |
 | sealed interface | [AllofCombinedWithAnyofOneof.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofCombinedWithAnyofOneof.Schema0](#schema0)<br> schema class |
+| data class | [AllofCombinedWithAnyofOneof.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofCombinedWithAnyofOneof.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofCombinedWithAnyofOneof.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofCombinedWithAnyofOneof.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofCombinedWithAnyofOneof.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofCombinedWithAnyofOneof.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofCombinedWithAnyofOneof.Schema0](#schema0)<br> schema class |
 | sealed interface | [AllofCombinedWithAnyofOneof.Schema01Boxed](#schema01boxed)<br> sealed interface for validated payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema01BoxedVoid](#schema01boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema01BoxedBoolean](#schema01boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema01BoxedNumber](#schema01boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema01BoxedString](#schema01boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema01BoxedList](#schema01boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema01BoxedMap](#schema01boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofCombinedWithAnyofOneof.Schema01](#schema01)<br> schema class |
+| data class | [AllofCombinedWithAnyofOneof.Schema01BoxedVoid](#schema01boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofCombinedWithAnyofOneof.Schema01BoxedBoolean](#schema01boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofCombinedWithAnyofOneof.Schema01BoxedNumber](#schema01boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofCombinedWithAnyofOneof.Schema01BoxedString](#schema01boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofCombinedWithAnyofOneof.Schema01BoxedList](#schema01boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofCombinedWithAnyofOneof.Schema01BoxedMap](#schema01boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofCombinedWithAnyofOneof.Schema01](#schema01)<br> schema class |
 | sealed interface | [AllofCombinedWithAnyofOneof.Schema02Boxed](#schema02boxed)<br> sealed interface for validated payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema02BoxedVoid](#schema02boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema02BoxedBoolean](#schema02boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema02BoxedNumber](#schema02boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema02BoxedString](#schema02boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema02BoxedList](#schema02boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofCombinedWithAnyofOneof.Schema02BoxedMap](#schema02boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofCombinedWithAnyofOneof.Schema02](#schema02)<br> schema class |
+| data class | [AllofCombinedWithAnyofOneof.Schema02BoxedVoid](#schema02boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofCombinedWithAnyofOneof.Schema02BoxedBoolean](#schema02boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofCombinedWithAnyofOneof.Schema02BoxedNumber](#schema02boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofCombinedWithAnyofOneof.Schema02BoxedString](#schema02boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofCombinedWithAnyofOneof.Schema02BoxedList](#schema02boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofCombinedWithAnyofOneof.Schema02BoxedMap](#schema02boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofCombinedWithAnyofOneof.Schema02](#schema02)<br> schema class |
 
 ## AllofCombinedWithAnyofOneof1Boxed
 sealed interface AllofCombinedWithAnyofOneof1Boxed<br>
@@ -76,7 +76,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class AllofCombinedWithAnyofOneof1BoxedBoolean<br>
 implements [AllofCombinedWithAnyofOneof1Boxed](#allofcombinedwithanyofoneof1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -225,7 +225,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -372,7 +372,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema01BoxedBoolean<br>
 implements [Schema01Boxed](#schema01boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -519,7 +519,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema02BoxedBoolean<br>
 implements [Schema02Boxed](#schema02boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AllofSimpleTypes.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AllofSimpleTypes.md
@@ -165,19 +165,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [AllofSimpleTypes1BoxedString](#allofsimpletypes1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [AllofSimpleTypes1BoxedVoid](#allofsimpletypes1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [AllofSimpleTypes1BoxedNumber](#allofsimpletypes1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [AllofSimpleTypes1BoxedBoolean](#allofsimpletypes1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [AllofSimpleTypes1BoxedMap](#allofsimpletypes1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [AllofSimpleTypes1BoxedBoolean](#allofsimpletypes1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [AllofSimpleTypes1BoxedMap](#allofsimpletypes1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [AllofSimpleTypes1BoxedList](#allofsimpletypes1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [AllofSimpleTypes1Boxed](#allofsimpletypes1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -312,19 +312,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema1BoxedString](#schema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema1BoxedVoid](#schema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema1BoxedNumber](#schema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema1BoxedList](#schema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema1Boxed](#schema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -459,19 +459,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema0BoxedString](#schema0boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema0BoxedVoid](#schema0boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema0BoxedNumber](#schema0boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema0BoxedList](#schema0boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema0Boxed](#schema0boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AllofSimpleTypes.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AllofSimpleTypes.md
@@ -11,29 +11,29 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [AllofSimpleTypes.AllofSimpleTypes1Boxed](#allofsimpletypes1boxed)<br> sealed interface for validated payloads |
-| record | [AllofSimpleTypes.AllofSimpleTypes1BoxedVoid](#allofsimpletypes1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofSimpleTypes.AllofSimpleTypes1BoxedBoolean](#allofsimpletypes1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofSimpleTypes.AllofSimpleTypes1BoxedNumber](#allofsimpletypes1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofSimpleTypes.AllofSimpleTypes1BoxedString](#allofsimpletypes1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofSimpleTypes.AllofSimpleTypes1BoxedList](#allofsimpletypes1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofSimpleTypes.AllofSimpleTypes1BoxedMap](#allofsimpletypes1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofSimpleTypes.AllofSimpleTypes1](#allofsimpletypes1)<br> schema class |
+| data class | [AllofSimpleTypes.AllofSimpleTypes1BoxedVoid](#allofsimpletypes1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofSimpleTypes.AllofSimpleTypes1BoxedBoolean](#allofsimpletypes1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofSimpleTypes.AllofSimpleTypes1BoxedNumber](#allofsimpletypes1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofSimpleTypes.AllofSimpleTypes1BoxedString](#allofsimpletypes1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofSimpleTypes.AllofSimpleTypes1BoxedList](#allofsimpletypes1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofSimpleTypes.AllofSimpleTypes1BoxedMap](#allofsimpletypes1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofSimpleTypes.AllofSimpleTypes1](#allofsimpletypes1)<br> schema class |
 | sealed interface | [AllofSimpleTypes.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [AllofSimpleTypes.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofSimpleTypes.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofSimpleTypes.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofSimpleTypes.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofSimpleTypes.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofSimpleTypes.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofSimpleTypes.Schema1](#schema1)<br> schema class |
+| data class | [AllofSimpleTypes.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofSimpleTypes.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofSimpleTypes.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofSimpleTypes.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofSimpleTypes.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofSimpleTypes.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofSimpleTypes.Schema1](#schema1)<br> schema class |
 | sealed interface | [AllofSimpleTypes.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [AllofSimpleTypes.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofSimpleTypes.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofSimpleTypes.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofSimpleTypes.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofSimpleTypes.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofSimpleTypes.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofSimpleTypes.Schema0](#schema0)<br> schema class |
+| data class | [AllofSimpleTypes.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofSimpleTypes.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofSimpleTypes.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofSimpleTypes.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofSimpleTypes.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofSimpleTypes.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofSimpleTypes.Schema0](#schema0)<br> schema class |
 
 ## AllofSimpleTypes1Boxed
 sealed interface AllofSimpleTypes1Boxed<br>
@@ -68,7 +68,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class AllofSimpleTypes1BoxedBoolean<br>
 implements [AllofSimpleTypes1Boxed](#allofsimpletypes1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -215,7 +215,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema1BoxedBoolean<br>
 implements [Schema1Boxed](#schema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -362,7 +362,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AllofWithBaseSchema.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AllofWithBaseSchema.md
@@ -184,19 +184,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [AllofWithBaseSchemaMap](#allofwithbaseschemamap) | validate(arg: [Map&lt;?, ?&gt;](#allofwithbaseschemamapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [AllofWithBaseSchemaMap](#allofwithbaseschemamap) | validate(arg: [Map&lt;*, *&gt;](#allofwithbaseschemamapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [AllofWithBaseSchema1BoxedString](#allofwithbaseschema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [AllofWithBaseSchema1BoxedVoid](#allofwithbaseschema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [AllofWithBaseSchema1BoxedNumber](#allofwithbaseschema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [AllofWithBaseSchema1BoxedBoolean](#allofwithbaseschema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [AllofWithBaseSchema1BoxedMap](#allofwithbaseschema1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#allofwithbaseschemamapbuilder), configuration: SchemaConfiguration) |
+| [AllofWithBaseSchema1BoxedBoolean](#allofwithbaseschema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [AllofWithBaseSchema1BoxedMap](#allofwithbaseschema1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#allofwithbaseschemamapbuilder), configuration: SchemaConfiguration) |
 | [AllofWithBaseSchema1BoxedList](#allofwithbaseschema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [AllofWithBaseSchema1Boxed](#allofwithbaseschema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -424,19 +424,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [Schema1Map](#schema1map) | validate(arg: [Map&lt;?, ?&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [Schema1Map](#schema1map) | validate(arg: [Map&lt;*, *&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema1BoxedString](#schema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema1BoxedVoid](#schema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema1BoxedNumber](#schema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
+| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
 | [Schema1BoxedList](#schema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema1Boxed](#schema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -661,19 +661,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [Schema0Map](#schema0map) | validate(arg: [Map&lt;?, ?&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [Schema0Map](#schema0map) | validate(arg: [Map&lt;*, *&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema0BoxedString](#schema0boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema0BoxedVoid](#schema0boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema0BoxedNumber](#schema0boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
+| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox([Map&lt;*, *&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
 | [Schema0BoxedList](#schema0boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema0Boxed](#schema0boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AllofWithBaseSchema.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AllofWithBaseSchema.md
@@ -13,44 +13,44 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [AllofWithBaseSchema.AllofWithBaseSchema1Boxed](#allofwithbaseschema1boxed)<br> sealed interface for validated payloads |
-| record | [AllofWithBaseSchema.AllofWithBaseSchema1BoxedVoid](#allofwithbaseschema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofWithBaseSchema.AllofWithBaseSchema1BoxedBoolean](#allofwithbaseschema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofWithBaseSchema.AllofWithBaseSchema1BoxedNumber](#allofwithbaseschema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofWithBaseSchema.AllofWithBaseSchema1BoxedString](#allofwithbaseschema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofWithBaseSchema.AllofWithBaseSchema1BoxedList](#allofwithbaseschema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofWithBaseSchema.AllofWithBaseSchema1BoxedMap](#allofwithbaseschema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofWithBaseSchema.AllofWithBaseSchema1](#allofwithbaseschema1)<br> schema class |
-| static class | [AllofWithBaseSchema.AllofWithBaseSchemaMapBuilder](#allofwithbaseschemamapbuilder)<br> builder for Map payloads |
-| static class | [AllofWithBaseSchema.AllofWithBaseSchemaMap](#allofwithbaseschemamap)<br> output class for Map payloads |
+| data class | [AllofWithBaseSchema.AllofWithBaseSchema1BoxedVoid](#allofwithbaseschema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofWithBaseSchema.AllofWithBaseSchema1BoxedBoolean](#allofwithbaseschema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofWithBaseSchema.AllofWithBaseSchema1BoxedNumber](#allofwithbaseschema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofWithBaseSchema.AllofWithBaseSchema1BoxedString](#allofwithbaseschema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofWithBaseSchema.AllofWithBaseSchema1BoxedList](#allofwithbaseschema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofWithBaseSchema.AllofWithBaseSchema1BoxedMap](#allofwithbaseschema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofWithBaseSchema.AllofWithBaseSchema1](#allofwithbaseschema1)<br> schema class |
+| class | [AllofWithBaseSchema.AllofWithBaseSchemaMapBuilder](#allofwithbaseschemamapbuilder)<br> builder for Map payloads |
+| class | [AllofWithBaseSchema.AllofWithBaseSchemaMap](#allofwithbaseschemamap)<br> output class for Map payloads |
 | sealed interface | [AllofWithBaseSchema.BarBoxed](#barboxed)<br> sealed interface for validated payloads |
-| record | [AllofWithBaseSchema.BarBoxedNumber](#barboxednumber)<br> boxed class to store validated Number payloads |
-| static class | [AllofWithBaseSchema.Bar](#bar)<br> schema class |
+| data class | [AllofWithBaseSchema.BarBoxedNumber](#barboxednumber)<br> boxed class to store validated Number payloads |
+| class | [AllofWithBaseSchema.Bar](#bar)<br> schema class |
 | sealed interface | [AllofWithBaseSchema.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [AllofWithBaseSchema.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofWithBaseSchema.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofWithBaseSchema.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofWithBaseSchema.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofWithBaseSchema.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofWithBaseSchema.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofWithBaseSchema.Schema1](#schema1)<br> schema class |
-| static class | [AllofWithBaseSchema.Schema1MapBuilder](#schema1mapbuilder)<br> builder for Map payloads |
-| static class | [AllofWithBaseSchema.Schema1Map](#schema1map)<br> output class for Map payloads |
+| data class | [AllofWithBaseSchema.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofWithBaseSchema.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofWithBaseSchema.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofWithBaseSchema.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofWithBaseSchema.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofWithBaseSchema.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofWithBaseSchema.Schema1](#schema1)<br> schema class |
+| class | [AllofWithBaseSchema.Schema1MapBuilder](#schema1mapbuilder)<br> builder for Map payloads |
+| class | [AllofWithBaseSchema.Schema1Map](#schema1map)<br> output class for Map payloads |
 | sealed interface | [AllofWithBaseSchema.BazBoxed](#bazboxed)<br> sealed interface for validated payloads |
-| record | [AllofWithBaseSchema.BazBoxedVoid](#bazboxedvoid)<br> boxed class to store validated null payloads |
-| static class | [AllofWithBaseSchema.Baz](#baz)<br> schema class |
+| data class | [AllofWithBaseSchema.BazBoxedVoid](#bazboxedvoid)<br> boxed class to store validated null payloads |
+| class | [AllofWithBaseSchema.Baz](#baz)<br> schema class |
 | sealed interface | [AllofWithBaseSchema.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [AllofWithBaseSchema.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofWithBaseSchema.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofWithBaseSchema.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofWithBaseSchema.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofWithBaseSchema.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofWithBaseSchema.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofWithBaseSchema.Schema0](#schema0)<br> schema class |
-| static class | [AllofWithBaseSchema.Schema0MapBuilder](#schema0mapbuilder)<br> builder for Map payloads |
-| static class | [AllofWithBaseSchema.Schema0Map](#schema0map)<br> output class for Map payloads |
+| data class | [AllofWithBaseSchema.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofWithBaseSchema.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofWithBaseSchema.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofWithBaseSchema.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofWithBaseSchema.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofWithBaseSchema.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofWithBaseSchema.Schema0](#schema0)<br> schema class |
+| class | [AllofWithBaseSchema.Schema0MapBuilder](#schema0mapbuilder)<br> builder for Map payloads |
+| class | [AllofWithBaseSchema.Schema0Map](#schema0map)<br> output class for Map payloads |
 | sealed interface | [AllofWithBaseSchema.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [AllofWithBaseSchema.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
-| static class | [AllofWithBaseSchema.Foo](#foo)<br> schema class |
+| data class | [AllofWithBaseSchema.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
+| class | [AllofWithBaseSchema.Foo](#foo)<br> schema class |
 
 ## AllofWithBaseSchema1Boxed
 sealed interface AllofWithBaseSchema1Boxed<br>
@@ -85,7 +85,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class AllofWithBaseSchema1BoxedBoolean<br>
 implements [AllofWithBaseSchema1Boxed](#allofwithbaseschema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -326,7 +326,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema1BoxedBoolean<br>
 implements [Schema1Boxed](#schema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -563,7 +563,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AllofWithOneEmptySchema.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AllofWithOneEmptySchema.md
@@ -11,21 +11,21 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [AllofWithOneEmptySchema.AllofWithOneEmptySchema1Boxed](#allofwithoneemptyschema1boxed)<br> sealed interface for validated payloads |
-| record | [AllofWithOneEmptySchema.AllofWithOneEmptySchema1BoxedVoid](#allofwithoneemptyschema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofWithOneEmptySchema.AllofWithOneEmptySchema1BoxedBoolean](#allofwithoneemptyschema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofWithOneEmptySchema.AllofWithOneEmptySchema1BoxedNumber](#allofwithoneemptyschema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofWithOneEmptySchema.AllofWithOneEmptySchema1BoxedString](#allofwithoneemptyschema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofWithOneEmptySchema.AllofWithOneEmptySchema1BoxedList](#allofwithoneemptyschema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofWithOneEmptySchema.AllofWithOneEmptySchema1BoxedMap](#allofwithoneemptyschema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofWithOneEmptySchema.AllofWithOneEmptySchema1](#allofwithoneemptyschema1)<br> schema class |
+| data class | [AllofWithOneEmptySchema.AllofWithOneEmptySchema1BoxedVoid](#allofwithoneemptyschema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofWithOneEmptySchema.AllofWithOneEmptySchema1BoxedBoolean](#allofwithoneemptyschema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofWithOneEmptySchema.AllofWithOneEmptySchema1BoxedNumber](#allofwithoneemptyschema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofWithOneEmptySchema.AllofWithOneEmptySchema1BoxedString](#allofwithoneemptyschema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofWithOneEmptySchema.AllofWithOneEmptySchema1BoxedList](#allofwithoneemptyschema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofWithOneEmptySchema.AllofWithOneEmptySchema1BoxedMap](#allofwithoneemptyschema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofWithOneEmptySchema.AllofWithOneEmptySchema1](#allofwithoneemptyschema1)<br> schema class |
 | sealed interface | [AllofWithOneEmptySchema.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [AllofWithOneEmptySchema.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofWithOneEmptySchema.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofWithOneEmptySchema.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofWithOneEmptySchema.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofWithOneEmptySchema.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofWithOneEmptySchema.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofWithOneEmptySchema.Schema0](#schema0)<br> schema class |
+| data class | [AllofWithOneEmptySchema.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofWithOneEmptySchema.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofWithOneEmptySchema.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofWithOneEmptySchema.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofWithOneEmptySchema.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofWithOneEmptySchema.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofWithOneEmptySchema.Schema0](#schema0)<br> schema class |
 
 ## AllofWithOneEmptySchema1Boxed
 sealed interface AllofWithOneEmptySchema1Boxed<br>
@@ -60,7 +60,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class AllofWithOneEmptySchema1BoxedBoolean<br>
 implements [AllofWithOneEmptySchema1Boxed](#allofwithoneemptyschema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -207,7 +207,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AllofWithOneEmptySchema.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AllofWithOneEmptySchema.md
@@ -157,19 +157,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [AllofWithOneEmptySchema1BoxedString](#allofwithoneemptyschema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [AllofWithOneEmptySchema1BoxedVoid](#allofwithoneemptyschema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [AllofWithOneEmptySchema1BoxedNumber](#allofwithoneemptyschema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [AllofWithOneEmptySchema1BoxedBoolean](#allofwithoneemptyschema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [AllofWithOneEmptySchema1BoxedMap](#allofwithoneemptyschema1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [AllofWithOneEmptySchema1BoxedBoolean](#allofwithoneemptyschema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [AllofWithOneEmptySchema1BoxedMap](#allofwithoneemptyschema1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [AllofWithOneEmptySchema1BoxedList](#allofwithoneemptyschema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [AllofWithOneEmptySchema1Boxed](#allofwithoneemptyschema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AllofWithTheFirstEmptySchema.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AllofWithTheFirstEmptySchema.md
@@ -11,24 +11,24 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [AllofWithTheFirstEmptySchema.AllofWithTheFirstEmptySchema1Boxed](#allofwiththefirstemptyschema1boxed)<br> sealed interface for validated payloads |
-| record | [AllofWithTheFirstEmptySchema.AllofWithTheFirstEmptySchema1BoxedVoid](#allofwiththefirstemptyschema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofWithTheFirstEmptySchema.AllofWithTheFirstEmptySchema1BoxedBoolean](#allofwiththefirstemptyschema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofWithTheFirstEmptySchema.AllofWithTheFirstEmptySchema1BoxedNumber](#allofwiththefirstemptyschema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofWithTheFirstEmptySchema.AllofWithTheFirstEmptySchema1BoxedString](#allofwiththefirstemptyschema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofWithTheFirstEmptySchema.AllofWithTheFirstEmptySchema1BoxedList](#allofwiththefirstemptyschema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofWithTheFirstEmptySchema.AllofWithTheFirstEmptySchema1BoxedMap](#allofwiththefirstemptyschema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofWithTheFirstEmptySchema.AllofWithTheFirstEmptySchema1](#allofwiththefirstemptyschema1)<br> schema class |
+| data class | [AllofWithTheFirstEmptySchema.AllofWithTheFirstEmptySchema1BoxedVoid](#allofwiththefirstemptyschema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofWithTheFirstEmptySchema.AllofWithTheFirstEmptySchema1BoxedBoolean](#allofwiththefirstemptyschema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofWithTheFirstEmptySchema.AllofWithTheFirstEmptySchema1BoxedNumber](#allofwiththefirstemptyschema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofWithTheFirstEmptySchema.AllofWithTheFirstEmptySchema1BoxedString](#allofwiththefirstemptyschema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofWithTheFirstEmptySchema.AllofWithTheFirstEmptySchema1BoxedList](#allofwiththefirstemptyschema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofWithTheFirstEmptySchema.AllofWithTheFirstEmptySchema1BoxedMap](#allofwiththefirstemptyschema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofWithTheFirstEmptySchema.AllofWithTheFirstEmptySchema1](#allofwiththefirstemptyschema1)<br> schema class |
 | sealed interface | [AllofWithTheFirstEmptySchema.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [AllofWithTheFirstEmptySchema.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [AllofWithTheFirstEmptySchema.Schema1](#schema1)<br> schema class |
+| data class | [AllofWithTheFirstEmptySchema.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
+| class | [AllofWithTheFirstEmptySchema.Schema1](#schema1)<br> schema class |
 | sealed interface | [AllofWithTheFirstEmptySchema.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [AllofWithTheFirstEmptySchema.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofWithTheFirstEmptySchema.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofWithTheFirstEmptySchema.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofWithTheFirstEmptySchema.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofWithTheFirstEmptySchema.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofWithTheFirstEmptySchema.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofWithTheFirstEmptySchema.Schema0](#schema0)<br> schema class |
+| data class | [AllofWithTheFirstEmptySchema.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofWithTheFirstEmptySchema.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofWithTheFirstEmptySchema.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofWithTheFirstEmptySchema.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofWithTheFirstEmptySchema.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofWithTheFirstEmptySchema.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofWithTheFirstEmptySchema.Schema0](#schema0)<br> schema class |
 
 ## AllofWithTheFirstEmptySchema1Boxed
 sealed interface AllofWithTheFirstEmptySchema1Boxed<br>
@@ -63,7 +63,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class AllofWithTheFirstEmptySchema1BoxedBoolean<br>
 implements [AllofWithTheFirstEmptySchema1Boxed](#allofwiththefirstemptyschema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -245,7 +245,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AllofWithTheFirstEmptySchema.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AllofWithTheFirstEmptySchema.md
@@ -160,19 +160,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [AllofWithTheFirstEmptySchema1BoxedString](#allofwiththefirstemptyschema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [AllofWithTheFirstEmptySchema1BoxedVoid](#allofwiththefirstemptyschema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [AllofWithTheFirstEmptySchema1BoxedNumber](#allofwiththefirstemptyschema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [AllofWithTheFirstEmptySchema1BoxedBoolean](#allofwiththefirstemptyschema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [AllofWithTheFirstEmptySchema1BoxedMap](#allofwiththefirstemptyschema1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [AllofWithTheFirstEmptySchema1BoxedBoolean](#allofwiththefirstemptyschema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [AllofWithTheFirstEmptySchema1BoxedMap](#allofwiththefirstemptyschema1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [AllofWithTheFirstEmptySchema1BoxedList](#allofwiththefirstemptyschema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [AllofWithTheFirstEmptySchema1Boxed](#allofwiththefirstemptyschema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AllofWithTheLastEmptySchema.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AllofWithTheLastEmptySchema.md
@@ -160,19 +160,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [AllofWithTheLastEmptySchema1BoxedString](#allofwiththelastemptyschema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [AllofWithTheLastEmptySchema1BoxedVoid](#allofwiththelastemptyschema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [AllofWithTheLastEmptySchema1BoxedNumber](#allofwiththelastemptyschema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [AllofWithTheLastEmptySchema1BoxedBoolean](#allofwiththelastemptyschema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [AllofWithTheLastEmptySchema1BoxedMap](#allofwiththelastemptyschema1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [AllofWithTheLastEmptySchema1BoxedBoolean](#allofwiththelastemptyschema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [AllofWithTheLastEmptySchema1BoxedMap](#allofwiththelastemptyschema1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [AllofWithTheLastEmptySchema1BoxedList](#allofwiththelastemptyschema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [AllofWithTheLastEmptySchema1Boxed](#allofwiththelastemptyschema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AllofWithTheLastEmptySchema.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AllofWithTheLastEmptySchema.md
@@ -11,24 +11,24 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [AllofWithTheLastEmptySchema.AllofWithTheLastEmptySchema1Boxed](#allofwiththelastemptyschema1boxed)<br> sealed interface for validated payloads |
-| record | [AllofWithTheLastEmptySchema.AllofWithTheLastEmptySchema1BoxedVoid](#allofwiththelastemptyschema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofWithTheLastEmptySchema.AllofWithTheLastEmptySchema1BoxedBoolean](#allofwiththelastemptyschema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofWithTheLastEmptySchema.AllofWithTheLastEmptySchema1BoxedNumber](#allofwiththelastemptyschema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofWithTheLastEmptySchema.AllofWithTheLastEmptySchema1BoxedString](#allofwiththelastemptyschema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofWithTheLastEmptySchema.AllofWithTheLastEmptySchema1BoxedList](#allofwiththelastemptyschema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofWithTheLastEmptySchema.AllofWithTheLastEmptySchema1BoxedMap](#allofwiththelastemptyschema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofWithTheLastEmptySchema.AllofWithTheLastEmptySchema1](#allofwiththelastemptyschema1)<br> schema class |
+| data class | [AllofWithTheLastEmptySchema.AllofWithTheLastEmptySchema1BoxedVoid](#allofwiththelastemptyschema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofWithTheLastEmptySchema.AllofWithTheLastEmptySchema1BoxedBoolean](#allofwiththelastemptyschema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofWithTheLastEmptySchema.AllofWithTheLastEmptySchema1BoxedNumber](#allofwiththelastemptyschema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofWithTheLastEmptySchema.AllofWithTheLastEmptySchema1BoxedString](#allofwiththelastemptyschema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofWithTheLastEmptySchema.AllofWithTheLastEmptySchema1BoxedList](#allofwiththelastemptyschema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofWithTheLastEmptySchema.AllofWithTheLastEmptySchema1BoxedMap](#allofwiththelastemptyschema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofWithTheLastEmptySchema.AllofWithTheLastEmptySchema1](#allofwiththelastemptyschema1)<br> schema class |
 | sealed interface | [AllofWithTheLastEmptySchema.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [AllofWithTheLastEmptySchema.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofWithTheLastEmptySchema.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofWithTheLastEmptySchema.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofWithTheLastEmptySchema.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofWithTheLastEmptySchema.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofWithTheLastEmptySchema.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofWithTheLastEmptySchema.Schema1](#schema1)<br> schema class |
+| data class | [AllofWithTheLastEmptySchema.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofWithTheLastEmptySchema.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofWithTheLastEmptySchema.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofWithTheLastEmptySchema.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofWithTheLastEmptySchema.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofWithTheLastEmptySchema.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofWithTheLastEmptySchema.Schema1](#schema1)<br> schema class |
 | sealed interface | [AllofWithTheLastEmptySchema.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [AllofWithTheLastEmptySchema.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [AllofWithTheLastEmptySchema.Schema0](#schema0)<br> schema class |
+| data class | [AllofWithTheLastEmptySchema.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| class | [AllofWithTheLastEmptySchema.Schema0](#schema0)<br> schema class |
 
 ## AllofWithTheLastEmptySchema1Boxed
 sealed interface AllofWithTheLastEmptySchema1Boxed<br>
@@ -63,7 +63,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class AllofWithTheLastEmptySchema1BoxedBoolean<br>
 implements [AllofWithTheLastEmptySchema1Boxed](#allofwiththelastemptyschema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -210,7 +210,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema1BoxedBoolean<br>
 implements [Schema1Boxed](#schema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AllofWithTwoEmptySchemas.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AllofWithTwoEmptySchemas.md
@@ -165,19 +165,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [AllofWithTwoEmptySchemas1BoxedString](#allofwithtwoemptyschemas1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [AllofWithTwoEmptySchemas1BoxedVoid](#allofwithtwoemptyschemas1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [AllofWithTwoEmptySchemas1BoxedNumber](#allofwithtwoemptyschemas1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [AllofWithTwoEmptySchemas1BoxedBoolean](#allofwithtwoemptyschemas1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [AllofWithTwoEmptySchemas1BoxedMap](#allofwithtwoemptyschemas1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [AllofWithTwoEmptySchemas1BoxedBoolean](#allofwithtwoemptyschemas1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [AllofWithTwoEmptySchemas1BoxedMap](#allofwithtwoemptyschemas1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [AllofWithTwoEmptySchemas1BoxedList](#allofwithtwoemptyschemas1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [AllofWithTwoEmptySchemas1Boxed](#allofwithtwoemptyschemas1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AllofWithTwoEmptySchemas.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AllofWithTwoEmptySchemas.md
@@ -11,29 +11,29 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [AllofWithTwoEmptySchemas.AllofWithTwoEmptySchemas1Boxed](#allofwithtwoemptyschemas1boxed)<br> sealed interface for validated payloads |
-| record | [AllofWithTwoEmptySchemas.AllofWithTwoEmptySchemas1BoxedVoid](#allofwithtwoemptyschemas1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofWithTwoEmptySchemas.AllofWithTwoEmptySchemas1BoxedBoolean](#allofwithtwoemptyschemas1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofWithTwoEmptySchemas.AllofWithTwoEmptySchemas1BoxedNumber](#allofwithtwoemptyschemas1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofWithTwoEmptySchemas.AllofWithTwoEmptySchemas1BoxedString](#allofwithtwoemptyschemas1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofWithTwoEmptySchemas.AllofWithTwoEmptySchemas1BoxedList](#allofwithtwoemptyschemas1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofWithTwoEmptySchemas.AllofWithTwoEmptySchemas1BoxedMap](#allofwithtwoemptyschemas1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofWithTwoEmptySchemas.AllofWithTwoEmptySchemas1](#allofwithtwoemptyschemas1)<br> schema class |
+| data class | [AllofWithTwoEmptySchemas.AllofWithTwoEmptySchemas1BoxedVoid](#allofwithtwoemptyschemas1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofWithTwoEmptySchemas.AllofWithTwoEmptySchemas1BoxedBoolean](#allofwithtwoemptyschemas1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofWithTwoEmptySchemas.AllofWithTwoEmptySchemas1BoxedNumber](#allofwithtwoemptyschemas1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofWithTwoEmptySchemas.AllofWithTwoEmptySchemas1BoxedString](#allofwithtwoemptyschemas1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofWithTwoEmptySchemas.AllofWithTwoEmptySchemas1BoxedList](#allofwithtwoemptyschemas1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofWithTwoEmptySchemas.AllofWithTwoEmptySchemas1BoxedMap](#allofwithtwoemptyschemas1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofWithTwoEmptySchemas.AllofWithTwoEmptySchemas1](#allofwithtwoemptyschemas1)<br> schema class |
 | sealed interface | [AllofWithTwoEmptySchemas.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [AllofWithTwoEmptySchemas.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofWithTwoEmptySchemas.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofWithTwoEmptySchemas.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofWithTwoEmptySchemas.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofWithTwoEmptySchemas.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofWithTwoEmptySchemas.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofWithTwoEmptySchemas.Schema1](#schema1)<br> schema class |
+| data class | [AllofWithTwoEmptySchemas.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofWithTwoEmptySchemas.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofWithTwoEmptySchemas.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofWithTwoEmptySchemas.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofWithTwoEmptySchemas.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofWithTwoEmptySchemas.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofWithTwoEmptySchemas.Schema1](#schema1)<br> schema class |
 | sealed interface | [AllofWithTwoEmptySchemas.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [AllofWithTwoEmptySchemas.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AllofWithTwoEmptySchemas.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AllofWithTwoEmptySchemas.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AllofWithTwoEmptySchemas.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [AllofWithTwoEmptySchemas.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [AllofWithTwoEmptySchemas.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AllofWithTwoEmptySchemas.Schema0](#schema0)<br> schema class |
+| data class | [AllofWithTwoEmptySchemas.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AllofWithTwoEmptySchemas.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AllofWithTwoEmptySchemas.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AllofWithTwoEmptySchemas.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AllofWithTwoEmptySchemas.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AllofWithTwoEmptySchemas.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AllofWithTwoEmptySchemas.Schema0](#schema0)<br> schema class |
 
 ## AllofWithTwoEmptySchemas1Boxed
 sealed interface AllofWithTwoEmptySchemas1Boxed<br>
@@ -68,7 +68,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class AllofWithTwoEmptySchemas1BoxedBoolean<br>
 implements [AllofWithTwoEmptySchemas1Boxed](#allofwithtwoemptyschemas1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -215,7 +215,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema1BoxedBoolean<br>
 implements [Schema1Boxed](#schema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -340,7 +340,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/Anyof.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/Anyof.md
@@ -11,24 +11,24 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [Anyof.Anyof1Boxed](#anyof1boxed)<br> sealed interface for validated payloads |
-| record | [Anyof.Anyof1BoxedVoid](#anyof1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [Anyof.Anyof1BoxedBoolean](#anyof1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [Anyof.Anyof1BoxedNumber](#anyof1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [Anyof.Anyof1BoxedString](#anyof1boxedstring)<br> boxed class to store validated String payloads |
-| record | [Anyof.Anyof1BoxedList](#anyof1boxedlist)<br> boxed class to store validated List payloads |
-| record | [Anyof.Anyof1BoxedMap](#anyof1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [Anyof.Anyof1](#anyof1)<br> schema class |
+| data class | [Anyof.Anyof1BoxedVoid](#anyof1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [Anyof.Anyof1BoxedBoolean](#anyof1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [Anyof.Anyof1BoxedNumber](#anyof1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [Anyof.Anyof1BoxedString](#anyof1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [Anyof.Anyof1BoxedList](#anyof1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [Anyof.Anyof1BoxedMap](#anyof1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [Anyof.Anyof1](#anyof1)<br> schema class |
 | sealed interface | [Anyof.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [Anyof.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [Anyof.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [Anyof.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [Anyof.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [Anyof.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [Anyof.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [Anyof.Schema1](#schema1)<br> schema class |
+| data class | [Anyof.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [Anyof.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [Anyof.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [Anyof.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [Anyof.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [Anyof.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [Anyof.Schema1](#schema1)<br> schema class |
 | sealed interface | [Anyof.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [Anyof.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [Anyof.Schema0](#schema0)<br> schema class |
+| data class | [Anyof.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| class | [Anyof.Schema0](#schema0)<br> schema class |
 
 ## Anyof1Boxed
 sealed interface Anyof1Boxed<br>
@@ -63,7 +63,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Anyof1BoxedBoolean<br>
 implements [Anyof1Boxed](#anyof1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -210,7 +210,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema1BoxedBoolean<br>
 implements [Schema1Boxed](#schema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/Anyof.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/Anyof.md
@@ -160,19 +160,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Anyof1BoxedString](#anyof1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Anyof1BoxedVoid](#anyof1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Anyof1BoxedNumber](#anyof1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Anyof1BoxedBoolean](#anyof1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Anyof1BoxedMap](#anyof1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Anyof1BoxedBoolean](#anyof1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Anyof1BoxedMap](#anyof1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Anyof1BoxedList](#anyof1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Anyof1Boxed](#anyof1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -307,19 +307,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema1BoxedString](#schema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema1BoxedVoid](#schema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema1BoxedNumber](#schema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema1BoxedList](#schema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema1Boxed](#schema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AnyofComplexTypes.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AnyofComplexTypes.md
@@ -13,39 +13,39 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [AnyofComplexTypes.AnyofComplexTypes1Boxed](#anyofcomplextypes1boxed)<br> sealed interface for validated payloads |
-| record | [AnyofComplexTypes.AnyofComplexTypes1BoxedVoid](#anyofcomplextypes1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AnyofComplexTypes.AnyofComplexTypes1BoxedBoolean](#anyofcomplextypes1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AnyofComplexTypes.AnyofComplexTypes1BoxedNumber](#anyofcomplextypes1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AnyofComplexTypes.AnyofComplexTypes1BoxedString](#anyofcomplextypes1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AnyofComplexTypes.AnyofComplexTypes1BoxedList](#anyofcomplextypes1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AnyofComplexTypes.AnyofComplexTypes1BoxedMap](#anyofcomplextypes1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AnyofComplexTypes.AnyofComplexTypes1](#anyofcomplextypes1)<br> schema class |
+| data class | [AnyofComplexTypes.AnyofComplexTypes1BoxedVoid](#anyofcomplextypes1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AnyofComplexTypes.AnyofComplexTypes1BoxedBoolean](#anyofcomplextypes1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AnyofComplexTypes.AnyofComplexTypes1BoxedNumber](#anyofcomplextypes1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AnyofComplexTypes.AnyofComplexTypes1BoxedString](#anyofcomplextypes1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AnyofComplexTypes.AnyofComplexTypes1BoxedList](#anyofcomplextypes1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AnyofComplexTypes.AnyofComplexTypes1BoxedMap](#anyofcomplextypes1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AnyofComplexTypes.AnyofComplexTypes1](#anyofcomplextypes1)<br> schema class |
 | sealed interface | [AnyofComplexTypes.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [AnyofComplexTypes.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AnyofComplexTypes.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AnyofComplexTypes.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AnyofComplexTypes.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AnyofComplexTypes.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AnyofComplexTypes.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AnyofComplexTypes.Schema1](#schema1)<br> schema class |
-| static class | [AnyofComplexTypes.Schema1MapBuilder](#schema1mapbuilder)<br> builder for Map payloads |
-| static class | [AnyofComplexTypes.Schema1Map](#schema1map)<br> output class for Map payloads |
+| data class | [AnyofComplexTypes.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AnyofComplexTypes.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AnyofComplexTypes.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AnyofComplexTypes.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AnyofComplexTypes.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AnyofComplexTypes.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AnyofComplexTypes.Schema1](#schema1)<br> schema class |
+| class | [AnyofComplexTypes.Schema1MapBuilder](#schema1mapbuilder)<br> builder for Map payloads |
+| class | [AnyofComplexTypes.Schema1Map](#schema1map)<br> output class for Map payloads |
 | sealed interface | [AnyofComplexTypes.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [AnyofComplexTypes.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
-| static class | [AnyofComplexTypes.Foo](#foo)<br> schema class |
+| data class | [AnyofComplexTypes.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
+| class | [AnyofComplexTypes.Foo](#foo)<br> schema class |
 | sealed interface | [AnyofComplexTypes.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [AnyofComplexTypes.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AnyofComplexTypes.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AnyofComplexTypes.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AnyofComplexTypes.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [AnyofComplexTypes.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [AnyofComplexTypes.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AnyofComplexTypes.Schema0](#schema0)<br> schema class |
-| static class | [AnyofComplexTypes.Schema0MapBuilder](#schema0mapbuilder)<br> builder for Map payloads |
-| static class | [AnyofComplexTypes.Schema0Map](#schema0map)<br> output class for Map payloads |
+| data class | [AnyofComplexTypes.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AnyofComplexTypes.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AnyofComplexTypes.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AnyofComplexTypes.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AnyofComplexTypes.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AnyofComplexTypes.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AnyofComplexTypes.Schema0](#schema0)<br> schema class |
+| class | [AnyofComplexTypes.Schema0MapBuilder](#schema0mapbuilder)<br> builder for Map payloads |
+| class | [AnyofComplexTypes.Schema0Map](#schema0map)<br> output class for Map payloads |
 | sealed interface | [AnyofComplexTypes.BarBoxed](#barboxed)<br> sealed interface for validated payloads |
-| record | [AnyofComplexTypes.BarBoxedNumber](#barboxednumber)<br> boxed class to store validated Number payloads |
-| static class | [AnyofComplexTypes.Bar](#bar)<br> schema class |
+| data class | [AnyofComplexTypes.BarBoxedNumber](#barboxednumber)<br> boxed class to store validated Number payloads |
+| class | [AnyofComplexTypes.Bar](#bar)<br> schema class |
 
 ## AnyofComplexTypes1Boxed
 sealed interface AnyofComplexTypes1Boxed<br>
@@ -80,7 +80,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class AnyofComplexTypes1BoxedBoolean<br>
 implements [AnyofComplexTypes1Boxed](#anyofcomplextypes1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -227,7 +227,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema1BoxedBoolean<br>
 implements [Schema1Boxed](#schema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -464,7 +464,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AnyofComplexTypes.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AnyofComplexTypes.md
@@ -177,19 +177,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [AnyofComplexTypes1BoxedString](#anyofcomplextypes1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [AnyofComplexTypes1BoxedVoid](#anyofcomplextypes1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [AnyofComplexTypes1BoxedNumber](#anyofcomplextypes1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [AnyofComplexTypes1BoxedBoolean](#anyofcomplextypes1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [AnyofComplexTypes1BoxedMap](#anyofcomplextypes1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [AnyofComplexTypes1BoxedBoolean](#anyofcomplextypes1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [AnyofComplexTypes1BoxedMap](#anyofcomplextypes1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [AnyofComplexTypes1BoxedList](#anyofcomplextypes1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [AnyofComplexTypes1Boxed](#anyofcomplextypes1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -325,19 +325,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [Schema1Map](#schema1map) | validate(arg: [Map&lt;?, ?&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [Schema1Map](#schema1map) | validate(arg: [Map&lt;*, *&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema1BoxedString](#schema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema1BoxedVoid](#schema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema1BoxedNumber](#schema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
+| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
 | [Schema1BoxedList](#schema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema1Boxed](#schema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -562,19 +562,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [Schema0Map](#schema0map) | validate(arg: [Map&lt;?, ?&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [Schema0Map](#schema0map) | validate(arg: [Map&lt;*, *&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema0BoxedString](#schema0boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema0BoxedVoid](#schema0boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema0BoxedNumber](#schema0boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
+| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox([Map&lt;*, *&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
 | [Schema0BoxedList](#schema0boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema0Boxed](#schema0boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AnyofWithBaseSchema.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AnyofWithBaseSchema.md
@@ -62,25 +62,21 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.AnyofWithBaseSchema;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.AnyofWithBaseSchema
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // String validation
-String validatedPayload = AnyofWithBaseSchema.AnyofWithBaseSchema1.validate(
+val validatedPayload: String = AnyofWithBaseSchema.AnyofWithBaseSchema1.validate(
     "a",
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -220,26 +216,26 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| Integer | minLength = 4 |
+| Int | minLength = 4 |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema1BoxedString](#schema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema1BoxedVoid](#schema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema1BoxedNumber](#schema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema1BoxedList](#schema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema1Boxed](#schema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -367,26 +363,26 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| Integer | maxLength = 2 |
+| Int | maxLength = 2 |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema0BoxedString](#schema0boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema0BoxedVoid](#schema0boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema0BoxedNumber](#schema0boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema0BoxedList](#schema0boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema0Boxed](#schema0boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AnyofWithBaseSchema.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AnyofWithBaseSchema.md
@@ -11,24 +11,24 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [AnyofWithBaseSchema.AnyofWithBaseSchema1Boxed](#anyofwithbaseschema1boxed)<br> sealed interface for validated payloads |
-| record | [AnyofWithBaseSchema.AnyofWithBaseSchema1BoxedString](#anyofwithbaseschema1boxedstring)<br> boxed class to store validated String payloads |
-| static class | [AnyofWithBaseSchema.AnyofWithBaseSchema1](#anyofwithbaseschema1)<br> schema class |
+| data class | [AnyofWithBaseSchema.AnyofWithBaseSchema1BoxedString](#anyofwithbaseschema1boxedstring)<br> boxed class to store validated String payloads |
+| class | [AnyofWithBaseSchema.AnyofWithBaseSchema1](#anyofwithbaseschema1)<br> schema class |
 | sealed interface | [AnyofWithBaseSchema.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [AnyofWithBaseSchema.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AnyofWithBaseSchema.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AnyofWithBaseSchema.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AnyofWithBaseSchema.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AnyofWithBaseSchema.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AnyofWithBaseSchema.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AnyofWithBaseSchema.Schema1](#schema1)<br> schema class |
+| data class | [AnyofWithBaseSchema.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AnyofWithBaseSchema.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AnyofWithBaseSchema.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AnyofWithBaseSchema.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AnyofWithBaseSchema.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AnyofWithBaseSchema.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AnyofWithBaseSchema.Schema1](#schema1)<br> schema class |
 | sealed interface | [AnyofWithBaseSchema.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [AnyofWithBaseSchema.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AnyofWithBaseSchema.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AnyofWithBaseSchema.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AnyofWithBaseSchema.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [AnyofWithBaseSchema.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [AnyofWithBaseSchema.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AnyofWithBaseSchema.Schema0](#schema0)<br> schema class |
+| data class | [AnyofWithBaseSchema.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AnyofWithBaseSchema.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AnyofWithBaseSchema.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AnyofWithBaseSchema.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AnyofWithBaseSchema.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AnyofWithBaseSchema.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AnyofWithBaseSchema.Schema0](#schema0)<br> schema class |
 
 ## AnyofWithBaseSchema1Boxed
 sealed interface AnyofWithBaseSchema1Boxed<br>
@@ -126,7 +126,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema1BoxedBoolean<br>
 implements [Schema1Boxed](#schema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -273,7 +273,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AnyofWithOneEmptySchema.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AnyofWithOneEmptySchema.md
@@ -11,24 +11,24 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [AnyofWithOneEmptySchema.AnyofWithOneEmptySchema1Boxed](#anyofwithoneemptyschema1boxed)<br> sealed interface for validated payloads |
-| record | [AnyofWithOneEmptySchema.AnyofWithOneEmptySchema1BoxedVoid](#anyofwithoneemptyschema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AnyofWithOneEmptySchema.AnyofWithOneEmptySchema1BoxedBoolean](#anyofwithoneemptyschema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AnyofWithOneEmptySchema.AnyofWithOneEmptySchema1BoxedNumber](#anyofwithoneemptyschema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AnyofWithOneEmptySchema.AnyofWithOneEmptySchema1BoxedString](#anyofwithoneemptyschema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AnyofWithOneEmptySchema.AnyofWithOneEmptySchema1BoxedList](#anyofwithoneemptyschema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AnyofWithOneEmptySchema.AnyofWithOneEmptySchema1BoxedMap](#anyofwithoneemptyschema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AnyofWithOneEmptySchema.AnyofWithOneEmptySchema1](#anyofwithoneemptyschema1)<br> schema class |
+| data class | [AnyofWithOneEmptySchema.AnyofWithOneEmptySchema1BoxedVoid](#anyofwithoneemptyschema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AnyofWithOneEmptySchema.AnyofWithOneEmptySchema1BoxedBoolean](#anyofwithoneemptyschema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AnyofWithOneEmptySchema.AnyofWithOneEmptySchema1BoxedNumber](#anyofwithoneemptyschema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AnyofWithOneEmptySchema.AnyofWithOneEmptySchema1BoxedString](#anyofwithoneemptyschema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AnyofWithOneEmptySchema.AnyofWithOneEmptySchema1BoxedList](#anyofwithoneemptyschema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AnyofWithOneEmptySchema.AnyofWithOneEmptySchema1BoxedMap](#anyofwithoneemptyschema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AnyofWithOneEmptySchema.AnyofWithOneEmptySchema1](#anyofwithoneemptyschema1)<br> schema class |
 | sealed interface | [AnyofWithOneEmptySchema.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [AnyofWithOneEmptySchema.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [AnyofWithOneEmptySchema.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [AnyofWithOneEmptySchema.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [AnyofWithOneEmptySchema.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [AnyofWithOneEmptySchema.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [AnyofWithOneEmptySchema.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [AnyofWithOneEmptySchema.Schema1](#schema1)<br> schema class |
+| data class | [AnyofWithOneEmptySchema.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [AnyofWithOneEmptySchema.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [AnyofWithOneEmptySchema.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [AnyofWithOneEmptySchema.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [AnyofWithOneEmptySchema.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [AnyofWithOneEmptySchema.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [AnyofWithOneEmptySchema.Schema1](#schema1)<br> schema class |
 | sealed interface | [AnyofWithOneEmptySchema.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [AnyofWithOneEmptySchema.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [AnyofWithOneEmptySchema.Schema0](#schema0)<br> schema class |
+| data class | [AnyofWithOneEmptySchema.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| class | [AnyofWithOneEmptySchema.Schema0](#schema0)<br> schema class |
 
 ## AnyofWithOneEmptySchema1Boxed
 sealed interface AnyofWithOneEmptySchema1Boxed<br>
@@ -63,7 +63,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class AnyofWithOneEmptySchema1BoxedBoolean<br>
 implements [AnyofWithOneEmptySchema1Boxed](#anyofwithoneemptyschema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -210,7 +210,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema1BoxedBoolean<br>
 implements [Schema1Boxed](#schema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AnyofWithOneEmptySchema.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/AnyofWithOneEmptySchema.md
@@ -160,19 +160,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [AnyofWithOneEmptySchema1BoxedString](#anyofwithoneemptyschema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [AnyofWithOneEmptySchema1BoxedVoid](#anyofwithoneemptyschema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [AnyofWithOneEmptySchema1BoxedNumber](#anyofwithoneemptyschema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [AnyofWithOneEmptySchema1BoxedBoolean](#anyofwithoneemptyschema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [AnyofWithOneEmptySchema1BoxedMap](#anyofwithoneemptyschema1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [AnyofWithOneEmptySchema1BoxedBoolean](#anyofwithoneemptyschema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [AnyofWithOneEmptySchema1BoxedMap](#anyofwithoneemptyschema1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [AnyofWithOneEmptySchema1BoxedList](#anyofwithoneemptyschema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [AnyofWithOneEmptySchema1Boxed](#anyofwithoneemptyschema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ArrayTypeMatchesArrays.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ArrayTypeMatchesArrays.md
@@ -11,8 +11,8 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [ArrayTypeMatchesArrays.ArrayTypeMatchesArrays1Boxed](#arraytypematchesarrays1boxed)<br> sealed interface for validated payloads |
-| record | [ArrayTypeMatchesArrays.ArrayTypeMatchesArrays1BoxedList](#arraytypematchesarrays1boxedlist)<br> boxed class to store validated List payloads |
-| static class | [ArrayTypeMatchesArrays.ArrayTypeMatchesArrays1](#arraytypematchesarrays1)<br> schema class |
+| data class | [ArrayTypeMatchesArrays.ArrayTypeMatchesArrays1BoxedList](#arraytypematchesarrays1boxedlist)<br> boxed class to store validated List payloads |
+| class | [ArrayTypeMatchesArrays.ArrayTypeMatchesArrays1](#arraytypematchesarrays1)<br> schema class |
 
 ## ArrayTypeMatchesArrays1Boxed
 sealed interface ArrayTypeMatchesArrays1Boxed<br>

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/BooleanTypeMatchesBooleans.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/BooleanTypeMatchesBooleans.md
@@ -11,8 +11,8 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [BooleanTypeMatchesBooleans.BooleanTypeMatchesBooleans1Boxed](#booleantypematchesbooleans1boxed)<br> sealed interface for validated payloads |
-| record | [BooleanTypeMatchesBooleans.BooleanTypeMatchesBooleans1BoxedBoolean](#booleantypematchesbooleans1boxedboolean)<br> boxed class to store validated boolean payloads |
-| static class | [BooleanTypeMatchesBooleans.BooleanTypeMatchesBooleans1](#booleantypematchesbooleans1)<br> schema class |
+| data class | [BooleanTypeMatchesBooleans.BooleanTypeMatchesBooleans1BoxedBoolean](#booleantypematchesbooleans1boxedboolean)<br> boxed class to store validated boolean payloads |
+| class | [BooleanTypeMatchesBooleans.BooleanTypeMatchesBooleans1](#booleantypematchesbooleans1)<br> schema class |
 
 ## BooleanTypeMatchesBooleans1Boxed
 sealed interface BooleanTypeMatchesBooleans1Boxed<br>
@@ -25,7 +25,7 @@ sealed interface that stores validated payloads using boxed classes
 data class BooleanTypeMatchesBooleans1BoxedBoolean<br>
 implements [BooleanTypeMatchesBooleans1Boxed](#booleantypematchesbooleans1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ByInt.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ByInt.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [ByInt.ByInt1Boxed](#byint1boxed)<br> sealed interface for validated payloads |
-| record | [ByInt.ByInt1BoxedVoid](#byint1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [ByInt.ByInt1BoxedBoolean](#byint1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [ByInt.ByInt1BoxedNumber](#byint1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [ByInt.ByInt1BoxedString](#byint1boxedstring)<br> boxed class to store validated String payloads |
-| record | [ByInt.ByInt1BoxedList](#byint1boxedlist)<br> boxed class to store validated List payloads |
-| record | [ByInt.ByInt1BoxedMap](#byint1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [ByInt.ByInt1](#byint1)<br> schema class |
+| data class | [ByInt.ByInt1BoxedVoid](#byint1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [ByInt.ByInt1BoxedBoolean](#byint1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [ByInt.ByInt1BoxedNumber](#byint1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [ByInt.ByInt1BoxedString](#byint1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [ByInt.ByInt1BoxedList](#byint1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [ByInt.ByInt1BoxedMap](#byint1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [ByInt.ByInt1](#byint1)<br> schema class |
 
 ## ByInt1Boxed
 sealed interface ByInt1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class ByInt1BoxedBoolean<br>
 implements [ByInt1Boxed](#byint1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ByInt.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ByInt.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [ByInt1BoxedString](#byint1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [ByInt1BoxedVoid](#byint1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [ByInt1BoxedNumber](#byint1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [ByInt1BoxedBoolean](#byint1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [ByInt1BoxedMap](#byint1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [ByInt1BoxedBoolean](#byint1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [ByInt1BoxedMap](#byint1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [ByInt1BoxedList](#byint1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [ByInt1Boxed](#byint1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ByNumber.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ByNumber.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [ByNumber1BoxedString](#bynumber1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [ByNumber1BoxedVoid](#bynumber1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [ByNumber1BoxedNumber](#bynumber1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [ByNumber1BoxedBoolean](#bynumber1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [ByNumber1BoxedMap](#bynumber1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [ByNumber1BoxedBoolean](#bynumber1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [ByNumber1BoxedMap](#bynumber1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [ByNumber1BoxedList](#bynumber1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [ByNumber1Boxed](#bynumber1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ByNumber.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ByNumber.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [ByNumber.ByNumber1Boxed](#bynumber1boxed)<br> sealed interface for validated payloads |
-| record | [ByNumber.ByNumber1BoxedVoid](#bynumber1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [ByNumber.ByNumber1BoxedBoolean](#bynumber1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [ByNumber.ByNumber1BoxedNumber](#bynumber1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [ByNumber.ByNumber1BoxedString](#bynumber1boxedstring)<br> boxed class to store validated String payloads |
-| record | [ByNumber.ByNumber1BoxedList](#bynumber1boxedlist)<br> boxed class to store validated List payloads |
-| record | [ByNumber.ByNumber1BoxedMap](#bynumber1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [ByNumber.ByNumber1](#bynumber1)<br> schema class |
+| data class | [ByNumber.ByNumber1BoxedVoid](#bynumber1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [ByNumber.ByNumber1BoxedBoolean](#bynumber1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [ByNumber.ByNumber1BoxedNumber](#bynumber1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [ByNumber.ByNumber1BoxedString](#bynumber1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [ByNumber.ByNumber1BoxedList](#bynumber1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [ByNumber.ByNumber1BoxedMap](#bynumber1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [ByNumber.ByNumber1](#bynumber1)<br> schema class |
 
 ## ByNumber1Boxed
 sealed interface ByNumber1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class ByNumber1BoxedBoolean<br>
 implements [ByNumber1Boxed](#bynumber1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/BySmallNumber.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/BySmallNumber.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [BySmallNumber1BoxedString](#bysmallnumber1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [BySmallNumber1BoxedVoid](#bysmallnumber1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [BySmallNumber1BoxedNumber](#bysmallnumber1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [BySmallNumber1BoxedBoolean](#bysmallnumber1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [BySmallNumber1BoxedMap](#bysmallnumber1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [BySmallNumber1BoxedBoolean](#bysmallnumber1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [BySmallNumber1BoxedMap](#bysmallnumber1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [BySmallNumber1BoxedList](#bysmallnumber1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [BySmallNumber1Boxed](#bysmallnumber1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/BySmallNumber.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/BySmallNumber.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [BySmallNumber.BySmallNumber1Boxed](#bysmallnumber1boxed)<br> sealed interface for validated payloads |
-| record | [BySmallNumber.BySmallNumber1BoxedVoid](#bysmallnumber1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [BySmallNumber.BySmallNumber1BoxedBoolean](#bysmallnumber1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [BySmallNumber.BySmallNumber1BoxedNumber](#bysmallnumber1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [BySmallNumber.BySmallNumber1BoxedString](#bysmallnumber1boxedstring)<br> boxed class to store validated String payloads |
-| record | [BySmallNumber.BySmallNumber1BoxedList](#bysmallnumber1boxedlist)<br> boxed class to store validated List payloads |
-| record | [BySmallNumber.BySmallNumber1BoxedMap](#bysmallnumber1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [BySmallNumber.BySmallNumber1](#bysmallnumber1)<br> schema class |
+| data class | [BySmallNumber.BySmallNumber1BoxedVoid](#bysmallnumber1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [BySmallNumber.BySmallNumber1BoxedBoolean](#bysmallnumber1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [BySmallNumber.BySmallNumber1BoxedNumber](#bysmallnumber1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [BySmallNumber.BySmallNumber1BoxedString](#bysmallnumber1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [BySmallNumber.BySmallNumber1BoxedList](#bysmallnumber1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [BySmallNumber.BySmallNumber1BoxedMap](#bysmallnumber1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [BySmallNumber.BySmallNumber1](#bysmallnumber1)<br> schema class |
 
 ## BySmallNumber1Boxed
 sealed interface BySmallNumber1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class BySmallNumber1BoxedBoolean<br>
 implements [BySmallNumber1Boxed](#bysmallnumber1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ConstNulCharactersInStrings.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ConstNulCharactersInStrings.md
@@ -12,13 +12,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [ConstNulCharactersInStrings.ConstNulCharactersInStrings1Boxed](#constnulcharactersinstrings1boxed)<br> sealed interface for validated payloads |
-| record | [ConstNulCharactersInStrings.ConstNulCharactersInStrings1BoxedVoid](#constnulcharactersinstrings1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [ConstNulCharactersInStrings.ConstNulCharactersInStrings1BoxedBoolean](#constnulcharactersinstrings1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [ConstNulCharactersInStrings.ConstNulCharactersInStrings1BoxedNumber](#constnulcharactersinstrings1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [ConstNulCharactersInStrings.ConstNulCharactersInStrings1BoxedString](#constnulcharactersinstrings1boxedstring)<br> boxed class to store validated String payloads |
-| record | [ConstNulCharactersInStrings.ConstNulCharactersInStrings1BoxedList](#constnulcharactersinstrings1boxedlist)<br> boxed class to store validated List payloads |
-| record | [ConstNulCharactersInStrings.ConstNulCharactersInStrings1BoxedMap](#constnulcharactersinstrings1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [ConstNulCharactersInStrings.ConstNulCharactersInStrings1](#constnulcharactersinstrings1)<br> schema class |
+| data class | [ConstNulCharactersInStrings.ConstNulCharactersInStrings1BoxedVoid](#constnulcharactersinstrings1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [ConstNulCharactersInStrings.ConstNulCharactersInStrings1BoxedBoolean](#constnulcharactersinstrings1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [ConstNulCharactersInStrings.ConstNulCharactersInStrings1BoxedNumber](#constnulcharactersinstrings1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [ConstNulCharactersInStrings.ConstNulCharactersInStrings1BoxedString](#constnulcharactersinstrings1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [ConstNulCharactersInStrings.ConstNulCharactersInStrings1BoxedList](#constnulcharactersinstrings1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [ConstNulCharactersInStrings.ConstNulCharactersInStrings1BoxedMap](#constnulcharactersinstrings1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [ConstNulCharactersInStrings.ConstNulCharactersInStrings1](#constnulcharactersinstrings1)<br> schema class |
 | enum | [ConstNulCharactersInStrings.StringConstNulCharactersInStringsConst](#stringconstnulcharactersinstringsconst)<br>String enum |
 
 ## ConstNulCharactersInStrings1Boxed
@@ -54,7 +54,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class ConstNulCharactersInStrings1BoxedBoolean<br>
 implements [ConstNulCharactersInStrings1Boxed](#constnulcharactersinstrings1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ConstNulCharactersInStrings.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ConstNulCharactersInStrings.md
@@ -151,19 +151,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [ConstNulCharactersInStrings1BoxedString](#constnulcharactersinstrings1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [ConstNulCharactersInStrings1BoxedVoid](#constnulcharactersinstrings1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [ConstNulCharactersInStrings1BoxedNumber](#constnulcharactersinstrings1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [ConstNulCharactersInStrings1BoxedBoolean](#constnulcharactersinstrings1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [ConstNulCharactersInStrings1BoxedMap](#constnulcharactersinstrings1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [ConstNulCharactersInStrings1BoxedBoolean](#constnulcharactersinstrings1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [ConstNulCharactersInStrings1BoxedMap](#constnulcharactersinstrings1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [ConstNulCharactersInStrings1BoxedList](#constnulcharactersinstrings1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [ConstNulCharactersInStrings1Boxed](#constnulcharactersinstrings1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ContainsKeywordValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ContainsKeywordValidation.md
@@ -157,19 +157,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [ContainsKeywordValidation1BoxedString](#containskeywordvalidation1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [ContainsKeywordValidation1BoxedVoid](#containskeywordvalidation1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [ContainsKeywordValidation1BoxedNumber](#containskeywordvalidation1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [ContainsKeywordValidation1BoxedBoolean](#containskeywordvalidation1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [ContainsKeywordValidation1BoxedMap](#containskeywordvalidation1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [ContainsKeywordValidation1BoxedBoolean](#containskeywordvalidation1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [ContainsKeywordValidation1BoxedMap](#containskeywordvalidation1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [ContainsKeywordValidation1BoxedList](#containskeywordvalidation1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [ContainsKeywordValidation1Boxed](#containskeywordvalidation1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -304,19 +304,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [ContainsBoxedString](#containsboxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [ContainsBoxedVoid](#containsboxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [ContainsBoxedNumber](#containsboxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [ContainsBoxedBoolean](#containsboxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [ContainsBoxedMap](#containsboxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [ContainsBoxedBoolean](#containsboxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [ContainsBoxedMap](#containsboxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [ContainsBoxedList](#containsboxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [ContainsBoxed](#containsboxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ContainsKeywordValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ContainsKeywordValidation.md
@@ -11,21 +11,21 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [ContainsKeywordValidation.ContainsKeywordValidation1Boxed](#containskeywordvalidation1boxed)<br> sealed interface for validated payloads |
-| record | [ContainsKeywordValidation.ContainsKeywordValidation1BoxedVoid](#containskeywordvalidation1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [ContainsKeywordValidation.ContainsKeywordValidation1BoxedBoolean](#containskeywordvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [ContainsKeywordValidation.ContainsKeywordValidation1BoxedNumber](#containskeywordvalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [ContainsKeywordValidation.ContainsKeywordValidation1BoxedString](#containskeywordvalidation1boxedstring)<br> boxed class to store validated String payloads |
-| record | [ContainsKeywordValidation.ContainsKeywordValidation1BoxedList](#containskeywordvalidation1boxedlist)<br> boxed class to store validated List payloads |
-| record | [ContainsKeywordValidation.ContainsKeywordValidation1BoxedMap](#containskeywordvalidation1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [ContainsKeywordValidation.ContainsKeywordValidation1](#containskeywordvalidation1)<br> schema class |
+| data class | [ContainsKeywordValidation.ContainsKeywordValidation1BoxedVoid](#containskeywordvalidation1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [ContainsKeywordValidation.ContainsKeywordValidation1BoxedBoolean](#containskeywordvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [ContainsKeywordValidation.ContainsKeywordValidation1BoxedNumber](#containskeywordvalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [ContainsKeywordValidation.ContainsKeywordValidation1BoxedString](#containskeywordvalidation1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [ContainsKeywordValidation.ContainsKeywordValidation1BoxedList](#containskeywordvalidation1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [ContainsKeywordValidation.ContainsKeywordValidation1BoxedMap](#containskeywordvalidation1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [ContainsKeywordValidation.ContainsKeywordValidation1](#containskeywordvalidation1)<br> schema class |
 | sealed interface | [ContainsKeywordValidation.ContainsBoxed](#containsboxed)<br> sealed interface for validated payloads |
-| record | [ContainsKeywordValidation.ContainsBoxedVoid](#containsboxedvoid)<br> boxed class to store validated null payloads |
-| record | [ContainsKeywordValidation.ContainsBoxedBoolean](#containsboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [ContainsKeywordValidation.ContainsBoxedNumber](#containsboxednumber)<br> boxed class to store validated Number payloads |
-| record | [ContainsKeywordValidation.ContainsBoxedString](#containsboxedstring)<br> boxed class to store validated String payloads |
-| record | [ContainsKeywordValidation.ContainsBoxedList](#containsboxedlist)<br> boxed class to store validated List payloads |
-| record | [ContainsKeywordValidation.ContainsBoxedMap](#containsboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [ContainsKeywordValidation.Contains](#contains)<br> schema class |
+| data class | [ContainsKeywordValidation.ContainsBoxedVoid](#containsboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [ContainsKeywordValidation.ContainsBoxedBoolean](#containsboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [ContainsKeywordValidation.ContainsBoxedNumber](#containsboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [ContainsKeywordValidation.ContainsBoxedString](#containsboxedstring)<br> boxed class to store validated String payloads |
+| data class | [ContainsKeywordValidation.ContainsBoxedList](#containsboxedlist)<br> boxed class to store validated List payloads |
+| data class | [ContainsKeywordValidation.ContainsBoxedMap](#containsboxedmap)<br> boxed class to store validated Map payloads |
+| class | [ContainsKeywordValidation.Contains](#contains)<br> schema class |
 
 ## ContainsKeywordValidation1Boxed
 sealed interface ContainsKeywordValidation1Boxed<br>
@@ -60,7 +60,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class ContainsKeywordValidation1BoxedBoolean<br>
 implements [ContainsKeywordValidation1Boxed](#containskeywordvalidation1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -207,7 +207,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class ContainsBoxedBoolean<br>
 implements [ContainsBoxed](#containsboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ContainsWithNullInstanceElements.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ContainsWithNullInstanceElements.md
@@ -152,19 +152,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [ContainsWithNullInstanceElements1BoxedString](#containswithnullinstanceelements1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [ContainsWithNullInstanceElements1BoxedVoid](#containswithnullinstanceelements1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [ContainsWithNullInstanceElements1BoxedNumber](#containswithnullinstanceelements1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [ContainsWithNullInstanceElements1BoxedBoolean](#containswithnullinstanceelements1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [ContainsWithNullInstanceElements1BoxedMap](#containswithnullinstanceelements1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [ContainsWithNullInstanceElements1BoxedBoolean](#containswithnullinstanceelements1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [ContainsWithNullInstanceElements1BoxedMap](#containswithnullinstanceelements1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [ContainsWithNullInstanceElements1BoxedList](#containswithnullinstanceelements1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [ContainsWithNullInstanceElements1Boxed](#containswithnullinstanceelements1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ContainsWithNullInstanceElements.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ContainsWithNullInstanceElements.md
@@ -11,16 +11,16 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [ContainsWithNullInstanceElements.ContainsWithNullInstanceElements1Boxed](#containswithnullinstanceelements1boxed)<br> sealed interface for validated payloads |
-| record | [ContainsWithNullInstanceElements.ContainsWithNullInstanceElements1BoxedVoid](#containswithnullinstanceelements1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [ContainsWithNullInstanceElements.ContainsWithNullInstanceElements1BoxedBoolean](#containswithnullinstanceelements1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [ContainsWithNullInstanceElements.ContainsWithNullInstanceElements1BoxedNumber](#containswithnullinstanceelements1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [ContainsWithNullInstanceElements.ContainsWithNullInstanceElements1BoxedString](#containswithnullinstanceelements1boxedstring)<br> boxed class to store validated String payloads |
-| record | [ContainsWithNullInstanceElements.ContainsWithNullInstanceElements1BoxedList](#containswithnullinstanceelements1boxedlist)<br> boxed class to store validated List payloads |
-| record | [ContainsWithNullInstanceElements.ContainsWithNullInstanceElements1BoxedMap](#containswithnullinstanceelements1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [ContainsWithNullInstanceElements.ContainsWithNullInstanceElements1](#containswithnullinstanceelements1)<br> schema class |
+| data class | [ContainsWithNullInstanceElements.ContainsWithNullInstanceElements1BoxedVoid](#containswithnullinstanceelements1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [ContainsWithNullInstanceElements.ContainsWithNullInstanceElements1BoxedBoolean](#containswithnullinstanceelements1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [ContainsWithNullInstanceElements.ContainsWithNullInstanceElements1BoxedNumber](#containswithnullinstanceelements1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [ContainsWithNullInstanceElements.ContainsWithNullInstanceElements1BoxedString](#containswithnullinstanceelements1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [ContainsWithNullInstanceElements.ContainsWithNullInstanceElements1BoxedList](#containswithnullinstanceelements1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [ContainsWithNullInstanceElements.ContainsWithNullInstanceElements1BoxedMap](#containswithnullinstanceelements1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [ContainsWithNullInstanceElements.ContainsWithNullInstanceElements1](#containswithnullinstanceelements1)<br> schema class |
 | sealed interface | [ContainsWithNullInstanceElements.ContainsBoxed](#containsboxed)<br> sealed interface for validated payloads |
-| record | [ContainsWithNullInstanceElements.ContainsBoxedVoid](#containsboxedvoid)<br> boxed class to store validated null payloads |
-| static class | [ContainsWithNullInstanceElements.Contains](#contains)<br> schema class |
+| data class | [ContainsWithNullInstanceElements.ContainsBoxedVoid](#containsboxedvoid)<br> boxed class to store validated null payloads |
+| class | [ContainsWithNullInstanceElements.Contains](#contains)<br> schema class |
 
 ## ContainsWithNullInstanceElements1Boxed
 sealed interface ContainsWithNullInstanceElements1Boxed<br>
@@ -55,7 +55,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class ContainsWithNullInstanceElements1BoxedBoolean<br>
 implements [ContainsWithNullInstanceElements1Boxed](#containswithnullinstanceelements1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/DateFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/DateFormat.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [DateFormat1BoxedString](#dateformat1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [DateFormat1BoxedVoid](#dateformat1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [DateFormat1BoxedNumber](#dateformat1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [DateFormat1BoxedBoolean](#dateformat1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [DateFormat1BoxedMap](#dateformat1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [DateFormat1BoxedBoolean](#dateformat1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [DateFormat1BoxedMap](#dateformat1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [DateFormat1BoxedList](#dateformat1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [DateFormat1Boxed](#dateformat1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/DateFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/DateFormat.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [DateFormat.DateFormat1Boxed](#dateformat1boxed)<br> sealed interface for validated payloads |
-| record | [DateFormat.DateFormat1BoxedVoid](#dateformat1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [DateFormat.DateFormat1BoxedBoolean](#dateformat1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [DateFormat.DateFormat1BoxedNumber](#dateformat1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [DateFormat.DateFormat1BoxedString](#dateformat1boxedstring)<br> boxed class to store validated String payloads |
-| record | [DateFormat.DateFormat1BoxedList](#dateformat1boxedlist)<br> boxed class to store validated List payloads |
-| record | [DateFormat.DateFormat1BoxedMap](#dateformat1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [DateFormat.DateFormat1](#dateformat1)<br> schema class |
+| data class | [DateFormat.DateFormat1BoxedVoid](#dateformat1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [DateFormat.DateFormat1BoxedBoolean](#dateformat1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [DateFormat.DateFormat1BoxedNumber](#dateformat1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [DateFormat.DateFormat1BoxedString](#dateformat1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [DateFormat.DateFormat1BoxedList](#dateformat1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [DateFormat.DateFormat1BoxedMap](#dateformat1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [DateFormat.DateFormat1](#dateformat1)<br> schema class |
 
 ## DateFormat1Boxed
 sealed interface DateFormat1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class DateFormat1BoxedBoolean<br>
 implements [DateFormat1Boxed](#dateformat1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/DateTimeFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/DateTimeFormat.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [DateTimeFormat.DateTimeFormat1Boxed](#datetimeformat1boxed)<br> sealed interface for validated payloads |
-| record | [DateTimeFormat.DateTimeFormat1BoxedVoid](#datetimeformat1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [DateTimeFormat.DateTimeFormat1BoxedBoolean](#datetimeformat1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [DateTimeFormat.DateTimeFormat1BoxedNumber](#datetimeformat1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [DateTimeFormat.DateTimeFormat1BoxedString](#datetimeformat1boxedstring)<br> boxed class to store validated String payloads |
-| record | [DateTimeFormat.DateTimeFormat1BoxedList](#datetimeformat1boxedlist)<br> boxed class to store validated List payloads |
-| record | [DateTimeFormat.DateTimeFormat1BoxedMap](#datetimeformat1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [DateTimeFormat.DateTimeFormat1](#datetimeformat1)<br> schema class |
+| data class | [DateTimeFormat.DateTimeFormat1BoxedVoid](#datetimeformat1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [DateTimeFormat.DateTimeFormat1BoxedBoolean](#datetimeformat1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [DateTimeFormat.DateTimeFormat1BoxedNumber](#datetimeformat1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [DateTimeFormat.DateTimeFormat1BoxedString](#datetimeformat1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [DateTimeFormat.DateTimeFormat1BoxedList](#datetimeformat1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [DateTimeFormat.DateTimeFormat1BoxedMap](#datetimeformat1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [DateTimeFormat.DateTimeFormat1](#datetimeformat1)<br> schema class |
 
 ## DateTimeFormat1Boxed
 sealed interface DateTimeFormat1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class DateTimeFormat1BoxedBoolean<br>
 implements [DateTimeFormat1Boxed](#datetimeformat1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/DateTimeFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/DateTimeFormat.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [DateTimeFormat1BoxedString](#datetimeformat1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [DateTimeFormat1BoxedVoid](#datetimeformat1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [DateTimeFormat1BoxedNumber](#datetimeformat1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [DateTimeFormat1BoxedBoolean](#datetimeformat1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [DateTimeFormat1BoxedMap](#datetimeformat1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [DateTimeFormat1BoxedBoolean](#datetimeformat1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [DateTimeFormat1BoxedMap](#datetimeformat1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [DateTimeFormat1BoxedList](#datetimeformat1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [DateTimeFormat1Boxed](#datetimeformat1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/DependentSchemasDependenciesWithEscapedCharacters.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/DependentSchemasDependenciesWithEscapedCharacters.md
@@ -13,31 +13,31 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [DependentSchemasDependenciesWithEscapedCharacters.DependentSchemasDependenciesWithEscapedCharacters1Boxed](#dependentschemasdependencieswithescapedcharacters1boxed)<br> sealed interface for validated payloads |
-| record | [DependentSchemasDependenciesWithEscapedCharacters.DependentSchemasDependenciesWithEscapedCharacters1BoxedVoid](#dependentschemasdependencieswithescapedcharacters1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [DependentSchemasDependenciesWithEscapedCharacters.DependentSchemasDependenciesWithEscapedCharacters1BoxedBoolean](#dependentschemasdependencieswithescapedcharacters1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [DependentSchemasDependenciesWithEscapedCharacters.DependentSchemasDependenciesWithEscapedCharacters1BoxedNumber](#dependentschemasdependencieswithescapedcharacters1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [DependentSchemasDependenciesWithEscapedCharacters.DependentSchemasDependenciesWithEscapedCharacters1BoxedString](#dependentschemasdependencieswithescapedcharacters1boxedstring)<br> boxed class to store validated String payloads |
-| record | [DependentSchemasDependenciesWithEscapedCharacters.DependentSchemasDependenciesWithEscapedCharacters1BoxedList](#dependentschemasdependencieswithescapedcharacters1boxedlist)<br> boxed class to store validated List payloads |
-| record | [DependentSchemasDependenciesWithEscapedCharacters.DependentSchemasDependenciesWithEscapedCharacters1BoxedMap](#dependentschemasdependencieswithescapedcharacters1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [DependentSchemasDependenciesWithEscapedCharacters.DependentSchemasDependenciesWithEscapedCharacters1](#dependentschemasdependencieswithescapedcharacters1)<br> schema class |
+| data class | [DependentSchemasDependenciesWithEscapedCharacters.DependentSchemasDependenciesWithEscapedCharacters1BoxedVoid](#dependentschemasdependencieswithescapedcharacters1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [DependentSchemasDependenciesWithEscapedCharacters.DependentSchemasDependenciesWithEscapedCharacters1BoxedBoolean](#dependentschemasdependencieswithescapedcharacters1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [DependentSchemasDependenciesWithEscapedCharacters.DependentSchemasDependenciesWithEscapedCharacters1BoxedNumber](#dependentschemasdependencieswithescapedcharacters1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [DependentSchemasDependenciesWithEscapedCharacters.DependentSchemasDependenciesWithEscapedCharacters1BoxedString](#dependentschemasdependencieswithescapedcharacters1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [DependentSchemasDependenciesWithEscapedCharacters.DependentSchemasDependenciesWithEscapedCharacters1BoxedList](#dependentschemasdependencieswithescapedcharacters1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [DependentSchemasDependenciesWithEscapedCharacters.DependentSchemasDependenciesWithEscapedCharacters1BoxedMap](#dependentschemasdependencieswithescapedcharacters1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [DependentSchemasDependenciesWithEscapedCharacters.DependentSchemasDependenciesWithEscapedCharacters1](#dependentschemasdependencieswithescapedcharacters1)<br> schema class |
 | sealed interface | [DependentSchemasDependenciesWithEscapedCharacters.FoobarBoxed](#foobarboxed)<br> sealed interface for validated payloads |
-| record | [DependentSchemasDependenciesWithEscapedCharacters.FoobarBoxedVoid](#foobarboxedvoid)<br> boxed class to store validated null payloads |
-| record | [DependentSchemasDependenciesWithEscapedCharacters.FoobarBoxedBoolean](#foobarboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [DependentSchemasDependenciesWithEscapedCharacters.FoobarBoxedNumber](#foobarboxednumber)<br> boxed class to store validated Number payloads |
-| record | [DependentSchemasDependenciesWithEscapedCharacters.FoobarBoxedString](#foobarboxedstring)<br> boxed class to store validated String payloads |
-| record | [DependentSchemasDependenciesWithEscapedCharacters.FoobarBoxedList](#foobarboxedlist)<br> boxed class to store validated List payloads |
-| record | [DependentSchemasDependenciesWithEscapedCharacters.FoobarBoxedMap](#foobarboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [DependentSchemasDependenciesWithEscapedCharacters.Foobar](#foobar)<br> schema class |
-| static class | [DependentSchemasDependenciesWithEscapedCharacters.FoobarMapBuilder](#foobarmapbuilder)<br> builder for Map payloads |
-| static class | [DependentSchemasDependenciesWithEscapedCharacters.FoobarMap](#foobarmap)<br> output class for Map payloads |
+| data class | [DependentSchemasDependenciesWithEscapedCharacters.FoobarBoxedVoid](#foobarboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [DependentSchemasDependenciesWithEscapedCharacters.FoobarBoxedBoolean](#foobarboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [DependentSchemasDependenciesWithEscapedCharacters.FoobarBoxedNumber](#foobarboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [DependentSchemasDependenciesWithEscapedCharacters.FoobarBoxedString](#foobarboxedstring)<br> boxed class to store validated String payloads |
+| data class | [DependentSchemasDependenciesWithEscapedCharacters.FoobarBoxedList](#foobarboxedlist)<br> boxed class to store validated List payloads |
+| data class | [DependentSchemasDependenciesWithEscapedCharacters.FoobarBoxedMap](#foobarboxedmap)<br> boxed class to store validated Map payloads |
+| class | [DependentSchemasDependenciesWithEscapedCharacters.Foobar](#foobar)<br> schema class |
+| class | [DependentSchemasDependenciesWithEscapedCharacters.FoobarMapBuilder](#foobarmapbuilder)<br> builder for Map payloads |
+| class | [DependentSchemasDependenciesWithEscapedCharacters.FoobarMap](#foobarmap)<br> output class for Map payloads |
 | sealed interface | [DependentSchemasDependenciesWithEscapedCharacters.FootbarBoxed](#footbarboxed)<br> sealed interface for validated payloads |
-| record | [DependentSchemasDependenciesWithEscapedCharacters.FootbarBoxedVoid](#footbarboxedvoid)<br> boxed class to store validated null payloads |
-| record | [DependentSchemasDependenciesWithEscapedCharacters.FootbarBoxedBoolean](#footbarboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [DependentSchemasDependenciesWithEscapedCharacters.FootbarBoxedNumber](#footbarboxednumber)<br> boxed class to store validated Number payloads |
-| record | [DependentSchemasDependenciesWithEscapedCharacters.FootbarBoxedString](#footbarboxedstring)<br> boxed class to store validated String payloads |
-| record | [DependentSchemasDependenciesWithEscapedCharacters.FootbarBoxedList](#footbarboxedlist)<br> boxed class to store validated List payloads |
-| record | [DependentSchemasDependenciesWithEscapedCharacters.FootbarBoxedMap](#footbarboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [DependentSchemasDependenciesWithEscapedCharacters.Footbar](#footbar)<br> schema class |
+| data class | [DependentSchemasDependenciesWithEscapedCharacters.FootbarBoxedVoid](#footbarboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [DependentSchemasDependenciesWithEscapedCharacters.FootbarBoxedBoolean](#footbarboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [DependentSchemasDependenciesWithEscapedCharacters.FootbarBoxedNumber](#footbarboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [DependentSchemasDependenciesWithEscapedCharacters.FootbarBoxedString](#footbarboxedstring)<br> boxed class to store validated String payloads |
+| data class | [DependentSchemasDependenciesWithEscapedCharacters.FootbarBoxedList](#footbarboxedlist)<br> boxed class to store validated List payloads |
+| data class | [DependentSchemasDependenciesWithEscapedCharacters.FootbarBoxedMap](#footbarboxedmap)<br> boxed class to store validated Map payloads |
+| class | [DependentSchemasDependenciesWithEscapedCharacters.Footbar](#footbar)<br> schema class |
 
 ## DependentSchemasDependenciesWithEscapedCharacters1Boxed
 sealed interface DependentSchemasDependenciesWithEscapedCharacters1Boxed<br>
@@ -72,7 +72,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class DependentSchemasDependenciesWithEscapedCharacters1BoxedBoolean<br>
 implements [DependentSchemasDependenciesWithEscapedCharacters1Boxed](#dependentschemasdependencieswithescapedcharacters1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -219,7 +219,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class FoobarBoxedBoolean<br>
 implements [FoobarBoxed](#foobarboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -428,7 +428,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class FootbarBoxedBoolean<br>
 implements [FootbarBoxed](#footbarboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/DependentSchemasDependenciesWithEscapedCharacters.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/DependentSchemasDependenciesWithEscapedCharacters.md
@@ -169,19 +169,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [DependentSchemasDependenciesWithEscapedCharacters1BoxedString](#dependentschemasdependencieswithescapedcharacters1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [DependentSchemasDependenciesWithEscapedCharacters1BoxedVoid](#dependentschemasdependencieswithescapedcharacters1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [DependentSchemasDependenciesWithEscapedCharacters1BoxedNumber](#dependentschemasdependencieswithescapedcharacters1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [DependentSchemasDependenciesWithEscapedCharacters1BoxedBoolean](#dependentschemasdependencieswithescapedcharacters1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [DependentSchemasDependenciesWithEscapedCharacters1BoxedMap](#dependentschemasdependencieswithescapedcharacters1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [DependentSchemasDependenciesWithEscapedCharacters1BoxedBoolean](#dependentschemasdependencieswithescapedcharacters1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [DependentSchemasDependenciesWithEscapedCharacters1BoxedMap](#dependentschemasdependencieswithescapedcharacters1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [DependentSchemasDependenciesWithEscapedCharacters1BoxedList](#dependentschemasdependencieswithescapedcharacters1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [DependentSchemasDependenciesWithEscapedCharacters1Boxed](#dependentschemasdependencieswithescapedcharacters1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -316,19 +316,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [FoobarMap](#foobarmap) | validate(arg: [Map&lt;?, ?&gt;](#foobarmapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [FoobarMap](#foobarmap) | validate(arg: [Map&lt;*, *&gt;](#foobarmapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [FoobarBoxedString](#foobarboxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [FoobarBoxedVoid](#foobarboxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [FoobarBoxedNumber](#foobarboxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [FoobarBoxedBoolean](#foobarboxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [FoobarBoxedMap](#foobarboxedmap) | validateAndBox([Map&lt;?, ?&gt;](#foobarmapbuilder), configuration: SchemaConfiguration) |
+| [FoobarBoxedBoolean](#foobarboxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [FoobarBoxedMap](#foobarboxedmap) | validateAndBox([Map&lt;*, *&gt;](#foobarmapbuilder), configuration: SchemaConfiguration) |
 | [FoobarBoxedList](#foobarboxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [FoobarBoxed](#foobarboxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -518,26 +518,26 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| Integer | minProperties = 4 |
+| Int | minProperties = 4 |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [FootbarBoxedString](#footbarboxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [FootbarBoxedVoid](#footbarboxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [FootbarBoxedNumber](#footbarboxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [FootbarBoxedBoolean](#footbarboxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [FootbarBoxedMap](#footbarboxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [FootbarBoxedBoolean](#footbarboxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [FootbarBoxedMap](#footbarboxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [FootbarBoxedList](#footbarboxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [FootbarBoxed](#footbarboxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/DependentSchemasDependentSubschemaIncompatibleWithRoot.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/DependentSchemasDependentSubschemaIncompatibleWithRoot.md
@@ -13,44 +13,44 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [DependentSchemasDependentSubschemaIncompatibleWithRoot.DependentSchemasDependentSubschemaIncompatibleWithRoot1Boxed](#dependentschemasdependentsubschemaincompatiblewithroot1boxed)<br> sealed interface for validated payloads |
-| record | [DependentSchemasDependentSubschemaIncompatibleWithRoot.DependentSchemasDependentSubschemaIncompatibleWithRoot1BoxedVoid](#dependentschemasdependentsubschemaincompatiblewithroot1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [DependentSchemasDependentSubschemaIncompatibleWithRoot.DependentSchemasDependentSubschemaIncompatibleWithRoot1BoxedBoolean](#dependentschemasdependentsubschemaincompatiblewithroot1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [DependentSchemasDependentSubschemaIncompatibleWithRoot.DependentSchemasDependentSubschemaIncompatibleWithRoot1BoxedNumber](#dependentschemasdependentsubschemaincompatiblewithroot1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [DependentSchemasDependentSubschemaIncompatibleWithRoot.DependentSchemasDependentSubschemaIncompatibleWithRoot1BoxedString](#dependentschemasdependentsubschemaincompatiblewithroot1boxedstring)<br> boxed class to store validated String payloads |
-| record | [DependentSchemasDependentSubschemaIncompatibleWithRoot.DependentSchemasDependentSubschemaIncompatibleWithRoot1BoxedList](#dependentschemasdependentsubschemaincompatiblewithroot1boxedlist)<br> boxed class to store validated List payloads |
-| record | [DependentSchemasDependentSubschemaIncompatibleWithRoot.DependentSchemasDependentSubschemaIncompatibleWithRoot1BoxedMap](#dependentschemasdependentsubschemaincompatiblewithroot1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.DependentSchemasDependentSubschemaIncompatibleWithRoot1](#dependentschemasdependentsubschemaincompatiblewithroot1)<br> schema class |
-| static class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.DependentSchemasDependentSubschemaIncompatibleWithRootMapBuilder](#dependentschemasdependentsubschemaincompatiblewithrootmapbuilder)<br> builder for Map payloads |
-| static class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.DependentSchemasDependentSubschemaIncompatibleWithRootMap](#dependentschemasdependentsubschemaincompatiblewithrootmap)<br> output class for Map payloads |
+| data class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.DependentSchemasDependentSubschemaIncompatibleWithRoot1BoxedVoid](#dependentschemasdependentsubschemaincompatiblewithroot1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.DependentSchemasDependentSubschemaIncompatibleWithRoot1BoxedBoolean](#dependentschemasdependentsubschemaincompatiblewithroot1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.DependentSchemasDependentSubschemaIncompatibleWithRoot1BoxedNumber](#dependentschemasdependentsubschemaincompatiblewithroot1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.DependentSchemasDependentSubschemaIncompatibleWithRoot1BoxedString](#dependentschemasdependentsubschemaincompatiblewithroot1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.DependentSchemasDependentSubschemaIncompatibleWithRoot1BoxedList](#dependentschemasdependentsubschemaincompatiblewithroot1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.DependentSchemasDependentSubschemaIncompatibleWithRoot1BoxedMap](#dependentschemasdependentsubschemaincompatiblewithroot1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.DependentSchemasDependentSubschemaIncompatibleWithRoot1](#dependentschemasdependentsubschemaincompatiblewithroot1)<br> schema class |
+| class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.DependentSchemasDependentSubschemaIncompatibleWithRootMapBuilder](#dependentschemasdependentsubschemaincompatiblewithrootmapbuilder)<br> builder for Map payloads |
+| class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.DependentSchemasDependentSubschemaIncompatibleWithRootMap](#dependentschemasdependentsubschemaincompatiblewithrootmap)<br> output class for Map payloads |
 | sealed interface | [DependentSchemasDependentSubschemaIncompatibleWithRoot.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [DependentSchemasDependentSubschemaIncompatibleWithRoot.FooBoxedVoid](#fooboxedvoid)<br> boxed class to store validated null payloads |
-| record | [DependentSchemasDependentSubschemaIncompatibleWithRoot.FooBoxedBoolean](#fooboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [DependentSchemasDependentSubschemaIncompatibleWithRoot.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
-| record | [DependentSchemasDependentSubschemaIncompatibleWithRoot.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
-| record | [DependentSchemasDependentSubschemaIncompatibleWithRoot.FooBoxedList](#fooboxedlist)<br> boxed class to store validated List payloads |
-| record | [DependentSchemasDependentSubschemaIncompatibleWithRoot.FooBoxedMap](#fooboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.Foo](#foo)<br> schema class |
+| data class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.FooBoxedVoid](#fooboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.FooBoxedBoolean](#fooboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
+| data class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.FooBoxedList](#fooboxedlist)<br> boxed class to store validated List payloads |
+| data class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.FooBoxedMap](#fooboxedmap)<br> boxed class to store validated Map payloads |
+| class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.Foo](#foo)<br> schema class |
 | sealed interface | [DependentSchemasDependentSubschemaIncompatibleWithRoot.Foo1Boxed](#foo1boxed)<br> sealed interface for validated payloads |
-| record | [DependentSchemasDependentSubschemaIncompatibleWithRoot.Foo1BoxedMap](#foo1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.Foo1](#foo1)<br> schema class |
-| static class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.FooMapBuilder1](#foomapbuilder1)<br> builder for Map payloads |
-| static class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.FooMap](#foomap)<br> output class for Map payloads |
+| data class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.Foo1BoxedMap](#foo1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.Foo1](#foo1)<br> schema class |
+| class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.FooMapBuilder1](#foomapbuilder1)<br> builder for Map payloads |
+| class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.FooMap](#foomap)<br> output class for Map payloads |
 | sealed interface | [DependentSchemasDependentSubschemaIncompatibleWithRoot.BarBoxed](#barboxed)<br> sealed interface for validated payloads |
-| record | [DependentSchemasDependentSubschemaIncompatibleWithRoot.BarBoxedVoid](#barboxedvoid)<br> boxed class to store validated null payloads |
-| record | [DependentSchemasDependentSubschemaIncompatibleWithRoot.BarBoxedBoolean](#barboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [DependentSchemasDependentSubschemaIncompatibleWithRoot.BarBoxedNumber](#barboxednumber)<br> boxed class to store validated Number payloads |
-| record | [DependentSchemasDependentSubschemaIncompatibleWithRoot.BarBoxedString](#barboxedstring)<br> boxed class to store validated String payloads |
-| record | [DependentSchemasDependentSubschemaIncompatibleWithRoot.BarBoxedList](#barboxedlist)<br> boxed class to store validated List payloads |
-| record | [DependentSchemasDependentSubschemaIncompatibleWithRoot.BarBoxedMap](#barboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.Bar](#bar)<br> schema class |
+| data class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.BarBoxedVoid](#barboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.BarBoxedBoolean](#barboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.BarBoxedNumber](#barboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.BarBoxedString](#barboxedstring)<br> boxed class to store validated String payloads |
+| data class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.BarBoxedList](#barboxedlist)<br> boxed class to store validated List payloads |
+| data class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.BarBoxedMap](#barboxedmap)<br> boxed class to store validated Map payloads |
+| class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.Bar](#bar)<br> schema class |
 | sealed interface | [DependentSchemasDependentSubschemaIncompatibleWithRoot.AdditionalPropertiesBoxed](#additionalpropertiesboxed)<br> sealed interface for validated payloads |
-| record | [DependentSchemasDependentSubschemaIncompatibleWithRoot.AdditionalPropertiesBoxedVoid](#additionalpropertiesboxedvoid)<br> boxed class to store validated null payloads |
-| record | [DependentSchemasDependentSubschemaIncompatibleWithRoot.AdditionalPropertiesBoxedBoolean](#additionalpropertiesboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [DependentSchemasDependentSubschemaIncompatibleWithRoot.AdditionalPropertiesBoxedNumber](#additionalpropertiesboxednumber)<br> boxed class to store validated Number payloads |
-| record | [DependentSchemasDependentSubschemaIncompatibleWithRoot.AdditionalPropertiesBoxedString](#additionalpropertiesboxedstring)<br> boxed class to store validated String payloads |
-| record | [DependentSchemasDependentSubschemaIncompatibleWithRoot.AdditionalPropertiesBoxedList](#additionalpropertiesboxedlist)<br> boxed class to store validated List payloads |
-| record | [DependentSchemasDependentSubschemaIncompatibleWithRoot.AdditionalPropertiesBoxedMap](#additionalpropertiesboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.AdditionalProperties](#additionalproperties)<br> schema class |
+| data class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.AdditionalPropertiesBoxedVoid](#additionalpropertiesboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.AdditionalPropertiesBoxedBoolean](#additionalpropertiesboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.AdditionalPropertiesBoxedNumber](#additionalpropertiesboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.AdditionalPropertiesBoxedString](#additionalpropertiesboxedstring)<br> boxed class to store validated String payloads |
+| data class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.AdditionalPropertiesBoxedList](#additionalpropertiesboxedlist)<br> boxed class to store validated List payloads |
+| data class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.AdditionalPropertiesBoxedMap](#additionalpropertiesboxedmap)<br> boxed class to store validated Map payloads |
+| class | [DependentSchemasDependentSubschemaIncompatibleWithRoot.AdditionalProperties](#additionalproperties)<br> schema class |
 
 ## DependentSchemasDependentSubschemaIncompatibleWithRoot1Boxed
 sealed interface DependentSchemasDependentSubschemaIncompatibleWithRoot1Boxed<br>
@@ -85,7 +85,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class DependentSchemasDependentSubschemaIncompatibleWithRoot1BoxedBoolean<br>
 implements [DependentSchemasDependentSubschemaIncompatibleWithRoot1Boxed](#dependentschemasdependentsubschemaincompatiblewithroot1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -280,7 +280,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class FooBoxedBoolean<br>
 implements [FooBoxed](#fooboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -508,7 +508,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class BarBoxedBoolean<br>
 implements [BarBoxed](#barboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -633,7 +633,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class AdditionalPropertiesBoxedBoolean<br>
 implements [AdditionalPropertiesBoxed](#additionalpropertiesboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/DependentSchemasDependentSubschemaIncompatibleWithRoot.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/DependentSchemasDependentSubschemaIncompatibleWithRoot.md
@@ -183,19 +183,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [DependentSchemasDependentSubschemaIncompatibleWithRootMap](#dependentschemasdependentsubschemaincompatiblewithrootmap) | validate(arg: [Map&lt;?, ?&gt;](#dependentschemasdependentsubschemaincompatiblewithrootmapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [DependentSchemasDependentSubschemaIncompatibleWithRootMap](#dependentschemasdependentsubschemaincompatiblewithrootmap) | validate(arg: [Map&lt;*, *&gt;](#dependentschemasdependentsubschemaincompatiblewithrootmapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [DependentSchemasDependentSubschemaIncompatibleWithRoot1BoxedString](#dependentschemasdependentsubschemaincompatiblewithroot1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [DependentSchemasDependentSubschemaIncompatibleWithRoot1BoxedVoid](#dependentschemasdependentsubschemaincompatiblewithroot1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [DependentSchemasDependentSubschemaIncompatibleWithRoot1BoxedNumber](#dependentschemasdependentsubschemaincompatiblewithroot1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [DependentSchemasDependentSubschemaIncompatibleWithRoot1BoxedBoolean](#dependentschemasdependentsubschemaincompatiblewithroot1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [DependentSchemasDependentSubschemaIncompatibleWithRoot1BoxedMap](#dependentschemasdependentsubschemaincompatiblewithroot1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#dependentschemasdependentsubschemaincompatiblewithrootmapbuilder), configuration: SchemaConfiguration) |
+| [DependentSchemasDependentSubschemaIncompatibleWithRoot1BoxedBoolean](#dependentschemasdependentsubschemaincompatiblewithroot1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [DependentSchemasDependentSubschemaIncompatibleWithRoot1BoxedMap](#dependentschemasdependentsubschemaincompatiblewithroot1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#dependentschemasdependentsubschemaincompatiblewithrootmapbuilder), configuration: SchemaConfiguration) |
 | [DependentSchemasDependentSubschemaIncompatibleWithRoot1BoxedList](#dependentschemasdependentsubschemaincompatiblewithroot1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [DependentSchemasDependentSubschemaIncompatibleWithRoot1Boxed](#dependentschemasdependentsubschemaincompatiblewithroot1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -404,27 +404,23 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.DependentSchemasDependentSubschemaIncompatibleWithRoot;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.DependentSchemasDependentSubschemaIncompatibleWithRoot
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // Map validation
-DependentSchemasDependentSubschemaIncompatibleWithRoot.FooMap validatedPayload =
+val validatedPayload: DependentSchemasDependentSubschemaIncompatibleWithRoot.FooMap =
     DependentSchemasDependentSubschemaIncompatibleWithRoot.Foo1.validate(
-    new DependentSchemasDependentSubschemaIncompatibleWithRoot.FooMapBuilder1()
+    DependentSchemasDependentSubschemaIncompatibleWithRoot.FooMapBuilder1()
     .build(),
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -437,8 +433,8 @@ DependentSchemasDependentSubschemaIncompatibleWithRoot.FooMap validatedPayload =
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| [FooMap](#foomap) | validate(arg: [Map&lt;?, ?&gt;](#foomapbuilder1), configuration: SchemaConfiguration) |
-| [Foo1BoxedMap](#foo1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#foomapbuilder1), configuration: SchemaConfiguration) |
+| [FooMap](#foomap) | validate(arg: [Map&lt;*, *&gt;](#foomapbuilder1), configuration: SchemaConfiguration) |
+| [Foo1BoxedMap](#foo1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#foomapbuilder1), configuration: SchemaConfiguration) |
 | [Foo1Boxed](#foo1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
 

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/DependentSchemasSingleDependency.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/DependentSchemasSingleDependency.md
@@ -13,29 +13,29 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [DependentSchemasSingleDependency.DependentSchemasSingleDependency1Boxed](#dependentschemassingledependency1boxed)<br> sealed interface for validated payloads |
-| record | [DependentSchemasSingleDependency.DependentSchemasSingleDependency1BoxedVoid](#dependentschemassingledependency1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [DependentSchemasSingleDependency.DependentSchemasSingleDependency1BoxedBoolean](#dependentschemassingledependency1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [DependentSchemasSingleDependency.DependentSchemasSingleDependency1BoxedNumber](#dependentschemassingledependency1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [DependentSchemasSingleDependency.DependentSchemasSingleDependency1BoxedString](#dependentschemassingledependency1boxedstring)<br> boxed class to store validated String payloads |
-| record | [DependentSchemasSingleDependency.DependentSchemasSingleDependency1BoxedList](#dependentschemassingledependency1boxedlist)<br> boxed class to store validated List payloads |
-| record | [DependentSchemasSingleDependency.DependentSchemasSingleDependency1BoxedMap](#dependentschemassingledependency1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [DependentSchemasSingleDependency.DependentSchemasSingleDependency1](#dependentschemassingledependency1)<br> schema class |
+| data class | [DependentSchemasSingleDependency.DependentSchemasSingleDependency1BoxedVoid](#dependentschemassingledependency1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [DependentSchemasSingleDependency.DependentSchemasSingleDependency1BoxedBoolean](#dependentschemassingledependency1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [DependentSchemasSingleDependency.DependentSchemasSingleDependency1BoxedNumber](#dependentschemassingledependency1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [DependentSchemasSingleDependency.DependentSchemasSingleDependency1BoxedString](#dependentschemassingledependency1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [DependentSchemasSingleDependency.DependentSchemasSingleDependency1BoxedList](#dependentschemassingledependency1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [DependentSchemasSingleDependency.DependentSchemasSingleDependency1BoxedMap](#dependentschemassingledependency1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [DependentSchemasSingleDependency.DependentSchemasSingleDependency1](#dependentschemassingledependency1)<br> schema class |
 | sealed interface | [DependentSchemasSingleDependency.BarBoxed](#barboxed)<br> sealed interface for validated payloads |
-| record | [DependentSchemasSingleDependency.BarBoxedVoid](#barboxedvoid)<br> boxed class to store validated null payloads |
-| record | [DependentSchemasSingleDependency.BarBoxedBoolean](#barboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [DependentSchemasSingleDependency.BarBoxedNumber](#barboxednumber)<br> boxed class to store validated Number payloads |
-| record | [DependentSchemasSingleDependency.BarBoxedString](#barboxedstring)<br> boxed class to store validated String payloads |
-| record | [DependentSchemasSingleDependency.BarBoxedList](#barboxedlist)<br> boxed class to store validated List payloads |
-| record | [DependentSchemasSingleDependency.BarBoxedMap](#barboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [DependentSchemasSingleDependency.Bar](#bar)<br> schema class |
-| static class | [DependentSchemasSingleDependency.BarMapBuilder1](#barmapbuilder1)<br> builder for Map payloads |
-| static class | [DependentSchemasSingleDependency.BarMap](#barmap)<br> output class for Map payloads |
+| data class | [DependentSchemasSingleDependency.BarBoxedVoid](#barboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [DependentSchemasSingleDependency.BarBoxedBoolean](#barboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [DependentSchemasSingleDependency.BarBoxedNumber](#barboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [DependentSchemasSingleDependency.BarBoxedString](#barboxedstring)<br> boxed class to store validated String payloads |
+| data class | [DependentSchemasSingleDependency.BarBoxedList](#barboxedlist)<br> boxed class to store validated List payloads |
+| data class | [DependentSchemasSingleDependency.BarBoxedMap](#barboxedmap)<br> boxed class to store validated Map payloads |
+| class | [DependentSchemasSingleDependency.Bar](#bar)<br> schema class |
+| class | [DependentSchemasSingleDependency.BarMapBuilder1](#barmapbuilder1)<br> builder for Map payloads |
+| class | [DependentSchemasSingleDependency.BarMap](#barmap)<br> output class for Map payloads |
 | sealed interface | [DependentSchemasSingleDependency.Bar1Boxed](#bar1boxed)<br> sealed interface for validated payloads |
-| record | [DependentSchemasSingleDependency.Bar1BoxedNumber](#bar1boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [DependentSchemasSingleDependency.Bar1](#bar1)<br> schema class |
+| data class | [DependentSchemasSingleDependency.Bar1BoxedNumber](#bar1boxednumber)<br> boxed class to store validated Number payloads |
+| class | [DependentSchemasSingleDependency.Bar1](#bar1)<br> schema class |
 | sealed interface | [DependentSchemasSingleDependency.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [DependentSchemasSingleDependency.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
-| static class | [DependentSchemasSingleDependency.Foo](#foo)<br> schema class |
+| data class | [DependentSchemasSingleDependency.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
+| class | [DependentSchemasSingleDependency.Foo](#foo)<br> schema class |
 
 ## DependentSchemasSingleDependency1Boxed
 sealed interface DependentSchemasSingleDependency1Boxed<br>
@@ -70,7 +70,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class DependentSchemasSingleDependency1BoxedBoolean<br>
 implements [DependentSchemasSingleDependency1Boxed](#dependentschemassingledependency1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -217,7 +217,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class BarBoxedBoolean<br>
 implements [BarBoxed](#barboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/DependentSchemasSingleDependency.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/DependentSchemasSingleDependency.md
@@ -167,19 +167,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [DependentSchemasSingleDependency1BoxedString](#dependentschemassingledependency1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [DependentSchemasSingleDependency1BoxedVoid](#dependentschemassingledependency1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [DependentSchemasSingleDependency1BoxedNumber](#dependentschemassingledependency1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [DependentSchemasSingleDependency1BoxedBoolean](#dependentschemassingledependency1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [DependentSchemasSingleDependency1BoxedMap](#dependentschemassingledependency1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [DependentSchemasSingleDependency1BoxedBoolean](#dependentschemassingledependency1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [DependentSchemasSingleDependency1BoxedMap](#dependentschemassingledependency1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [DependentSchemasSingleDependency1BoxedList](#dependentschemassingledependency1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [DependentSchemasSingleDependency1Boxed](#dependentschemassingledependency1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -314,19 +314,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [BarMap](#barmap) | validate(arg: [Map&lt;?, ?&gt;](#barmapbuilder1), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [BarMap](#barmap) | validate(arg: [Map&lt;*, *&gt;](#barmapbuilder1), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [BarBoxedString](#barboxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [BarBoxedVoid](#barboxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [BarBoxedNumber](#barboxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [BarBoxedBoolean](#barboxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [BarBoxedMap](#barboxedmap) | validateAndBox([Map&lt;?, ?&gt;](#barmapbuilder1), configuration: SchemaConfiguration) |
+| [BarBoxedBoolean](#barboxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [BarBoxedMap](#barboxedmap) | validateAndBox([Map&lt;*, *&gt;](#barmapbuilder1), configuration: SchemaConfiguration) |
 | [BarBoxedList](#barboxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [BarBoxed](#barboxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/DurationFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/DurationFormat.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [DurationFormat.DurationFormat1Boxed](#durationformat1boxed)<br> sealed interface for validated payloads |
-| record | [DurationFormat.DurationFormat1BoxedVoid](#durationformat1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [DurationFormat.DurationFormat1BoxedBoolean](#durationformat1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [DurationFormat.DurationFormat1BoxedNumber](#durationformat1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [DurationFormat.DurationFormat1BoxedString](#durationformat1boxedstring)<br> boxed class to store validated String payloads |
-| record | [DurationFormat.DurationFormat1BoxedList](#durationformat1boxedlist)<br> boxed class to store validated List payloads |
-| record | [DurationFormat.DurationFormat1BoxedMap](#durationformat1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [DurationFormat.DurationFormat1](#durationformat1)<br> schema class |
+| data class | [DurationFormat.DurationFormat1BoxedVoid](#durationformat1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [DurationFormat.DurationFormat1BoxedBoolean](#durationformat1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [DurationFormat.DurationFormat1BoxedNumber](#durationformat1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [DurationFormat.DurationFormat1BoxedString](#durationformat1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [DurationFormat.DurationFormat1BoxedList](#durationformat1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [DurationFormat.DurationFormat1BoxedMap](#durationformat1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [DurationFormat.DurationFormat1](#durationformat1)<br> schema class |
 
 ## DurationFormat1Boxed
 sealed interface DurationFormat1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class DurationFormat1BoxedBoolean<br>
 implements [DurationFormat1Boxed](#durationformat1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/DurationFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/DurationFormat.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [DurationFormat1BoxedString](#durationformat1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [DurationFormat1BoxedVoid](#durationformat1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [DurationFormat1BoxedNumber](#durationformat1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [DurationFormat1BoxedBoolean](#durationformat1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [DurationFormat1BoxedMap](#durationformat1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [DurationFormat1BoxedBoolean](#durationformat1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [DurationFormat1BoxedMap](#durationformat1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [DurationFormat1BoxedList](#durationformat1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [DurationFormat1Boxed](#durationformat1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/EmailFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/EmailFormat.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [EmailFormat1BoxedString](#emailformat1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [EmailFormat1BoxedVoid](#emailformat1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [EmailFormat1BoxedNumber](#emailformat1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [EmailFormat1BoxedBoolean](#emailformat1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [EmailFormat1BoxedMap](#emailformat1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [EmailFormat1BoxedBoolean](#emailformat1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [EmailFormat1BoxedMap](#emailformat1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [EmailFormat1BoxedList](#emailformat1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [EmailFormat1Boxed](#emailformat1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/EmailFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/EmailFormat.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [EmailFormat.EmailFormat1Boxed](#emailformat1boxed)<br> sealed interface for validated payloads |
-| record | [EmailFormat.EmailFormat1BoxedVoid](#emailformat1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [EmailFormat.EmailFormat1BoxedBoolean](#emailformat1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [EmailFormat.EmailFormat1BoxedNumber](#emailformat1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [EmailFormat.EmailFormat1BoxedString](#emailformat1boxedstring)<br> boxed class to store validated String payloads |
-| record | [EmailFormat.EmailFormat1BoxedList](#emailformat1boxedlist)<br> boxed class to store validated List payloads |
-| record | [EmailFormat.EmailFormat1BoxedMap](#emailformat1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [EmailFormat.EmailFormat1](#emailformat1)<br> schema class |
+| data class | [EmailFormat.EmailFormat1BoxedVoid](#emailformat1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [EmailFormat.EmailFormat1BoxedBoolean](#emailformat1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [EmailFormat.EmailFormat1BoxedNumber](#emailformat1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [EmailFormat.EmailFormat1BoxedString](#emailformat1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [EmailFormat.EmailFormat1BoxedList](#emailformat1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [EmailFormat.EmailFormat1BoxedMap](#emailformat1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [EmailFormat.EmailFormat1](#emailformat1)<br> schema class |
 
 ## EmailFormat1Boxed
 sealed interface EmailFormat1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class EmailFormat1BoxedBoolean<br>
 implements [EmailFormat1Boxed](#emailformat1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/EmptyDependents.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/EmptyDependents.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [EmptyDependents.EmptyDependents1Boxed](#emptydependents1boxed)<br> sealed interface for validated payloads |
-| record | [EmptyDependents.EmptyDependents1BoxedVoid](#emptydependents1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [EmptyDependents.EmptyDependents1BoxedBoolean](#emptydependents1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [EmptyDependents.EmptyDependents1BoxedNumber](#emptydependents1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [EmptyDependents.EmptyDependents1BoxedString](#emptydependents1boxedstring)<br> boxed class to store validated String payloads |
-| record | [EmptyDependents.EmptyDependents1BoxedList](#emptydependents1boxedlist)<br> boxed class to store validated List payloads |
-| record | [EmptyDependents.EmptyDependents1BoxedMap](#emptydependents1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [EmptyDependents.EmptyDependents1](#emptydependents1)<br> schema class |
+| data class | [EmptyDependents.EmptyDependents1BoxedVoid](#emptydependents1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [EmptyDependents.EmptyDependents1BoxedBoolean](#emptydependents1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [EmptyDependents.EmptyDependents1BoxedNumber](#emptydependents1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [EmptyDependents.EmptyDependents1BoxedString](#emptydependents1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [EmptyDependents.EmptyDependents1BoxedList](#emptydependents1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [EmptyDependents.EmptyDependents1BoxedMap](#emptydependents1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [EmptyDependents.EmptyDependents1](#emptydependents1)<br> schema class |
 
 ## EmptyDependents1Boxed
 sealed interface EmptyDependents1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class EmptyDependents1BoxedBoolean<br>
 implements [EmptyDependents1Boxed](#emptydependents1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/EmptyDependents.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/EmptyDependents.md
@@ -156,19 +156,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [EmptyDependents1BoxedString](#emptydependents1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [EmptyDependents1BoxedVoid](#emptydependents1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [EmptyDependents1BoxedNumber](#emptydependents1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [EmptyDependents1BoxedBoolean](#emptydependents1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [EmptyDependents1BoxedMap](#emptydependents1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [EmptyDependents1BoxedBoolean](#emptydependents1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [EmptyDependents1BoxedMap](#emptydependents1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [EmptyDependents1BoxedList](#emptydependents1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [EmptyDependents1Boxed](#emptydependents1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/EnumWith0DoesNotMatchFalse.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/EnumWith0DoesNotMatchFalse.md
@@ -51,25 +51,21 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.EnumWith0DoesNotMatchFalse;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.EnumWith0DoesNotMatchFalse
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // int validation
-int validatedPayload = EnumWith0DoesNotMatchFalse.EnumWith0DoesNotMatchFalse1.validate(
+val validatedPayload: Int = EnumWith0DoesNotMatchFalse.EnumWith0DoesNotMatchFalse1.validate(
     1,
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -90,7 +86,7 @@ int validatedPayload = EnumWith0DoesNotMatchFalse.EnumWith0DoesNotMatchFalse1.va
 public enum IntegerEnumWith0DoesNotMatchFalseEnums<br>
 extends `Enum<IntegerEnumWith0DoesNotMatchFalseEnums>`
 
-A class that stores Integer enum values
+A class that stores Int enum values
 
 ### Enum Constant Summary
 | Enum Constant | Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/EnumWith0DoesNotMatchFalse.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/EnumWith0DoesNotMatchFalse.md
@@ -12,8 +12,8 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [EnumWith0DoesNotMatchFalse.EnumWith0DoesNotMatchFalse1Boxed](#enumwith0doesnotmatchfalse1boxed)<br> sealed interface for validated payloads |
-| record | [EnumWith0DoesNotMatchFalse.EnumWith0DoesNotMatchFalse1BoxedNumber](#enumwith0doesnotmatchfalse1boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [EnumWith0DoesNotMatchFalse.EnumWith0DoesNotMatchFalse1](#enumwith0doesnotmatchfalse1)<br> schema class |
+| data class | [EnumWith0DoesNotMatchFalse.EnumWith0DoesNotMatchFalse1BoxedNumber](#enumwith0doesnotmatchfalse1boxednumber)<br> boxed class to store validated Number payloads |
+| class | [EnumWith0DoesNotMatchFalse.EnumWith0DoesNotMatchFalse1](#enumwith0doesnotmatchfalse1)<br> schema class |
 | enum | [EnumWith0DoesNotMatchFalse.IntegerEnumWith0DoesNotMatchFalseEnums](#integerenumwith0doesnotmatchfalseenums)<br>Integer enum |
 | enum | [EnumWith0DoesNotMatchFalse.LongEnumWith0DoesNotMatchFalseEnums](#longenumwith0doesnotmatchfalseenums)<br>Long enum |
 | enum | [EnumWith0DoesNotMatchFalse.FloatEnumWith0DoesNotMatchFalseEnums](#floatenumwith0doesnotmatchfalseenums)<br>Float enum |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/EnumWith1DoesNotMatchTrue.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/EnumWith1DoesNotMatchTrue.md
@@ -51,25 +51,21 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.EnumWith1DoesNotMatchTrue;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.EnumWith1DoesNotMatchTrue
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // int validation
-int validatedPayload = EnumWith1DoesNotMatchTrue.EnumWith1DoesNotMatchTrue1.validate(
+val validatedPayload: Int = EnumWith1DoesNotMatchTrue.EnumWith1DoesNotMatchTrue1.validate(
     1,
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -90,7 +86,7 @@ int validatedPayload = EnumWith1DoesNotMatchTrue.EnumWith1DoesNotMatchTrue1.vali
 public enum IntegerEnumWith1DoesNotMatchTrueEnums<br>
 extends `Enum<IntegerEnumWith1DoesNotMatchTrueEnums>`
 
-A class that stores Integer enum values
+A class that stores Int enum values
 
 ### Enum Constant Summary
 | Enum Constant | Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/EnumWith1DoesNotMatchTrue.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/EnumWith1DoesNotMatchTrue.md
@@ -12,8 +12,8 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [EnumWith1DoesNotMatchTrue.EnumWith1DoesNotMatchTrue1Boxed](#enumwith1doesnotmatchtrue1boxed)<br> sealed interface for validated payloads |
-| record | [EnumWith1DoesNotMatchTrue.EnumWith1DoesNotMatchTrue1BoxedNumber](#enumwith1doesnotmatchtrue1boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [EnumWith1DoesNotMatchTrue.EnumWith1DoesNotMatchTrue1](#enumwith1doesnotmatchtrue1)<br> schema class |
+| data class | [EnumWith1DoesNotMatchTrue.EnumWith1DoesNotMatchTrue1BoxedNumber](#enumwith1doesnotmatchtrue1boxednumber)<br> boxed class to store validated Number payloads |
+| class | [EnumWith1DoesNotMatchTrue.EnumWith1DoesNotMatchTrue1](#enumwith1doesnotmatchtrue1)<br> schema class |
 | enum | [EnumWith1DoesNotMatchTrue.IntegerEnumWith1DoesNotMatchTrueEnums](#integerenumwith1doesnotmatchtrueenums)<br>Integer enum |
 | enum | [EnumWith1DoesNotMatchTrue.LongEnumWith1DoesNotMatchTrueEnums](#longenumwith1doesnotmatchtrueenums)<br>Long enum |
 | enum | [EnumWith1DoesNotMatchTrue.FloatEnumWith1DoesNotMatchTrueEnums](#floatenumwith1doesnotmatchtrueenums)<br>Float enum |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/EnumWithEscapedCharacters.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/EnumWithEscapedCharacters.md
@@ -12,8 +12,8 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [EnumWithEscapedCharacters.EnumWithEscapedCharacters1Boxed](#enumwithescapedcharacters1boxed)<br> sealed interface for validated payloads |
-| record | [EnumWithEscapedCharacters.EnumWithEscapedCharacters1BoxedString](#enumwithescapedcharacters1boxedstring)<br> boxed class to store validated String payloads |
-| static class | [EnumWithEscapedCharacters.EnumWithEscapedCharacters1](#enumwithescapedcharacters1)<br> schema class |
+| data class | [EnumWithEscapedCharacters.EnumWithEscapedCharacters1BoxedString](#enumwithescapedcharacters1boxedstring)<br> boxed class to store validated String payloads |
+| class | [EnumWithEscapedCharacters.EnumWithEscapedCharacters1](#enumwithescapedcharacters1)<br> schema class |
 | enum | [EnumWithEscapedCharacters.StringEnumWithEscapedCharactersEnums](#stringenumwithescapedcharactersenums)<br>String enum |
 
 ## EnumWithEscapedCharacters1Boxed

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/EnumWithEscapedCharacters.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/EnumWithEscapedCharacters.md
@@ -48,25 +48,21 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.EnumWithEscapedCharacters;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.EnumWithEscapedCharacters
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // String validation
-String validatedPayload = EnumWithEscapedCharacters.EnumWithEscapedCharacters1.validate(
+val validatedPayload: String = EnumWithEscapedCharacters.EnumWithEscapedCharacters1.validate(
     "foo\nbar",
     configuration
-);
+)
 ```
 
 ### Field Summary

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/EnumWithFalseDoesNotMatch0.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/EnumWithFalseDoesNotMatch0.md
@@ -48,25 +48,21 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.EnumWithFalseDoesNotMatch0;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.EnumWithFalseDoesNotMatch0
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // boolean validation
-boolean validatedPayload = EnumWithFalseDoesNotMatch0.EnumWithFalseDoesNotMatch01.validate(
+val validatedPayload: Boolean = EnumWithFalseDoesNotMatch0.EnumWithFalseDoesNotMatch01.validate(
     false,
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -78,9 +74,9 @@ boolean validatedPayload = EnumWithFalseDoesNotMatch0.EnumWithFalseDoesNotMatch0
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| boolean | validate(arg: [BooleanEnumWithFalseDoesNotMatch0Enums](#booleanenumwithfalsedoesnotmatch0enums), configuration: SchemaConfiguration) |
-| [EnumWithFalseDoesNotMatch01BoxedBoolean](#enumwithfalsedoesnotmatch01boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: [BooleanEnumWithFalseDoesNotMatch0Enums](#booleanenumwithfalsedoesnotmatch0enums), configuration: SchemaConfiguration) |
+| [EnumWithFalseDoesNotMatch01BoxedBoolean](#enumwithfalsedoesnotmatch01boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
 | [EnumWithFalseDoesNotMatch01Boxed](#enumwithfalsedoesnotmatch01boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
 

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/EnumWithFalseDoesNotMatch0.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/EnumWithFalseDoesNotMatch0.md
@@ -12,8 +12,8 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [EnumWithFalseDoesNotMatch0.EnumWithFalseDoesNotMatch01Boxed](#enumwithfalsedoesnotmatch01boxed)<br> sealed interface for validated payloads |
-| record | [EnumWithFalseDoesNotMatch0.EnumWithFalseDoesNotMatch01BoxedBoolean](#enumwithfalsedoesnotmatch01boxedboolean)<br> boxed class to store validated boolean payloads |
-| static class | [EnumWithFalseDoesNotMatch0.EnumWithFalseDoesNotMatch01](#enumwithfalsedoesnotmatch01)<br> schema class |
+| data class | [EnumWithFalseDoesNotMatch0.EnumWithFalseDoesNotMatch01BoxedBoolean](#enumwithfalsedoesnotmatch01boxedboolean)<br> boxed class to store validated boolean payloads |
+| class | [EnumWithFalseDoesNotMatch0.EnumWithFalseDoesNotMatch01](#enumwithfalsedoesnotmatch01)<br> schema class |
 | enum | [EnumWithFalseDoesNotMatch0.BooleanEnumWithFalseDoesNotMatch0Enums](#booleanenumwithfalsedoesnotmatch0enums)<br>boolean enum |
 
 ## EnumWithFalseDoesNotMatch01Boxed
@@ -27,7 +27,7 @@ sealed interface that stores validated payloads using boxed classes
 data class EnumWithFalseDoesNotMatch01BoxedBoolean<br>
 implements [EnumWithFalseDoesNotMatch01Boxed](#enumwithfalsedoesnotmatch01boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/EnumWithTrueDoesNotMatch1.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/EnumWithTrueDoesNotMatch1.md
@@ -12,8 +12,8 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [EnumWithTrueDoesNotMatch1.EnumWithTrueDoesNotMatch11Boxed](#enumwithtruedoesnotmatch11boxed)<br> sealed interface for validated payloads |
-| record | [EnumWithTrueDoesNotMatch1.EnumWithTrueDoesNotMatch11BoxedBoolean](#enumwithtruedoesnotmatch11boxedboolean)<br> boxed class to store validated boolean payloads |
-| static class | [EnumWithTrueDoesNotMatch1.EnumWithTrueDoesNotMatch11](#enumwithtruedoesnotmatch11)<br> schema class |
+| data class | [EnumWithTrueDoesNotMatch1.EnumWithTrueDoesNotMatch11BoxedBoolean](#enumwithtruedoesnotmatch11boxedboolean)<br> boxed class to store validated boolean payloads |
+| class | [EnumWithTrueDoesNotMatch1.EnumWithTrueDoesNotMatch11](#enumwithtruedoesnotmatch11)<br> schema class |
 | enum | [EnumWithTrueDoesNotMatch1.BooleanEnumWithTrueDoesNotMatch1Enums](#booleanenumwithtruedoesnotmatch1enums)<br>boolean enum |
 
 ## EnumWithTrueDoesNotMatch11Boxed
@@ -27,7 +27,7 @@ sealed interface that stores validated payloads using boxed classes
 data class EnumWithTrueDoesNotMatch11BoxedBoolean<br>
 implements [EnumWithTrueDoesNotMatch11Boxed](#enumwithtruedoesnotmatch11boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/EnumWithTrueDoesNotMatch1.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/EnumWithTrueDoesNotMatch1.md
@@ -48,25 +48,21 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.EnumWithTrueDoesNotMatch1;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.EnumWithTrueDoesNotMatch1
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // boolean validation
-boolean validatedPayload = EnumWithTrueDoesNotMatch1.EnumWithTrueDoesNotMatch11.validate(
+val validatedPayload: Boolean = EnumWithTrueDoesNotMatch1.EnumWithTrueDoesNotMatch11.validate(
     true,
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -78,9 +74,9 @@ boolean validatedPayload = EnumWithTrueDoesNotMatch1.EnumWithTrueDoesNotMatch11.
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| boolean | validate(arg: [BooleanEnumWithTrueDoesNotMatch1Enums](#booleanenumwithtruedoesnotmatch1enums), configuration: SchemaConfiguration) |
-| [EnumWithTrueDoesNotMatch11BoxedBoolean](#enumwithtruedoesnotmatch11boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: [BooleanEnumWithTrueDoesNotMatch1Enums](#booleanenumwithtruedoesnotmatch1enums), configuration: SchemaConfiguration) |
+| [EnumWithTrueDoesNotMatch11BoxedBoolean](#enumwithtruedoesnotmatch11boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
 | [EnumWithTrueDoesNotMatch11Boxed](#enumwithtruedoesnotmatch11boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
 

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/EnumsInProperties.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/EnumsInProperties.md
@@ -14,17 +14,17 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [EnumsInProperties.EnumsInProperties1Boxed](#enumsinproperties1boxed)<br> sealed interface for validated payloads |
-| record | [EnumsInProperties.EnumsInProperties1BoxedMap](#enumsinproperties1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [EnumsInProperties.EnumsInProperties1](#enumsinproperties1)<br> schema class |
-| static class | [EnumsInProperties.EnumsInPropertiesMapBuilder](#enumsinpropertiesmapbuilder)<br> builder for Map payloads |
-| static class | [EnumsInProperties.EnumsInPropertiesMap](#enumsinpropertiesmap)<br> output class for Map payloads |
+| data class | [EnumsInProperties.EnumsInProperties1BoxedMap](#enumsinproperties1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [EnumsInProperties.EnumsInProperties1](#enumsinproperties1)<br> schema class |
+| class | [EnumsInProperties.EnumsInPropertiesMapBuilder](#enumsinpropertiesmapbuilder)<br> builder for Map payloads |
+| class | [EnumsInProperties.EnumsInPropertiesMap](#enumsinpropertiesmap)<br> output class for Map payloads |
 | sealed interface | [EnumsInProperties.BarBoxed](#barboxed)<br> sealed interface for validated payloads |
-| record | [EnumsInProperties.BarBoxedString](#barboxedstring)<br> boxed class to store validated String payloads |
-| static class | [EnumsInProperties.Bar](#bar)<br> schema class |
+| data class | [EnumsInProperties.BarBoxedString](#barboxedstring)<br> boxed class to store validated String payloads |
+| class | [EnumsInProperties.Bar](#bar)<br> schema class |
 | enum | [EnumsInProperties.StringBarEnums](#stringbarenums)<br>String enum |
 | sealed interface | [EnumsInProperties.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [EnumsInProperties.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
-| static class | [EnumsInProperties.Foo](#foo)<br> schema class |
+| data class | [EnumsInProperties.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
+| class | [EnumsInProperties.Foo](#foo)<br> schema class |
 | enum | [EnumsInProperties.StringFooEnums](#stringfooenums)<br>String enum |
 
 ## EnumsInProperties1Boxed

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/EnumsInProperties.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/EnumsInProperties.md
@@ -59,31 +59,27 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.EnumsInProperties;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.EnumsInProperties
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // Map validation
-EnumsInProperties.EnumsInPropertiesMap validatedPayload =
+val validatedPayload: EnumsInProperties.EnumsInPropertiesMap =
     EnumsInProperties.EnumsInProperties1.validate(
-    new EnumsInProperties.EnumsInPropertiesMapBuilder()
+    EnumsInProperties.EnumsInPropertiesMapBuilder()
         .bar("bar")
 
         .foo("foo")
 
     .build(),
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -96,8 +92,8 @@ EnumsInProperties.EnumsInPropertiesMap validatedPayload =
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| [EnumsInPropertiesMap](#enumsinpropertiesmap) | validate(arg: [Map&lt;?, ?&gt;](#enumsinpropertiesmapbuilder), configuration: SchemaConfiguration) |
-| [EnumsInProperties1BoxedMap](#enumsinproperties1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#enumsinpropertiesmapbuilder), configuration: SchemaConfiguration) |
+| [EnumsInPropertiesMap](#enumsinpropertiesmap) | validate(arg: [Map&lt;*, *&gt;](#enumsinpropertiesmapbuilder), configuration: SchemaConfiguration) |
+| [EnumsInProperties1BoxedMap](#enumsinproperties1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#enumsinpropertiesmapbuilder), configuration: SchemaConfiguration) |
 | [EnumsInProperties1Boxed](#enumsinproperties1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
 
@@ -191,25 +187,21 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.EnumsInProperties;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.EnumsInProperties
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // String validation
-String validatedPayload = EnumsInProperties.Bar.validate(
+val validatedPayload: String = EnumsInProperties.Bar.validate(
     "bar",
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -270,25 +262,21 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.EnumsInProperties;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.EnumsInProperties
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // String validation
-String validatedPayload = EnumsInProperties.Foo.validate(
+val validatedPayload: String = EnumsInProperties.Foo.validate(
     "foo",
     configuration
-);
+)
 ```
 
 ### Field Summary

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ExclusivemaximumValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ExclusivemaximumValidation.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [ExclusivemaximumValidation.ExclusivemaximumValidation1Boxed](#exclusivemaximumvalidation1boxed)<br> sealed interface for validated payloads |
-| record | [ExclusivemaximumValidation.ExclusivemaximumValidation1BoxedVoid](#exclusivemaximumvalidation1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [ExclusivemaximumValidation.ExclusivemaximumValidation1BoxedBoolean](#exclusivemaximumvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [ExclusivemaximumValidation.ExclusivemaximumValidation1BoxedNumber](#exclusivemaximumvalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [ExclusivemaximumValidation.ExclusivemaximumValidation1BoxedString](#exclusivemaximumvalidation1boxedstring)<br> boxed class to store validated String payloads |
-| record | [ExclusivemaximumValidation.ExclusivemaximumValidation1BoxedList](#exclusivemaximumvalidation1boxedlist)<br> boxed class to store validated List payloads |
-| record | [ExclusivemaximumValidation.ExclusivemaximumValidation1BoxedMap](#exclusivemaximumvalidation1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [ExclusivemaximumValidation.ExclusivemaximumValidation1](#exclusivemaximumvalidation1)<br> schema class |
+| data class | [ExclusivemaximumValidation.ExclusivemaximumValidation1BoxedVoid](#exclusivemaximumvalidation1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [ExclusivemaximumValidation.ExclusivemaximumValidation1BoxedBoolean](#exclusivemaximumvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [ExclusivemaximumValidation.ExclusivemaximumValidation1BoxedNumber](#exclusivemaximumvalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [ExclusivemaximumValidation.ExclusivemaximumValidation1BoxedString](#exclusivemaximumvalidation1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [ExclusivemaximumValidation.ExclusivemaximumValidation1BoxedList](#exclusivemaximumvalidation1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [ExclusivemaximumValidation.ExclusivemaximumValidation1BoxedMap](#exclusivemaximumvalidation1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [ExclusivemaximumValidation.ExclusivemaximumValidation1](#exclusivemaximumvalidation1)<br> schema class |
 
 ## ExclusivemaximumValidation1Boxed
 sealed interface ExclusivemaximumValidation1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class ExclusivemaximumValidation1BoxedBoolean<br>
 implements [ExclusivemaximumValidation1Boxed](#exclusivemaximumvalidation1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ExclusivemaximumValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ExclusivemaximumValidation.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [ExclusivemaximumValidation1BoxedString](#exclusivemaximumvalidation1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [ExclusivemaximumValidation1BoxedVoid](#exclusivemaximumvalidation1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [ExclusivemaximumValidation1BoxedNumber](#exclusivemaximumvalidation1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [ExclusivemaximumValidation1BoxedBoolean](#exclusivemaximumvalidation1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [ExclusivemaximumValidation1BoxedMap](#exclusivemaximumvalidation1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [ExclusivemaximumValidation1BoxedBoolean](#exclusivemaximumvalidation1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [ExclusivemaximumValidation1BoxedMap](#exclusivemaximumvalidation1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [ExclusivemaximumValidation1BoxedList](#exclusivemaximumvalidation1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [ExclusivemaximumValidation1Boxed](#exclusivemaximumvalidation1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ExclusiveminimumValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ExclusiveminimumValidation.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [ExclusiveminimumValidation1BoxedString](#exclusiveminimumvalidation1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [ExclusiveminimumValidation1BoxedVoid](#exclusiveminimumvalidation1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [ExclusiveminimumValidation1BoxedNumber](#exclusiveminimumvalidation1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [ExclusiveminimumValidation1BoxedBoolean](#exclusiveminimumvalidation1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [ExclusiveminimumValidation1BoxedMap](#exclusiveminimumvalidation1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [ExclusiveminimumValidation1BoxedBoolean](#exclusiveminimumvalidation1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [ExclusiveminimumValidation1BoxedMap](#exclusiveminimumvalidation1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [ExclusiveminimumValidation1BoxedList](#exclusiveminimumvalidation1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [ExclusiveminimumValidation1Boxed](#exclusiveminimumvalidation1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ExclusiveminimumValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ExclusiveminimumValidation.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [ExclusiveminimumValidation.ExclusiveminimumValidation1Boxed](#exclusiveminimumvalidation1boxed)<br> sealed interface for validated payloads |
-| record | [ExclusiveminimumValidation.ExclusiveminimumValidation1BoxedVoid](#exclusiveminimumvalidation1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [ExclusiveminimumValidation.ExclusiveminimumValidation1BoxedBoolean](#exclusiveminimumvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [ExclusiveminimumValidation.ExclusiveminimumValidation1BoxedNumber](#exclusiveminimumvalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [ExclusiveminimumValidation.ExclusiveminimumValidation1BoxedString](#exclusiveminimumvalidation1boxedstring)<br> boxed class to store validated String payloads |
-| record | [ExclusiveminimumValidation.ExclusiveminimumValidation1BoxedList](#exclusiveminimumvalidation1boxedlist)<br> boxed class to store validated List payloads |
-| record | [ExclusiveminimumValidation.ExclusiveminimumValidation1BoxedMap](#exclusiveminimumvalidation1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [ExclusiveminimumValidation.ExclusiveminimumValidation1](#exclusiveminimumvalidation1)<br> schema class |
+| data class | [ExclusiveminimumValidation.ExclusiveminimumValidation1BoxedVoid](#exclusiveminimumvalidation1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [ExclusiveminimumValidation.ExclusiveminimumValidation1BoxedBoolean](#exclusiveminimumvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [ExclusiveminimumValidation.ExclusiveminimumValidation1BoxedNumber](#exclusiveminimumvalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [ExclusiveminimumValidation.ExclusiveminimumValidation1BoxedString](#exclusiveminimumvalidation1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [ExclusiveminimumValidation.ExclusiveminimumValidation1BoxedList](#exclusiveminimumvalidation1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [ExclusiveminimumValidation.ExclusiveminimumValidation1BoxedMap](#exclusiveminimumvalidation1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [ExclusiveminimumValidation.ExclusiveminimumValidation1](#exclusiveminimumvalidation1)<br> schema class |
 
 ## ExclusiveminimumValidation1Boxed
 sealed interface ExclusiveminimumValidation1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class ExclusiveminimumValidation1BoxedBoolean<br>
 implements [ExclusiveminimumValidation1Boxed](#exclusiveminimumvalidation1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/FloatDivisionInf.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/FloatDivisionInf.md
@@ -11,8 +11,8 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [FloatDivisionInf.FloatDivisionInf1Boxed](#floatdivisioninf1boxed)<br> sealed interface for validated payloads |
-| record | [FloatDivisionInf.FloatDivisionInf1BoxedNumber](#floatdivisioninf1boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [FloatDivisionInf.FloatDivisionInf1](#floatdivisioninf1)<br> schema class |
+| data class | [FloatDivisionInf.FloatDivisionInf1BoxedNumber](#floatdivisioninf1boxednumber)<br> boxed class to store validated Number payloads |
+| class | [FloatDivisionInf.FloatDivisionInf1](#floatdivisioninf1)<br> schema class |
 
 ## FloatDivisionInf1Boxed
 sealed interface FloatDivisionInf1Boxed<br>

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/FloatDivisionInf.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/FloatDivisionInf.md
@@ -46,25 +46,21 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.FloatDivisionInf;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.FloatDivisionInf
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // int validation
-int validatedPayload = FloatDivisionInf.FloatDivisionInf1.validate(
+val validatedPayload: Int = FloatDivisionInf.FloatDivisionInf1.validate(
     1L,
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -77,7 +73,7 @@ int validatedPayload = FloatDivisionInf.FloatDivisionInf1.validate(
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
 | [FloatDivisionInf1BoxedNumber](#floatdivisioninf1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
 | [FloatDivisionInf1Boxed](#floatdivisioninf1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ForbiddenProperty.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ForbiddenProperty.md
@@ -169,19 +169,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [ForbiddenPropertyMap](#forbiddenpropertymap) | validate(arg: [Map&lt;?, ?&gt;](#forbiddenpropertymapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [ForbiddenPropertyMap](#forbiddenpropertymap) | validate(arg: [Map&lt;*, *&gt;](#forbiddenpropertymapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [ForbiddenProperty1BoxedString](#forbiddenproperty1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [ForbiddenProperty1BoxedVoid](#forbiddenproperty1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [ForbiddenProperty1BoxedNumber](#forbiddenproperty1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [ForbiddenProperty1BoxedBoolean](#forbiddenproperty1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [ForbiddenProperty1BoxedMap](#forbiddenproperty1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#forbiddenpropertymapbuilder), configuration: SchemaConfiguration) |
+| [ForbiddenProperty1BoxedBoolean](#forbiddenproperty1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [ForbiddenProperty1BoxedMap](#forbiddenproperty1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#forbiddenpropertymapbuilder), configuration: SchemaConfiguration) |
 | [ForbiddenProperty1BoxedList](#forbiddenproperty1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [ForbiddenProperty1Boxed](#forbiddenproperty1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -363,19 +363,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [FooBoxedString](#fooboxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [FooBoxedVoid](#fooboxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [FooBoxedNumber](#fooboxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [FooBoxedBoolean](#fooboxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [FooBoxedMap](#fooboxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [FooBoxedBoolean](#fooboxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [FooBoxedMap](#fooboxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [FooBoxedList](#fooboxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [FooBoxed](#fooboxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ForbiddenProperty.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ForbiddenProperty.md
@@ -13,31 +13,31 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [ForbiddenProperty.ForbiddenProperty1Boxed](#forbiddenproperty1boxed)<br> sealed interface for validated payloads |
-| record | [ForbiddenProperty.ForbiddenProperty1BoxedVoid](#forbiddenproperty1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [ForbiddenProperty.ForbiddenProperty1BoxedBoolean](#forbiddenproperty1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [ForbiddenProperty.ForbiddenProperty1BoxedNumber](#forbiddenproperty1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [ForbiddenProperty.ForbiddenProperty1BoxedString](#forbiddenproperty1boxedstring)<br> boxed class to store validated String payloads |
-| record | [ForbiddenProperty.ForbiddenProperty1BoxedList](#forbiddenproperty1boxedlist)<br> boxed class to store validated List payloads |
-| record | [ForbiddenProperty.ForbiddenProperty1BoxedMap](#forbiddenproperty1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [ForbiddenProperty.ForbiddenProperty1](#forbiddenproperty1)<br> schema class |
-| static class | [ForbiddenProperty.ForbiddenPropertyMapBuilder](#forbiddenpropertymapbuilder)<br> builder for Map payloads |
-| static class | [ForbiddenProperty.ForbiddenPropertyMap](#forbiddenpropertymap)<br> output class for Map payloads |
+| data class | [ForbiddenProperty.ForbiddenProperty1BoxedVoid](#forbiddenproperty1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [ForbiddenProperty.ForbiddenProperty1BoxedBoolean](#forbiddenproperty1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [ForbiddenProperty.ForbiddenProperty1BoxedNumber](#forbiddenproperty1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [ForbiddenProperty.ForbiddenProperty1BoxedString](#forbiddenproperty1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [ForbiddenProperty.ForbiddenProperty1BoxedList](#forbiddenproperty1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [ForbiddenProperty.ForbiddenProperty1BoxedMap](#forbiddenproperty1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [ForbiddenProperty.ForbiddenProperty1](#forbiddenproperty1)<br> schema class |
+| class | [ForbiddenProperty.ForbiddenPropertyMapBuilder](#forbiddenpropertymapbuilder)<br> builder for Map payloads |
+| class | [ForbiddenProperty.ForbiddenPropertyMap](#forbiddenpropertymap)<br> output class for Map payloads |
 | sealed interface | [ForbiddenProperty.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [ForbiddenProperty.FooBoxedVoid](#fooboxedvoid)<br> boxed class to store validated null payloads |
-| record | [ForbiddenProperty.FooBoxedBoolean](#fooboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [ForbiddenProperty.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
-| record | [ForbiddenProperty.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
-| record | [ForbiddenProperty.FooBoxedList](#fooboxedlist)<br> boxed class to store validated List payloads |
-| record | [ForbiddenProperty.FooBoxedMap](#fooboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [ForbiddenProperty.Foo](#foo)<br> schema class |
+| data class | [ForbiddenProperty.FooBoxedVoid](#fooboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [ForbiddenProperty.FooBoxedBoolean](#fooboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [ForbiddenProperty.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [ForbiddenProperty.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
+| data class | [ForbiddenProperty.FooBoxedList](#fooboxedlist)<br> boxed class to store validated List payloads |
+| data class | [ForbiddenProperty.FooBoxedMap](#fooboxedmap)<br> boxed class to store validated Map payloads |
+| class | [ForbiddenProperty.Foo](#foo)<br> schema class |
 | sealed interface | [ForbiddenProperty.NotBoxed](#notboxed)<br> sealed interface for validated payloads |
-| record | [ForbiddenProperty.NotBoxedVoid](#notboxedvoid)<br> boxed class to store validated null payloads |
-| record | [ForbiddenProperty.NotBoxedBoolean](#notboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [ForbiddenProperty.NotBoxedNumber](#notboxednumber)<br> boxed class to store validated Number payloads |
-| record | [ForbiddenProperty.NotBoxedString](#notboxedstring)<br> boxed class to store validated String payloads |
-| record | [ForbiddenProperty.NotBoxedList](#notboxedlist)<br> boxed class to store validated List payloads |
-| record | [ForbiddenProperty.NotBoxedMap](#notboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [ForbiddenProperty.Not](#not)<br> schema class |
+| data class | [ForbiddenProperty.NotBoxedVoid](#notboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [ForbiddenProperty.NotBoxedBoolean](#notboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [ForbiddenProperty.NotBoxedNumber](#notboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [ForbiddenProperty.NotBoxedString](#notboxedstring)<br> boxed class to store validated String payloads |
+| data class | [ForbiddenProperty.NotBoxedList](#notboxedlist)<br> boxed class to store validated List payloads |
+| data class | [ForbiddenProperty.NotBoxedMap](#notboxedmap)<br> boxed class to store validated Map payloads |
+| class | [ForbiddenProperty.Not](#not)<br> schema class |
 
 ## ForbiddenProperty1Boxed
 sealed interface ForbiddenProperty1Boxed<br>
@@ -72,7 +72,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class ForbiddenProperty1BoxedBoolean<br>
 implements [ForbiddenProperty1Boxed](#forbiddenproperty1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -266,7 +266,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class FooBoxedBoolean<br>
 implements [FooBoxed](#fooboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -413,7 +413,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class NotBoxedBoolean<br>
 implements [NotBoxed](#notboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/HostnameFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/HostnameFormat.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [HostnameFormat1BoxedString](#hostnameformat1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [HostnameFormat1BoxedVoid](#hostnameformat1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [HostnameFormat1BoxedNumber](#hostnameformat1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [HostnameFormat1BoxedBoolean](#hostnameformat1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [HostnameFormat1BoxedMap](#hostnameformat1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [HostnameFormat1BoxedBoolean](#hostnameformat1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [HostnameFormat1BoxedMap](#hostnameformat1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [HostnameFormat1BoxedList](#hostnameformat1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [HostnameFormat1Boxed](#hostnameformat1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/HostnameFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/HostnameFormat.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [HostnameFormat.HostnameFormat1Boxed](#hostnameformat1boxed)<br> sealed interface for validated payloads |
-| record | [HostnameFormat.HostnameFormat1BoxedVoid](#hostnameformat1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [HostnameFormat.HostnameFormat1BoxedBoolean](#hostnameformat1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [HostnameFormat.HostnameFormat1BoxedNumber](#hostnameformat1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [HostnameFormat.HostnameFormat1BoxedString](#hostnameformat1boxedstring)<br> boxed class to store validated String payloads |
-| record | [HostnameFormat.HostnameFormat1BoxedList](#hostnameformat1boxedlist)<br> boxed class to store validated List payloads |
-| record | [HostnameFormat.HostnameFormat1BoxedMap](#hostnameformat1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [HostnameFormat.HostnameFormat1](#hostnameformat1)<br> schema class |
+| data class | [HostnameFormat.HostnameFormat1BoxedVoid](#hostnameformat1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [HostnameFormat.HostnameFormat1BoxedBoolean](#hostnameformat1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [HostnameFormat.HostnameFormat1BoxedNumber](#hostnameformat1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [HostnameFormat.HostnameFormat1BoxedString](#hostnameformat1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [HostnameFormat.HostnameFormat1BoxedList](#hostnameformat1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [HostnameFormat.HostnameFormat1BoxedMap](#hostnameformat1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [HostnameFormat.HostnameFormat1](#hostnameformat1)<br> schema class |
 
 ## HostnameFormat1Boxed
 sealed interface HostnameFormat1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class HostnameFormat1BoxedBoolean<br>
 implements [HostnameFormat1Boxed](#hostnameformat1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IdnEmailFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IdnEmailFormat.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [IdnEmailFormat1BoxedString](#idnemailformat1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [IdnEmailFormat1BoxedVoid](#idnemailformat1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [IdnEmailFormat1BoxedNumber](#idnemailformat1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [IdnEmailFormat1BoxedBoolean](#idnemailformat1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [IdnEmailFormat1BoxedMap](#idnemailformat1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [IdnEmailFormat1BoxedBoolean](#idnemailformat1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [IdnEmailFormat1BoxedMap](#idnemailformat1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [IdnEmailFormat1BoxedList](#idnemailformat1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [IdnEmailFormat1Boxed](#idnemailformat1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IdnEmailFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IdnEmailFormat.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [IdnEmailFormat.IdnEmailFormat1Boxed](#idnemailformat1boxed)<br> sealed interface for validated payloads |
-| record | [IdnEmailFormat.IdnEmailFormat1BoxedVoid](#idnemailformat1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [IdnEmailFormat.IdnEmailFormat1BoxedBoolean](#idnemailformat1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [IdnEmailFormat.IdnEmailFormat1BoxedNumber](#idnemailformat1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [IdnEmailFormat.IdnEmailFormat1BoxedString](#idnemailformat1boxedstring)<br> boxed class to store validated String payloads |
-| record | [IdnEmailFormat.IdnEmailFormat1BoxedList](#idnemailformat1boxedlist)<br> boxed class to store validated List payloads |
-| record | [IdnEmailFormat.IdnEmailFormat1BoxedMap](#idnemailformat1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [IdnEmailFormat.IdnEmailFormat1](#idnemailformat1)<br> schema class |
+| data class | [IdnEmailFormat.IdnEmailFormat1BoxedVoid](#idnemailformat1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [IdnEmailFormat.IdnEmailFormat1BoxedBoolean](#idnemailformat1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [IdnEmailFormat.IdnEmailFormat1BoxedNumber](#idnemailformat1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [IdnEmailFormat.IdnEmailFormat1BoxedString](#idnemailformat1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [IdnEmailFormat.IdnEmailFormat1BoxedList](#idnemailformat1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [IdnEmailFormat.IdnEmailFormat1BoxedMap](#idnemailformat1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [IdnEmailFormat.IdnEmailFormat1](#idnemailformat1)<br> schema class |
 
 ## IdnEmailFormat1Boxed
 sealed interface IdnEmailFormat1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class IdnEmailFormat1BoxedBoolean<br>
 implements [IdnEmailFormat1Boxed](#idnemailformat1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IdnHostnameFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IdnHostnameFormat.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [IdnHostnameFormat.IdnHostnameFormat1Boxed](#idnhostnameformat1boxed)<br> sealed interface for validated payloads |
-| record | [IdnHostnameFormat.IdnHostnameFormat1BoxedVoid](#idnhostnameformat1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [IdnHostnameFormat.IdnHostnameFormat1BoxedBoolean](#idnhostnameformat1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [IdnHostnameFormat.IdnHostnameFormat1BoxedNumber](#idnhostnameformat1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [IdnHostnameFormat.IdnHostnameFormat1BoxedString](#idnhostnameformat1boxedstring)<br> boxed class to store validated String payloads |
-| record | [IdnHostnameFormat.IdnHostnameFormat1BoxedList](#idnhostnameformat1boxedlist)<br> boxed class to store validated List payloads |
-| record | [IdnHostnameFormat.IdnHostnameFormat1BoxedMap](#idnhostnameformat1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [IdnHostnameFormat.IdnHostnameFormat1](#idnhostnameformat1)<br> schema class |
+| data class | [IdnHostnameFormat.IdnHostnameFormat1BoxedVoid](#idnhostnameformat1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [IdnHostnameFormat.IdnHostnameFormat1BoxedBoolean](#idnhostnameformat1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [IdnHostnameFormat.IdnHostnameFormat1BoxedNumber](#idnhostnameformat1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [IdnHostnameFormat.IdnHostnameFormat1BoxedString](#idnhostnameformat1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [IdnHostnameFormat.IdnHostnameFormat1BoxedList](#idnhostnameformat1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [IdnHostnameFormat.IdnHostnameFormat1BoxedMap](#idnhostnameformat1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [IdnHostnameFormat.IdnHostnameFormat1](#idnhostnameformat1)<br> schema class |
 
 ## IdnHostnameFormat1Boxed
 sealed interface IdnHostnameFormat1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class IdnHostnameFormat1BoxedBoolean<br>
 implements [IdnHostnameFormat1Boxed](#idnhostnameformat1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IdnHostnameFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IdnHostnameFormat.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [IdnHostnameFormat1BoxedString](#idnhostnameformat1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [IdnHostnameFormat1BoxedVoid](#idnhostnameformat1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [IdnHostnameFormat1BoxedNumber](#idnhostnameformat1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [IdnHostnameFormat1BoxedBoolean](#idnhostnameformat1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [IdnHostnameFormat1BoxedMap](#idnhostnameformat1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [IdnHostnameFormat1BoxedBoolean](#idnhostnameformat1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [IdnHostnameFormat1BoxedMap](#idnhostnameformat1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [IdnHostnameFormat1BoxedList](#idnhostnameformat1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [IdnHostnameFormat1Boxed](#idnhostnameformat1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IfAndElseWithoutThen.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IfAndElseWithoutThen.md
@@ -166,19 +166,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [IfAndElseWithoutThen1BoxedString](#ifandelsewithoutthen1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [IfAndElseWithoutThen1BoxedVoid](#ifandelsewithoutthen1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [IfAndElseWithoutThen1BoxedNumber](#ifandelsewithoutthen1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [IfAndElseWithoutThen1BoxedBoolean](#ifandelsewithoutthen1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [IfAndElseWithoutThen1BoxedMap](#ifandelsewithoutthen1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [IfAndElseWithoutThen1BoxedBoolean](#ifandelsewithoutthen1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [IfAndElseWithoutThen1BoxedMap](#ifandelsewithoutthen1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [IfAndElseWithoutThen1BoxedList](#ifandelsewithoutthen1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [IfAndElseWithoutThen1Boxed](#ifandelsewithoutthen1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -313,19 +313,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [IfSchemaBoxedString](#ifschemaboxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [IfSchemaBoxedVoid](#ifschemaboxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [IfSchemaBoxedNumber](#ifschemaboxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [IfSchemaBoxedBoolean](#ifschemaboxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [IfSchemaBoxedMap](#ifschemaboxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [IfSchemaBoxedBoolean](#ifschemaboxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [IfSchemaBoxedMap](#ifschemaboxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [IfSchemaBoxedList](#ifschemaboxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [IfSchemaBoxed](#ifschemaboxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -460,19 +460,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [ElseSchemaBoxedString](#elseschemaboxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [ElseSchemaBoxedVoid](#elseschemaboxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [ElseSchemaBoxedNumber](#elseschemaboxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [ElseSchemaBoxedBoolean](#elseschemaboxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [ElseSchemaBoxedMap](#elseschemaboxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [ElseSchemaBoxedBoolean](#elseschemaboxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [ElseSchemaBoxedMap](#elseschemaboxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [ElseSchemaBoxedList](#elseschemaboxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [ElseSchemaBoxed](#elseschemaboxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IfAndElseWithoutThen.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IfAndElseWithoutThen.md
@@ -11,29 +11,29 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [IfAndElseWithoutThen.IfAndElseWithoutThen1Boxed](#ifandelsewithoutthen1boxed)<br> sealed interface for validated payloads |
-| record | [IfAndElseWithoutThen.IfAndElseWithoutThen1BoxedVoid](#ifandelsewithoutthen1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [IfAndElseWithoutThen.IfAndElseWithoutThen1BoxedBoolean](#ifandelsewithoutthen1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [IfAndElseWithoutThen.IfAndElseWithoutThen1BoxedNumber](#ifandelsewithoutthen1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [IfAndElseWithoutThen.IfAndElseWithoutThen1BoxedString](#ifandelsewithoutthen1boxedstring)<br> boxed class to store validated String payloads |
-| record | [IfAndElseWithoutThen.IfAndElseWithoutThen1BoxedList](#ifandelsewithoutthen1boxedlist)<br> boxed class to store validated List payloads |
-| record | [IfAndElseWithoutThen.IfAndElseWithoutThen1BoxedMap](#ifandelsewithoutthen1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [IfAndElseWithoutThen.IfAndElseWithoutThen1](#ifandelsewithoutthen1)<br> schema class |
+| data class | [IfAndElseWithoutThen.IfAndElseWithoutThen1BoxedVoid](#ifandelsewithoutthen1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [IfAndElseWithoutThen.IfAndElseWithoutThen1BoxedBoolean](#ifandelsewithoutthen1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [IfAndElseWithoutThen.IfAndElseWithoutThen1BoxedNumber](#ifandelsewithoutthen1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [IfAndElseWithoutThen.IfAndElseWithoutThen1BoxedString](#ifandelsewithoutthen1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [IfAndElseWithoutThen.IfAndElseWithoutThen1BoxedList](#ifandelsewithoutthen1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [IfAndElseWithoutThen.IfAndElseWithoutThen1BoxedMap](#ifandelsewithoutthen1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [IfAndElseWithoutThen.IfAndElseWithoutThen1](#ifandelsewithoutthen1)<br> schema class |
 | sealed interface | [IfAndElseWithoutThen.IfSchemaBoxed](#ifschemaboxed)<br> sealed interface for validated payloads |
-| record | [IfAndElseWithoutThen.IfSchemaBoxedVoid](#ifschemaboxedvoid)<br> boxed class to store validated null payloads |
-| record | [IfAndElseWithoutThen.IfSchemaBoxedBoolean](#ifschemaboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [IfAndElseWithoutThen.IfSchemaBoxedNumber](#ifschemaboxednumber)<br> boxed class to store validated Number payloads |
-| record | [IfAndElseWithoutThen.IfSchemaBoxedString](#ifschemaboxedstring)<br> boxed class to store validated String payloads |
-| record | [IfAndElseWithoutThen.IfSchemaBoxedList](#ifschemaboxedlist)<br> boxed class to store validated List payloads |
-| record | [IfAndElseWithoutThen.IfSchemaBoxedMap](#ifschemaboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [IfAndElseWithoutThen.IfSchema](#ifschema)<br> schema class |
+| data class | [IfAndElseWithoutThen.IfSchemaBoxedVoid](#ifschemaboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [IfAndElseWithoutThen.IfSchemaBoxedBoolean](#ifschemaboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [IfAndElseWithoutThen.IfSchemaBoxedNumber](#ifschemaboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [IfAndElseWithoutThen.IfSchemaBoxedString](#ifschemaboxedstring)<br> boxed class to store validated String payloads |
+| data class | [IfAndElseWithoutThen.IfSchemaBoxedList](#ifschemaboxedlist)<br> boxed class to store validated List payloads |
+| data class | [IfAndElseWithoutThen.IfSchemaBoxedMap](#ifschemaboxedmap)<br> boxed class to store validated Map payloads |
+| class | [IfAndElseWithoutThen.IfSchema](#ifschema)<br> schema class |
 | sealed interface | [IfAndElseWithoutThen.ElseSchemaBoxed](#elseschemaboxed)<br> sealed interface for validated payloads |
-| record | [IfAndElseWithoutThen.ElseSchemaBoxedVoid](#elseschemaboxedvoid)<br> boxed class to store validated null payloads |
-| record | [IfAndElseWithoutThen.ElseSchemaBoxedBoolean](#elseschemaboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [IfAndElseWithoutThen.ElseSchemaBoxedNumber](#elseschemaboxednumber)<br> boxed class to store validated Number payloads |
-| record | [IfAndElseWithoutThen.ElseSchemaBoxedString](#elseschemaboxedstring)<br> boxed class to store validated String payloads |
-| record | [IfAndElseWithoutThen.ElseSchemaBoxedList](#elseschemaboxedlist)<br> boxed class to store validated List payloads |
-| record | [IfAndElseWithoutThen.ElseSchemaBoxedMap](#elseschemaboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [IfAndElseWithoutThen.ElseSchema](#elseschema)<br> schema class |
+| data class | [IfAndElseWithoutThen.ElseSchemaBoxedVoid](#elseschemaboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [IfAndElseWithoutThen.ElseSchemaBoxedBoolean](#elseschemaboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [IfAndElseWithoutThen.ElseSchemaBoxedNumber](#elseschemaboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [IfAndElseWithoutThen.ElseSchemaBoxedString](#elseschemaboxedstring)<br> boxed class to store validated String payloads |
+| data class | [IfAndElseWithoutThen.ElseSchemaBoxedList](#elseschemaboxedlist)<br> boxed class to store validated List payloads |
+| data class | [IfAndElseWithoutThen.ElseSchemaBoxedMap](#elseschemaboxedmap)<br> boxed class to store validated Map payloads |
+| class | [IfAndElseWithoutThen.ElseSchema](#elseschema)<br> schema class |
 
 ## IfAndElseWithoutThen1Boxed
 sealed interface IfAndElseWithoutThen1Boxed<br>
@@ -68,7 +68,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class IfAndElseWithoutThen1BoxedBoolean<br>
 implements [IfAndElseWithoutThen1Boxed](#ifandelsewithoutthen1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -216,7 +216,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class IfSchemaBoxedBoolean<br>
 implements [IfSchemaBoxed](#ifschemaboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -363,7 +363,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class ElseSchemaBoxedBoolean<br>
 implements [ElseSchemaBoxed](#elseschemaboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IfAndThenWithoutElse.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IfAndThenWithoutElse.md
@@ -11,29 +11,29 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [IfAndThenWithoutElse.IfAndThenWithoutElse1Boxed](#ifandthenwithoutelse1boxed)<br> sealed interface for validated payloads |
-| record | [IfAndThenWithoutElse.IfAndThenWithoutElse1BoxedVoid](#ifandthenwithoutelse1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [IfAndThenWithoutElse.IfAndThenWithoutElse1BoxedBoolean](#ifandthenwithoutelse1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [IfAndThenWithoutElse.IfAndThenWithoutElse1BoxedNumber](#ifandthenwithoutelse1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [IfAndThenWithoutElse.IfAndThenWithoutElse1BoxedString](#ifandthenwithoutelse1boxedstring)<br> boxed class to store validated String payloads |
-| record | [IfAndThenWithoutElse.IfAndThenWithoutElse1BoxedList](#ifandthenwithoutelse1boxedlist)<br> boxed class to store validated List payloads |
-| record | [IfAndThenWithoutElse.IfAndThenWithoutElse1BoxedMap](#ifandthenwithoutelse1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [IfAndThenWithoutElse.IfAndThenWithoutElse1](#ifandthenwithoutelse1)<br> schema class |
+| data class | [IfAndThenWithoutElse.IfAndThenWithoutElse1BoxedVoid](#ifandthenwithoutelse1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [IfAndThenWithoutElse.IfAndThenWithoutElse1BoxedBoolean](#ifandthenwithoutelse1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [IfAndThenWithoutElse.IfAndThenWithoutElse1BoxedNumber](#ifandthenwithoutelse1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [IfAndThenWithoutElse.IfAndThenWithoutElse1BoxedString](#ifandthenwithoutelse1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [IfAndThenWithoutElse.IfAndThenWithoutElse1BoxedList](#ifandthenwithoutelse1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [IfAndThenWithoutElse.IfAndThenWithoutElse1BoxedMap](#ifandthenwithoutelse1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [IfAndThenWithoutElse.IfAndThenWithoutElse1](#ifandthenwithoutelse1)<br> schema class |
 | sealed interface | [IfAndThenWithoutElse.ThenBoxed](#thenboxed)<br> sealed interface for validated payloads |
-| record | [IfAndThenWithoutElse.ThenBoxedVoid](#thenboxedvoid)<br> boxed class to store validated null payloads |
-| record | [IfAndThenWithoutElse.ThenBoxedBoolean](#thenboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [IfAndThenWithoutElse.ThenBoxedNumber](#thenboxednumber)<br> boxed class to store validated Number payloads |
-| record | [IfAndThenWithoutElse.ThenBoxedString](#thenboxedstring)<br> boxed class to store validated String payloads |
-| record | [IfAndThenWithoutElse.ThenBoxedList](#thenboxedlist)<br> boxed class to store validated List payloads |
-| record | [IfAndThenWithoutElse.ThenBoxedMap](#thenboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [IfAndThenWithoutElse.Then](#then)<br> schema class |
+| data class | [IfAndThenWithoutElse.ThenBoxedVoid](#thenboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [IfAndThenWithoutElse.ThenBoxedBoolean](#thenboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [IfAndThenWithoutElse.ThenBoxedNumber](#thenboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [IfAndThenWithoutElse.ThenBoxedString](#thenboxedstring)<br> boxed class to store validated String payloads |
+| data class | [IfAndThenWithoutElse.ThenBoxedList](#thenboxedlist)<br> boxed class to store validated List payloads |
+| data class | [IfAndThenWithoutElse.ThenBoxedMap](#thenboxedmap)<br> boxed class to store validated Map payloads |
+| class | [IfAndThenWithoutElse.Then](#then)<br> schema class |
 | sealed interface | [IfAndThenWithoutElse.IfSchemaBoxed](#ifschemaboxed)<br> sealed interface for validated payloads |
-| record | [IfAndThenWithoutElse.IfSchemaBoxedVoid](#ifschemaboxedvoid)<br> boxed class to store validated null payloads |
-| record | [IfAndThenWithoutElse.IfSchemaBoxedBoolean](#ifschemaboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [IfAndThenWithoutElse.IfSchemaBoxedNumber](#ifschemaboxednumber)<br> boxed class to store validated Number payloads |
-| record | [IfAndThenWithoutElse.IfSchemaBoxedString](#ifschemaboxedstring)<br> boxed class to store validated String payloads |
-| record | [IfAndThenWithoutElse.IfSchemaBoxedList](#ifschemaboxedlist)<br> boxed class to store validated List payloads |
-| record | [IfAndThenWithoutElse.IfSchemaBoxedMap](#ifschemaboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [IfAndThenWithoutElse.IfSchema](#ifschema)<br> schema class |
+| data class | [IfAndThenWithoutElse.IfSchemaBoxedVoid](#ifschemaboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [IfAndThenWithoutElse.IfSchemaBoxedBoolean](#ifschemaboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [IfAndThenWithoutElse.IfSchemaBoxedNumber](#ifschemaboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [IfAndThenWithoutElse.IfSchemaBoxedString](#ifschemaboxedstring)<br> boxed class to store validated String payloads |
+| data class | [IfAndThenWithoutElse.IfSchemaBoxedList](#ifschemaboxedlist)<br> boxed class to store validated List payloads |
+| data class | [IfAndThenWithoutElse.IfSchemaBoxedMap](#ifschemaboxedmap)<br> boxed class to store validated Map payloads |
+| class | [IfAndThenWithoutElse.IfSchema](#ifschema)<br> schema class |
 
 ## IfAndThenWithoutElse1Boxed
 sealed interface IfAndThenWithoutElse1Boxed<br>
@@ -68,7 +68,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class IfAndThenWithoutElse1BoxedBoolean<br>
 implements [IfAndThenWithoutElse1Boxed](#ifandthenwithoutelse1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -216,7 +216,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class ThenBoxedBoolean<br>
 implements [ThenBoxed](#thenboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -363,7 +363,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class IfSchemaBoxedBoolean<br>
 implements [IfSchemaBoxed](#ifschemaboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IfAndThenWithoutElse.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IfAndThenWithoutElse.md
@@ -166,19 +166,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [IfAndThenWithoutElse1BoxedString](#ifandthenwithoutelse1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [IfAndThenWithoutElse1BoxedVoid](#ifandthenwithoutelse1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [IfAndThenWithoutElse1BoxedNumber](#ifandthenwithoutelse1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [IfAndThenWithoutElse1BoxedBoolean](#ifandthenwithoutelse1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [IfAndThenWithoutElse1BoxedMap](#ifandthenwithoutelse1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [IfAndThenWithoutElse1BoxedBoolean](#ifandthenwithoutelse1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [IfAndThenWithoutElse1BoxedMap](#ifandthenwithoutelse1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [IfAndThenWithoutElse1BoxedList](#ifandthenwithoutelse1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [IfAndThenWithoutElse1Boxed](#ifandthenwithoutelse1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -313,19 +313,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [ThenBoxedString](#thenboxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [ThenBoxedVoid](#thenboxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [ThenBoxedNumber](#thenboxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [ThenBoxedBoolean](#thenboxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [ThenBoxedMap](#thenboxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [ThenBoxedBoolean](#thenboxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [ThenBoxedMap](#thenboxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [ThenBoxedList](#thenboxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [ThenBoxed](#thenboxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -460,19 +460,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [IfSchemaBoxedString](#ifschemaboxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [IfSchemaBoxedVoid](#ifschemaboxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [IfSchemaBoxedNumber](#ifschemaboxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [IfSchemaBoxedBoolean](#ifschemaboxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [IfSchemaBoxedMap](#ifschemaboxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [IfSchemaBoxedBoolean](#ifschemaboxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [IfSchemaBoxedMap](#ifschemaboxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [IfSchemaBoxedList](#ifschemaboxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [IfSchemaBoxed](#ifschemaboxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.md
@@ -178,19 +178,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence1BoxedString](#ifappearsattheendwhenserializedkeywordprocessingsequence1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence1BoxedVoid](#ifappearsattheendwhenserializedkeywordprocessingsequence1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence1BoxedNumber](#ifappearsattheendwhenserializedkeywordprocessingsequence1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence1BoxedBoolean](#ifappearsattheendwhenserializedkeywordprocessingsequence1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence1BoxedMap](#ifappearsattheendwhenserializedkeywordprocessingsequence1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence1BoxedBoolean](#ifappearsattheendwhenserializedkeywordprocessingsequence1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence1BoxedMap](#ifappearsattheendwhenserializedkeywordprocessingsequence1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence1BoxedList](#ifappearsattheendwhenserializedkeywordprocessingsequence1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence1Boxed](#ifappearsattheendwhenserializedkeywordprocessingsequence1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -325,19 +325,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [ThenBoxedString](#thenboxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [ThenBoxedVoid](#thenboxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [ThenBoxedNumber](#thenboxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [ThenBoxedBoolean](#thenboxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [ThenBoxedMap](#thenboxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [ThenBoxedBoolean](#thenboxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [ThenBoxedMap](#thenboxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [ThenBoxedList](#thenboxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [ThenBoxed](#thenboxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -476,26 +476,26 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| Integer | maxLength = 4 |
+| Int | maxLength = 4 |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [IfSchemaBoxedString](#ifschemaboxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [IfSchemaBoxedVoid](#ifschemaboxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [IfSchemaBoxedNumber](#ifschemaboxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [IfSchemaBoxedBoolean](#ifschemaboxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [IfSchemaBoxedMap](#ifschemaboxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [IfSchemaBoxedBoolean](#ifschemaboxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [IfSchemaBoxedMap](#ifschemaboxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [IfSchemaBoxedList](#ifschemaboxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [IfSchemaBoxed](#ifschemaboxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -630,19 +630,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [ElseSchemaBoxedString](#elseschemaboxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [ElseSchemaBoxedVoid](#elseschemaboxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [ElseSchemaBoxedNumber](#elseschemaboxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [ElseSchemaBoxedBoolean](#elseschemaboxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [ElseSchemaBoxedMap](#elseschemaboxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [ElseSchemaBoxedBoolean](#elseschemaboxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [ElseSchemaBoxedMap](#elseschemaboxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [ElseSchemaBoxedList](#elseschemaboxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [ElseSchemaBoxed](#elseschemaboxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.md
@@ -12,38 +12,38 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence1Boxed](#ifappearsattheendwhenserializedkeywordprocessingsequence1boxed)<br> sealed interface for validated payloads |
-| record | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence1BoxedVoid](#ifappearsattheendwhenserializedkeywordprocessingsequence1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence1BoxedBoolean](#ifappearsattheendwhenserializedkeywordprocessingsequence1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence1BoxedNumber](#ifappearsattheendwhenserializedkeywordprocessingsequence1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence1BoxedString](#ifappearsattheendwhenserializedkeywordprocessingsequence1boxedstring)<br> boxed class to store validated String payloads |
-| record | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence1BoxedList](#ifappearsattheendwhenserializedkeywordprocessingsequence1boxedlist)<br> boxed class to store validated List payloads |
-| record | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence1BoxedMap](#ifappearsattheendwhenserializedkeywordprocessingsequence1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence1](#ifappearsattheendwhenserializedkeywordprocessingsequence1)<br> schema class |
+| data class | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence1BoxedVoid](#ifappearsattheendwhenserializedkeywordprocessingsequence1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence1BoxedBoolean](#ifappearsattheendwhenserializedkeywordprocessingsequence1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence1BoxedNumber](#ifappearsattheendwhenserializedkeywordprocessingsequence1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence1BoxedString](#ifappearsattheendwhenserializedkeywordprocessingsequence1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence1BoxedList](#ifappearsattheendwhenserializedkeywordprocessingsequence1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence1BoxedMap](#ifappearsattheendwhenserializedkeywordprocessingsequence1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence1](#ifappearsattheendwhenserializedkeywordprocessingsequence1)<br> schema class |
 | sealed interface | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.ThenBoxed](#thenboxed)<br> sealed interface for validated payloads |
-| record | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.ThenBoxedVoid](#thenboxedvoid)<br> boxed class to store validated null payloads |
-| record | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.ThenBoxedBoolean](#thenboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.ThenBoxedNumber](#thenboxednumber)<br> boxed class to store validated Number payloads |
-| record | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.ThenBoxedString](#thenboxedstring)<br> boxed class to store validated String payloads |
-| record | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.ThenBoxedList](#thenboxedlist)<br> boxed class to store validated List payloads |
-| record | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.ThenBoxedMap](#thenboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.Then](#then)<br> schema class |
+| data class | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.ThenBoxedVoid](#thenboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.ThenBoxedBoolean](#thenboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.ThenBoxedNumber](#thenboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.ThenBoxedString](#thenboxedstring)<br> boxed class to store validated String payloads |
+| data class | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.ThenBoxedList](#thenboxedlist)<br> boxed class to store validated List payloads |
+| data class | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.ThenBoxedMap](#thenboxedmap)<br> boxed class to store validated Map payloads |
+| class | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.Then](#then)<br> schema class |
 | enum | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.StringThenConst](#stringthenconst)<br>String enum |
 | sealed interface | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.IfSchemaBoxed](#ifschemaboxed)<br> sealed interface for validated payloads |
-| record | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.IfSchemaBoxedVoid](#ifschemaboxedvoid)<br> boxed class to store validated null payloads |
-| record | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.IfSchemaBoxedBoolean](#ifschemaboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.IfSchemaBoxedNumber](#ifschemaboxednumber)<br> boxed class to store validated Number payloads |
-| record | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.IfSchemaBoxedString](#ifschemaboxedstring)<br> boxed class to store validated String payloads |
-| record | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.IfSchemaBoxedList](#ifschemaboxedlist)<br> boxed class to store validated List payloads |
-| record | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.IfSchemaBoxedMap](#ifschemaboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.IfSchema](#ifschema)<br> schema class |
+| data class | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.IfSchemaBoxedVoid](#ifschemaboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.IfSchemaBoxedBoolean](#ifschemaboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.IfSchemaBoxedNumber](#ifschemaboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.IfSchemaBoxedString](#ifschemaboxedstring)<br> boxed class to store validated String payloads |
+| data class | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.IfSchemaBoxedList](#ifschemaboxedlist)<br> boxed class to store validated List payloads |
+| data class | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.IfSchemaBoxedMap](#ifschemaboxedmap)<br> boxed class to store validated Map payloads |
+| class | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.IfSchema](#ifschema)<br> schema class |
 | sealed interface | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.ElseSchemaBoxed](#elseschemaboxed)<br> sealed interface for validated payloads |
-| record | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.ElseSchemaBoxedVoid](#elseschemaboxedvoid)<br> boxed class to store validated null payloads |
-| record | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.ElseSchemaBoxedBoolean](#elseschemaboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.ElseSchemaBoxedNumber](#elseschemaboxednumber)<br> boxed class to store validated Number payloads |
-| record | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.ElseSchemaBoxedString](#elseschemaboxedstring)<br> boxed class to store validated String payloads |
-| record | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.ElseSchemaBoxedList](#elseschemaboxedlist)<br> boxed class to store validated List payloads |
-| record | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.ElseSchemaBoxedMap](#elseschemaboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.ElseSchema](#elseschema)<br> schema class |
+| data class | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.ElseSchemaBoxedVoid](#elseschemaboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.ElseSchemaBoxedBoolean](#elseschemaboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.ElseSchemaBoxedNumber](#elseschemaboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.ElseSchemaBoxedString](#elseschemaboxedstring)<br> boxed class to store validated String payloads |
+| data class | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.ElseSchemaBoxedList](#elseschemaboxedlist)<br> boxed class to store validated List payloads |
+| data class | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.ElseSchemaBoxedMap](#elseschemaboxedmap)<br> boxed class to store validated Map payloads |
+| class | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.ElseSchema](#elseschema)<br> schema class |
 | enum | [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence.StringElseConst](#stringelseconst)<br>String enum |
 
 ## IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence1Boxed
@@ -79,7 +79,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence1BoxedBoolean<br>
 implements [IfAppearsAtTheEndWhenSerializedKeywordProcessingSequence1Boxed](#ifappearsattheendwhenserializedkeywordprocessingsequence1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -228,7 +228,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class ThenBoxedBoolean<br>
 implements [ThenBoxed](#thenboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -386,7 +386,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class IfSchemaBoxedBoolean<br>
 implements [IfSchemaBoxed](#ifschemaboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -533,7 +533,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class ElseSchemaBoxedBoolean<br>
 implements [ElseSchemaBoxed](#elseschemaboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IgnoreElseWithoutIf.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IgnoreElseWithoutIf.md
@@ -159,19 +159,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [IgnoreElseWithoutIf1BoxedString](#ignoreelsewithoutif1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [IgnoreElseWithoutIf1BoxedVoid](#ignoreelsewithoutif1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [IgnoreElseWithoutIf1BoxedNumber](#ignoreelsewithoutif1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [IgnoreElseWithoutIf1BoxedBoolean](#ignoreelsewithoutif1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [IgnoreElseWithoutIf1BoxedMap](#ignoreelsewithoutif1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [IgnoreElseWithoutIf1BoxedBoolean](#ignoreelsewithoutif1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [IgnoreElseWithoutIf1BoxedMap](#ignoreelsewithoutif1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [IgnoreElseWithoutIf1BoxedList](#ignoreelsewithoutif1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [IgnoreElseWithoutIf1Boxed](#ignoreelsewithoutif1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -306,19 +306,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [ElseSchemaBoxedString](#elseschemaboxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [ElseSchemaBoxedVoid](#elseschemaboxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [ElseSchemaBoxedNumber](#elseschemaboxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [ElseSchemaBoxedBoolean](#elseschemaboxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [ElseSchemaBoxedMap](#elseschemaboxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [ElseSchemaBoxedBoolean](#elseschemaboxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [ElseSchemaBoxedMap](#elseschemaboxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [ElseSchemaBoxedList](#elseschemaboxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [ElseSchemaBoxed](#elseschemaboxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IgnoreElseWithoutIf.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IgnoreElseWithoutIf.md
@@ -12,21 +12,21 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [IgnoreElseWithoutIf.IgnoreElseWithoutIf1Boxed](#ignoreelsewithoutif1boxed)<br> sealed interface for validated payloads |
-| record | [IgnoreElseWithoutIf.IgnoreElseWithoutIf1BoxedVoid](#ignoreelsewithoutif1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [IgnoreElseWithoutIf.IgnoreElseWithoutIf1BoxedBoolean](#ignoreelsewithoutif1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [IgnoreElseWithoutIf.IgnoreElseWithoutIf1BoxedNumber](#ignoreelsewithoutif1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [IgnoreElseWithoutIf.IgnoreElseWithoutIf1BoxedString](#ignoreelsewithoutif1boxedstring)<br> boxed class to store validated String payloads |
-| record | [IgnoreElseWithoutIf.IgnoreElseWithoutIf1BoxedList](#ignoreelsewithoutif1boxedlist)<br> boxed class to store validated List payloads |
-| record | [IgnoreElseWithoutIf.IgnoreElseWithoutIf1BoxedMap](#ignoreelsewithoutif1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [IgnoreElseWithoutIf.IgnoreElseWithoutIf1](#ignoreelsewithoutif1)<br> schema class |
+| data class | [IgnoreElseWithoutIf.IgnoreElseWithoutIf1BoxedVoid](#ignoreelsewithoutif1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [IgnoreElseWithoutIf.IgnoreElseWithoutIf1BoxedBoolean](#ignoreelsewithoutif1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [IgnoreElseWithoutIf.IgnoreElseWithoutIf1BoxedNumber](#ignoreelsewithoutif1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [IgnoreElseWithoutIf.IgnoreElseWithoutIf1BoxedString](#ignoreelsewithoutif1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [IgnoreElseWithoutIf.IgnoreElseWithoutIf1BoxedList](#ignoreelsewithoutif1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [IgnoreElseWithoutIf.IgnoreElseWithoutIf1BoxedMap](#ignoreelsewithoutif1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [IgnoreElseWithoutIf.IgnoreElseWithoutIf1](#ignoreelsewithoutif1)<br> schema class |
 | sealed interface | [IgnoreElseWithoutIf.ElseSchemaBoxed](#elseschemaboxed)<br> sealed interface for validated payloads |
-| record | [IgnoreElseWithoutIf.ElseSchemaBoxedVoid](#elseschemaboxedvoid)<br> boxed class to store validated null payloads |
-| record | [IgnoreElseWithoutIf.ElseSchemaBoxedBoolean](#elseschemaboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [IgnoreElseWithoutIf.ElseSchemaBoxedNumber](#elseschemaboxednumber)<br> boxed class to store validated Number payloads |
-| record | [IgnoreElseWithoutIf.ElseSchemaBoxedString](#elseschemaboxedstring)<br> boxed class to store validated String payloads |
-| record | [IgnoreElseWithoutIf.ElseSchemaBoxedList](#elseschemaboxedlist)<br> boxed class to store validated List payloads |
-| record | [IgnoreElseWithoutIf.ElseSchemaBoxedMap](#elseschemaboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [IgnoreElseWithoutIf.ElseSchema](#elseschema)<br> schema class |
+| data class | [IgnoreElseWithoutIf.ElseSchemaBoxedVoid](#elseschemaboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [IgnoreElseWithoutIf.ElseSchemaBoxedBoolean](#elseschemaboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [IgnoreElseWithoutIf.ElseSchemaBoxedNumber](#elseschemaboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [IgnoreElseWithoutIf.ElseSchemaBoxedString](#elseschemaboxedstring)<br> boxed class to store validated String payloads |
+| data class | [IgnoreElseWithoutIf.ElseSchemaBoxedList](#elseschemaboxedlist)<br> boxed class to store validated List payloads |
+| data class | [IgnoreElseWithoutIf.ElseSchemaBoxedMap](#elseschemaboxedmap)<br> boxed class to store validated Map payloads |
+| class | [IgnoreElseWithoutIf.ElseSchema](#elseschema)<br> schema class |
 | enum | [IgnoreElseWithoutIf.StringElseConst](#stringelseconst)<br>String enum |
 
 ## IgnoreElseWithoutIf1Boxed
@@ -62,7 +62,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class IgnoreElseWithoutIf1BoxedBoolean<br>
 implements [IgnoreElseWithoutIf1Boxed](#ignoreelsewithoutif1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -209,7 +209,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class ElseSchemaBoxedBoolean<br>
 implements [ElseSchemaBoxed](#elseschemaboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IgnoreIfWithoutThenOrElse.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IgnoreIfWithoutThenOrElse.md
@@ -12,21 +12,21 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [IgnoreIfWithoutThenOrElse.IgnoreIfWithoutThenOrElse1Boxed](#ignoreifwithoutthenorelse1boxed)<br> sealed interface for validated payloads |
-| record | [IgnoreIfWithoutThenOrElse.IgnoreIfWithoutThenOrElse1BoxedVoid](#ignoreifwithoutthenorelse1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [IgnoreIfWithoutThenOrElse.IgnoreIfWithoutThenOrElse1BoxedBoolean](#ignoreifwithoutthenorelse1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [IgnoreIfWithoutThenOrElse.IgnoreIfWithoutThenOrElse1BoxedNumber](#ignoreifwithoutthenorelse1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [IgnoreIfWithoutThenOrElse.IgnoreIfWithoutThenOrElse1BoxedString](#ignoreifwithoutthenorelse1boxedstring)<br> boxed class to store validated String payloads |
-| record | [IgnoreIfWithoutThenOrElse.IgnoreIfWithoutThenOrElse1BoxedList](#ignoreifwithoutthenorelse1boxedlist)<br> boxed class to store validated List payloads |
-| record | [IgnoreIfWithoutThenOrElse.IgnoreIfWithoutThenOrElse1BoxedMap](#ignoreifwithoutthenorelse1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [IgnoreIfWithoutThenOrElse.IgnoreIfWithoutThenOrElse1](#ignoreifwithoutthenorelse1)<br> schema class |
+| data class | [IgnoreIfWithoutThenOrElse.IgnoreIfWithoutThenOrElse1BoxedVoid](#ignoreifwithoutthenorelse1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [IgnoreIfWithoutThenOrElse.IgnoreIfWithoutThenOrElse1BoxedBoolean](#ignoreifwithoutthenorelse1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [IgnoreIfWithoutThenOrElse.IgnoreIfWithoutThenOrElse1BoxedNumber](#ignoreifwithoutthenorelse1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [IgnoreIfWithoutThenOrElse.IgnoreIfWithoutThenOrElse1BoxedString](#ignoreifwithoutthenorelse1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [IgnoreIfWithoutThenOrElse.IgnoreIfWithoutThenOrElse1BoxedList](#ignoreifwithoutthenorelse1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [IgnoreIfWithoutThenOrElse.IgnoreIfWithoutThenOrElse1BoxedMap](#ignoreifwithoutthenorelse1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [IgnoreIfWithoutThenOrElse.IgnoreIfWithoutThenOrElse1](#ignoreifwithoutthenorelse1)<br> schema class |
 | sealed interface | [IgnoreIfWithoutThenOrElse.IfSchemaBoxed](#ifschemaboxed)<br> sealed interface for validated payloads |
-| record | [IgnoreIfWithoutThenOrElse.IfSchemaBoxedVoid](#ifschemaboxedvoid)<br> boxed class to store validated null payloads |
-| record | [IgnoreIfWithoutThenOrElse.IfSchemaBoxedBoolean](#ifschemaboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [IgnoreIfWithoutThenOrElse.IfSchemaBoxedNumber](#ifschemaboxednumber)<br> boxed class to store validated Number payloads |
-| record | [IgnoreIfWithoutThenOrElse.IfSchemaBoxedString](#ifschemaboxedstring)<br> boxed class to store validated String payloads |
-| record | [IgnoreIfWithoutThenOrElse.IfSchemaBoxedList](#ifschemaboxedlist)<br> boxed class to store validated List payloads |
-| record | [IgnoreIfWithoutThenOrElse.IfSchemaBoxedMap](#ifschemaboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [IgnoreIfWithoutThenOrElse.IfSchema](#ifschema)<br> schema class |
+| data class | [IgnoreIfWithoutThenOrElse.IfSchemaBoxedVoid](#ifschemaboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [IgnoreIfWithoutThenOrElse.IfSchemaBoxedBoolean](#ifschemaboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [IgnoreIfWithoutThenOrElse.IfSchemaBoxedNumber](#ifschemaboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [IgnoreIfWithoutThenOrElse.IfSchemaBoxedString](#ifschemaboxedstring)<br> boxed class to store validated String payloads |
+| data class | [IgnoreIfWithoutThenOrElse.IfSchemaBoxedList](#ifschemaboxedlist)<br> boxed class to store validated List payloads |
+| data class | [IgnoreIfWithoutThenOrElse.IfSchemaBoxedMap](#ifschemaboxedmap)<br> boxed class to store validated Map payloads |
+| class | [IgnoreIfWithoutThenOrElse.IfSchema](#ifschema)<br> schema class |
 | enum | [IgnoreIfWithoutThenOrElse.StringIfConst](#stringifconst)<br>String enum |
 
 ## IgnoreIfWithoutThenOrElse1Boxed
@@ -62,7 +62,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class IgnoreIfWithoutThenOrElse1BoxedBoolean<br>
 implements [IgnoreIfWithoutThenOrElse1Boxed](#ignoreifwithoutthenorelse1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -209,7 +209,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class IfSchemaBoxedBoolean<br>
 implements [IfSchemaBoxed](#ifschemaboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IgnoreIfWithoutThenOrElse.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IgnoreIfWithoutThenOrElse.md
@@ -159,19 +159,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [IgnoreIfWithoutThenOrElse1BoxedString](#ignoreifwithoutthenorelse1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [IgnoreIfWithoutThenOrElse1BoxedVoid](#ignoreifwithoutthenorelse1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [IgnoreIfWithoutThenOrElse1BoxedNumber](#ignoreifwithoutthenorelse1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [IgnoreIfWithoutThenOrElse1BoxedBoolean](#ignoreifwithoutthenorelse1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [IgnoreIfWithoutThenOrElse1BoxedMap](#ignoreifwithoutthenorelse1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [IgnoreIfWithoutThenOrElse1BoxedBoolean](#ignoreifwithoutthenorelse1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [IgnoreIfWithoutThenOrElse1BoxedMap](#ignoreifwithoutthenorelse1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [IgnoreIfWithoutThenOrElse1BoxedList](#ignoreifwithoutthenorelse1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [IgnoreIfWithoutThenOrElse1Boxed](#ignoreifwithoutthenorelse1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -306,19 +306,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [IfSchemaBoxedString](#ifschemaboxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [IfSchemaBoxedVoid](#ifschemaboxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [IfSchemaBoxedNumber](#ifschemaboxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [IfSchemaBoxedBoolean](#ifschemaboxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [IfSchemaBoxedMap](#ifschemaboxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [IfSchemaBoxedBoolean](#ifschemaboxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [IfSchemaBoxedMap](#ifschemaboxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [IfSchemaBoxedList](#ifschemaboxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [IfSchemaBoxed](#ifschemaboxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IgnoreThenWithoutIf.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IgnoreThenWithoutIf.md
@@ -159,19 +159,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [IgnoreThenWithoutIf1BoxedString](#ignorethenwithoutif1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [IgnoreThenWithoutIf1BoxedVoid](#ignorethenwithoutif1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [IgnoreThenWithoutIf1BoxedNumber](#ignorethenwithoutif1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [IgnoreThenWithoutIf1BoxedBoolean](#ignorethenwithoutif1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [IgnoreThenWithoutIf1BoxedMap](#ignorethenwithoutif1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [IgnoreThenWithoutIf1BoxedBoolean](#ignorethenwithoutif1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [IgnoreThenWithoutIf1BoxedMap](#ignorethenwithoutif1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [IgnoreThenWithoutIf1BoxedList](#ignorethenwithoutif1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [IgnoreThenWithoutIf1Boxed](#ignorethenwithoutif1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -306,19 +306,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [ThenBoxedString](#thenboxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [ThenBoxedVoid](#thenboxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [ThenBoxedNumber](#thenboxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [ThenBoxedBoolean](#thenboxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [ThenBoxedMap](#thenboxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [ThenBoxedBoolean](#thenboxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [ThenBoxedMap](#thenboxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [ThenBoxedList](#thenboxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [ThenBoxed](#thenboxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IgnoreThenWithoutIf.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IgnoreThenWithoutIf.md
@@ -12,21 +12,21 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [IgnoreThenWithoutIf.IgnoreThenWithoutIf1Boxed](#ignorethenwithoutif1boxed)<br> sealed interface for validated payloads |
-| record | [IgnoreThenWithoutIf.IgnoreThenWithoutIf1BoxedVoid](#ignorethenwithoutif1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [IgnoreThenWithoutIf.IgnoreThenWithoutIf1BoxedBoolean](#ignorethenwithoutif1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [IgnoreThenWithoutIf.IgnoreThenWithoutIf1BoxedNumber](#ignorethenwithoutif1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [IgnoreThenWithoutIf.IgnoreThenWithoutIf1BoxedString](#ignorethenwithoutif1boxedstring)<br> boxed class to store validated String payloads |
-| record | [IgnoreThenWithoutIf.IgnoreThenWithoutIf1BoxedList](#ignorethenwithoutif1boxedlist)<br> boxed class to store validated List payloads |
-| record | [IgnoreThenWithoutIf.IgnoreThenWithoutIf1BoxedMap](#ignorethenwithoutif1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [IgnoreThenWithoutIf.IgnoreThenWithoutIf1](#ignorethenwithoutif1)<br> schema class |
+| data class | [IgnoreThenWithoutIf.IgnoreThenWithoutIf1BoxedVoid](#ignorethenwithoutif1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [IgnoreThenWithoutIf.IgnoreThenWithoutIf1BoxedBoolean](#ignorethenwithoutif1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [IgnoreThenWithoutIf.IgnoreThenWithoutIf1BoxedNumber](#ignorethenwithoutif1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [IgnoreThenWithoutIf.IgnoreThenWithoutIf1BoxedString](#ignorethenwithoutif1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [IgnoreThenWithoutIf.IgnoreThenWithoutIf1BoxedList](#ignorethenwithoutif1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [IgnoreThenWithoutIf.IgnoreThenWithoutIf1BoxedMap](#ignorethenwithoutif1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [IgnoreThenWithoutIf.IgnoreThenWithoutIf1](#ignorethenwithoutif1)<br> schema class |
 | sealed interface | [IgnoreThenWithoutIf.ThenBoxed](#thenboxed)<br> sealed interface for validated payloads |
-| record | [IgnoreThenWithoutIf.ThenBoxedVoid](#thenboxedvoid)<br> boxed class to store validated null payloads |
-| record | [IgnoreThenWithoutIf.ThenBoxedBoolean](#thenboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [IgnoreThenWithoutIf.ThenBoxedNumber](#thenboxednumber)<br> boxed class to store validated Number payloads |
-| record | [IgnoreThenWithoutIf.ThenBoxedString](#thenboxedstring)<br> boxed class to store validated String payloads |
-| record | [IgnoreThenWithoutIf.ThenBoxedList](#thenboxedlist)<br> boxed class to store validated List payloads |
-| record | [IgnoreThenWithoutIf.ThenBoxedMap](#thenboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [IgnoreThenWithoutIf.Then](#then)<br> schema class |
+| data class | [IgnoreThenWithoutIf.ThenBoxedVoid](#thenboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [IgnoreThenWithoutIf.ThenBoxedBoolean](#thenboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [IgnoreThenWithoutIf.ThenBoxedNumber](#thenboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [IgnoreThenWithoutIf.ThenBoxedString](#thenboxedstring)<br> boxed class to store validated String payloads |
+| data class | [IgnoreThenWithoutIf.ThenBoxedList](#thenboxedlist)<br> boxed class to store validated List payloads |
+| data class | [IgnoreThenWithoutIf.ThenBoxedMap](#thenboxedmap)<br> boxed class to store validated Map payloads |
+| class | [IgnoreThenWithoutIf.Then](#then)<br> schema class |
 | enum | [IgnoreThenWithoutIf.StringThenConst](#stringthenconst)<br>String enum |
 
 ## IgnoreThenWithoutIf1Boxed
@@ -62,7 +62,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class IgnoreThenWithoutIf1BoxedBoolean<br>
 implements [IgnoreThenWithoutIf1Boxed](#ignorethenwithoutif1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -209,7 +209,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class ThenBoxedBoolean<br>
 implements [ThenBoxed](#thenboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IntegerTypeMatchesIntegers.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IntegerTypeMatchesIntegers.md
@@ -11,8 +11,8 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [IntegerTypeMatchesIntegers.IntegerTypeMatchesIntegers1Boxed](#integertypematchesintegers1boxed)<br> sealed interface for validated payloads |
-| record | [IntegerTypeMatchesIntegers.IntegerTypeMatchesIntegers1BoxedNumber](#integertypematchesintegers1boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [IntegerTypeMatchesIntegers.IntegerTypeMatchesIntegers1](#integertypematchesintegers1)<br> schema class |
+| data class | [IntegerTypeMatchesIntegers.IntegerTypeMatchesIntegers1BoxedNumber](#integertypematchesintegers1boxednumber)<br> boxed class to store validated Number payloads |
+| class | [IntegerTypeMatchesIntegers.IntegerTypeMatchesIntegers1](#integertypematchesintegers1)<br> schema class |
 
 ## IntegerTypeMatchesIntegers1Boxed
 sealed interface IntegerTypeMatchesIntegers1Boxed<br>

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/Ipv4Format.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/Ipv4Format.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Ipv4Format1BoxedString](#ipv4format1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Ipv4Format1BoxedVoid](#ipv4format1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Ipv4Format1BoxedNumber](#ipv4format1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Ipv4Format1BoxedBoolean](#ipv4format1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Ipv4Format1BoxedMap](#ipv4format1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Ipv4Format1BoxedBoolean](#ipv4format1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Ipv4Format1BoxedMap](#ipv4format1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Ipv4Format1BoxedList](#ipv4format1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Ipv4Format1Boxed](#ipv4format1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/Ipv4Format.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/Ipv4Format.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [Ipv4Format.Ipv4Format1Boxed](#ipv4format1boxed)<br> sealed interface for validated payloads |
-| record | [Ipv4Format.Ipv4Format1BoxedVoid](#ipv4format1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [Ipv4Format.Ipv4Format1BoxedBoolean](#ipv4format1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [Ipv4Format.Ipv4Format1BoxedNumber](#ipv4format1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [Ipv4Format.Ipv4Format1BoxedString](#ipv4format1boxedstring)<br> boxed class to store validated String payloads |
-| record | [Ipv4Format.Ipv4Format1BoxedList](#ipv4format1boxedlist)<br> boxed class to store validated List payloads |
-| record | [Ipv4Format.Ipv4Format1BoxedMap](#ipv4format1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [Ipv4Format.Ipv4Format1](#ipv4format1)<br> schema class |
+| data class | [Ipv4Format.Ipv4Format1BoxedVoid](#ipv4format1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [Ipv4Format.Ipv4Format1BoxedBoolean](#ipv4format1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [Ipv4Format.Ipv4Format1BoxedNumber](#ipv4format1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [Ipv4Format.Ipv4Format1BoxedString](#ipv4format1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [Ipv4Format.Ipv4Format1BoxedList](#ipv4format1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [Ipv4Format.Ipv4Format1BoxedMap](#ipv4format1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [Ipv4Format.Ipv4Format1](#ipv4format1)<br> schema class |
 
 ## Ipv4Format1Boxed
 sealed interface Ipv4Format1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Ipv4Format1BoxedBoolean<br>
 implements [Ipv4Format1Boxed](#ipv4format1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/Ipv6Format.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/Ipv6Format.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Ipv6Format1BoxedString](#ipv6format1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Ipv6Format1BoxedVoid](#ipv6format1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Ipv6Format1BoxedNumber](#ipv6format1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Ipv6Format1BoxedBoolean](#ipv6format1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Ipv6Format1BoxedMap](#ipv6format1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Ipv6Format1BoxedBoolean](#ipv6format1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Ipv6Format1BoxedMap](#ipv6format1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Ipv6Format1BoxedList](#ipv6format1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Ipv6Format1Boxed](#ipv6format1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/Ipv6Format.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/Ipv6Format.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [Ipv6Format.Ipv6Format1Boxed](#ipv6format1boxed)<br> sealed interface for validated payloads |
-| record | [Ipv6Format.Ipv6Format1BoxedVoid](#ipv6format1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [Ipv6Format.Ipv6Format1BoxedBoolean](#ipv6format1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [Ipv6Format.Ipv6Format1BoxedNumber](#ipv6format1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [Ipv6Format.Ipv6Format1BoxedString](#ipv6format1boxedstring)<br> boxed class to store validated String payloads |
-| record | [Ipv6Format.Ipv6Format1BoxedList](#ipv6format1boxedlist)<br> boxed class to store validated List payloads |
-| record | [Ipv6Format.Ipv6Format1BoxedMap](#ipv6format1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [Ipv6Format.Ipv6Format1](#ipv6format1)<br> schema class |
+| data class | [Ipv6Format.Ipv6Format1BoxedVoid](#ipv6format1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [Ipv6Format.Ipv6Format1BoxedBoolean](#ipv6format1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [Ipv6Format.Ipv6Format1BoxedNumber](#ipv6format1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [Ipv6Format.Ipv6Format1BoxedString](#ipv6format1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [Ipv6Format.Ipv6Format1BoxedList](#ipv6format1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [Ipv6Format.Ipv6Format1BoxedMap](#ipv6format1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [Ipv6Format.Ipv6Format1](#ipv6format1)<br> schema class |
 
 ## Ipv6Format1Boxed
 sealed interface Ipv6Format1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Ipv6Format1BoxedBoolean<br>
 implements [Ipv6Format1Boxed](#ipv6format1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IriFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IriFormat.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [IriFormat1BoxedString](#iriformat1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [IriFormat1BoxedVoid](#iriformat1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [IriFormat1BoxedNumber](#iriformat1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [IriFormat1BoxedBoolean](#iriformat1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [IriFormat1BoxedMap](#iriformat1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [IriFormat1BoxedBoolean](#iriformat1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [IriFormat1BoxedMap](#iriformat1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [IriFormat1BoxedList](#iriformat1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [IriFormat1Boxed](#iriformat1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IriFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IriFormat.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [IriFormat.IriFormat1Boxed](#iriformat1boxed)<br> sealed interface for validated payloads |
-| record | [IriFormat.IriFormat1BoxedVoid](#iriformat1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [IriFormat.IriFormat1BoxedBoolean](#iriformat1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [IriFormat.IriFormat1BoxedNumber](#iriformat1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [IriFormat.IriFormat1BoxedString](#iriformat1boxedstring)<br> boxed class to store validated String payloads |
-| record | [IriFormat.IriFormat1BoxedList](#iriformat1boxedlist)<br> boxed class to store validated List payloads |
-| record | [IriFormat.IriFormat1BoxedMap](#iriformat1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [IriFormat.IriFormat1](#iriformat1)<br> schema class |
+| data class | [IriFormat.IriFormat1BoxedVoid](#iriformat1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [IriFormat.IriFormat1BoxedBoolean](#iriformat1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [IriFormat.IriFormat1BoxedNumber](#iriformat1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [IriFormat.IriFormat1BoxedString](#iriformat1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [IriFormat.IriFormat1BoxedList](#iriformat1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [IriFormat.IriFormat1BoxedMap](#iriformat1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [IriFormat.IriFormat1](#iriformat1)<br> schema class |
 
 ## IriFormat1Boxed
 sealed interface IriFormat1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class IriFormat1BoxedBoolean<br>
 implements [IriFormat1Boxed](#iriformat1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IriReferenceFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IriReferenceFormat.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [IriReferenceFormat1BoxedString](#irireferenceformat1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [IriReferenceFormat1BoxedVoid](#irireferenceformat1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [IriReferenceFormat1BoxedNumber](#irireferenceformat1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [IriReferenceFormat1BoxedBoolean](#irireferenceformat1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [IriReferenceFormat1BoxedMap](#irireferenceformat1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [IriReferenceFormat1BoxedBoolean](#irireferenceformat1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [IriReferenceFormat1BoxedMap](#irireferenceformat1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [IriReferenceFormat1BoxedList](#irireferenceformat1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [IriReferenceFormat1Boxed](#irireferenceformat1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IriReferenceFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/IriReferenceFormat.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [IriReferenceFormat.IriReferenceFormat1Boxed](#irireferenceformat1boxed)<br> sealed interface for validated payloads |
-| record | [IriReferenceFormat.IriReferenceFormat1BoxedVoid](#irireferenceformat1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [IriReferenceFormat.IriReferenceFormat1BoxedBoolean](#irireferenceformat1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [IriReferenceFormat.IriReferenceFormat1BoxedNumber](#irireferenceformat1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [IriReferenceFormat.IriReferenceFormat1BoxedString](#irireferenceformat1boxedstring)<br> boxed class to store validated String payloads |
-| record | [IriReferenceFormat.IriReferenceFormat1BoxedList](#irireferenceformat1boxedlist)<br> boxed class to store validated List payloads |
-| record | [IriReferenceFormat.IriReferenceFormat1BoxedMap](#irireferenceformat1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [IriReferenceFormat.IriReferenceFormat1](#irireferenceformat1)<br> schema class |
+| data class | [IriReferenceFormat.IriReferenceFormat1BoxedVoid](#irireferenceformat1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [IriReferenceFormat.IriReferenceFormat1BoxedBoolean](#irireferenceformat1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [IriReferenceFormat.IriReferenceFormat1BoxedNumber](#irireferenceformat1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [IriReferenceFormat.IriReferenceFormat1BoxedString](#irireferenceformat1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [IriReferenceFormat.IriReferenceFormat1BoxedList](#irireferenceformat1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [IriReferenceFormat.IriReferenceFormat1BoxedMap](#irireferenceformat1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [IriReferenceFormat.IriReferenceFormat1](#irireferenceformat1)<br> schema class |
 
 ## IriReferenceFormat1Boxed
 sealed interface IriReferenceFormat1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class IriReferenceFormat1BoxedBoolean<br>
 implements [IriReferenceFormat1Boxed](#irireferenceformat1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ItemsContains.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ItemsContains.md
@@ -13,26 +13,26 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [ItemsContains.ItemsContains1Boxed](#itemscontains1boxed)<br> sealed interface for validated payloads |
-| record | [ItemsContains.ItemsContains1BoxedList](#itemscontains1boxedlist)<br> boxed class to store validated List payloads |
-| static class | [ItemsContains.ItemsContains1](#itemscontains1)<br> schema class |
-| static class | [ItemsContains.ItemsContainsListBuilder](#itemscontainslistbuilder)<br> builder for List payloads |
-| static class | [ItemsContains.ItemsContainsList](#itemscontainslist)<br> output class for List payloads |
+| data class | [ItemsContains.ItemsContains1BoxedList](#itemscontains1boxedlist)<br> boxed class to store validated List payloads |
+| class | [ItemsContains.ItemsContains1](#itemscontains1)<br> schema class |
+| class | [ItemsContains.ItemsContainsListBuilder](#itemscontainslistbuilder)<br> builder for List payloads |
+| class | [ItemsContains.ItemsContainsList](#itemscontainslist)<br> output class for List payloads |
 | sealed interface | [ItemsContains.ItemsBoxed](#itemsboxed)<br> sealed interface for validated payloads |
-| record | [ItemsContains.ItemsBoxedVoid](#itemsboxedvoid)<br> boxed class to store validated null payloads |
-| record | [ItemsContains.ItemsBoxedBoolean](#itemsboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [ItemsContains.ItemsBoxedNumber](#itemsboxednumber)<br> boxed class to store validated Number payloads |
-| record | [ItemsContains.ItemsBoxedString](#itemsboxedstring)<br> boxed class to store validated String payloads |
-| record | [ItemsContains.ItemsBoxedList](#itemsboxedlist)<br> boxed class to store validated List payloads |
-| record | [ItemsContains.ItemsBoxedMap](#itemsboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [ItemsContains.Items](#items)<br> schema class |
+| data class | [ItemsContains.ItemsBoxedVoid](#itemsboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [ItemsContains.ItemsBoxedBoolean](#itemsboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [ItemsContains.ItemsBoxedNumber](#itemsboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [ItemsContains.ItemsBoxedString](#itemsboxedstring)<br> boxed class to store validated String payloads |
+| data class | [ItemsContains.ItemsBoxedList](#itemsboxedlist)<br> boxed class to store validated List payloads |
+| data class | [ItemsContains.ItemsBoxedMap](#itemsboxedmap)<br> boxed class to store validated Map payloads |
+| class | [ItemsContains.Items](#items)<br> schema class |
 | sealed interface | [ItemsContains.ContainsBoxed](#containsboxed)<br> sealed interface for validated payloads |
-| record | [ItemsContains.ContainsBoxedVoid](#containsboxedvoid)<br> boxed class to store validated null payloads |
-| record | [ItemsContains.ContainsBoxedBoolean](#containsboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [ItemsContains.ContainsBoxedNumber](#containsboxednumber)<br> boxed class to store validated Number payloads |
-| record | [ItemsContains.ContainsBoxedString](#containsboxedstring)<br> boxed class to store validated String payloads |
-| record | [ItemsContains.ContainsBoxedList](#containsboxedlist)<br> boxed class to store validated List payloads |
-| record | [ItemsContains.ContainsBoxedMap](#containsboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [ItemsContains.Contains](#contains)<br> schema class |
+| data class | [ItemsContains.ContainsBoxedVoid](#containsboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [ItemsContains.ContainsBoxedBoolean](#containsboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [ItemsContains.ContainsBoxedNumber](#containsboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [ItemsContains.ContainsBoxedString](#containsboxedstring)<br> boxed class to store validated String payloads |
+| data class | [ItemsContains.ContainsBoxedList](#containsboxedlist)<br> boxed class to store validated List payloads |
+| data class | [ItemsContains.ContainsBoxedMap](#containsboxedmap)<br> boxed class to store validated Map payloads |
+| class | [ItemsContains.Contains](#contains)<br> schema class |
 
 ## ItemsContains1Boxed
 sealed interface ItemsContains1Boxed<br>
@@ -170,7 +170,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class ItemsBoxedBoolean<br>
 implements [ItemsBoxed](#itemsboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -317,7 +317,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class ContainsBoxedBoolean<br>
 implements [ContainsBoxed](#containsboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ItemsContains.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ItemsContains.md
@@ -66,27 +66,23 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.ItemsContains;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.ItemsContains
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // List validation
-ItemsContains.ItemsContainsList validatedPayload =
+val validatedPayload: ItemsContains.ItemsContainsList =
     ItemsContains.ItemsContains1.validate(
-    new ItemsContains.ItemsContainsListBuilder()
+    ItemsContains.ItemsContainsListBuilder()
     .build(),
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -271,19 +267,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [ItemsBoxedString](#itemsboxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [ItemsBoxedVoid](#itemsboxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [ItemsBoxedNumber](#itemsboxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [ItemsBoxedBoolean](#itemsboxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [ItemsBoxedMap](#itemsboxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [ItemsBoxedBoolean](#itemsboxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [ItemsBoxedMap](#itemsboxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [ItemsBoxedList](#itemsboxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [ItemsBoxed](#itemsboxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -418,19 +414,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [ContainsBoxedString](#containsboxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [ContainsBoxedVoid](#containsboxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [ContainsBoxedNumber](#containsboxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [ContainsBoxedBoolean](#containsboxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [ContainsBoxedMap](#containsboxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [ContainsBoxedBoolean](#containsboxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [ContainsBoxedMap](#containsboxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [ContainsBoxedList](#containsboxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [ContainsBoxed](#containsboxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ItemsDoesNotLookInApplicatorsValidCase.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ItemsDoesNotLookInApplicatorsValidCase.md
@@ -58,27 +58,23 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.ItemsDoesNotLookInApplicatorsValidCase;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.ItemsDoesNotLookInApplicatorsValidCase
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // List validation
-ItemsDoesNotLookInApplicatorsValidCase.ItemsDoesNotLookInApplicatorsValidCaseList validatedPayload =
+val validatedPayload: ItemsDoesNotLookInApplicatorsValidCase.ItemsDoesNotLookInApplicatorsValidCaseList =
     ItemsDoesNotLookInApplicatorsValidCase.ItemsDoesNotLookInApplicatorsValidCase1.validate(
-    new ItemsDoesNotLookInApplicatorsValidCase.ItemsDoesNotLookInApplicatorsValidCaseListBuilder()
+    ItemsDoesNotLookInApplicatorsValidCase.ItemsDoesNotLookInApplicatorsValidCaseListBuilder()
     .build(),
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -262,19 +258,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [ItemsBoxedString](#itemsboxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [ItemsBoxedVoid](#itemsboxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [ItemsBoxedNumber](#itemsboxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [ItemsBoxedBoolean](#itemsboxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [ItemsBoxedMap](#itemsboxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [ItemsBoxedBoolean](#itemsboxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [ItemsBoxedMap](#itemsboxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [ItemsBoxedList](#itemsboxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [ItemsBoxed](#itemsboxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ItemsDoesNotLookInApplicatorsValidCase.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ItemsDoesNotLookInApplicatorsValidCase.md
@@ -13,18 +13,18 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [ItemsDoesNotLookInApplicatorsValidCase.ItemsDoesNotLookInApplicatorsValidCase1Boxed](#itemsdoesnotlookinapplicatorsvalidcase1boxed)<br> sealed interface for validated payloads |
-| record | [ItemsDoesNotLookInApplicatorsValidCase.ItemsDoesNotLookInApplicatorsValidCase1BoxedList](#itemsdoesnotlookinapplicatorsvalidcase1boxedlist)<br> boxed class to store validated List payloads |
-| static class | [ItemsDoesNotLookInApplicatorsValidCase.ItemsDoesNotLookInApplicatorsValidCase1](#itemsdoesnotlookinapplicatorsvalidcase1)<br> schema class |
-| static class | [ItemsDoesNotLookInApplicatorsValidCase.ItemsDoesNotLookInApplicatorsValidCaseListBuilder](#itemsdoesnotlookinapplicatorsvalidcaselistbuilder)<br> builder for List payloads |
-| static class | [ItemsDoesNotLookInApplicatorsValidCase.ItemsDoesNotLookInApplicatorsValidCaseList](#itemsdoesnotlookinapplicatorsvalidcaselist)<br> output class for List payloads |
+| data class | [ItemsDoesNotLookInApplicatorsValidCase.ItemsDoesNotLookInApplicatorsValidCase1BoxedList](#itemsdoesnotlookinapplicatorsvalidcase1boxedlist)<br> boxed class to store validated List payloads |
+| class | [ItemsDoesNotLookInApplicatorsValidCase.ItemsDoesNotLookInApplicatorsValidCase1](#itemsdoesnotlookinapplicatorsvalidcase1)<br> schema class |
+| class | [ItemsDoesNotLookInApplicatorsValidCase.ItemsDoesNotLookInApplicatorsValidCaseListBuilder](#itemsdoesnotlookinapplicatorsvalidcaselistbuilder)<br> builder for List payloads |
+| class | [ItemsDoesNotLookInApplicatorsValidCase.ItemsDoesNotLookInApplicatorsValidCaseList](#itemsdoesnotlookinapplicatorsvalidcaselist)<br> output class for List payloads |
 | sealed interface | [ItemsDoesNotLookInApplicatorsValidCase.ItemsBoxed](#itemsboxed)<br> sealed interface for validated payloads |
-| record | [ItemsDoesNotLookInApplicatorsValidCase.ItemsBoxedVoid](#itemsboxedvoid)<br> boxed class to store validated null payloads |
-| record | [ItemsDoesNotLookInApplicatorsValidCase.ItemsBoxedBoolean](#itemsboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [ItemsDoesNotLookInApplicatorsValidCase.ItemsBoxedNumber](#itemsboxednumber)<br> boxed class to store validated Number payloads |
-| record | [ItemsDoesNotLookInApplicatorsValidCase.ItemsBoxedString](#itemsboxedstring)<br> boxed class to store validated String payloads |
-| record | [ItemsDoesNotLookInApplicatorsValidCase.ItemsBoxedList](#itemsboxedlist)<br> boxed class to store validated List payloads |
-| record | [ItemsDoesNotLookInApplicatorsValidCase.ItemsBoxedMap](#itemsboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [ItemsDoesNotLookInApplicatorsValidCase.Items](#items)<br> schema class |
+| data class | [ItemsDoesNotLookInApplicatorsValidCase.ItemsBoxedVoid](#itemsboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [ItemsDoesNotLookInApplicatorsValidCase.ItemsBoxedBoolean](#itemsboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [ItemsDoesNotLookInApplicatorsValidCase.ItemsBoxedNumber](#itemsboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [ItemsDoesNotLookInApplicatorsValidCase.ItemsBoxedString](#itemsboxedstring)<br> boxed class to store validated String payloads |
+| data class | [ItemsDoesNotLookInApplicatorsValidCase.ItemsBoxedList](#itemsboxedlist)<br> boxed class to store validated List payloads |
+| data class | [ItemsDoesNotLookInApplicatorsValidCase.ItemsBoxedMap](#itemsboxedmap)<br> boxed class to store validated Map payloads |
+| class | [ItemsDoesNotLookInApplicatorsValidCase.Items](#items)<br> schema class |
 
 ## ItemsDoesNotLookInApplicatorsValidCase1Boxed
 sealed interface ItemsDoesNotLookInApplicatorsValidCase1Boxed<br>
@@ -161,7 +161,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class ItemsBoxedBoolean<br>
 implements [ItemsBoxed](#itemsboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ItemsWithNullInstanceElements.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ItemsWithNullInstanceElements.md
@@ -13,13 +13,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [ItemsWithNullInstanceElements.ItemsWithNullInstanceElements1Boxed](#itemswithnullinstanceelements1boxed)<br> sealed interface for validated payloads |
-| record | [ItemsWithNullInstanceElements.ItemsWithNullInstanceElements1BoxedList](#itemswithnullinstanceelements1boxedlist)<br> boxed class to store validated List payloads |
-| static class | [ItemsWithNullInstanceElements.ItemsWithNullInstanceElements1](#itemswithnullinstanceelements1)<br> schema class |
-| static class | [ItemsWithNullInstanceElements.ItemsWithNullInstanceElementsListBuilder](#itemswithnullinstanceelementslistbuilder)<br> builder for List payloads |
-| static class | [ItemsWithNullInstanceElements.ItemsWithNullInstanceElementsList](#itemswithnullinstanceelementslist)<br> output class for List payloads |
+| data class | [ItemsWithNullInstanceElements.ItemsWithNullInstanceElements1BoxedList](#itemswithnullinstanceelements1boxedlist)<br> boxed class to store validated List payloads |
+| class | [ItemsWithNullInstanceElements.ItemsWithNullInstanceElements1](#itemswithnullinstanceelements1)<br> schema class |
+| class | [ItemsWithNullInstanceElements.ItemsWithNullInstanceElementsListBuilder](#itemswithnullinstanceelementslistbuilder)<br> builder for List payloads |
+| class | [ItemsWithNullInstanceElements.ItemsWithNullInstanceElementsList](#itemswithnullinstanceelementslist)<br> output class for List payloads |
 | sealed interface | [ItemsWithNullInstanceElements.ItemsBoxed](#itemsboxed)<br> sealed interface for validated payloads |
-| record | [ItemsWithNullInstanceElements.ItemsBoxedVoid](#itemsboxedvoid)<br> boxed class to store validated null payloads |
-| static class | [ItemsWithNullInstanceElements.Items](#items)<br> schema class |
+| data class | [ItemsWithNullInstanceElements.ItemsBoxedVoid](#itemsboxedvoid)<br> boxed class to store validated null payloads |
+| class | [ItemsWithNullInstanceElements.Items](#items)<br> schema class |
 
 ## ItemsWithNullInstanceElements1Boxed
 sealed interface ItemsWithNullInstanceElements1Boxed<br>

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ItemsWithNullInstanceElements.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ItemsWithNullInstanceElements.md
@@ -53,29 +53,25 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.ItemsWithNullInstanceElements;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.ItemsWithNullInstanceElements
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // List validation
-ItemsWithNullInstanceElements.ItemsWithNullInstanceElementsList validatedPayload =
+val validatedPayload: ItemsWithNullInstanceElements.ItemsWithNullInstanceElementsList =
     ItemsWithNullInstanceElements.ItemsWithNullInstanceElements1.validate(
-    new ItemsWithNullInstanceElements.ItemsWithNullInstanceElementsListBuilder()
+    ItemsWithNullInstanceElements.ItemsWithNullInstanceElementsListBuilder()
         .add(null)
 
     .build(),
     configuration
-);
+)
 ```
 
 ### Field Summary

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/JsonPointerFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/JsonPointerFormat.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [JsonPointerFormat.JsonPointerFormat1Boxed](#jsonpointerformat1boxed)<br> sealed interface for validated payloads |
-| record | [JsonPointerFormat.JsonPointerFormat1BoxedVoid](#jsonpointerformat1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [JsonPointerFormat.JsonPointerFormat1BoxedBoolean](#jsonpointerformat1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [JsonPointerFormat.JsonPointerFormat1BoxedNumber](#jsonpointerformat1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [JsonPointerFormat.JsonPointerFormat1BoxedString](#jsonpointerformat1boxedstring)<br> boxed class to store validated String payloads |
-| record | [JsonPointerFormat.JsonPointerFormat1BoxedList](#jsonpointerformat1boxedlist)<br> boxed class to store validated List payloads |
-| record | [JsonPointerFormat.JsonPointerFormat1BoxedMap](#jsonpointerformat1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [JsonPointerFormat.JsonPointerFormat1](#jsonpointerformat1)<br> schema class |
+| data class | [JsonPointerFormat.JsonPointerFormat1BoxedVoid](#jsonpointerformat1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [JsonPointerFormat.JsonPointerFormat1BoxedBoolean](#jsonpointerformat1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [JsonPointerFormat.JsonPointerFormat1BoxedNumber](#jsonpointerformat1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [JsonPointerFormat.JsonPointerFormat1BoxedString](#jsonpointerformat1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [JsonPointerFormat.JsonPointerFormat1BoxedList](#jsonpointerformat1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [JsonPointerFormat.JsonPointerFormat1BoxedMap](#jsonpointerformat1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [JsonPointerFormat.JsonPointerFormat1](#jsonpointerformat1)<br> schema class |
 
 ## JsonPointerFormat1Boxed
 sealed interface JsonPointerFormat1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class JsonPointerFormat1BoxedBoolean<br>
 implements [JsonPointerFormat1Boxed](#jsonpointerformat1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/JsonPointerFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/JsonPointerFormat.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [JsonPointerFormat1BoxedString](#jsonpointerformat1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [JsonPointerFormat1BoxedVoid](#jsonpointerformat1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [JsonPointerFormat1BoxedNumber](#jsonpointerformat1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [JsonPointerFormat1BoxedBoolean](#jsonpointerformat1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [JsonPointerFormat1BoxedMap](#jsonpointerformat1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [JsonPointerFormat1BoxedBoolean](#jsonpointerformat1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [JsonPointerFormat1BoxedMap](#jsonpointerformat1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [JsonPointerFormat1BoxedList](#jsonpointerformat1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [JsonPointerFormat1Boxed](#jsonpointerformat1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MaxcontainsWithoutContainsIsIgnored.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MaxcontainsWithoutContainsIsIgnored.md
@@ -142,26 +142,26 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| Integer | maxContains = 1 |
+| Int | maxContains = 1 |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [MaxcontainsWithoutContainsIsIgnored1BoxedString](#maxcontainswithoutcontainsisignored1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [MaxcontainsWithoutContainsIsIgnored1BoxedVoid](#maxcontainswithoutcontainsisignored1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [MaxcontainsWithoutContainsIsIgnored1BoxedNumber](#maxcontainswithoutcontainsisignored1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [MaxcontainsWithoutContainsIsIgnored1BoxedBoolean](#maxcontainswithoutcontainsisignored1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [MaxcontainsWithoutContainsIsIgnored1BoxedMap](#maxcontainswithoutcontainsisignored1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [MaxcontainsWithoutContainsIsIgnored1BoxedBoolean](#maxcontainswithoutcontainsisignored1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [MaxcontainsWithoutContainsIsIgnored1BoxedMap](#maxcontainswithoutcontainsisignored1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [MaxcontainsWithoutContainsIsIgnored1BoxedList](#maxcontainswithoutcontainsisignored1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [MaxcontainsWithoutContainsIsIgnored1Boxed](#maxcontainswithoutcontainsisignored1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MaxcontainsWithoutContainsIsIgnored.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MaxcontainsWithoutContainsIsIgnored.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [MaxcontainsWithoutContainsIsIgnored.MaxcontainsWithoutContainsIsIgnored1Boxed](#maxcontainswithoutcontainsisignored1boxed)<br> sealed interface for validated payloads |
-| record | [MaxcontainsWithoutContainsIsIgnored.MaxcontainsWithoutContainsIsIgnored1BoxedVoid](#maxcontainswithoutcontainsisignored1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [MaxcontainsWithoutContainsIsIgnored.MaxcontainsWithoutContainsIsIgnored1BoxedBoolean](#maxcontainswithoutcontainsisignored1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [MaxcontainsWithoutContainsIsIgnored.MaxcontainsWithoutContainsIsIgnored1BoxedNumber](#maxcontainswithoutcontainsisignored1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [MaxcontainsWithoutContainsIsIgnored.MaxcontainsWithoutContainsIsIgnored1BoxedString](#maxcontainswithoutcontainsisignored1boxedstring)<br> boxed class to store validated String payloads |
-| record | [MaxcontainsWithoutContainsIsIgnored.MaxcontainsWithoutContainsIsIgnored1BoxedList](#maxcontainswithoutcontainsisignored1boxedlist)<br> boxed class to store validated List payloads |
-| record | [MaxcontainsWithoutContainsIsIgnored.MaxcontainsWithoutContainsIsIgnored1BoxedMap](#maxcontainswithoutcontainsisignored1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [MaxcontainsWithoutContainsIsIgnored.MaxcontainsWithoutContainsIsIgnored1](#maxcontainswithoutcontainsisignored1)<br> schema class |
+| data class | [MaxcontainsWithoutContainsIsIgnored.MaxcontainsWithoutContainsIsIgnored1BoxedVoid](#maxcontainswithoutcontainsisignored1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [MaxcontainsWithoutContainsIsIgnored.MaxcontainsWithoutContainsIsIgnored1BoxedBoolean](#maxcontainswithoutcontainsisignored1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [MaxcontainsWithoutContainsIsIgnored.MaxcontainsWithoutContainsIsIgnored1BoxedNumber](#maxcontainswithoutcontainsisignored1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [MaxcontainsWithoutContainsIsIgnored.MaxcontainsWithoutContainsIsIgnored1BoxedString](#maxcontainswithoutcontainsisignored1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [MaxcontainsWithoutContainsIsIgnored.MaxcontainsWithoutContainsIsIgnored1BoxedList](#maxcontainswithoutcontainsisignored1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [MaxcontainsWithoutContainsIsIgnored.MaxcontainsWithoutContainsIsIgnored1BoxedMap](#maxcontainswithoutcontainsisignored1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [MaxcontainsWithoutContainsIsIgnored.MaxcontainsWithoutContainsIsIgnored1](#maxcontainswithoutcontainsisignored1)<br> schema class |
 
 ## MaxcontainsWithoutContainsIsIgnored1Boxed
 sealed interface MaxcontainsWithoutContainsIsIgnored1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class MaxcontainsWithoutContainsIsIgnored1BoxedBoolean<br>
 implements [MaxcontainsWithoutContainsIsIgnored1Boxed](#maxcontainswithoutcontainsisignored1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MaximumValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MaximumValidation.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [MaximumValidation.MaximumValidation1Boxed](#maximumvalidation1boxed)<br> sealed interface for validated payloads |
-| record | [MaximumValidation.MaximumValidation1BoxedVoid](#maximumvalidation1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [MaximumValidation.MaximumValidation1BoxedBoolean](#maximumvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [MaximumValidation.MaximumValidation1BoxedNumber](#maximumvalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [MaximumValidation.MaximumValidation1BoxedString](#maximumvalidation1boxedstring)<br> boxed class to store validated String payloads |
-| record | [MaximumValidation.MaximumValidation1BoxedList](#maximumvalidation1boxedlist)<br> boxed class to store validated List payloads |
-| record | [MaximumValidation.MaximumValidation1BoxedMap](#maximumvalidation1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [MaximumValidation.MaximumValidation1](#maximumvalidation1)<br> schema class |
+| data class | [MaximumValidation.MaximumValidation1BoxedVoid](#maximumvalidation1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [MaximumValidation.MaximumValidation1BoxedBoolean](#maximumvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [MaximumValidation.MaximumValidation1BoxedNumber](#maximumvalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [MaximumValidation.MaximumValidation1BoxedString](#maximumvalidation1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [MaximumValidation.MaximumValidation1BoxedList](#maximumvalidation1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [MaximumValidation.MaximumValidation1BoxedMap](#maximumvalidation1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [MaximumValidation.MaximumValidation1](#maximumvalidation1)<br> schema class |
 
 ## MaximumValidation1Boxed
 sealed interface MaximumValidation1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class MaximumValidation1BoxedBoolean<br>
 implements [MaximumValidation1Boxed](#maximumvalidation1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MaximumValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MaximumValidation.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [MaximumValidation1BoxedString](#maximumvalidation1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [MaximumValidation1BoxedVoid](#maximumvalidation1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [MaximumValidation1BoxedNumber](#maximumvalidation1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [MaximumValidation1BoxedBoolean](#maximumvalidation1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [MaximumValidation1BoxedMap](#maximumvalidation1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [MaximumValidation1BoxedBoolean](#maximumvalidation1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [MaximumValidation1BoxedMap](#maximumvalidation1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [MaximumValidation1BoxedList](#maximumvalidation1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [MaximumValidation1Boxed](#maximumvalidation1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MaximumValidationWithUnsignedInteger.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MaximumValidationWithUnsignedInteger.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [MaximumValidationWithUnsignedInteger.MaximumValidationWithUnsignedInteger1Boxed](#maximumvalidationwithunsignedinteger1boxed)<br> sealed interface for validated payloads |
-| record | [MaximumValidationWithUnsignedInteger.MaximumValidationWithUnsignedInteger1BoxedVoid](#maximumvalidationwithunsignedinteger1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [MaximumValidationWithUnsignedInteger.MaximumValidationWithUnsignedInteger1BoxedBoolean](#maximumvalidationwithunsignedinteger1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [MaximumValidationWithUnsignedInteger.MaximumValidationWithUnsignedInteger1BoxedNumber](#maximumvalidationwithunsignedinteger1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [MaximumValidationWithUnsignedInteger.MaximumValidationWithUnsignedInteger1BoxedString](#maximumvalidationwithunsignedinteger1boxedstring)<br> boxed class to store validated String payloads |
-| record | [MaximumValidationWithUnsignedInteger.MaximumValidationWithUnsignedInteger1BoxedList](#maximumvalidationwithunsignedinteger1boxedlist)<br> boxed class to store validated List payloads |
-| record | [MaximumValidationWithUnsignedInteger.MaximumValidationWithUnsignedInteger1BoxedMap](#maximumvalidationwithunsignedinteger1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [MaximumValidationWithUnsignedInteger.MaximumValidationWithUnsignedInteger1](#maximumvalidationwithunsignedinteger1)<br> schema class |
+| data class | [MaximumValidationWithUnsignedInteger.MaximumValidationWithUnsignedInteger1BoxedVoid](#maximumvalidationwithunsignedinteger1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [MaximumValidationWithUnsignedInteger.MaximumValidationWithUnsignedInteger1BoxedBoolean](#maximumvalidationwithunsignedinteger1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [MaximumValidationWithUnsignedInteger.MaximumValidationWithUnsignedInteger1BoxedNumber](#maximumvalidationwithunsignedinteger1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [MaximumValidationWithUnsignedInteger.MaximumValidationWithUnsignedInteger1BoxedString](#maximumvalidationwithunsignedinteger1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [MaximumValidationWithUnsignedInteger.MaximumValidationWithUnsignedInteger1BoxedList](#maximumvalidationwithunsignedinteger1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [MaximumValidationWithUnsignedInteger.MaximumValidationWithUnsignedInteger1BoxedMap](#maximumvalidationwithunsignedinteger1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [MaximumValidationWithUnsignedInteger.MaximumValidationWithUnsignedInteger1](#maximumvalidationwithunsignedinteger1)<br> schema class |
 
 ## MaximumValidationWithUnsignedInteger1Boxed
 sealed interface MaximumValidationWithUnsignedInteger1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class MaximumValidationWithUnsignedInteger1BoxedBoolean<br>
 implements [MaximumValidationWithUnsignedInteger1Boxed](#maximumvalidationwithunsignedinteger1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MaximumValidationWithUnsignedInteger.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MaximumValidationWithUnsignedInteger.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [MaximumValidationWithUnsignedInteger1BoxedString](#maximumvalidationwithunsignedinteger1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [MaximumValidationWithUnsignedInteger1BoxedVoid](#maximumvalidationwithunsignedinteger1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [MaximumValidationWithUnsignedInteger1BoxedNumber](#maximumvalidationwithunsignedinteger1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [MaximumValidationWithUnsignedInteger1BoxedBoolean](#maximumvalidationwithunsignedinteger1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [MaximumValidationWithUnsignedInteger1BoxedMap](#maximumvalidationwithunsignedinteger1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [MaximumValidationWithUnsignedInteger1BoxedBoolean](#maximumvalidationwithunsignedinteger1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [MaximumValidationWithUnsignedInteger1BoxedMap](#maximumvalidationwithunsignedinteger1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [MaximumValidationWithUnsignedInteger1BoxedList](#maximumvalidationwithunsignedinteger1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [MaximumValidationWithUnsignedInteger1Boxed](#maximumvalidationwithunsignedinteger1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MaxitemsValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MaxitemsValidation.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [MaxitemsValidation.MaxitemsValidation1Boxed](#maxitemsvalidation1boxed)<br> sealed interface for validated payloads |
-| record | [MaxitemsValidation.MaxitemsValidation1BoxedVoid](#maxitemsvalidation1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [MaxitemsValidation.MaxitemsValidation1BoxedBoolean](#maxitemsvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [MaxitemsValidation.MaxitemsValidation1BoxedNumber](#maxitemsvalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [MaxitemsValidation.MaxitemsValidation1BoxedString](#maxitemsvalidation1boxedstring)<br> boxed class to store validated String payloads |
-| record | [MaxitemsValidation.MaxitemsValidation1BoxedList](#maxitemsvalidation1boxedlist)<br> boxed class to store validated List payloads |
-| record | [MaxitemsValidation.MaxitemsValidation1BoxedMap](#maxitemsvalidation1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [MaxitemsValidation.MaxitemsValidation1](#maxitemsvalidation1)<br> schema class |
+| data class | [MaxitemsValidation.MaxitemsValidation1BoxedVoid](#maxitemsvalidation1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [MaxitemsValidation.MaxitemsValidation1BoxedBoolean](#maxitemsvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [MaxitemsValidation.MaxitemsValidation1BoxedNumber](#maxitemsvalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [MaxitemsValidation.MaxitemsValidation1BoxedString](#maxitemsvalidation1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [MaxitemsValidation.MaxitemsValidation1BoxedList](#maxitemsvalidation1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [MaxitemsValidation.MaxitemsValidation1BoxedMap](#maxitemsvalidation1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [MaxitemsValidation.MaxitemsValidation1](#maxitemsvalidation1)<br> schema class |
 
 ## MaxitemsValidation1Boxed
 sealed interface MaxitemsValidation1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class MaxitemsValidation1BoxedBoolean<br>
 implements [MaxitemsValidation1Boxed](#maxitemsvalidation1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MaxitemsValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MaxitemsValidation.md
@@ -142,26 +142,26 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| Integer | maxItems = 2 |
+| Int | maxItems = 2 |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [MaxitemsValidation1BoxedString](#maxitemsvalidation1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [MaxitemsValidation1BoxedVoid](#maxitemsvalidation1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [MaxitemsValidation1BoxedNumber](#maxitemsvalidation1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [MaxitemsValidation1BoxedBoolean](#maxitemsvalidation1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [MaxitemsValidation1BoxedMap](#maxitemsvalidation1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [MaxitemsValidation1BoxedBoolean](#maxitemsvalidation1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [MaxitemsValidation1BoxedMap](#maxitemsvalidation1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [MaxitemsValidation1BoxedList](#maxitemsvalidation1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [MaxitemsValidation1Boxed](#maxitemsvalidation1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MaxlengthValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MaxlengthValidation.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [MaxlengthValidation.MaxlengthValidation1Boxed](#maxlengthvalidation1boxed)<br> sealed interface for validated payloads |
-| record | [MaxlengthValidation.MaxlengthValidation1BoxedVoid](#maxlengthvalidation1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [MaxlengthValidation.MaxlengthValidation1BoxedBoolean](#maxlengthvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [MaxlengthValidation.MaxlengthValidation1BoxedNumber](#maxlengthvalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [MaxlengthValidation.MaxlengthValidation1BoxedString](#maxlengthvalidation1boxedstring)<br> boxed class to store validated String payloads |
-| record | [MaxlengthValidation.MaxlengthValidation1BoxedList](#maxlengthvalidation1boxedlist)<br> boxed class to store validated List payloads |
-| record | [MaxlengthValidation.MaxlengthValidation1BoxedMap](#maxlengthvalidation1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [MaxlengthValidation.MaxlengthValidation1](#maxlengthvalidation1)<br> schema class |
+| data class | [MaxlengthValidation.MaxlengthValidation1BoxedVoid](#maxlengthvalidation1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [MaxlengthValidation.MaxlengthValidation1BoxedBoolean](#maxlengthvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [MaxlengthValidation.MaxlengthValidation1BoxedNumber](#maxlengthvalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [MaxlengthValidation.MaxlengthValidation1BoxedString](#maxlengthvalidation1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [MaxlengthValidation.MaxlengthValidation1BoxedList](#maxlengthvalidation1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [MaxlengthValidation.MaxlengthValidation1BoxedMap](#maxlengthvalidation1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [MaxlengthValidation.MaxlengthValidation1](#maxlengthvalidation1)<br> schema class |
 
 ## MaxlengthValidation1Boxed
 sealed interface MaxlengthValidation1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class MaxlengthValidation1BoxedBoolean<br>
 implements [MaxlengthValidation1Boxed](#maxlengthvalidation1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MaxlengthValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MaxlengthValidation.md
@@ -142,26 +142,26 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| Integer | maxLength = 2 |
+| Int | maxLength = 2 |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [MaxlengthValidation1BoxedString](#maxlengthvalidation1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [MaxlengthValidation1BoxedVoid](#maxlengthvalidation1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [MaxlengthValidation1BoxedNumber](#maxlengthvalidation1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [MaxlengthValidation1BoxedBoolean](#maxlengthvalidation1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [MaxlengthValidation1BoxedMap](#maxlengthvalidation1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [MaxlengthValidation1BoxedBoolean](#maxlengthvalidation1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [MaxlengthValidation1BoxedMap](#maxlengthvalidation1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [MaxlengthValidation1BoxedList](#maxlengthvalidation1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [MaxlengthValidation1Boxed](#maxlengthvalidation1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/Maxproperties0MeansTheObjectIsEmpty.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/Maxproperties0MeansTheObjectIsEmpty.md
@@ -142,26 +142,26 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| Integer | maxProperties = 0 |
+| Int | maxProperties = 0 |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Maxproperties0MeansTheObjectIsEmpty1BoxedString](#maxproperties0meanstheobjectisempty1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Maxproperties0MeansTheObjectIsEmpty1BoxedVoid](#maxproperties0meanstheobjectisempty1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Maxproperties0MeansTheObjectIsEmpty1BoxedNumber](#maxproperties0meanstheobjectisempty1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Maxproperties0MeansTheObjectIsEmpty1BoxedBoolean](#maxproperties0meanstheobjectisempty1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Maxproperties0MeansTheObjectIsEmpty1BoxedMap](#maxproperties0meanstheobjectisempty1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Maxproperties0MeansTheObjectIsEmpty1BoxedBoolean](#maxproperties0meanstheobjectisempty1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Maxproperties0MeansTheObjectIsEmpty1BoxedMap](#maxproperties0meanstheobjectisempty1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Maxproperties0MeansTheObjectIsEmpty1BoxedList](#maxproperties0meanstheobjectisempty1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Maxproperties0MeansTheObjectIsEmpty1Boxed](#maxproperties0meanstheobjectisempty1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/Maxproperties0MeansTheObjectIsEmpty.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/Maxproperties0MeansTheObjectIsEmpty.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [Maxproperties0MeansTheObjectIsEmpty.Maxproperties0MeansTheObjectIsEmpty1Boxed](#maxproperties0meanstheobjectisempty1boxed)<br> sealed interface for validated payloads |
-| record | [Maxproperties0MeansTheObjectIsEmpty.Maxproperties0MeansTheObjectIsEmpty1BoxedVoid](#maxproperties0meanstheobjectisempty1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [Maxproperties0MeansTheObjectIsEmpty.Maxproperties0MeansTheObjectIsEmpty1BoxedBoolean](#maxproperties0meanstheobjectisempty1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [Maxproperties0MeansTheObjectIsEmpty.Maxproperties0MeansTheObjectIsEmpty1BoxedNumber](#maxproperties0meanstheobjectisempty1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [Maxproperties0MeansTheObjectIsEmpty.Maxproperties0MeansTheObjectIsEmpty1BoxedString](#maxproperties0meanstheobjectisempty1boxedstring)<br> boxed class to store validated String payloads |
-| record | [Maxproperties0MeansTheObjectIsEmpty.Maxproperties0MeansTheObjectIsEmpty1BoxedList](#maxproperties0meanstheobjectisempty1boxedlist)<br> boxed class to store validated List payloads |
-| record | [Maxproperties0MeansTheObjectIsEmpty.Maxproperties0MeansTheObjectIsEmpty1BoxedMap](#maxproperties0meanstheobjectisempty1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [Maxproperties0MeansTheObjectIsEmpty.Maxproperties0MeansTheObjectIsEmpty1](#maxproperties0meanstheobjectisempty1)<br> schema class |
+| data class | [Maxproperties0MeansTheObjectIsEmpty.Maxproperties0MeansTheObjectIsEmpty1BoxedVoid](#maxproperties0meanstheobjectisempty1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [Maxproperties0MeansTheObjectIsEmpty.Maxproperties0MeansTheObjectIsEmpty1BoxedBoolean](#maxproperties0meanstheobjectisempty1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [Maxproperties0MeansTheObjectIsEmpty.Maxproperties0MeansTheObjectIsEmpty1BoxedNumber](#maxproperties0meanstheobjectisempty1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [Maxproperties0MeansTheObjectIsEmpty.Maxproperties0MeansTheObjectIsEmpty1BoxedString](#maxproperties0meanstheobjectisempty1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [Maxproperties0MeansTheObjectIsEmpty.Maxproperties0MeansTheObjectIsEmpty1BoxedList](#maxproperties0meanstheobjectisempty1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [Maxproperties0MeansTheObjectIsEmpty.Maxproperties0MeansTheObjectIsEmpty1BoxedMap](#maxproperties0meanstheobjectisempty1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [Maxproperties0MeansTheObjectIsEmpty.Maxproperties0MeansTheObjectIsEmpty1](#maxproperties0meanstheobjectisempty1)<br> schema class |
 
 ## Maxproperties0MeansTheObjectIsEmpty1Boxed
 sealed interface Maxproperties0MeansTheObjectIsEmpty1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Maxproperties0MeansTheObjectIsEmpty1BoxedBoolean<br>
 implements [Maxproperties0MeansTheObjectIsEmpty1Boxed](#maxproperties0meanstheobjectisempty1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MaxpropertiesValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MaxpropertiesValidation.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [MaxpropertiesValidation.MaxpropertiesValidation1Boxed](#maxpropertiesvalidation1boxed)<br> sealed interface for validated payloads |
-| record | [MaxpropertiesValidation.MaxpropertiesValidation1BoxedVoid](#maxpropertiesvalidation1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [MaxpropertiesValidation.MaxpropertiesValidation1BoxedBoolean](#maxpropertiesvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [MaxpropertiesValidation.MaxpropertiesValidation1BoxedNumber](#maxpropertiesvalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [MaxpropertiesValidation.MaxpropertiesValidation1BoxedString](#maxpropertiesvalidation1boxedstring)<br> boxed class to store validated String payloads |
-| record | [MaxpropertiesValidation.MaxpropertiesValidation1BoxedList](#maxpropertiesvalidation1boxedlist)<br> boxed class to store validated List payloads |
-| record | [MaxpropertiesValidation.MaxpropertiesValidation1BoxedMap](#maxpropertiesvalidation1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [MaxpropertiesValidation.MaxpropertiesValidation1](#maxpropertiesvalidation1)<br> schema class |
+| data class | [MaxpropertiesValidation.MaxpropertiesValidation1BoxedVoid](#maxpropertiesvalidation1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [MaxpropertiesValidation.MaxpropertiesValidation1BoxedBoolean](#maxpropertiesvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [MaxpropertiesValidation.MaxpropertiesValidation1BoxedNumber](#maxpropertiesvalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [MaxpropertiesValidation.MaxpropertiesValidation1BoxedString](#maxpropertiesvalidation1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [MaxpropertiesValidation.MaxpropertiesValidation1BoxedList](#maxpropertiesvalidation1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [MaxpropertiesValidation.MaxpropertiesValidation1BoxedMap](#maxpropertiesvalidation1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [MaxpropertiesValidation.MaxpropertiesValidation1](#maxpropertiesvalidation1)<br> schema class |
 
 ## MaxpropertiesValidation1Boxed
 sealed interface MaxpropertiesValidation1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class MaxpropertiesValidation1BoxedBoolean<br>
 implements [MaxpropertiesValidation1Boxed](#maxpropertiesvalidation1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MaxpropertiesValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MaxpropertiesValidation.md
@@ -142,26 +142,26 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| Integer | maxProperties = 2 |
+| Int | maxProperties = 2 |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [MaxpropertiesValidation1BoxedString](#maxpropertiesvalidation1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [MaxpropertiesValidation1BoxedVoid](#maxpropertiesvalidation1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [MaxpropertiesValidation1BoxedNumber](#maxpropertiesvalidation1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [MaxpropertiesValidation1BoxedBoolean](#maxpropertiesvalidation1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [MaxpropertiesValidation1BoxedMap](#maxpropertiesvalidation1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [MaxpropertiesValidation1BoxedBoolean](#maxpropertiesvalidation1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [MaxpropertiesValidation1BoxedMap](#maxpropertiesvalidation1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [MaxpropertiesValidation1BoxedList](#maxpropertiesvalidation1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [MaxpropertiesValidation1Boxed](#maxpropertiesvalidation1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MincontainsWithoutContainsIsIgnored.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MincontainsWithoutContainsIsIgnored.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [MincontainsWithoutContainsIsIgnored.MincontainsWithoutContainsIsIgnored1Boxed](#mincontainswithoutcontainsisignored1boxed)<br> sealed interface for validated payloads |
-| record | [MincontainsWithoutContainsIsIgnored.MincontainsWithoutContainsIsIgnored1BoxedVoid](#mincontainswithoutcontainsisignored1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [MincontainsWithoutContainsIsIgnored.MincontainsWithoutContainsIsIgnored1BoxedBoolean](#mincontainswithoutcontainsisignored1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [MincontainsWithoutContainsIsIgnored.MincontainsWithoutContainsIsIgnored1BoxedNumber](#mincontainswithoutcontainsisignored1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [MincontainsWithoutContainsIsIgnored.MincontainsWithoutContainsIsIgnored1BoxedString](#mincontainswithoutcontainsisignored1boxedstring)<br> boxed class to store validated String payloads |
-| record | [MincontainsWithoutContainsIsIgnored.MincontainsWithoutContainsIsIgnored1BoxedList](#mincontainswithoutcontainsisignored1boxedlist)<br> boxed class to store validated List payloads |
-| record | [MincontainsWithoutContainsIsIgnored.MincontainsWithoutContainsIsIgnored1BoxedMap](#mincontainswithoutcontainsisignored1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [MincontainsWithoutContainsIsIgnored.MincontainsWithoutContainsIsIgnored1](#mincontainswithoutcontainsisignored1)<br> schema class |
+| data class | [MincontainsWithoutContainsIsIgnored.MincontainsWithoutContainsIsIgnored1BoxedVoid](#mincontainswithoutcontainsisignored1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [MincontainsWithoutContainsIsIgnored.MincontainsWithoutContainsIsIgnored1BoxedBoolean](#mincontainswithoutcontainsisignored1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [MincontainsWithoutContainsIsIgnored.MincontainsWithoutContainsIsIgnored1BoxedNumber](#mincontainswithoutcontainsisignored1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [MincontainsWithoutContainsIsIgnored.MincontainsWithoutContainsIsIgnored1BoxedString](#mincontainswithoutcontainsisignored1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [MincontainsWithoutContainsIsIgnored.MincontainsWithoutContainsIsIgnored1BoxedList](#mincontainswithoutcontainsisignored1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [MincontainsWithoutContainsIsIgnored.MincontainsWithoutContainsIsIgnored1BoxedMap](#mincontainswithoutcontainsisignored1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [MincontainsWithoutContainsIsIgnored.MincontainsWithoutContainsIsIgnored1](#mincontainswithoutcontainsisignored1)<br> schema class |
 
 ## MincontainsWithoutContainsIsIgnored1Boxed
 sealed interface MincontainsWithoutContainsIsIgnored1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class MincontainsWithoutContainsIsIgnored1BoxedBoolean<br>
 implements [MincontainsWithoutContainsIsIgnored1Boxed](#mincontainswithoutcontainsisignored1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MincontainsWithoutContainsIsIgnored.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MincontainsWithoutContainsIsIgnored.md
@@ -142,26 +142,26 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| Integer | minContains = 1 |
+| Int | minContains = 1 |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [MincontainsWithoutContainsIsIgnored1BoxedString](#mincontainswithoutcontainsisignored1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [MincontainsWithoutContainsIsIgnored1BoxedVoid](#mincontainswithoutcontainsisignored1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [MincontainsWithoutContainsIsIgnored1BoxedNumber](#mincontainswithoutcontainsisignored1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [MincontainsWithoutContainsIsIgnored1BoxedBoolean](#mincontainswithoutcontainsisignored1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [MincontainsWithoutContainsIsIgnored1BoxedMap](#mincontainswithoutcontainsisignored1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [MincontainsWithoutContainsIsIgnored1BoxedBoolean](#mincontainswithoutcontainsisignored1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [MincontainsWithoutContainsIsIgnored1BoxedMap](#mincontainswithoutcontainsisignored1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [MincontainsWithoutContainsIsIgnored1BoxedList](#mincontainswithoutcontainsisignored1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [MincontainsWithoutContainsIsIgnored1Boxed](#mincontainswithoutcontainsisignored1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MinimumValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MinimumValidation.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [MinimumValidation.MinimumValidation1Boxed](#minimumvalidation1boxed)<br> sealed interface for validated payloads |
-| record | [MinimumValidation.MinimumValidation1BoxedVoid](#minimumvalidation1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [MinimumValidation.MinimumValidation1BoxedBoolean](#minimumvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [MinimumValidation.MinimumValidation1BoxedNumber](#minimumvalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [MinimumValidation.MinimumValidation1BoxedString](#minimumvalidation1boxedstring)<br> boxed class to store validated String payloads |
-| record | [MinimumValidation.MinimumValidation1BoxedList](#minimumvalidation1boxedlist)<br> boxed class to store validated List payloads |
-| record | [MinimumValidation.MinimumValidation1BoxedMap](#minimumvalidation1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [MinimumValidation.MinimumValidation1](#minimumvalidation1)<br> schema class |
+| data class | [MinimumValidation.MinimumValidation1BoxedVoid](#minimumvalidation1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [MinimumValidation.MinimumValidation1BoxedBoolean](#minimumvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [MinimumValidation.MinimumValidation1BoxedNumber](#minimumvalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [MinimumValidation.MinimumValidation1BoxedString](#minimumvalidation1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [MinimumValidation.MinimumValidation1BoxedList](#minimumvalidation1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [MinimumValidation.MinimumValidation1BoxedMap](#minimumvalidation1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [MinimumValidation.MinimumValidation1](#minimumvalidation1)<br> schema class |
 
 ## MinimumValidation1Boxed
 sealed interface MinimumValidation1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class MinimumValidation1BoxedBoolean<br>
 implements [MinimumValidation1Boxed](#minimumvalidation1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MinimumValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MinimumValidation.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [MinimumValidation1BoxedString](#minimumvalidation1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [MinimumValidation1BoxedVoid](#minimumvalidation1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [MinimumValidation1BoxedNumber](#minimumvalidation1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [MinimumValidation1BoxedBoolean](#minimumvalidation1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [MinimumValidation1BoxedMap](#minimumvalidation1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [MinimumValidation1BoxedBoolean](#minimumvalidation1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [MinimumValidation1BoxedMap](#minimumvalidation1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [MinimumValidation1BoxedList](#minimumvalidation1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [MinimumValidation1Boxed](#minimumvalidation1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MinimumValidationWithSignedInteger.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MinimumValidationWithSignedInteger.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [MinimumValidationWithSignedInteger1BoxedString](#minimumvalidationwithsignedinteger1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [MinimumValidationWithSignedInteger1BoxedVoid](#minimumvalidationwithsignedinteger1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [MinimumValidationWithSignedInteger1BoxedNumber](#minimumvalidationwithsignedinteger1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [MinimumValidationWithSignedInteger1BoxedBoolean](#minimumvalidationwithsignedinteger1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [MinimumValidationWithSignedInteger1BoxedMap](#minimumvalidationwithsignedinteger1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [MinimumValidationWithSignedInteger1BoxedBoolean](#minimumvalidationwithsignedinteger1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [MinimumValidationWithSignedInteger1BoxedMap](#minimumvalidationwithsignedinteger1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [MinimumValidationWithSignedInteger1BoxedList](#minimumvalidationwithsignedinteger1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [MinimumValidationWithSignedInteger1Boxed](#minimumvalidationwithsignedinteger1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MinimumValidationWithSignedInteger.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MinimumValidationWithSignedInteger.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [MinimumValidationWithSignedInteger.MinimumValidationWithSignedInteger1Boxed](#minimumvalidationwithsignedinteger1boxed)<br> sealed interface for validated payloads |
-| record | [MinimumValidationWithSignedInteger.MinimumValidationWithSignedInteger1BoxedVoid](#minimumvalidationwithsignedinteger1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [MinimumValidationWithSignedInteger.MinimumValidationWithSignedInteger1BoxedBoolean](#minimumvalidationwithsignedinteger1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [MinimumValidationWithSignedInteger.MinimumValidationWithSignedInteger1BoxedNumber](#minimumvalidationwithsignedinteger1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [MinimumValidationWithSignedInteger.MinimumValidationWithSignedInteger1BoxedString](#minimumvalidationwithsignedinteger1boxedstring)<br> boxed class to store validated String payloads |
-| record | [MinimumValidationWithSignedInteger.MinimumValidationWithSignedInteger1BoxedList](#minimumvalidationwithsignedinteger1boxedlist)<br> boxed class to store validated List payloads |
-| record | [MinimumValidationWithSignedInteger.MinimumValidationWithSignedInteger1BoxedMap](#minimumvalidationwithsignedinteger1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [MinimumValidationWithSignedInteger.MinimumValidationWithSignedInteger1](#minimumvalidationwithsignedinteger1)<br> schema class |
+| data class | [MinimumValidationWithSignedInteger.MinimumValidationWithSignedInteger1BoxedVoid](#minimumvalidationwithsignedinteger1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [MinimumValidationWithSignedInteger.MinimumValidationWithSignedInteger1BoxedBoolean](#minimumvalidationwithsignedinteger1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [MinimumValidationWithSignedInteger.MinimumValidationWithSignedInteger1BoxedNumber](#minimumvalidationwithsignedinteger1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [MinimumValidationWithSignedInteger.MinimumValidationWithSignedInteger1BoxedString](#minimumvalidationwithsignedinteger1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [MinimumValidationWithSignedInteger.MinimumValidationWithSignedInteger1BoxedList](#minimumvalidationwithsignedinteger1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [MinimumValidationWithSignedInteger.MinimumValidationWithSignedInteger1BoxedMap](#minimumvalidationwithsignedinteger1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [MinimumValidationWithSignedInteger.MinimumValidationWithSignedInteger1](#minimumvalidationwithsignedinteger1)<br> schema class |
 
 ## MinimumValidationWithSignedInteger1Boxed
 sealed interface MinimumValidationWithSignedInteger1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class MinimumValidationWithSignedInteger1BoxedBoolean<br>
 implements [MinimumValidationWithSignedInteger1Boxed](#minimumvalidationwithsignedinteger1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MinitemsValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MinitemsValidation.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [MinitemsValidation.MinitemsValidation1Boxed](#minitemsvalidation1boxed)<br> sealed interface for validated payloads |
-| record | [MinitemsValidation.MinitemsValidation1BoxedVoid](#minitemsvalidation1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [MinitemsValidation.MinitemsValidation1BoxedBoolean](#minitemsvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [MinitemsValidation.MinitemsValidation1BoxedNumber](#minitemsvalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [MinitemsValidation.MinitemsValidation1BoxedString](#minitemsvalidation1boxedstring)<br> boxed class to store validated String payloads |
-| record | [MinitemsValidation.MinitemsValidation1BoxedList](#minitemsvalidation1boxedlist)<br> boxed class to store validated List payloads |
-| record | [MinitemsValidation.MinitemsValidation1BoxedMap](#minitemsvalidation1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [MinitemsValidation.MinitemsValidation1](#minitemsvalidation1)<br> schema class |
+| data class | [MinitemsValidation.MinitemsValidation1BoxedVoid](#minitemsvalidation1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [MinitemsValidation.MinitemsValidation1BoxedBoolean](#minitemsvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [MinitemsValidation.MinitemsValidation1BoxedNumber](#minitemsvalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [MinitemsValidation.MinitemsValidation1BoxedString](#minitemsvalidation1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [MinitemsValidation.MinitemsValidation1BoxedList](#minitemsvalidation1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [MinitemsValidation.MinitemsValidation1BoxedMap](#minitemsvalidation1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [MinitemsValidation.MinitemsValidation1](#minitemsvalidation1)<br> schema class |
 
 ## MinitemsValidation1Boxed
 sealed interface MinitemsValidation1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class MinitemsValidation1BoxedBoolean<br>
 implements [MinitemsValidation1Boxed](#minitemsvalidation1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MinitemsValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MinitemsValidation.md
@@ -142,26 +142,26 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| Integer | minItems = 1 |
+| Int | minItems = 1 |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [MinitemsValidation1BoxedString](#minitemsvalidation1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [MinitemsValidation1BoxedVoid](#minitemsvalidation1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [MinitemsValidation1BoxedNumber](#minitemsvalidation1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [MinitemsValidation1BoxedBoolean](#minitemsvalidation1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [MinitemsValidation1BoxedMap](#minitemsvalidation1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [MinitemsValidation1BoxedBoolean](#minitemsvalidation1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [MinitemsValidation1BoxedMap](#minitemsvalidation1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [MinitemsValidation1BoxedList](#minitemsvalidation1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [MinitemsValidation1Boxed](#minitemsvalidation1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MinlengthValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MinlengthValidation.md
@@ -142,26 +142,26 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| Integer | minLength = 2 |
+| Int | minLength = 2 |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [MinlengthValidation1BoxedString](#minlengthvalidation1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [MinlengthValidation1BoxedVoid](#minlengthvalidation1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [MinlengthValidation1BoxedNumber](#minlengthvalidation1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [MinlengthValidation1BoxedBoolean](#minlengthvalidation1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [MinlengthValidation1BoxedMap](#minlengthvalidation1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [MinlengthValidation1BoxedBoolean](#minlengthvalidation1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [MinlengthValidation1BoxedMap](#minlengthvalidation1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [MinlengthValidation1BoxedList](#minlengthvalidation1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [MinlengthValidation1Boxed](#minlengthvalidation1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MinlengthValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MinlengthValidation.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [MinlengthValidation.MinlengthValidation1Boxed](#minlengthvalidation1boxed)<br> sealed interface for validated payloads |
-| record | [MinlengthValidation.MinlengthValidation1BoxedVoid](#minlengthvalidation1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [MinlengthValidation.MinlengthValidation1BoxedBoolean](#minlengthvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [MinlengthValidation.MinlengthValidation1BoxedNumber](#minlengthvalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [MinlengthValidation.MinlengthValidation1BoxedString](#minlengthvalidation1boxedstring)<br> boxed class to store validated String payloads |
-| record | [MinlengthValidation.MinlengthValidation1BoxedList](#minlengthvalidation1boxedlist)<br> boxed class to store validated List payloads |
-| record | [MinlengthValidation.MinlengthValidation1BoxedMap](#minlengthvalidation1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [MinlengthValidation.MinlengthValidation1](#minlengthvalidation1)<br> schema class |
+| data class | [MinlengthValidation.MinlengthValidation1BoxedVoid](#minlengthvalidation1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [MinlengthValidation.MinlengthValidation1BoxedBoolean](#minlengthvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [MinlengthValidation.MinlengthValidation1BoxedNumber](#minlengthvalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [MinlengthValidation.MinlengthValidation1BoxedString](#minlengthvalidation1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [MinlengthValidation.MinlengthValidation1BoxedList](#minlengthvalidation1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [MinlengthValidation.MinlengthValidation1BoxedMap](#minlengthvalidation1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [MinlengthValidation.MinlengthValidation1](#minlengthvalidation1)<br> schema class |
 
 ## MinlengthValidation1Boxed
 sealed interface MinlengthValidation1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class MinlengthValidation1BoxedBoolean<br>
 implements [MinlengthValidation1Boxed](#minlengthvalidation1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MinpropertiesValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MinpropertiesValidation.md
@@ -142,26 +142,26 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| Integer | minProperties = 1 |
+| Int | minProperties = 1 |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [MinpropertiesValidation1BoxedString](#minpropertiesvalidation1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [MinpropertiesValidation1BoxedVoid](#minpropertiesvalidation1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [MinpropertiesValidation1BoxedNumber](#minpropertiesvalidation1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [MinpropertiesValidation1BoxedBoolean](#minpropertiesvalidation1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [MinpropertiesValidation1BoxedMap](#minpropertiesvalidation1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [MinpropertiesValidation1BoxedBoolean](#minpropertiesvalidation1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [MinpropertiesValidation1BoxedMap](#minpropertiesvalidation1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [MinpropertiesValidation1BoxedList](#minpropertiesvalidation1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [MinpropertiesValidation1Boxed](#minpropertiesvalidation1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MinpropertiesValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MinpropertiesValidation.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [MinpropertiesValidation.MinpropertiesValidation1Boxed](#minpropertiesvalidation1boxed)<br> sealed interface for validated payloads |
-| record | [MinpropertiesValidation.MinpropertiesValidation1BoxedVoid](#minpropertiesvalidation1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [MinpropertiesValidation.MinpropertiesValidation1BoxedBoolean](#minpropertiesvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [MinpropertiesValidation.MinpropertiesValidation1BoxedNumber](#minpropertiesvalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [MinpropertiesValidation.MinpropertiesValidation1BoxedString](#minpropertiesvalidation1boxedstring)<br> boxed class to store validated String payloads |
-| record | [MinpropertiesValidation.MinpropertiesValidation1BoxedList](#minpropertiesvalidation1boxedlist)<br> boxed class to store validated List payloads |
-| record | [MinpropertiesValidation.MinpropertiesValidation1BoxedMap](#minpropertiesvalidation1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [MinpropertiesValidation.MinpropertiesValidation1](#minpropertiesvalidation1)<br> schema class |
+| data class | [MinpropertiesValidation.MinpropertiesValidation1BoxedVoid](#minpropertiesvalidation1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [MinpropertiesValidation.MinpropertiesValidation1BoxedBoolean](#minpropertiesvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [MinpropertiesValidation.MinpropertiesValidation1BoxedNumber](#minpropertiesvalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [MinpropertiesValidation.MinpropertiesValidation1BoxedString](#minpropertiesvalidation1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [MinpropertiesValidation.MinpropertiesValidation1BoxedList](#minpropertiesvalidation1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [MinpropertiesValidation.MinpropertiesValidation1BoxedMap](#minpropertiesvalidation1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [MinpropertiesValidation.MinpropertiesValidation1](#minpropertiesvalidation1)<br> schema class |
 
 ## MinpropertiesValidation1Boxed
 sealed interface MinpropertiesValidation1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class MinpropertiesValidation1BoxedBoolean<br>
 implements [MinpropertiesValidation1Boxed](#minpropertiesvalidation1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MultipleDependentsRequired.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MultipleDependentsRequired.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [MultipleDependentsRequired.MultipleDependentsRequired1Boxed](#multipledependentsrequired1boxed)<br> sealed interface for validated payloads |
-| record | [MultipleDependentsRequired.MultipleDependentsRequired1BoxedVoid](#multipledependentsrequired1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [MultipleDependentsRequired.MultipleDependentsRequired1BoxedBoolean](#multipledependentsrequired1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [MultipleDependentsRequired.MultipleDependentsRequired1BoxedNumber](#multipledependentsrequired1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [MultipleDependentsRequired.MultipleDependentsRequired1BoxedString](#multipledependentsrequired1boxedstring)<br> boxed class to store validated String payloads |
-| record | [MultipleDependentsRequired.MultipleDependentsRequired1BoxedList](#multipledependentsrequired1boxedlist)<br> boxed class to store validated List payloads |
-| record | [MultipleDependentsRequired.MultipleDependentsRequired1BoxedMap](#multipledependentsrequired1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [MultipleDependentsRequired.MultipleDependentsRequired1](#multipledependentsrequired1)<br> schema class |
+| data class | [MultipleDependentsRequired.MultipleDependentsRequired1BoxedVoid](#multipledependentsrequired1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [MultipleDependentsRequired.MultipleDependentsRequired1BoxedBoolean](#multipledependentsrequired1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [MultipleDependentsRequired.MultipleDependentsRequired1BoxedNumber](#multipledependentsrequired1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [MultipleDependentsRequired.MultipleDependentsRequired1BoxedString](#multipledependentsrequired1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [MultipleDependentsRequired.MultipleDependentsRequired1BoxedList](#multipledependentsrequired1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [MultipleDependentsRequired.MultipleDependentsRequired1BoxedMap](#multipledependentsrequired1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [MultipleDependentsRequired.MultipleDependentsRequired1](#multipledependentsrequired1)<br> schema class |
 
 ## MultipleDependentsRequired1Boxed
 sealed interface MultipleDependentsRequired1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class MultipleDependentsRequired1BoxedBoolean<br>
 implements [MultipleDependentsRequired1Boxed](#multipledependentsrequired1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MultipleDependentsRequired.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MultipleDependentsRequired.md
@@ -158,19 +158,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [MultipleDependentsRequired1BoxedString](#multipledependentsrequired1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [MultipleDependentsRequired1BoxedVoid](#multipledependentsrequired1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [MultipleDependentsRequired1BoxedNumber](#multipledependentsrequired1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [MultipleDependentsRequired1BoxedBoolean](#multipledependentsrequired1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [MultipleDependentsRequired1BoxedMap](#multipledependentsrequired1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [MultipleDependentsRequired1BoxedBoolean](#multipledependentsrequired1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [MultipleDependentsRequired1BoxedMap](#multipledependentsrequired1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [MultipleDependentsRequired1BoxedList](#multipledependentsrequired1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [MultipleDependentsRequired1Boxed](#multipledependentsrequired1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MultipleSimultaneousPatternpropertiesAreValidated.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MultipleSimultaneousPatternpropertiesAreValidated.md
@@ -11,24 +11,24 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [MultipleSimultaneousPatternpropertiesAreValidated.MultipleSimultaneousPatternpropertiesAreValidated1Boxed](#multiplesimultaneouspatternpropertiesarevalidated1boxed)<br> sealed interface for validated payloads |
-| record | [MultipleSimultaneousPatternpropertiesAreValidated.MultipleSimultaneousPatternpropertiesAreValidated1BoxedVoid](#multiplesimultaneouspatternpropertiesarevalidated1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [MultipleSimultaneousPatternpropertiesAreValidated.MultipleSimultaneousPatternpropertiesAreValidated1BoxedBoolean](#multiplesimultaneouspatternpropertiesarevalidated1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [MultipleSimultaneousPatternpropertiesAreValidated.MultipleSimultaneousPatternpropertiesAreValidated1BoxedNumber](#multiplesimultaneouspatternpropertiesarevalidated1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [MultipleSimultaneousPatternpropertiesAreValidated.MultipleSimultaneousPatternpropertiesAreValidated1BoxedString](#multiplesimultaneouspatternpropertiesarevalidated1boxedstring)<br> boxed class to store validated String payloads |
-| record | [MultipleSimultaneousPatternpropertiesAreValidated.MultipleSimultaneousPatternpropertiesAreValidated1BoxedList](#multiplesimultaneouspatternpropertiesarevalidated1boxedlist)<br> boxed class to store validated List payloads |
-| record | [MultipleSimultaneousPatternpropertiesAreValidated.MultipleSimultaneousPatternpropertiesAreValidated1BoxedMap](#multiplesimultaneouspatternpropertiesarevalidated1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [MultipleSimultaneousPatternpropertiesAreValidated.MultipleSimultaneousPatternpropertiesAreValidated1](#multiplesimultaneouspatternpropertiesarevalidated1)<br> schema class |
+| data class | [MultipleSimultaneousPatternpropertiesAreValidated.MultipleSimultaneousPatternpropertiesAreValidated1BoxedVoid](#multiplesimultaneouspatternpropertiesarevalidated1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [MultipleSimultaneousPatternpropertiesAreValidated.MultipleSimultaneousPatternpropertiesAreValidated1BoxedBoolean](#multiplesimultaneouspatternpropertiesarevalidated1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [MultipleSimultaneousPatternpropertiesAreValidated.MultipleSimultaneousPatternpropertiesAreValidated1BoxedNumber](#multiplesimultaneouspatternpropertiesarevalidated1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [MultipleSimultaneousPatternpropertiesAreValidated.MultipleSimultaneousPatternpropertiesAreValidated1BoxedString](#multiplesimultaneouspatternpropertiesarevalidated1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [MultipleSimultaneousPatternpropertiesAreValidated.MultipleSimultaneousPatternpropertiesAreValidated1BoxedList](#multiplesimultaneouspatternpropertiesarevalidated1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [MultipleSimultaneousPatternpropertiesAreValidated.MultipleSimultaneousPatternpropertiesAreValidated1BoxedMap](#multiplesimultaneouspatternpropertiesarevalidated1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [MultipleSimultaneousPatternpropertiesAreValidated.MultipleSimultaneousPatternpropertiesAreValidated1](#multiplesimultaneouspatternpropertiesarevalidated1)<br> schema class |
 | sealed interface | [MultipleSimultaneousPatternpropertiesAreValidated.AaaBoxed](#aaaboxed)<br> sealed interface for validated payloads |
-| record | [MultipleSimultaneousPatternpropertiesAreValidated.AaaBoxedVoid](#aaaboxedvoid)<br> boxed class to store validated null payloads |
-| record | [MultipleSimultaneousPatternpropertiesAreValidated.AaaBoxedBoolean](#aaaboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [MultipleSimultaneousPatternpropertiesAreValidated.AaaBoxedNumber](#aaaboxednumber)<br> boxed class to store validated Number payloads |
-| record | [MultipleSimultaneousPatternpropertiesAreValidated.AaaBoxedString](#aaaboxedstring)<br> boxed class to store validated String payloads |
-| record | [MultipleSimultaneousPatternpropertiesAreValidated.AaaBoxedList](#aaaboxedlist)<br> boxed class to store validated List payloads |
-| record | [MultipleSimultaneousPatternpropertiesAreValidated.AaaBoxedMap](#aaaboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [MultipleSimultaneousPatternpropertiesAreValidated.Aaa](#aaa)<br> schema class |
+| data class | [MultipleSimultaneousPatternpropertiesAreValidated.AaaBoxedVoid](#aaaboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [MultipleSimultaneousPatternpropertiesAreValidated.AaaBoxedBoolean](#aaaboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [MultipleSimultaneousPatternpropertiesAreValidated.AaaBoxedNumber](#aaaboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [MultipleSimultaneousPatternpropertiesAreValidated.AaaBoxedString](#aaaboxedstring)<br> boxed class to store validated String payloads |
+| data class | [MultipleSimultaneousPatternpropertiesAreValidated.AaaBoxedList](#aaaboxedlist)<br> boxed class to store validated List payloads |
+| data class | [MultipleSimultaneousPatternpropertiesAreValidated.AaaBoxedMap](#aaaboxedmap)<br> boxed class to store validated Map payloads |
+| class | [MultipleSimultaneousPatternpropertiesAreValidated.Aaa](#aaa)<br> schema class |
 | sealed interface | [MultipleSimultaneousPatternpropertiesAreValidated.ABoxed](#aboxed)<br> sealed interface for validated payloads |
-| record | [MultipleSimultaneousPatternpropertiesAreValidated.ABoxedNumber](#aboxednumber)<br> boxed class to store validated Number payloads |
-| static class | [MultipleSimultaneousPatternpropertiesAreValidated.A](#a)<br> schema class |
+| data class | [MultipleSimultaneousPatternpropertiesAreValidated.ABoxedNumber](#aboxednumber)<br> boxed class to store validated Number payloads |
+| class | [MultipleSimultaneousPatternpropertiesAreValidated.A](#a)<br> schema class |
 
 ## MultipleSimultaneousPatternpropertiesAreValidated1Boxed
 sealed interface MultipleSimultaneousPatternpropertiesAreValidated1Boxed<br>
@@ -63,7 +63,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class MultipleSimultaneousPatternpropertiesAreValidated1BoxedBoolean<br>
 implements [MultipleSimultaneousPatternpropertiesAreValidated1Boxed](#multiplesimultaneouspatternpropertiesarevalidated1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -210,7 +210,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class AaaBoxedBoolean<br>
 implements [AaaBoxed](#aaaboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MultipleSimultaneousPatternpropertiesAreValidated.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MultipleSimultaneousPatternpropertiesAreValidated.md
@@ -160,19 +160,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [MultipleSimultaneousPatternpropertiesAreValidated1BoxedString](#multiplesimultaneouspatternpropertiesarevalidated1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [MultipleSimultaneousPatternpropertiesAreValidated1BoxedVoid](#multiplesimultaneouspatternpropertiesarevalidated1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [MultipleSimultaneousPatternpropertiesAreValidated1BoxedNumber](#multiplesimultaneouspatternpropertiesarevalidated1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [MultipleSimultaneousPatternpropertiesAreValidated1BoxedBoolean](#multiplesimultaneouspatternpropertiesarevalidated1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [MultipleSimultaneousPatternpropertiesAreValidated1BoxedMap](#multiplesimultaneouspatternpropertiesarevalidated1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [MultipleSimultaneousPatternpropertiesAreValidated1BoxedBoolean](#multiplesimultaneouspatternpropertiesarevalidated1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [MultipleSimultaneousPatternpropertiesAreValidated1BoxedMap](#multiplesimultaneouspatternpropertiesarevalidated1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [MultipleSimultaneousPatternpropertiesAreValidated1BoxedList](#multiplesimultaneouspatternpropertiesarevalidated1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [MultipleSimultaneousPatternpropertiesAreValidated1Boxed](#multiplesimultaneouspatternpropertiesarevalidated1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -307,19 +307,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [AaaBoxedString](#aaaboxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [AaaBoxedVoid](#aaaboxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [AaaBoxedNumber](#aaaboxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [AaaBoxedBoolean](#aaaboxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [AaaBoxedMap](#aaaboxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [AaaBoxedBoolean](#aaaboxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [AaaBoxedMap](#aaaboxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [AaaBoxedList](#aaaboxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [AaaBoxed](#aaaboxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MultipleTypesCanBeSpecifiedInAnArray.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MultipleTypesCanBeSpecifiedInAnArray.md
@@ -65,31 +65,27 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.MultipleTypesCanBeSpecifiedInAnArray;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.MultipleTypesCanBeSpecifiedInAnArray
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // int validation
-int validatedPayload = MultipleTypesCanBeSpecifiedInAnArray.MultipleTypesCanBeSpecifiedInAnArray1.validate(
+val validatedPayload: Int = MultipleTypesCanBeSpecifiedInAnArray.MultipleTypesCanBeSpecifiedInAnArray1.validate(
     1L,
     configuration
-);
+)
 
 // String validation
-String validatedPayload = MultipleTypesCanBeSpecifiedInAnArray.MultipleTypesCanBeSpecifiedInAnArray1.validate(
+val validatedPayload: String = MultipleTypesCanBeSpecifiedInAnArray.MultipleTypesCanBeSpecifiedInAnArray1.validate(
     "a",
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -101,7 +97,7 @@ String validatedPayload = MultipleTypesCanBeSpecifiedInAnArray.MultipleTypesCanB
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
 | [MultipleTypesCanBeSpecifiedInAnArray1BoxedNumber](#multipletypescanbespecifiedinanarray1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | [MultipleTypesCanBeSpecifiedInAnArray1BoxedString](#multipletypescanbespecifiedinanarray1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MultipleTypesCanBeSpecifiedInAnArray.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/MultipleTypesCanBeSpecifiedInAnArray.md
@@ -11,9 +11,9 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [MultipleTypesCanBeSpecifiedInAnArray.MultipleTypesCanBeSpecifiedInAnArray1Boxed](#multipletypescanbespecifiedinanarray1boxed)<br> sealed interface for validated payloads |
-| record | [MultipleTypesCanBeSpecifiedInAnArray.MultipleTypesCanBeSpecifiedInAnArray1BoxedNumber](#multipletypescanbespecifiedinanarray1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [MultipleTypesCanBeSpecifiedInAnArray.MultipleTypesCanBeSpecifiedInAnArray1BoxedString](#multipletypescanbespecifiedinanarray1boxedstring)<br> boxed class to store validated String payloads |
-| static class | [MultipleTypesCanBeSpecifiedInAnArray.MultipleTypesCanBeSpecifiedInAnArray1](#multipletypescanbespecifiedinanarray1)<br> schema class |
+| data class | [MultipleTypesCanBeSpecifiedInAnArray.MultipleTypesCanBeSpecifiedInAnArray1BoxedNumber](#multipletypescanbespecifiedinanarray1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [MultipleTypesCanBeSpecifiedInAnArray.MultipleTypesCanBeSpecifiedInAnArray1BoxedString](#multipletypescanbespecifiedinanarray1boxedstring)<br> boxed class to store validated String payloads |
+| class | [MultipleTypesCanBeSpecifiedInAnArray.MultipleTypesCanBeSpecifiedInAnArray1](#multipletypescanbespecifiedinanarray1)<br> schema class |
 
 ## MultipleTypesCanBeSpecifiedInAnArray1Boxed
 sealed interface MultipleTypesCanBeSpecifiedInAnArray1Boxed<br>

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NestedAllofToCheckValidationSemantics.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NestedAllofToCheckValidationSemantics.md
@@ -11,24 +11,24 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [NestedAllofToCheckValidationSemantics.NestedAllofToCheckValidationSemantics1Boxed](#nestedalloftocheckvalidationsemantics1boxed)<br> sealed interface for validated payloads |
-| record | [NestedAllofToCheckValidationSemantics.NestedAllofToCheckValidationSemantics1BoxedVoid](#nestedalloftocheckvalidationsemantics1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [NestedAllofToCheckValidationSemantics.NestedAllofToCheckValidationSemantics1BoxedBoolean](#nestedalloftocheckvalidationsemantics1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [NestedAllofToCheckValidationSemantics.NestedAllofToCheckValidationSemantics1BoxedNumber](#nestedalloftocheckvalidationsemantics1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [NestedAllofToCheckValidationSemantics.NestedAllofToCheckValidationSemantics1BoxedString](#nestedalloftocheckvalidationsemantics1boxedstring)<br> boxed class to store validated String payloads |
-| record | [NestedAllofToCheckValidationSemantics.NestedAllofToCheckValidationSemantics1BoxedList](#nestedalloftocheckvalidationsemantics1boxedlist)<br> boxed class to store validated List payloads |
-| record | [NestedAllofToCheckValidationSemantics.NestedAllofToCheckValidationSemantics1BoxedMap](#nestedalloftocheckvalidationsemantics1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [NestedAllofToCheckValidationSemantics.NestedAllofToCheckValidationSemantics1](#nestedalloftocheckvalidationsemantics1)<br> schema class |
+| data class | [NestedAllofToCheckValidationSemantics.NestedAllofToCheckValidationSemantics1BoxedVoid](#nestedalloftocheckvalidationsemantics1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [NestedAllofToCheckValidationSemantics.NestedAllofToCheckValidationSemantics1BoxedBoolean](#nestedalloftocheckvalidationsemantics1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [NestedAllofToCheckValidationSemantics.NestedAllofToCheckValidationSemantics1BoxedNumber](#nestedalloftocheckvalidationsemantics1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [NestedAllofToCheckValidationSemantics.NestedAllofToCheckValidationSemantics1BoxedString](#nestedalloftocheckvalidationsemantics1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [NestedAllofToCheckValidationSemantics.NestedAllofToCheckValidationSemantics1BoxedList](#nestedalloftocheckvalidationsemantics1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [NestedAllofToCheckValidationSemantics.NestedAllofToCheckValidationSemantics1BoxedMap](#nestedalloftocheckvalidationsemantics1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [NestedAllofToCheckValidationSemantics.NestedAllofToCheckValidationSemantics1](#nestedalloftocheckvalidationsemantics1)<br> schema class |
 | sealed interface | [NestedAllofToCheckValidationSemantics.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [NestedAllofToCheckValidationSemantics.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [NestedAllofToCheckValidationSemantics.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [NestedAllofToCheckValidationSemantics.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [NestedAllofToCheckValidationSemantics.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [NestedAllofToCheckValidationSemantics.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [NestedAllofToCheckValidationSemantics.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [NestedAllofToCheckValidationSemantics.Schema0](#schema0)<br> schema class |
+| data class | [NestedAllofToCheckValidationSemantics.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [NestedAllofToCheckValidationSemantics.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [NestedAllofToCheckValidationSemantics.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [NestedAllofToCheckValidationSemantics.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [NestedAllofToCheckValidationSemantics.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [NestedAllofToCheckValidationSemantics.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [NestedAllofToCheckValidationSemantics.Schema0](#schema0)<br> schema class |
 | sealed interface | [NestedAllofToCheckValidationSemantics.Schema01Boxed](#schema01boxed)<br> sealed interface for validated payloads |
-| record | [NestedAllofToCheckValidationSemantics.Schema01BoxedVoid](#schema01boxedvoid)<br> boxed class to store validated null payloads |
-| static class | [NestedAllofToCheckValidationSemantics.Schema01](#schema01)<br> schema class |
+| data class | [NestedAllofToCheckValidationSemantics.Schema01BoxedVoid](#schema01boxedvoid)<br> boxed class to store validated null payloads |
+| class | [NestedAllofToCheckValidationSemantics.Schema01](#schema01)<br> schema class |
 
 ## NestedAllofToCheckValidationSemantics1Boxed
 sealed interface NestedAllofToCheckValidationSemantics1Boxed<br>
@@ -63,7 +63,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class NestedAllofToCheckValidationSemantics1BoxedBoolean<br>
 implements [NestedAllofToCheckValidationSemantics1Boxed](#nestedalloftocheckvalidationsemantics1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -210,7 +210,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NestedAllofToCheckValidationSemantics.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NestedAllofToCheckValidationSemantics.md
@@ -160,19 +160,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [NestedAllofToCheckValidationSemantics1BoxedString](#nestedalloftocheckvalidationsemantics1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [NestedAllofToCheckValidationSemantics1BoxedVoid](#nestedalloftocheckvalidationsemantics1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [NestedAllofToCheckValidationSemantics1BoxedNumber](#nestedalloftocheckvalidationsemantics1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [NestedAllofToCheckValidationSemantics1BoxedBoolean](#nestedalloftocheckvalidationsemantics1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [NestedAllofToCheckValidationSemantics1BoxedMap](#nestedalloftocheckvalidationsemantics1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [NestedAllofToCheckValidationSemantics1BoxedBoolean](#nestedalloftocheckvalidationsemantics1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [NestedAllofToCheckValidationSemantics1BoxedMap](#nestedalloftocheckvalidationsemantics1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [NestedAllofToCheckValidationSemantics1BoxedList](#nestedalloftocheckvalidationsemantics1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [NestedAllofToCheckValidationSemantics1Boxed](#nestedalloftocheckvalidationsemantics1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -307,19 +307,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema0BoxedString](#schema0boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema0BoxedVoid](#schema0boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema0BoxedNumber](#schema0boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema0BoxedList](#schema0boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema0Boxed](#schema0boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NestedAnyofToCheckValidationSemantics.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NestedAnyofToCheckValidationSemantics.md
@@ -11,24 +11,24 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [NestedAnyofToCheckValidationSemantics.NestedAnyofToCheckValidationSemantics1Boxed](#nestedanyoftocheckvalidationsemantics1boxed)<br> sealed interface for validated payloads |
-| record | [NestedAnyofToCheckValidationSemantics.NestedAnyofToCheckValidationSemantics1BoxedVoid](#nestedanyoftocheckvalidationsemantics1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [NestedAnyofToCheckValidationSemantics.NestedAnyofToCheckValidationSemantics1BoxedBoolean](#nestedanyoftocheckvalidationsemantics1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [NestedAnyofToCheckValidationSemantics.NestedAnyofToCheckValidationSemantics1BoxedNumber](#nestedanyoftocheckvalidationsemantics1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [NestedAnyofToCheckValidationSemantics.NestedAnyofToCheckValidationSemantics1BoxedString](#nestedanyoftocheckvalidationsemantics1boxedstring)<br> boxed class to store validated String payloads |
-| record | [NestedAnyofToCheckValidationSemantics.NestedAnyofToCheckValidationSemantics1BoxedList](#nestedanyoftocheckvalidationsemantics1boxedlist)<br> boxed class to store validated List payloads |
-| record | [NestedAnyofToCheckValidationSemantics.NestedAnyofToCheckValidationSemantics1BoxedMap](#nestedanyoftocheckvalidationsemantics1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [NestedAnyofToCheckValidationSemantics.NestedAnyofToCheckValidationSemantics1](#nestedanyoftocheckvalidationsemantics1)<br> schema class |
+| data class | [NestedAnyofToCheckValidationSemantics.NestedAnyofToCheckValidationSemantics1BoxedVoid](#nestedanyoftocheckvalidationsemantics1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [NestedAnyofToCheckValidationSemantics.NestedAnyofToCheckValidationSemantics1BoxedBoolean](#nestedanyoftocheckvalidationsemantics1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [NestedAnyofToCheckValidationSemantics.NestedAnyofToCheckValidationSemantics1BoxedNumber](#nestedanyoftocheckvalidationsemantics1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [NestedAnyofToCheckValidationSemantics.NestedAnyofToCheckValidationSemantics1BoxedString](#nestedanyoftocheckvalidationsemantics1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [NestedAnyofToCheckValidationSemantics.NestedAnyofToCheckValidationSemantics1BoxedList](#nestedanyoftocheckvalidationsemantics1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [NestedAnyofToCheckValidationSemantics.NestedAnyofToCheckValidationSemantics1BoxedMap](#nestedanyoftocheckvalidationsemantics1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [NestedAnyofToCheckValidationSemantics.NestedAnyofToCheckValidationSemantics1](#nestedanyoftocheckvalidationsemantics1)<br> schema class |
 | sealed interface | [NestedAnyofToCheckValidationSemantics.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [NestedAnyofToCheckValidationSemantics.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [NestedAnyofToCheckValidationSemantics.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [NestedAnyofToCheckValidationSemantics.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [NestedAnyofToCheckValidationSemantics.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [NestedAnyofToCheckValidationSemantics.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [NestedAnyofToCheckValidationSemantics.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [NestedAnyofToCheckValidationSemantics.Schema0](#schema0)<br> schema class |
+| data class | [NestedAnyofToCheckValidationSemantics.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [NestedAnyofToCheckValidationSemantics.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [NestedAnyofToCheckValidationSemantics.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [NestedAnyofToCheckValidationSemantics.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [NestedAnyofToCheckValidationSemantics.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [NestedAnyofToCheckValidationSemantics.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [NestedAnyofToCheckValidationSemantics.Schema0](#schema0)<br> schema class |
 | sealed interface | [NestedAnyofToCheckValidationSemantics.Schema01Boxed](#schema01boxed)<br> sealed interface for validated payloads |
-| record | [NestedAnyofToCheckValidationSemantics.Schema01BoxedVoid](#schema01boxedvoid)<br> boxed class to store validated null payloads |
-| static class | [NestedAnyofToCheckValidationSemantics.Schema01](#schema01)<br> schema class |
+| data class | [NestedAnyofToCheckValidationSemantics.Schema01BoxedVoid](#schema01boxedvoid)<br> boxed class to store validated null payloads |
+| class | [NestedAnyofToCheckValidationSemantics.Schema01](#schema01)<br> schema class |
 
 ## NestedAnyofToCheckValidationSemantics1Boxed
 sealed interface NestedAnyofToCheckValidationSemantics1Boxed<br>
@@ -63,7 +63,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class NestedAnyofToCheckValidationSemantics1BoxedBoolean<br>
 implements [NestedAnyofToCheckValidationSemantics1Boxed](#nestedanyoftocheckvalidationsemantics1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -210,7 +210,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NestedAnyofToCheckValidationSemantics.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NestedAnyofToCheckValidationSemantics.md
@@ -160,19 +160,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [NestedAnyofToCheckValidationSemantics1BoxedString](#nestedanyoftocheckvalidationsemantics1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [NestedAnyofToCheckValidationSemantics1BoxedVoid](#nestedanyoftocheckvalidationsemantics1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [NestedAnyofToCheckValidationSemantics1BoxedNumber](#nestedanyoftocheckvalidationsemantics1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [NestedAnyofToCheckValidationSemantics1BoxedBoolean](#nestedanyoftocheckvalidationsemantics1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [NestedAnyofToCheckValidationSemantics1BoxedMap](#nestedanyoftocheckvalidationsemantics1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [NestedAnyofToCheckValidationSemantics1BoxedBoolean](#nestedanyoftocheckvalidationsemantics1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [NestedAnyofToCheckValidationSemantics1BoxedMap](#nestedanyoftocheckvalidationsemantics1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [NestedAnyofToCheckValidationSemantics1BoxedList](#nestedanyoftocheckvalidationsemantics1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [NestedAnyofToCheckValidationSemantics1Boxed](#nestedanyoftocheckvalidationsemantics1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -307,19 +307,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema0BoxedString](#schema0boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema0BoxedVoid](#schema0boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema0BoxedNumber](#schema0boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema0BoxedList](#schema0boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema0Boxed](#schema0boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NestedItems.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NestedItems.md
@@ -68,24 +68,20 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.NestedItems;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.NestedItems
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // List validation
-NestedItems.NestedItemsList validatedPayload =
+val validatedPayload: NestedItems.NestedItemsList =
     NestedItems.NestedItems1.validate(
-    new NestedItems.NestedItemsListBuilder()
+    NestedItems.NestedItemsListBuilder()
         .add(
             listOf(
                 listOf(
@@ -97,7 +93,7 @@ NestedItems.NestedItemsList validatedPayload =
         )
     .build(),
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -175,24 +171,20 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.NestedItems;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.NestedItems
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // List validation
-NestedItems.ItemsList2 validatedPayload =
+val validatedPayload: NestedItems.ItemsList2 =
     NestedItems.Items.validate(
-    new NestedItems.ItemsListBuilder2()
+    NestedItems.ItemsListBuilder2()
         .add(
             listOf(
                 listOf(
@@ -202,7 +194,7 @@ NestedItems.ItemsList2 validatedPayload =
         )
     .build(),
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -280,24 +272,20 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.NestedItems;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.NestedItems
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // List validation
-NestedItems.ItemsList1 validatedPayload =
+val validatedPayload: NestedItems.ItemsList1 =
     NestedItems.Items1.validate(
-    new NestedItems.ItemsListBuilder1()
+    NestedItems.ItemsListBuilder1()
         .add(
             listOf(
                 1
@@ -305,7 +293,7 @@ NestedItems.ItemsList1 validatedPayload =
         )
     .build(),
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -383,29 +371,25 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.NestedItems;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.NestedItems
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // List validation
-NestedItems.ItemsList validatedPayload =
+val validatedPayload: NestedItems.ItemsList =
     NestedItems.Items2.validate(
-    new NestedItems.ItemsListBuilder()
+    NestedItems.ItemsListBuilder()
         .add(1)
 
     .build(),
     configuration
-);
+)
 ```
 
 ### Field Summary

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NestedItems.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NestedItems.md
@@ -13,28 +13,28 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [NestedItems.NestedItems1Boxed](#nesteditems1boxed)<br> sealed interface for validated payloads |
-| record | [NestedItems.NestedItems1BoxedList](#nesteditems1boxedlist)<br> boxed class to store validated List payloads |
-| static class | [NestedItems.NestedItems1](#nesteditems1)<br> schema class |
-| static class | [NestedItems.NestedItemsListBuilder](#nesteditemslistbuilder)<br> builder for List payloads |
-| static class | [NestedItems.NestedItemsList](#nesteditemslist)<br> output class for List payloads |
+| data class | [NestedItems.NestedItems1BoxedList](#nesteditems1boxedlist)<br> boxed class to store validated List payloads |
+| class | [NestedItems.NestedItems1](#nesteditems1)<br> schema class |
+| class | [NestedItems.NestedItemsListBuilder](#nesteditemslistbuilder)<br> builder for List payloads |
+| class | [NestedItems.NestedItemsList](#nesteditemslist)<br> output class for List payloads |
 | sealed interface | [NestedItems.ItemsBoxed](#itemsboxed)<br> sealed interface for validated payloads |
-| record | [NestedItems.ItemsBoxedList](#itemsboxedlist)<br> boxed class to store validated List payloads |
-| static class | [NestedItems.Items](#items)<br> schema class |
-| static class | [NestedItems.ItemsListBuilder2](#itemslistbuilder2)<br> builder for List payloads |
-| static class | [NestedItems.ItemsList2](#itemslist2)<br> output class for List payloads |
+| data class | [NestedItems.ItemsBoxedList](#itemsboxedlist)<br> boxed class to store validated List payloads |
+| class | [NestedItems.Items](#items)<br> schema class |
+| class | [NestedItems.ItemsListBuilder2](#itemslistbuilder2)<br> builder for List payloads |
+| class | [NestedItems.ItemsList2](#itemslist2)<br> output class for List payloads |
 | sealed interface | [NestedItems.Items1Boxed](#items1boxed)<br> sealed interface for validated payloads |
-| record | [NestedItems.Items1BoxedList](#items1boxedlist)<br> boxed class to store validated List payloads |
-| static class | [NestedItems.Items1](#items1)<br> schema class |
-| static class | [NestedItems.ItemsListBuilder1](#itemslistbuilder1)<br> builder for List payloads |
-| static class | [NestedItems.ItemsList1](#itemslist1)<br> output class for List payloads |
+| data class | [NestedItems.Items1BoxedList](#items1boxedlist)<br> boxed class to store validated List payloads |
+| class | [NestedItems.Items1](#items1)<br> schema class |
+| class | [NestedItems.ItemsListBuilder1](#itemslistbuilder1)<br> builder for List payloads |
+| class | [NestedItems.ItemsList1](#itemslist1)<br> output class for List payloads |
 | sealed interface | [NestedItems.Items2Boxed](#items2boxed)<br> sealed interface for validated payloads |
-| record | [NestedItems.Items2BoxedList](#items2boxedlist)<br> boxed class to store validated List payloads |
-| static class | [NestedItems.Items2](#items2)<br> schema class |
-| static class | [NestedItems.ItemsListBuilder](#itemslistbuilder)<br> builder for List payloads |
-| static class | [NestedItems.ItemsList](#itemslist)<br> output class for List payloads |
+| data class | [NestedItems.Items2BoxedList](#items2boxedlist)<br> boxed class to store validated List payloads |
+| class | [NestedItems.Items2](#items2)<br> schema class |
+| class | [NestedItems.ItemsListBuilder](#itemslistbuilder)<br> builder for List payloads |
+| class | [NestedItems.ItemsList](#itemslist)<br> output class for List payloads |
 | sealed interface | [NestedItems.Items3Boxed](#items3boxed)<br> sealed interface for validated payloads |
-| record | [NestedItems.Items3BoxedNumber](#items3boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [NestedItems.Items3](#items3)<br> schema class |
+| data class | [NestedItems.Items3BoxedNumber](#items3boxednumber)<br> boxed class to store validated Number payloads |
+| class | [NestedItems.Items3](#items3)<br> schema class |
 
 ## NestedItems1Boxed
 sealed interface NestedItems1Boxed<br>

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NestedOneofToCheckValidationSemantics.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NestedOneofToCheckValidationSemantics.md
@@ -160,19 +160,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [NestedOneofToCheckValidationSemantics1BoxedString](#nestedoneoftocheckvalidationsemantics1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [NestedOneofToCheckValidationSemantics1BoxedVoid](#nestedoneoftocheckvalidationsemantics1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [NestedOneofToCheckValidationSemantics1BoxedNumber](#nestedoneoftocheckvalidationsemantics1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [NestedOneofToCheckValidationSemantics1BoxedBoolean](#nestedoneoftocheckvalidationsemantics1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [NestedOneofToCheckValidationSemantics1BoxedMap](#nestedoneoftocheckvalidationsemantics1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [NestedOneofToCheckValidationSemantics1BoxedBoolean](#nestedoneoftocheckvalidationsemantics1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [NestedOneofToCheckValidationSemantics1BoxedMap](#nestedoneoftocheckvalidationsemantics1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [NestedOneofToCheckValidationSemantics1BoxedList](#nestedoneoftocheckvalidationsemantics1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [NestedOneofToCheckValidationSemantics1Boxed](#nestedoneoftocheckvalidationsemantics1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -307,19 +307,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema0BoxedString](#schema0boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema0BoxedVoid](#schema0boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema0BoxedNumber](#schema0boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema0BoxedList](#schema0boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema0Boxed](#schema0boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NestedOneofToCheckValidationSemantics.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NestedOneofToCheckValidationSemantics.md
@@ -11,24 +11,24 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [NestedOneofToCheckValidationSemantics.NestedOneofToCheckValidationSemantics1Boxed](#nestedoneoftocheckvalidationsemantics1boxed)<br> sealed interface for validated payloads |
-| record | [NestedOneofToCheckValidationSemantics.NestedOneofToCheckValidationSemantics1BoxedVoid](#nestedoneoftocheckvalidationsemantics1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [NestedOneofToCheckValidationSemantics.NestedOneofToCheckValidationSemantics1BoxedBoolean](#nestedoneoftocheckvalidationsemantics1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [NestedOneofToCheckValidationSemantics.NestedOneofToCheckValidationSemantics1BoxedNumber](#nestedoneoftocheckvalidationsemantics1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [NestedOneofToCheckValidationSemantics.NestedOneofToCheckValidationSemantics1BoxedString](#nestedoneoftocheckvalidationsemantics1boxedstring)<br> boxed class to store validated String payloads |
-| record | [NestedOneofToCheckValidationSemantics.NestedOneofToCheckValidationSemantics1BoxedList](#nestedoneoftocheckvalidationsemantics1boxedlist)<br> boxed class to store validated List payloads |
-| record | [NestedOneofToCheckValidationSemantics.NestedOneofToCheckValidationSemantics1BoxedMap](#nestedoneoftocheckvalidationsemantics1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [NestedOneofToCheckValidationSemantics.NestedOneofToCheckValidationSemantics1](#nestedoneoftocheckvalidationsemantics1)<br> schema class |
+| data class | [NestedOneofToCheckValidationSemantics.NestedOneofToCheckValidationSemantics1BoxedVoid](#nestedoneoftocheckvalidationsemantics1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [NestedOneofToCheckValidationSemantics.NestedOneofToCheckValidationSemantics1BoxedBoolean](#nestedoneoftocheckvalidationsemantics1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [NestedOneofToCheckValidationSemantics.NestedOneofToCheckValidationSemantics1BoxedNumber](#nestedoneoftocheckvalidationsemantics1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [NestedOneofToCheckValidationSemantics.NestedOneofToCheckValidationSemantics1BoxedString](#nestedoneoftocheckvalidationsemantics1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [NestedOneofToCheckValidationSemantics.NestedOneofToCheckValidationSemantics1BoxedList](#nestedoneoftocheckvalidationsemantics1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [NestedOneofToCheckValidationSemantics.NestedOneofToCheckValidationSemantics1BoxedMap](#nestedoneoftocheckvalidationsemantics1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [NestedOneofToCheckValidationSemantics.NestedOneofToCheckValidationSemantics1](#nestedoneoftocheckvalidationsemantics1)<br> schema class |
 | sealed interface | [NestedOneofToCheckValidationSemantics.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [NestedOneofToCheckValidationSemantics.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [NestedOneofToCheckValidationSemantics.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [NestedOneofToCheckValidationSemantics.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [NestedOneofToCheckValidationSemantics.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [NestedOneofToCheckValidationSemantics.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [NestedOneofToCheckValidationSemantics.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [NestedOneofToCheckValidationSemantics.Schema0](#schema0)<br> schema class |
+| data class | [NestedOneofToCheckValidationSemantics.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [NestedOneofToCheckValidationSemantics.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [NestedOneofToCheckValidationSemantics.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [NestedOneofToCheckValidationSemantics.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [NestedOneofToCheckValidationSemantics.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [NestedOneofToCheckValidationSemantics.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [NestedOneofToCheckValidationSemantics.Schema0](#schema0)<br> schema class |
 | sealed interface | [NestedOneofToCheckValidationSemantics.Schema01Boxed](#schema01boxed)<br> sealed interface for validated payloads |
-| record | [NestedOneofToCheckValidationSemantics.Schema01BoxedVoid](#schema01boxedvoid)<br> boxed class to store validated null payloads |
-| static class | [NestedOneofToCheckValidationSemantics.Schema01](#schema01)<br> schema class |
+| data class | [NestedOneofToCheckValidationSemantics.Schema01BoxedVoid](#schema01boxedvoid)<br> boxed class to store validated null payloads |
+| class | [NestedOneofToCheckValidationSemantics.Schema01](#schema01)<br> schema class |
 
 ## NestedOneofToCheckValidationSemantics1Boxed
 sealed interface NestedOneofToCheckValidationSemantics1Boxed<br>
@@ -63,7 +63,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class NestedOneofToCheckValidationSemantics1BoxedBoolean<br>
 implements [NestedOneofToCheckValidationSemantics1Boxed](#nestedoneoftocheckvalidationsemantics1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -210,7 +210,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NonAsciiPatternWithAdditionalproperties.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NonAsciiPatternWithAdditionalproperties.md
@@ -66,27 +66,23 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.NonAsciiPatternWithAdditionalproperties;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.NonAsciiPatternWithAdditionalproperties
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // Map validation
-NonAsciiPatternWithAdditionalproperties.NonAsciiPatternWithAdditionalpropertiesMap validatedPayload =
+val validatedPayload: NonAsciiPatternWithAdditionalproperties.NonAsciiPatternWithAdditionalpropertiesMap =
     NonAsciiPatternWithAdditionalproperties.NonAsciiPatternWithAdditionalproperties1.validate(
-    new NonAsciiPatternWithAdditionalproperties.NonAsciiPatternWithAdditionalpropertiesMapBuilder()
+    NonAsciiPatternWithAdditionalproperties.NonAsciiPatternWithAdditionalpropertiesMapBuilder()
     .build(),
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -99,8 +95,8 @@ NonAsciiPatternWithAdditionalproperties.NonAsciiPatternWithAdditionalpropertiesM
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| [NonAsciiPatternWithAdditionalpropertiesMap](#nonasciipatternwithadditionalpropertiesmap) | validate(arg: [Map&lt;?, ?&gt;](#nonasciipatternwithadditionalpropertiesmapbuilder), configuration: SchemaConfiguration) |
-| [NonAsciiPatternWithAdditionalproperties1BoxedMap](#nonasciipatternwithadditionalproperties1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#nonasciipatternwithadditionalpropertiesmapbuilder), configuration: SchemaConfiguration) |
+| [NonAsciiPatternWithAdditionalpropertiesMap](#nonasciipatternwithadditionalpropertiesmap) | validate(arg: [Map&lt;*, *&gt;](#nonasciipatternwithadditionalpropertiesmapbuilder), configuration: SchemaConfiguration) |
+| [NonAsciiPatternWithAdditionalproperties1BoxedMap](#nonasciipatternwithadditionalproperties1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#nonasciipatternwithadditionalpropertiesmapbuilder), configuration: SchemaConfiguration) |
 | [NonAsciiPatternWithAdditionalproperties1Boxed](#nonasciipatternwithadditionalproperties1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
 

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NonAsciiPatternWithAdditionalproperties.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NonAsciiPatternWithAdditionalproperties.md
@@ -13,26 +13,26 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [NonAsciiPatternWithAdditionalproperties.NonAsciiPatternWithAdditionalproperties1Boxed](#nonasciipatternwithadditionalproperties1boxed)<br> sealed interface for validated payloads |
-| record | [NonAsciiPatternWithAdditionalproperties.NonAsciiPatternWithAdditionalproperties1BoxedMap](#nonasciipatternwithadditionalproperties1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [NonAsciiPatternWithAdditionalproperties.NonAsciiPatternWithAdditionalproperties1](#nonasciipatternwithadditionalproperties1)<br> schema class |
-| static class | [NonAsciiPatternWithAdditionalproperties.NonAsciiPatternWithAdditionalpropertiesMapBuilder](#nonasciipatternwithadditionalpropertiesmapbuilder)<br> builder for Map payloads |
-| static class | [NonAsciiPatternWithAdditionalproperties.NonAsciiPatternWithAdditionalpropertiesMap](#nonasciipatternwithadditionalpropertiesmap)<br> output class for Map payloads |
+| data class | [NonAsciiPatternWithAdditionalproperties.NonAsciiPatternWithAdditionalproperties1BoxedMap](#nonasciipatternwithadditionalproperties1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [NonAsciiPatternWithAdditionalproperties.NonAsciiPatternWithAdditionalproperties1](#nonasciipatternwithadditionalproperties1)<br> schema class |
+| class | [NonAsciiPatternWithAdditionalproperties.NonAsciiPatternWithAdditionalpropertiesMapBuilder](#nonasciipatternwithadditionalpropertiesmapbuilder)<br> builder for Map payloads |
+| class | [NonAsciiPatternWithAdditionalproperties.NonAsciiPatternWithAdditionalpropertiesMap](#nonasciipatternwithadditionalpropertiesmap)<br> output class for Map payloads |
 | sealed interface | [NonAsciiPatternWithAdditionalproperties.CircumflexAccentLatinSmallLetterAWithAcuteBoxed](#circumflexaccentlatinsmallletterawithacuteboxed)<br> sealed interface for validated payloads |
-| record | [NonAsciiPatternWithAdditionalproperties.CircumflexAccentLatinSmallLetterAWithAcuteBoxedVoid](#circumflexaccentlatinsmallletterawithacuteboxedvoid)<br> boxed class to store validated null payloads |
-| record | [NonAsciiPatternWithAdditionalproperties.CircumflexAccentLatinSmallLetterAWithAcuteBoxedBoolean](#circumflexaccentlatinsmallletterawithacuteboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [NonAsciiPatternWithAdditionalproperties.CircumflexAccentLatinSmallLetterAWithAcuteBoxedNumber](#circumflexaccentlatinsmallletterawithacuteboxednumber)<br> boxed class to store validated Number payloads |
-| record | [NonAsciiPatternWithAdditionalproperties.CircumflexAccentLatinSmallLetterAWithAcuteBoxedString](#circumflexaccentlatinsmallletterawithacuteboxedstring)<br> boxed class to store validated String payloads |
-| record | [NonAsciiPatternWithAdditionalproperties.CircumflexAccentLatinSmallLetterAWithAcuteBoxedList](#circumflexaccentlatinsmallletterawithacuteboxedlist)<br> boxed class to store validated List payloads |
-| record | [NonAsciiPatternWithAdditionalproperties.CircumflexAccentLatinSmallLetterAWithAcuteBoxedMap](#circumflexaccentlatinsmallletterawithacuteboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [NonAsciiPatternWithAdditionalproperties.CircumflexAccentLatinSmallLetterAWithAcute](#circumflexaccentlatinsmallletterawithacute)<br> schema class |
+| data class | [NonAsciiPatternWithAdditionalproperties.CircumflexAccentLatinSmallLetterAWithAcuteBoxedVoid](#circumflexaccentlatinsmallletterawithacuteboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [NonAsciiPatternWithAdditionalproperties.CircumflexAccentLatinSmallLetterAWithAcuteBoxedBoolean](#circumflexaccentlatinsmallletterawithacuteboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [NonAsciiPatternWithAdditionalproperties.CircumflexAccentLatinSmallLetterAWithAcuteBoxedNumber](#circumflexaccentlatinsmallletterawithacuteboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [NonAsciiPatternWithAdditionalproperties.CircumflexAccentLatinSmallLetterAWithAcuteBoxedString](#circumflexaccentlatinsmallletterawithacuteboxedstring)<br> boxed class to store validated String payloads |
+| data class | [NonAsciiPatternWithAdditionalproperties.CircumflexAccentLatinSmallLetterAWithAcuteBoxedList](#circumflexaccentlatinsmallletterawithacuteboxedlist)<br> boxed class to store validated List payloads |
+| data class | [NonAsciiPatternWithAdditionalproperties.CircumflexAccentLatinSmallLetterAWithAcuteBoxedMap](#circumflexaccentlatinsmallletterawithacuteboxedmap)<br> boxed class to store validated Map payloads |
+| class | [NonAsciiPatternWithAdditionalproperties.CircumflexAccentLatinSmallLetterAWithAcute](#circumflexaccentlatinsmallletterawithacute)<br> schema class |
 | sealed interface | [NonAsciiPatternWithAdditionalproperties.AdditionalPropertiesBoxed](#additionalpropertiesboxed)<br> sealed interface for validated payloads |
-| record | [NonAsciiPatternWithAdditionalproperties.AdditionalPropertiesBoxedVoid](#additionalpropertiesboxedvoid)<br> boxed class to store validated null payloads |
-| record | [NonAsciiPatternWithAdditionalproperties.AdditionalPropertiesBoxedBoolean](#additionalpropertiesboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [NonAsciiPatternWithAdditionalproperties.AdditionalPropertiesBoxedNumber](#additionalpropertiesboxednumber)<br> boxed class to store validated Number payloads |
-| record | [NonAsciiPatternWithAdditionalproperties.AdditionalPropertiesBoxedString](#additionalpropertiesboxedstring)<br> boxed class to store validated String payloads |
-| record | [NonAsciiPatternWithAdditionalproperties.AdditionalPropertiesBoxedList](#additionalpropertiesboxedlist)<br> boxed class to store validated List payloads |
-| record | [NonAsciiPatternWithAdditionalproperties.AdditionalPropertiesBoxedMap](#additionalpropertiesboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [NonAsciiPatternWithAdditionalproperties.AdditionalProperties](#additionalproperties)<br> schema class |
+| data class | [NonAsciiPatternWithAdditionalproperties.AdditionalPropertiesBoxedVoid](#additionalpropertiesboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [NonAsciiPatternWithAdditionalproperties.AdditionalPropertiesBoxedBoolean](#additionalpropertiesboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [NonAsciiPatternWithAdditionalproperties.AdditionalPropertiesBoxedNumber](#additionalpropertiesboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [NonAsciiPatternWithAdditionalproperties.AdditionalPropertiesBoxedString](#additionalpropertiesboxedstring)<br> boxed class to store validated String payloads |
+| data class | [NonAsciiPatternWithAdditionalproperties.AdditionalPropertiesBoxedList](#additionalpropertiesboxedlist)<br> boxed class to store validated List payloads |
+| data class | [NonAsciiPatternWithAdditionalproperties.AdditionalPropertiesBoxedMap](#additionalpropertiesboxedmap)<br> boxed class to store validated Map payloads |
+| class | [NonAsciiPatternWithAdditionalproperties.AdditionalProperties](#additionalproperties)<br> schema class |
 
 ## NonAsciiPatternWithAdditionalproperties1Boxed
 sealed interface NonAsciiPatternWithAdditionalproperties1Boxed<br>
@@ -160,7 +160,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class CircumflexAccentLatinSmallLetterAWithAcuteBoxedBoolean<br>
 implements [CircumflexAccentLatinSmallLetterAWithAcuteBoxed](#circumflexaccentlatinsmallletterawithacuteboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -285,7 +285,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class AdditionalPropertiesBoxedBoolean<br>
 implements [AdditionalPropertiesBoxed](#additionalpropertiesboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NonInterferenceAcrossCombinedSchemas.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NonInterferenceAcrossCombinedSchemas.md
@@ -197,19 +197,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [NonInterferenceAcrossCombinedSchemas1BoxedString](#noninterferenceacrosscombinedschemas1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [NonInterferenceAcrossCombinedSchemas1BoxedVoid](#noninterferenceacrosscombinedschemas1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [NonInterferenceAcrossCombinedSchemas1BoxedNumber](#noninterferenceacrosscombinedschemas1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [NonInterferenceAcrossCombinedSchemas1BoxedBoolean](#noninterferenceacrosscombinedschemas1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [NonInterferenceAcrossCombinedSchemas1BoxedMap](#noninterferenceacrosscombinedschemas1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [NonInterferenceAcrossCombinedSchemas1BoxedBoolean](#noninterferenceacrosscombinedschemas1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [NonInterferenceAcrossCombinedSchemas1BoxedMap](#noninterferenceacrosscombinedschemas1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [NonInterferenceAcrossCombinedSchemas1BoxedList](#noninterferenceacrosscombinedschemas1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [NonInterferenceAcrossCombinedSchemas1Boxed](#noninterferenceacrosscombinedschemas1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -344,19 +344,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema2BoxedString](#schema2boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema2BoxedVoid](#schema2boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema2BoxedNumber](#schema2boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema2BoxedBoolean](#schema2boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema2BoxedMap](#schema2boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema2BoxedBoolean](#schema2boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema2BoxedMap](#schema2boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema2BoxedList](#schema2boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema2Boxed](#schema2boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -491,19 +491,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [ElseSchemaBoxedString](#elseschemaboxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [ElseSchemaBoxedVoid](#elseschemaboxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [ElseSchemaBoxedNumber](#elseschemaboxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [ElseSchemaBoxedBoolean](#elseschemaboxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [ElseSchemaBoxedMap](#elseschemaboxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [ElseSchemaBoxedBoolean](#elseschemaboxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [ElseSchemaBoxedMap](#elseschemaboxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [ElseSchemaBoxedList](#elseschemaboxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [ElseSchemaBoxed](#elseschemaboxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -638,19 +638,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema1BoxedString](#schema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema1BoxedVoid](#schema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema1BoxedNumber](#schema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema1BoxedList](#schema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema1Boxed](#schema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -785,19 +785,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [ThenBoxedString](#thenboxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [ThenBoxedVoid](#thenboxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [ThenBoxedNumber](#thenboxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [ThenBoxedBoolean](#thenboxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [ThenBoxedMap](#thenboxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [ThenBoxedBoolean](#thenboxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [ThenBoxedMap](#thenboxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [ThenBoxedList](#thenboxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [ThenBoxed](#thenboxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -932,19 +932,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema0BoxedString](#schema0boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema0BoxedVoid](#schema0boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema0BoxedNumber](#schema0boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema0BoxedList](#schema0boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema0Boxed](#schema0boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -1079,19 +1079,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [IfSchemaBoxedString](#ifschemaboxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [IfSchemaBoxedVoid](#ifschemaboxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [IfSchemaBoxedNumber](#ifschemaboxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [IfSchemaBoxedBoolean](#ifschemaboxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [IfSchemaBoxedMap](#ifschemaboxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [IfSchemaBoxedBoolean](#ifschemaboxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [IfSchemaBoxedMap](#ifschemaboxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [IfSchemaBoxedList](#ifschemaboxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [IfSchemaBoxed](#ifschemaboxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NonInterferenceAcrossCombinedSchemas.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NonInterferenceAcrossCombinedSchemas.md
@@ -11,61 +11,61 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [NonInterferenceAcrossCombinedSchemas.NonInterferenceAcrossCombinedSchemas1Boxed](#noninterferenceacrosscombinedschemas1boxed)<br> sealed interface for validated payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.NonInterferenceAcrossCombinedSchemas1BoxedVoid](#noninterferenceacrosscombinedschemas1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.NonInterferenceAcrossCombinedSchemas1BoxedBoolean](#noninterferenceacrosscombinedschemas1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.NonInterferenceAcrossCombinedSchemas1BoxedNumber](#noninterferenceacrosscombinedschemas1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.NonInterferenceAcrossCombinedSchemas1BoxedString](#noninterferenceacrosscombinedschemas1boxedstring)<br> boxed class to store validated String payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.NonInterferenceAcrossCombinedSchemas1BoxedList](#noninterferenceacrosscombinedschemas1boxedlist)<br> boxed class to store validated List payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.NonInterferenceAcrossCombinedSchemas1BoxedMap](#noninterferenceacrosscombinedschemas1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [NonInterferenceAcrossCombinedSchemas.NonInterferenceAcrossCombinedSchemas1](#noninterferenceacrosscombinedschemas1)<br> schema class |
+| data class | [NonInterferenceAcrossCombinedSchemas.NonInterferenceAcrossCombinedSchemas1BoxedVoid](#noninterferenceacrosscombinedschemas1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.NonInterferenceAcrossCombinedSchemas1BoxedBoolean](#noninterferenceacrosscombinedschemas1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.NonInterferenceAcrossCombinedSchemas1BoxedNumber](#noninterferenceacrosscombinedschemas1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.NonInterferenceAcrossCombinedSchemas1BoxedString](#noninterferenceacrosscombinedschemas1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.NonInterferenceAcrossCombinedSchemas1BoxedList](#noninterferenceacrosscombinedschemas1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.NonInterferenceAcrossCombinedSchemas1BoxedMap](#noninterferenceacrosscombinedschemas1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [NonInterferenceAcrossCombinedSchemas.NonInterferenceAcrossCombinedSchemas1](#noninterferenceacrosscombinedschemas1)<br> schema class |
 | sealed interface | [NonInterferenceAcrossCombinedSchemas.Schema2Boxed](#schema2boxed)<br> sealed interface for validated payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.Schema2BoxedVoid](#schema2boxedvoid)<br> boxed class to store validated null payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.Schema2BoxedBoolean](#schema2boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.Schema2BoxedNumber](#schema2boxednumber)<br> boxed class to store validated Number payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.Schema2BoxedString](#schema2boxedstring)<br> boxed class to store validated String payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.Schema2BoxedList](#schema2boxedlist)<br> boxed class to store validated List payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.Schema2BoxedMap](#schema2boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [NonInterferenceAcrossCombinedSchemas.Schema2](#schema2)<br> schema class |
+| data class | [NonInterferenceAcrossCombinedSchemas.Schema2BoxedVoid](#schema2boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.Schema2BoxedBoolean](#schema2boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.Schema2BoxedNumber](#schema2boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.Schema2BoxedString](#schema2boxedstring)<br> boxed class to store validated String payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.Schema2BoxedList](#schema2boxedlist)<br> boxed class to store validated List payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.Schema2BoxedMap](#schema2boxedmap)<br> boxed class to store validated Map payloads |
+| class | [NonInterferenceAcrossCombinedSchemas.Schema2](#schema2)<br> schema class |
 | sealed interface | [NonInterferenceAcrossCombinedSchemas.ElseSchemaBoxed](#elseschemaboxed)<br> sealed interface for validated payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.ElseSchemaBoxedVoid](#elseschemaboxedvoid)<br> boxed class to store validated null payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.ElseSchemaBoxedBoolean](#elseschemaboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.ElseSchemaBoxedNumber](#elseschemaboxednumber)<br> boxed class to store validated Number payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.ElseSchemaBoxedString](#elseschemaboxedstring)<br> boxed class to store validated String payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.ElseSchemaBoxedList](#elseschemaboxedlist)<br> boxed class to store validated List payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.ElseSchemaBoxedMap](#elseschemaboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [NonInterferenceAcrossCombinedSchemas.ElseSchema](#elseschema)<br> schema class |
+| data class | [NonInterferenceAcrossCombinedSchemas.ElseSchemaBoxedVoid](#elseschemaboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.ElseSchemaBoxedBoolean](#elseschemaboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.ElseSchemaBoxedNumber](#elseschemaboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.ElseSchemaBoxedString](#elseschemaboxedstring)<br> boxed class to store validated String payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.ElseSchemaBoxedList](#elseschemaboxedlist)<br> boxed class to store validated List payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.ElseSchemaBoxedMap](#elseschemaboxedmap)<br> boxed class to store validated Map payloads |
+| class | [NonInterferenceAcrossCombinedSchemas.ElseSchema](#elseschema)<br> schema class |
 | sealed interface | [NonInterferenceAcrossCombinedSchemas.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [NonInterferenceAcrossCombinedSchemas.Schema1](#schema1)<br> schema class |
+| data class | [NonInterferenceAcrossCombinedSchemas.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [NonInterferenceAcrossCombinedSchemas.Schema1](#schema1)<br> schema class |
 | sealed interface | [NonInterferenceAcrossCombinedSchemas.ThenBoxed](#thenboxed)<br> sealed interface for validated payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.ThenBoxedVoid](#thenboxedvoid)<br> boxed class to store validated null payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.ThenBoxedBoolean](#thenboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.ThenBoxedNumber](#thenboxednumber)<br> boxed class to store validated Number payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.ThenBoxedString](#thenboxedstring)<br> boxed class to store validated String payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.ThenBoxedList](#thenboxedlist)<br> boxed class to store validated List payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.ThenBoxedMap](#thenboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [NonInterferenceAcrossCombinedSchemas.Then](#then)<br> schema class |
+| data class | [NonInterferenceAcrossCombinedSchemas.ThenBoxedVoid](#thenboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.ThenBoxedBoolean](#thenboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.ThenBoxedNumber](#thenboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.ThenBoxedString](#thenboxedstring)<br> boxed class to store validated String payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.ThenBoxedList](#thenboxedlist)<br> boxed class to store validated List payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.ThenBoxedMap](#thenboxedmap)<br> boxed class to store validated Map payloads |
+| class | [NonInterferenceAcrossCombinedSchemas.Then](#then)<br> schema class |
 | sealed interface | [NonInterferenceAcrossCombinedSchemas.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [NonInterferenceAcrossCombinedSchemas.Schema0](#schema0)<br> schema class |
+| data class | [NonInterferenceAcrossCombinedSchemas.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [NonInterferenceAcrossCombinedSchemas.Schema0](#schema0)<br> schema class |
 | sealed interface | [NonInterferenceAcrossCombinedSchemas.IfSchemaBoxed](#ifschemaboxed)<br> sealed interface for validated payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.IfSchemaBoxedVoid](#ifschemaboxedvoid)<br> boxed class to store validated null payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.IfSchemaBoxedBoolean](#ifschemaboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.IfSchemaBoxedNumber](#ifschemaboxednumber)<br> boxed class to store validated Number payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.IfSchemaBoxedString](#ifschemaboxedstring)<br> boxed class to store validated String payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.IfSchemaBoxedList](#ifschemaboxedlist)<br> boxed class to store validated List payloads |
-| record | [NonInterferenceAcrossCombinedSchemas.IfSchemaBoxedMap](#ifschemaboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [NonInterferenceAcrossCombinedSchemas.IfSchema](#ifschema)<br> schema class |
+| data class | [NonInterferenceAcrossCombinedSchemas.IfSchemaBoxedVoid](#ifschemaboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.IfSchemaBoxedBoolean](#ifschemaboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.IfSchemaBoxedNumber](#ifschemaboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.IfSchemaBoxedString](#ifschemaboxedstring)<br> boxed class to store validated String payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.IfSchemaBoxedList](#ifschemaboxedlist)<br> boxed class to store validated List payloads |
+| data class | [NonInterferenceAcrossCombinedSchemas.IfSchemaBoxedMap](#ifschemaboxedmap)<br> boxed class to store validated Map payloads |
+| class | [NonInterferenceAcrossCombinedSchemas.IfSchema](#ifschema)<br> schema class |
 
 ## NonInterferenceAcrossCombinedSchemas1Boxed
 sealed interface NonInterferenceAcrossCombinedSchemas1Boxed<br>
@@ -100,7 +100,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class NonInterferenceAcrossCombinedSchemas1BoxedBoolean<br>
 implements [NonInterferenceAcrossCombinedSchemas1Boxed](#noninterferenceacrosscombinedschemas1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -247,7 +247,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema2BoxedBoolean<br>
 implements [Schema2Boxed](#schema2boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -394,7 +394,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class ElseSchemaBoxedBoolean<br>
 implements [ElseSchemaBoxed](#elseschemaboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -541,7 +541,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema1BoxedBoolean<br>
 implements [Schema1Boxed](#schema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -688,7 +688,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class ThenBoxedBoolean<br>
 implements [ThenBoxed](#thenboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -835,7 +835,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -982,7 +982,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class IfSchemaBoxedBoolean<br>
 implements [IfSchemaBoxed](#ifschemaboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/Not.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/Not.md
@@ -152,19 +152,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Not1BoxedString](#not1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Not1BoxedVoid](#not1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Not1BoxedNumber](#not1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Not1BoxedBoolean](#not1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Not1BoxedMap](#not1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Not1BoxedBoolean](#not1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Not1BoxedMap](#not1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Not1BoxedList](#not1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Not1Boxed](#not1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/Not.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/Not.md
@@ -11,16 +11,16 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [Not.Not1Boxed](#not1boxed)<br> sealed interface for validated payloads |
-| record | [Not.Not1BoxedVoid](#not1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [Not.Not1BoxedBoolean](#not1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [Not.Not1BoxedNumber](#not1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [Not.Not1BoxedString](#not1boxedstring)<br> boxed class to store validated String payloads |
-| record | [Not.Not1BoxedList](#not1boxedlist)<br> boxed class to store validated List payloads |
-| record | [Not.Not1BoxedMap](#not1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [Not.Not1](#not1)<br> schema class |
+| data class | [Not.Not1BoxedVoid](#not1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [Not.Not1BoxedBoolean](#not1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [Not.Not1BoxedNumber](#not1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [Not.Not1BoxedString](#not1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [Not.Not1BoxedList](#not1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [Not.Not1BoxedMap](#not1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [Not.Not1](#not1)<br> schema class |
 | sealed interface | [Not.Not2Boxed](#not2boxed)<br> sealed interface for validated payloads |
-| record | [Not.Not2BoxedNumber](#not2boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [Not.Not2](#not2)<br> schema class |
+| data class | [Not.Not2BoxedNumber](#not2boxednumber)<br> boxed class to store validated Number payloads |
+| class | [Not.Not2](#not2)<br> schema class |
 
 ## Not1Boxed
 sealed interface Not1Boxed<br>
@@ -55,7 +55,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Not1BoxedBoolean<br>
 implements [Not1Boxed](#not1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NotMoreComplexSchema.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NotMoreComplexSchema.md
@@ -159,19 +159,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [NotMoreComplexSchema1BoxedString](#notmorecomplexschema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [NotMoreComplexSchema1BoxedVoid](#notmorecomplexschema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [NotMoreComplexSchema1BoxedNumber](#notmorecomplexschema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [NotMoreComplexSchema1BoxedBoolean](#notmorecomplexschema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [NotMoreComplexSchema1BoxedMap](#notmorecomplexschema1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [NotMoreComplexSchema1BoxedBoolean](#notmorecomplexschema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [NotMoreComplexSchema1BoxedMap](#notmorecomplexschema1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [NotMoreComplexSchema1BoxedList](#notmorecomplexschema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [NotMoreComplexSchema1Boxed](#notmorecomplexschema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -208,29 +208,25 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.NotMoreComplexSchema;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.NotMoreComplexSchema
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // Map validation
-NotMoreComplexSchema.NotMap validatedPayload =
+val validatedPayload: NotMoreComplexSchema.NotMap =
     NotMoreComplexSchema.Not.validate(
-    new NotMoreComplexSchema.NotMapBuilder()
+    NotMoreComplexSchema.NotMapBuilder()
         .foo("a")
 
     .build(),
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -242,8 +238,8 @@ NotMoreComplexSchema.NotMap validatedPayload =
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| [NotMap](#notmap) | validate(arg: [Map&lt;?, ?&gt;](#notmapbuilder), configuration: SchemaConfiguration) |
-| [NotBoxedMap](#notboxedmap) | validateAndBox([Map&lt;?, ?&gt;](#notmapbuilder), configuration: SchemaConfiguration) |
+| [NotMap](#notmap) | validate(arg: [Map&lt;*, *&gt;](#notmapbuilder), configuration: SchemaConfiguration) |
+| [NotBoxedMap](#notboxedmap) | validateAndBox([Map&lt;*, *&gt;](#notmapbuilder), configuration: SchemaConfiguration) |
 | [NotBoxed](#notboxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
 

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NotMoreComplexSchema.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NotMoreComplexSchema.md
@@ -13,21 +13,21 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [NotMoreComplexSchema.NotMoreComplexSchema1Boxed](#notmorecomplexschema1boxed)<br> sealed interface for validated payloads |
-| record | [NotMoreComplexSchema.NotMoreComplexSchema1BoxedVoid](#notmorecomplexschema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [NotMoreComplexSchema.NotMoreComplexSchema1BoxedBoolean](#notmorecomplexschema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [NotMoreComplexSchema.NotMoreComplexSchema1BoxedNumber](#notmorecomplexschema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [NotMoreComplexSchema.NotMoreComplexSchema1BoxedString](#notmorecomplexschema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [NotMoreComplexSchema.NotMoreComplexSchema1BoxedList](#notmorecomplexschema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [NotMoreComplexSchema.NotMoreComplexSchema1BoxedMap](#notmorecomplexschema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [NotMoreComplexSchema.NotMoreComplexSchema1](#notmorecomplexschema1)<br> schema class |
+| data class | [NotMoreComplexSchema.NotMoreComplexSchema1BoxedVoid](#notmorecomplexschema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [NotMoreComplexSchema.NotMoreComplexSchema1BoxedBoolean](#notmorecomplexschema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [NotMoreComplexSchema.NotMoreComplexSchema1BoxedNumber](#notmorecomplexschema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [NotMoreComplexSchema.NotMoreComplexSchema1BoxedString](#notmorecomplexschema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [NotMoreComplexSchema.NotMoreComplexSchema1BoxedList](#notmorecomplexschema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [NotMoreComplexSchema.NotMoreComplexSchema1BoxedMap](#notmorecomplexschema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [NotMoreComplexSchema.NotMoreComplexSchema1](#notmorecomplexschema1)<br> schema class |
 | sealed interface | [NotMoreComplexSchema.NotBoxed](#notboxed)<br> sealed interface for validated payloads |
-| record | [NotMoreComplexSchema.NotBoxedMap](#notboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [NotMoreComplexSchema.Not](#not)<br> schema class |
-| static class | [NotMoreComplexSchema.NotMapBuilder](#notmapbuilder)<br> builder for Map payloads |
-| static class | [NotMoreComplexSchema.NotMap](#notmap)<br> output class for Map payloads |
+| data class | [NotMoreComplexSchema.NotBoxedMap](#notboxedmap)<br> boxed class to store validated Map payloads |
+| class | [NotMoreComplexSchema.Not](#not)<br> schema class |
+| class | [NotMoreComplexSchema.NotMapBuilder](#notmapbuilder)<br> builder for Map payloads |
+| class | [NotMoreComplexSchema.NotMap](#notmap)<br> output class for Map payloads |
 | sealed interface | [NotMoreComplexSchema.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [NotMoreComplexSchema.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
-| static class | [NotMoreComplexSchema.Foo](#foo)<br> schema class |
+| data class | [NotMoreComplexSchema.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
+| class | [NotMoreComplexSchema.Foo](#foo)<br> schema class |
 
 ## NotMoreComplexSchema1Boxed
 sealed interface NotMoreComplexSchema1Boxed<br>
@@ -62,7 +62,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class NotMoreComplexSchema1BoxedBoolean<br>
 implements [NotMoreComplexSchema1Boxed](#notmorecomplexschema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NotMultipleTypes.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NotMultipleTypes.md
@@ -11,17 +11,17 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [NotMultipleTypes.NotMultipleTypes1Boxed](#notmultipletypes1boxed)<br> sealed interface for validated payloads |
-| record | [NotMultipleTypes.NotMultipleTypes1BoxedVoid](#notmultipletypes1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [NotMultipleTypes.NotMultipleTypes1BoxedBoolean](#notmultipletypes1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [NotMultipleTypes.NotMultipleTypes1BoxedNumber](#notmultipletypes1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [NotMultipleTypes.NotMultipleTypes1BoxedString](#notmultipletypes1boxedstring)<br> boxed class to store validated String payloads |
-| record | [NotMultipleTypes.NotMultipleTypes1BoxedList](#notmultipletypes1boxedlist)<br> boxed class to store validated List payloads |
-| record | [NotMultipleTypes.NotMultipleTypes1BoxedMap](#notmultipletypes1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [NotMultipleTypes.NotMultipleTypes1](#notmultipletypes1)<br> schema class |
+| data class | [NotMultipleTypes.NotMultipleTypes1BoxedVoid](#notmultipletypes1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [NotMultipleTypes.NotMultipleTypes1BoxedBoolean](#notmultipletypes1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [NotMultipleTypes.NotMultipleTypes1BoxedNumber](#notmultipletypes1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [NotMultipleTypes.NotMultipleTypes1BoxedString](#notmultipletypes1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [NotMultipleTypes.NotMultipleTypes1BoxedList](#notmultipletypes1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [NotMultipleTypes.NotMultipleTypes1BoxedMap](#notmultipletypes1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [NotMultipleTypes.NotMultipleTypes1](#notmultipletypes1)<br> schema class |
 | sealed interface | [NotMultipleTypes.NotBoxed](#notboxed)<br> sealed interface for validated payloads |
-| record | [NotMultipleTypes.NotBoxedNumber](#notboxednumber)<br> boxed class to store validated Number payloads |
-| record | [NotMultipleTypes.NotBoxedBoolean](#notboxedboolean)<br> boxed class to store validated boolean payloads |
-| static class | [NotMultipleTypes.Not](#not)<br> schema class |
+| data class | [NotMultipleTypes.NotBoxedNumber](#notboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [NotMultipleTypes.NotBoxedBoolean](#notboxedboolean)<br> boxed class to store validated boolean payloads |
+| class | [NotMultipleTypes.Not](#not)<br> schema class |
 
 ## NotMultipleTypes1Boxed
 sealed interface NotMultipleTypes1Boxed<br>
@@ -56,7 +56,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class NotMultipleTypes1BoxedBoolean<br>
 implements [NotMultipleTypes1Boxed](#notmultipletypes1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -199,7 +199,7 @@ data class that stores validated Number payloads, sealed permits implementation
 data class NotBoxedBoolean<br>
 implements [NotBoxed](#notboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NotMultipleTypes.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NotMultipleTypes.md
@@ -153,19 +153,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [NotMultipleTypes1BoxedString](#notmultipletypes1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [NotMultipleTypes1BoxedVoid](#notmultipletypes1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [NotMultipleTypes1BoxedNumber](#notmultipletypes1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [NotMultipleTypes1BoxedBoolean](#notmultipletypes1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [NotMultipleTypes1BoxedMap](#notmultipletypes1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [NotMultipleTypes1BoxedBoolean](#notmultipletypes1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [NotMultipleTypes1BoxedMap](#notmultipletypes1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [NotMultipleTypes1BoxedList](#notmultipletypes1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [NotMultipleTypes1Boxed](#notmultipletypes1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -220,31 +220,27 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.NotMultipleTypes;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.NotMultipleTypes
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // int validation
-int validatedPayload = NotMultipleTypes.Not.validate(
+val validatedPayload: Int = NotMultipleTypes.Not.validate(
     1L,
     configuration
-);
+)
 
 // boolean validation
-boolean validatedPayload = NotMultipleTypes.Not.validate(
+val validatedPayload: Boolean = NotMultipleTypes.Not.validate(
     true,
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -256,10 +252,10 @@ boolean validatedPayload = NotMultipleTypes.Not.validate(
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
 | [NotBoxedNumber](#notboxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [NotBoxedBoolean](#notboxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [NotBoxedBoolean](#notboxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
 | [NotBoxed](#notboxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
 

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NulCharactersInStrings.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NulCharactersInStrings.md
@@ -12,8 +12,8 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [NulCharactersInStrings.NulCharactersInStrings1Boxed](#nulcharactersinstrings1boxed)<br> sealed interface for validated payloads |
-| record | [NulCharactersInStrings.NulCharactersInStrings1BoxedString](#nulcharactersinstrings1boxedstring)<br> boxed class to store validated String payloads |
-| static class | [NulCharactersInStrings.NulCharactersInStrings1](#nulcharactersinstrings1)<br> schema class |
+| data class | [NulCharactersInStrings.NulCharactersInStrings1BoxedString](#nulcharactersinstrings1boxedstring)<br> boxed class to store validated String payloads |
+| class | [NulCharactersInStrings.NulCharactersInStrings1](#nulcharactersinstrings1)<br> schema class |
 | enum | [NulCharactersInStrings.StringNulCharactersInStringsEnums](#stringnulcharactersinstringsenums)<br>String enum |
 
 ## NulCharactersInStrings1Boxed

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NulCharactersInStrings.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NulCharactersInStrings.md
@@ -48,25 +48,21 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.NulCharactersInStrings;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.NulCharactersInStrings
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // String validation
-String validatedPayload = NulCharactersInStrings.NulCharactersInStrings1.validate(
+val validatedPayload: String = NulCharactersInStrings.NulCharactersInStrings1.validate(
     "hello\u0000there",
     configuration
-);
+)
 ```
 
 ### Field Summary

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NullTypeMatchesOnlyTheNullObject.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NullTypeMatchesOnlyTheNullObject.md
@@ -11,8 +11,8 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [NullTypeMatchesOnlyTheNullObject.NullTypeMatchesOnlyTheNullObject1Boxed](#nulltypematchesonlythenullobject1boxed)<br> sealed interface for validated payloads |
-| record | [NullTypeMatchesOnlyTheNullObject.NullTypeMatchesOnlyTheNullObject1BoxedVoid](#nulltypematchesonlythenullobject1boxedvoid)<br> boxed class to store validated null payloads |
-| static class | [NullTypeMatchesOnlyTheNullObject.NullTypeMatchesOnlyTheNullObject1](#nulltypematchesonlythenullobject1)<br> schema class |
+| data class | [NullTypeMatchesOnlyTheNullObject.NullTypeMatchesOnlyTheNullObject1BoxedVoid](#nulltypematchesonlythenullobject1boxedvoid)<br> boxed class to store validated null payloads |
+| class | [NullTypeMatchesOnlyTheNullObject.NullTypeMatchesOnlyTheNullObject1](#nulltypematchesonlythenullobject1)<br> schema class |
 
 ## NullTypeMatchesOnlyTheNullObject1Boxed
 sealed interface NullTypeMatchesOnlyTheNullObject1Boxed<br>

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NumberTypeMatchesNumbers.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/NumberTypeMatchesNumbers.md
@@ -11,8 +11,8 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [NumberTypeMatchesNumbers.NumberTypeMatchesNumbers1Boxed](#numbertypematchesnumbers1boxed)<br> sealed interface for validated payloads |
-| record | [NumberTypeMatchesNumbers.NumberTypeMatchesNumbers1BoxedNumber](#numbertypematchesnumbers1boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [NumberTypeMatchesNumbers.NumberTypeMatchesNumbers1](#numbertypematchesnumbers1)<br> schema class |
+| data class | [NumberTypeMatchesNumbers.NumberTypeMatchesNumbers1BoxedNumber](#numbertypematchesnumbers1boxednumber)<br> boxed class to store validated Number payloads |
+| class | [NumberTypeMatchesNumbers.NumberTypeMatchesNumbers1](#numbertypematchesnumbers1)<br> schema class |
 
 ## NumberTypeMatchesNumbers1Boxed
 sealed interface NumberTypeMatchesNumbers1Boxed<br>

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ObjectPropertiesValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ObjectPropertiesValidation.md
@@ -159,19 +159,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [ObjectPropertiesValidationMap](#objectpropertiesvalidationmap) | validate(arg: [Map&lt;?, ?&gt;](#objectpropertiesvalidationmapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [ObjectPropertiesValidationMap](#objectpropertiesvalidationmap) | validate(arg: [Map&lt;*, *&gt;](#objectpropertiesvalidationmapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [ObjectPropertiesValidation1BoxedString](#objectpropertiesvalidation1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [ObjectPropertiesValidation1BoxedVoid](#objectpropertiesvalidation1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [ObjectPropertiesValidation1BoxedNumber](#objectpropertiesvalidation1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [ObjectPropertiesValidation1BoxedBoolean](#objectpropertiesvalidation1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [ObjectPropertiesValidation1BoxedMap](#objectpropertiesvalidation1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#objectpropertiesvalidationmapbuilder), configuration: SchemaConfiguration) |
+| [ObjectPropertiesValidation1BoxedBoolean](#objectpropertiesvalidation1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [ObjectPropertiesValidation1BoxedMap](#objectpropertiesvalidation1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#objectpropertiesvalidationmapbuilder), configuration: SchemaConfiguration) |
 | [ObjectPropertiesValidation1BoxedList](#objectpropertiesvalidation1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [ObjectPropertiesValidation1Boxed](#objectpropertiesvalidation1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ObjectPropertiesValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ObjectPropertiesValidation.md
@@ -13,21 +13,21 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [ObjectPropertiesValidation.ObjectPropertiesValidation1Boxed](#objectpropertiesvalidation1boxed)<br> sealed interface for validated payloads |
-| record | [ObjectPropertiesValidation.ObjectPropertiesValidation1BoxedVoid](#objectpropertiesvalidation1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [ObjectPropertiesValidation.ObjectPropertiesValidation1BoxedBoolean](#objectpropertiesvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [ObjectPropertiesValidation.ObjectPropertiesValidation1BoxedNumber](#objectpropertiesvalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [ObjectPropertiesValidation.ObjectPropertiesValidation1BoxedString](#objectpropertiesvalidation1boxedstring)<br> boxed class to store validated String payloads |
-| record | [ObjectPropertiesValidation.ObjectPropertiesValidation1BoxedList](#objectpropertiesvalidation1boxedlist)<br> boxed class to store validated List payloads |
-| record | [ObjectPropertiesValidation.ObjectPropertiesValidation1BoxedMap](#objectpropertiesvalidation1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [ObjectPropertiesValidation.ObjectPropertiesValidation1](#objectpropertiesvalidation1)<br> schema class |
-| static class | [ObjectPropertiesValidation.ObjectPropertiesValidationMapBuilder](#objectpropertiesvalidationmapbuilder)<br> builder for Map payloads |
-| static class | [ObjectPropertiesValidation.ObjectPropertiesValidationMap](#objectpropertiesvalidationmap)<br> output class for Map payloads |
+| data class | [ObjectPropertiesValidation.ObjectPropertiesValidation1BoxedVoid](#objectpropertiesvalidation1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [ObjectPropertiesValidation.ObjectPropertiesValidation1BoxedBoolean](#objectpropertiesvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [ObjectPropertiesValidation.ObjectPropertiesValidation1BoxedNumber](#objectpropertiesvalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [ObjectPropertiesValidation.ObjectPropertiesValidation1BoxedString](#objectpropertiesvalidation1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [ObjectPropertiesValidation.ObjectPropertiesValidation1BoxedList](#objectpropertiesvalidation1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [ObjectPropertiesValidation.ObjectPropertiesValidation1BoxedMap](#objectpropertiesvalidation1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [ObjectPropertiesValidation.ObjectPropertiesValidation1](#objectpropertiesvalidation1)<br> schema class |
+| class | [ObjectPropertiesValidation.ObjectPropertiesValidationMapBuilder](#objectpropertiesvalidationmapbuilder)<br> builder for Map payloads |
+| class | [ObjectPropertiesValidation.ObjectPropertiesValidationMap](#objectpropertiesvalidationmap)<br> output class for Map payloads |
 | sealed interface | [ObjectPropertiesValidation.BarBoxed](#barboxed)<br> sealed interface for validated payloads |
-| record | [ObjectPropertiesValidation.BarBoxedString](#barboxedstring)<br> boxed class to store validated String payloads |
-| static class | [ObjectPropertiesValidation.Bar](#bar)<br> schema class |
+| data class | [ObjectPropertiesValidation.BarBoxedString](#barboxedstring)<br> boxed class to store validated String payloads |
+| class | [ObjectPropertiesValidation.Bar](#bar)<br> schema class |
 | sealed interface | [ObjectPropertiesValidation.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [ObjectPropertiesValidation.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
-| static class | [ObjectPropertiesValidation.Foo](#foo)<br> schema class |
+| data class | [ObjectPropertiesValidation.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
+| class | [ObjectPropertiesValidation.Foo](#foo)<br> schema class |
 
 ## ObjectPropertiesValidation1Boxed
 sealed interface ObjectPropertiesValidation1Boxed<br>
@@ -62,7 +62,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class ObjectPropertiesValidation1BoxedBoolean<br>
 implements [ObjectPropertiesValidation1Boxed](#objectpropertiesvalidation1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ObjectTypeMatchesObjects.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ObjectTypeMatchesObjects.md
@@ -11,8 +11,8 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [ObjectTypeMatchesObjects.ObjectTypeMatchesObjects1Boxed](#objecttypematchesobjects1boxed)<br> sealed interface for validated payloads |
-| record | [ObjectTypeMatchesObjects.ObjectTypeMatchesObjects1BoxedMap](#objecttypematchesobjects1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [ObjectTypeMatchesObjects.ObjectTypeMatchesObjects1](#objecttypematchesobjects1)<br> schema class |
+| data class | [ObjectTypeMatchesObjects.ObjectTypeMatchesObjects1BoxedMap](#objecttypematchesobjects1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [ObjectTypeMatchesObjects.ObjectTypeMatchesObjects1](#objecttypematchesobjects1)<br> schema class |
 
 ## ObjectTypeMatchesObjects1Boxed
 sealed interface ObjectTypeMatchesObjects1Boxed<br>

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/Oneof.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/Oneof.md
@@ -160,19 +160,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Oneof1BoxedString](#oneof1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Oneof1BoxedVoid](#oneof1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Oneof1BoxedNumber](#oneof1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Oneof1BoxedBoolean](#oneof1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Oneof1BoxedMap](#oneof1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Oneof1BoxedBoolean](#oneof1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Oneof1BoxedMap](#oneof1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Oneof1BoxedList](#oneof1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Oneof1Boxed](#oneof1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -307,19 +307,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema1BoxedString](#schema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema1BoxedVoid](#schema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema1BoxedNumber](#schema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema1BoxedList](#schema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema1Boxed](#schema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/Oneof.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/Oneof.md
@@ -11,24 +11,24 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [Oneof.Oneof1Boxed](#oneof1boxed)<br> sealed interface for validated payloads |
-| record | [Oneof.Oneof1BoxedVoid](#oneof1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [Oneof.Oneof1BoxedBoolean](#oneof1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [Oneof.Oneof1BoxedNumber](#oneof1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [Oneof.Oneof1BoxedString](#oneof1boxedstring)<br> boxed class to store validated String payloads |
-| record | [Oneof.Oneof1BoxedList](#oneof1boxedlist)<br> boxed class to store validated List payloads |
-| record | [Oneof.Oneof1BoxedMap](#oneof1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [Oneof.Oneof1](#oneof1)<br> schema class |
+| data class | [Oneof.Oneof1BoxedVoid](#oneof1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [Oneof.Oneof1BoxedBoolean](#oneof1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [Oneof.Oneof1BoxedNumber](#oneof1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [Oneof.Oneof1BoxedString](#oneof1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [Oneof.Oneof1BoxedList](#oneof1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [Oneof.Oneof1BoxedMap](#oneof1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [Oneof.Oneof1](#oneof1)<br> schema class |
 | sealed interface | [Oneof.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [Oneof.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [Oneof.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [Oneof.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [Oneof.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [Oneof.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [Oneof.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [Oneof.Schema1](#schema1)<br> schema class |
+| data class | [Oneof.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [Oneof.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [Oneof.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [Oneof.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [Oneof.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [Oneof.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [Oneof.Schema1](#schema1)<br> schema class |
 | sealed interface | [Oneof.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [Oneof.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [Oneof.Schema0](#schema0)<br> schema class |
+| data class | [Oneof.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| class | [Oneof.Schema0](#schema0)<br> schema class |
 
 ## Oneof1Boxed
 sealed interface Oneof1Boxed<br>
@@ -63,7 +63,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Oneof1BoxedBoolean<br>
 implements [Oneof1Boxed](#oneof1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -210,7 +210,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema1BoxedBoolean<br>
 implements [Schema1Boxed](#schema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/OneofComplexTypes.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/OneofComplexTypes.md
@@ -177,19 +177,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [OneofComplexTypes1BoxedString](#oneofcomplextypes1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [OneofComplexTypes1BoxedVoid](#oneofcomplextypes1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [OneofComplexTypes1BoxedNumber](#oneofcomplextypes1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [OneofComplexTypes1BoxedBoolean](#oneofcomplextypes1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [OneofComplexTypes1BoxedMap](#oneofcomplextypes1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [OneofComplexTypes1BoxedBoolean](#oneofcomplextypes1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [OneofComplexTypes1BoxedMap](#oneofcomplextypes1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [OneofComplexTypes1BoxedList](#oneofcomplextypes1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [OneofComplexTypes1Boxed](#oneofcomplextypes1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -325,19 +325,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [Schema1Map](#schema1map) | validate(arg: [Map&lt;?, ?&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [Schema1Map](#schema1map) | validate(arg: [Map&lt;*, *&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema1BoxedString](#schema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema1BoxedVoid](#schema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema1BoxedNumber](#schema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
+| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
 | [Schema1BoxedList](#schema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema1Boxed](#schema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -562,19 +562,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [Schema0Map](#schema0map) | validate(arg: [Map&lt;?, ?&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [Schema0Map](#schema0map) | validate(arg: [Map&lt;*, *&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema0BoxedString](#schema0boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema0BoxedVoid](#schema0boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema0BoxedNumber](#schema0boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
+| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox([Map&lt;*, *&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
 | [Schema0BoxedList](#schema0boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema0Boxed](#schema0boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/OneofComplexTypes.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/OneofComplexTypes.md
@@ -13,39 +13,39 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [OneofComplexTypes.OneofComplexTypes1Boxed](#oneofcomplextypes1boxed)<br> sealed interface for validated payloads |
-| record | [OneofComplexTypes.OneofComplexTypes1BoxedVoid](#oneofcomplextypes1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [OneofComplexTypes.OneofComplexTypes1BoxedBoolean](#oneofcomplextypes1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [OneofComplexTypes.OneofComplexTypes1BoxedNumber](#oneofcomplextypes1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [OneofComplexTypes.OneofComplexTypes1BoxedString](#oneofcomplextypes1boxedstring)<br> boxed class to store validated String payloads |
-| record | [OneofComplexTypes.OneofComplexTypes1BoxedList](#oneofcomplextypes1boxedlist)<br> boxed class to store validated List payloads |
-| record | [OneofComplexTypes.OneofComplexTypes1BoxedMap](#oneofcomplextypes1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [OneofComplexTypes.OneofComplexTypes1](#oneofcomplextypes1)<br> schema class |
+| data class | [OneofComplexTypes.OneofComplexTypes1BoxedVoid](#oneofcomplextypes1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [OneofComplexTypes.OneofComplexTypes1BoxedBoolean](#oneofcomplextypes1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [OneofComplexTypes.OneofComplexTypes1BoxedNumber](#oneofcomplextypes1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [OneofComplexTypes.OneofComplexTypes1BoxedString](#oneofcomplextypes1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [OneofComplexTypes.OneofComplexTypes1BoxedList](#oneofcomplextypes1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [OneofComplexTypes.OneofComplexTypes1BoxedMap](#oneofcomplextypes1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [OneofComplexTypes.OneofComplexTypes1](#oneofcomplextypes1)<br> schema class |
 | sealed interface | [OneofComplexTypes.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [OneofComplexTypes.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [OneofComplexTypes.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [OneofComplexTypes.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [OneofComplexTypes.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [OneofComplexTypes.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [OneofComplexTypes.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [OneofComplexTypes.Schema1](#schema1)<br> schema class |
-| static class | [OneofComplexTypes.Schema1MapBuilder](#schema1mapbuilder)<br> builder for Map payloads |
-| static class | [OneofComplexTypes.Schema1Map](#schema1map)<br> output class for Map payloads |
+| data class | [OneofComplexTypes.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [OneofComplexTypes.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [OneofComplexTypes.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [OneofComplexTypes.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [OneofComplexTypes.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [OneofComplexTypes.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [OneofComplexTypes.Schema1](#schema1)<br> schema class |
+| class | [OneofComplexTypes.Schema1MapBuilder](#schema1mapbuilder)<br> builder for Map payloads |
+| class | [OneofComplexTypes.Schema1Map](#schema1map)<br> output class for Map payloads |
 | sealed interface | [OneofComplexTypes.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [OneofComplexTypes.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
-| static class | [OneofComplexTypes.Foo](#foo)<br> schema class |
+| data class | [OneofComplexTypes.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
+| class | [OneofComplexTypes.Foo](#foo)<br> schema class |
 | sealed interface | [OneofComplexTypes.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [OneofComplexTypes.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [OneofComplexTypes.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [OneofComplexTypes.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [OneofComplexTypes.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [OneofComplexTypes.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [OneofComplexTypes.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [OneofComplexTypes.Schema0](#schema0)<br> schema class |
-| static class | [OneofComplexTypes.Schema0MapBuilder](#schema0mapbuilder)<br> builder for Map payloads |
-| static class | [OneofComplexTypes.Schema0Map](#schema0map)<br> output class for Map payloads |
+| data class | [OneofComplexTypes.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [OneofComplexTypes.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [OneofComplexTypes.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [OneofComplexTypes.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [OneofComplexTypes.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [OneofComplexTypes.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [OneofComplexTypes.Schema0](#schema0)<br> schema class |
+| class | [OneofComplexTypes.Schema0MapBuilder](#schema0mapbuilder)<br> builder for Map payloads |
+| class | [OneofComplexTypes.Schema0Map](#schema0map)<br> output class for Map payloads |
 | sealed interface | [OneofComplexTypes.BarBoxed](#barboxed)<br> sealed interface for validated payloads |
-| record | [OneofComplexTypes.BarBoxedNumber](#barboxednumber)<br> boxed class to store validated Number payloads |
-| static class | [OneofComplexTypes.Bar](#bar)<br> schema class |
+| data class | [OneofComplexTypes.BarBoxedNumber](#barboxednumber)<br> boxed class to store validated Number payloads |
+| class | [OneofComplexTypes.Bar](#bar)<br> schema class |
 
 ## OneofComplexTypes1Boxed
 sealed interface OneofComplexTypes1Boxed<br>
@@ -80,7 +80,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class OneofComplexTypes1BoxedBoolean<br>
 implements [OneofComplexTypes1Boxed](#oneofcomplextypes1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -227,7 +227,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema1BoxedBoolean<br>
 implements [Schema1Boxed](#schema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -464,7 +464,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/OneofWithBaseSchema.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/OneofWithBaseSchema.md
@@ -62,25 +62,21 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.OneofWithBaseSchema;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.OneofWithBaseSchema
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // String validation
-String validatedPayload = OneofWithBaseSchema.OneofWithBaseSchema1.validate(
+val validatedPayload: String = OneofWithBaseSchema.OneofWithBaseSchema1.validate(
     "a",
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -220,26 +216,26 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| Integer | maxLength = 4 |
+| Int | maxLength = 4 |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema1BoxedString](#schema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema1BoxedVoid](#schema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema1BoxedNumber](#schema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema1BoxedList](#schema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema1Boxed](#schema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -367,26 +363,26 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| Integer | minLength = 2 |
+| Int | minLength = 2 |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema0BoxedString](#schema0boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema0BoxedVoid](#schema0boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema0BoxedNumber](#schema0boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema0BoxedList](#schema0boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema0Boxed](#schema0boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/OneofWithBaseSchema.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/OneofWithBaseSchema.md
@@ -11,24 +11,24 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [OneofWithBaseSchema.OneofWithBaseSchema1Boxed](#oneofwithbaseschema1boxed)<br> sealed interface for validated payloads |
-| record | [OneofWithBaseSchema.OneofWithBaseSchema1BoxedString](#oneofwithbaseschema1boxedstring)<br> boxed class to store validated String payloads |
-| static class | [OneofWithBaseSchema.OneofWithBaseSchema1](#oneofwithbaseschema1)<br> schema class |
+| data class | [OneofWithBaseSchema.OneofWithBaseSchema1BoxedString](#oneofwithbaseschema1boxedstring)<br> boxed class to store validated String payloads |
+| class | [OneofWithBaseSchema.OneofWithBaseSchema1](#oneofwithbaseschema1)<br> schema class |
 | sealed interface | [OneofWithBaseSchema.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [OneofWithBaseSchema.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [OneofWithBaseSchema.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [OneofWithBaseSchema.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [OneofWithBaseSchema.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [OneofWithBaseSchema.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [OneofWithBaseSchema.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [OneofWithBaseSchema.Schema1](#schema1)<br> schema class |
+| data class | [OneofWithBaseSchema.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [OneofWithBaseSchema.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [OneofWithBaseSchema.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [OneofWithBaseSchema.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [OneofWithBaseSchema.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [OneofWithBaseSchema.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [OneofWithBaseSchema.Schema1](#schema1)<br> schema class |
 | sealed interface | [OneofWithBaseSchema.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [OneofWithBaseSchema.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [OneofWithBaseSchema.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [OneofWithBaseSchema.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [OneofWithBaseSchema.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [OneofWithBaseSchema.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [OneofWithBaseSchema.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [OneofWithBaseSchema.Schema0](#schema0)<br> schema class |
+| data class | [OneofWithBaseSchema.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [OneofWithBaseSchema.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [OneofWithBaseSchema.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [OneofWithBaseSchema.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [OneofWithBaseSchema.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [OneofWithBaseSchema.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [OneofWithBaseSchema.Schema0](#schema0)<br> schema class |
 
 ## OneofWithBaseSchema1Boxed
 sealed interface OneofWithBaseSchema1Boxed<br>
@@ -126,7 +126,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema1BoxedBoolean<br>
 implements [Schema1Boxed](#schema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -273,7 +273,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/OneofWithEmptySchema.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/OneofWithEmptySchema.md
@@ -160,19 +160,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [OneofWithEmptySchema1BoxedString](#oneofwithemptyschema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [OneofWithEmptySchema1BoxedVoid](#oneofwithemptyschema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [OneofWithEmptySchema1BoxedNumber](#oneofwithemptyschema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [OneofWithEmptySchema1BoxedBoolean](#oneofwithemptyschema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [OneofWithEmptySchema1BoxedMap](#oneofwithemptyschema1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [OneofWithEmptySchema1BoxedBoolean](#oneofwithemptyschema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [OneofWithEmptySchema1BoxedMap](#oneofwithemptyschema1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [OneofWithEmptySchema1BoxedList](#oneofwithemptyschema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [OneofWithEmptySchema1Boxed](#oneofwithemptyschema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/OneofWithEmptySchema.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/OneofWithEmptySchema.md
@@ -11,24 +11,24 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [OneofWithEmptySchema.OneofWithEmptySchema1Boxed](#oneofwithemptyschema1boxed)<br> sealed interface for validated payloads |
-| record | [OneofWithEmptySchema.OneofWithEmptySchema1BoxedVoid](#oneofwithemptyschema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [OneofWithEmptySchema.OneofWithEmptySchema1BoxedBoolean](#oneofwithemptyschema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [OneofWithEmptySchema.OneofWithEmptySchema1BoxedNumber](#oneofwithemptyschema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [OneofWithEmptySchema.OneofWithEmptySchema1BoxedString](#oneofwithemptyschema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [OneofWithEmptySchema.OneofWithEmptySchema1BoxedList](#oneofwithemptyschema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [OneofWithEmptySchema.OneofWithEmptySchema1BoxedMap](#oneofwithemptyschema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [OneofWithEmptySchema.OneofWithEmptySchema1](#oneofwithemptyschema1)<br> schema class |
+| data class | [OneofWithEmptySchema.OneofWithEmptySchema1BoxedVoid](#oneofwithemptyschema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [OneofWithEmptySchema.OneofWithEmptySchema1BoxedBoolean](#oneofwithemptyschema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [OneofWithEmptySchema.OneofWithEmptySchema1BoxedNumber](#oneofwithemptyschema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [OneofWithEmptySchema.OneofWithEmptySchema1BoxedString](#oneofwithemptyschema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [OneofWithEmptySchema.OneofWithEmptySchema1BoxedList](#oneofwithemptyschema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [OneofWithEmptySchema.OneofWithEmptySchema1BoxedMap](#oneofwithemptyschema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [OneofWithEmptySchema.OneofWithEmptySchema1](#oneofwithemptyschema1)<br> schema class |
 | sealed interface | [OneofWithEmptySchema.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [OneofWithEmptySchema.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [OneofWithEmptySchema.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [OneofWithEmptySchema.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [OneofWithEmptySchema.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [OneofWithEmptySchema.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [OneofWithEmptySchema.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [OneofWithEmptySchema.Schema1](#schema1)<br> schema class |
+| data class | [OneofWithEmptySchema.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [OneofWithEmptySchema.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [OneofWithEmptySchema.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [OneofWithEmptySchema.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [OneofWithEmptySchema.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [OneofWithEmptySchema.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [OneofWithEmptySchema.Schema1](#schema1)<br> schema class |
 | sealed interface | [OneofWithEmptySchema.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [OneofWithEmptySchema.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [OneofWithEmptySchema.Schema0](#schema0)<br> schema class |
+| data class | [OneofWithEmptySchema.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| class | [OneofWithEmptySchema.Schema0](#schema0)<br> schema class |
 
 ## OneofWithEmptySchema1Boxed
 sealed interface OneofWithEmptySchema1Boxed<br>
@@ -63,7 +63,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class OneofWithEmptySchema1BoxedBoolean<br>
 implements [OneofWithEmptySchema1Boxed](#oneofwithemptyschema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -210,7 +210,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema1BoxedBoolean<br>
 implements [Schema1Boxed](#schema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/OneofWithRequired.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/OneofWithRequired.md
@@ -13,28 +13,28 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [OneofWithRequired.OneofWithRequired1Boxed](#oneofwithrequired1boxed)<br> sealed interface for validated payloads |
-| record | [OneofWithRequired.OneofWithRequired1BoxedMap](#oneofwithrequired1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [OneofWithRequired.OneofWithRequired1](#oneofwithrequired1)<br> schema class |
+| data class | [OneofWithRequired.OneofWithRequired1BoxedMap](#oneofwithrequired1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [OneofWithRequired.OneofWithRequired1](#oneofwithrequired1)<br> schema class |
 | sealed interface | [OneofWithRequired.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [OneofWithRequired.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [OneofWithRequired.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [OneofWithRequired.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [OneofWithRequired.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [OneofWithRequired.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [OneofWithRequired.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [OneofWithRequired.Schema1](#schema1)<br> schema class |
-| static class | [OneofWithRequired.Schema1MapBuilder](#schema1mapbuilder)<br> builder for Map payloads |
-| static class | [OneofWithRequired.Schema1Map](#schema1map)<br> output class for Map payloads |
+| data class | [OneofWithRequired.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [OneofWithRequired.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [OneofWithRequired.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [OneofWithRequired.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [OneofWithRequired.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [OneofWithRequired.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [OneofWithRequired.Schema1](#schema1)<br> schema class |
+| class | [OneofWithRequired.Schema1MapBuilder](#schema1mapbuilder)<br> builder for Map payloads |
+| class | [OneofWithRequired.Schema1Map](#schema1map)<br> output class for Map payloads |
 | sealed interface | [OneofWithRequired.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [OneofWithRequired.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [OneofWithRequired.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [OneofWithRequired.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [OneofWithRequired.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [OneofWithRequired.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [OneofWithRequired.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [OneofWithRequired.Schema0](#schema0)<br> schema class |
-| static class | [OneofWithRequired.Schema0MapBuilder](#schema0mapbuilder)<br> builder for Map payloads |
-| static class | [OneofWithRequired.Schema0Map](#schema0map)<br> output class for Map payloads |
+| data class | [OneofWithRequired.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [OneofWithRequired.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [OneofWithRequired.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [OneofWithRequired.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [OneofWithRequired.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [OneofWithRequired.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [OneofWithRequired.Schema0](#schema0)<br> schema class |
+| class | [OneofWithRequired.Schema0MapBuilder](#schema0mapbuilder)<br> builder for Map payloads |
+| class | [OneofWithRequired.Schema0Map](#schema0map)<br> output class for Map payloads |
 
 ## OneofWithRequired1Boxed
 sealed interface OneofWithRequired1Boxed<br>
@@ -113,7 +113,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema1BoxedBoolean<br>
 implements [Schema1Boxed](#schema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -380,7 +380,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/OneofWithRequired.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/OneofWithRequired.md
@@ -75,8 +75,8 @@ A schema class that validates payloads
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| FrozenMap<String, Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
-| [OneofWithRequired1BoxedMap](#oneofwithrequired1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| FrozenMap<String, Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
+| [OneofWithRequired1BoxedMap](#oneofwithrequired1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [OneofWithRequired1Boxed](#oneofwithrequired1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
 
@@ -210,19 +210,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [Schema1Map](#schema1map) | validate(arg: [Map&lt;?, ?&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [Schema1Map](#schema1map) | validate(arg: [Map&lt;*, *&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema1BoxedString](#schema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema1BoxedVoid](#schema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema1BoxedNumber](#schema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
+| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#schema1mapbuilder), configuration: SchemaConfiguration) |
 | [Schema1BoxedList](#schema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema1Boxed](#schema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -477,19 +477,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [Schema0Map](#schema0map) | validate(arg: [Map&lt;?, ?&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [Schema0Map](#schema0map) | validate(arg: [Map&lt;*, *&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema0BoxedString](#schema0boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema0BoxedVoid](#schema0boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema0BoxedNumber](#schema0boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
+| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox([Map&lt;*, *&gt;](#schema0mapbuilder), configuration: SchemaConfiguration) |
 | [Schema0BoxedList](#schema0boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema0Boxed](#schema0boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PatternIsNotAnchored.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PatternIsNotAnchored.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [PatternIsNotAnchored1BoxedString](#patternisnotanchored1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [PatternIsNotAnchored1BoxedVoid](#patternisnotanchored1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [PatternIsNotAnchored1BoxedNumber](#patternisnotanchored1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [PatternIsNotAnchored1BoxedBoolean](#patternisnotanchored1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [PatternIsNotAnchored1BoxedMap](#patternisnotanchored1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [PatternIsNotAnchored1BoxedBoolean](#patternisnotanchored1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [PatternIsNotAnchored1BoxedMap](#patternisnotanchored1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [PatternIsNotAnchored1BoxedList](#patternisnotanchored1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [PatternIsNotAnchored1Boxed](#patternisnotanchored1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PatternIsNotAnchored.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PatternIsNotAnchored.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [PatternIsNotAnchored.PatternIsNotAnchored1Boxed](#patternisnotanchored1boxed)<br> sealed interface for validated payloads |
-| record | [PatternIsNotAnchored.PatternIsNotAnchored1BoxedVoid](#patternisnotanchored1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [PatternIsNotAnchored.PatternIsNotAnchored1BoxedBoolean](#patternisnotanchored1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [PatternIsNotAnchored.PatternIsNotAnchored1BoxedNumber](#patternisnotanchored1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [PatternIsNotAnchored.PatternIsNotAnchored1BoxedString](#patternisnotanchored1boxedstring)<br> boxed class to store validated String payloads |
-| record | [PatternIsNotAnchored.PatternIsNotAnchored1BoxedList](#patternisnotanchored1boxedlist)<br> boxed class to store validated List payloads |
-| record | [PatternIsNotAnchored.PatternIsNotAnchored1BoxedMap](#patternisnotanchored1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [PatternIsNotAnchored.PatternIsNotAnchored1](#patternisnotanchored1)<br> schema class |
+| data class | [PatternIsNotAnchored.PatternIsNotAnchored1BoxedVoid](#patternisnotanchored1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [PatternIsNotAnchored.PatternIsNotAnchored1BoxedBoolean](#patternisnotanchored1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [PatternIsNotAnchored.PatternIsNotAnchored1BoxedNumber](#patternisnotanchored1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [PatternIsNotAnchored.PatternIsNotAnchored1BoxedString](#patternisnotanchored1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [PatternIsNotAnchored.PatternIsNotAnchored1BoxedList](#patternisnotanchored1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [PatternIsNotAnchored.PatternIsNotAnchored1BoxedMap](#patternisnotanchored1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [PatternIsNotAnchored.PatternIsNotAnchored1](#patternisnotanchored1)<br> schema class |
 
 ## PatternIsNotAnchored1Boxed
 sealed interface PatternIsNotAnchored1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class PatternIsNotAnchored1BoxedBoolean<br>
 implements [PatternIsNotAnchored1Boxed](#patternisnotanchored1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PatternValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PatternValidation.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [PatternValidation1BoxedString](#patternvalidation1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [PatternValidation1BoxedVoid](#patternvalidation1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [PatternValidation1BoxedNumber](#patternvalidation1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [PatternValidation1BoxedBoolean](#patternvalidation1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [PatternValidation1BoxedMap](#patternvalidation1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [PatternValidation1BoxedBoolean](#patternvalidation1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [PatternValidation1BoxedMap](#patternvalidation1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [PatternValidation1BoxedList](#patternvalidation1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [PatternValidation1Boxed](#patternvalidation1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PatternValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PatternValidation.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [PatternValidation.PatternValidation1Boxed](#patternvalidation1boxed)<br> sealed interface for validated payloads |
-| record | [PatternValidation.PatternValidation1BoxedVoid](#patternvalidation1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [PatternValidation.PatternValidation1BoxedBoolean](#patternvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [PatternValidation.PatternValidation1BoxedNumber](#patternvalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [PatternValidation.PatternValidation1BoxedString](#patternvalidation1boxedstring)<br> boxed class to store validated String payloads |
-| record | [PatternValidation.PatternValidation1BoxedList](#patternvalidation1boxedlist)<br> boxed class to store validated List payloads |
-| record | [PatternValidation.PatternValidation1BoxedMap](#patternvalidation1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [PatternValidation.PatternValidation1](#patternvalidation1)<br> schema class |
+| data class | [PatternValidation.PatternValidation1BoxedVoid](#patternvalidation1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [PatternValidation.PatternValidation1BoxedBoolean](#patternvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [PatternValidation.PatternValidation1BoxedNumber](#patternvalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [PatternValidation.PatternValidation1BoxedString](#patternvalidation1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [PatternValidation.PatternValidation1BoxedList](#patternvalidation1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [PatternValidation.PatternValidation1BoxedMap](#patternvalidation1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [PatternValidation.PatternValidation1](#patternvalidation1)<br> schema class |
 
 ## PatternValidation1Boxed
 sealed interface PatternValidation1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class PatternValidation1BoxedBoolean<br>
 implements [PatternValidation1Boxed](#patternvalidation1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PatternpropertiesValidatesPropertiesMatchingARegex.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PatternpropertiesValidatesPropertiesMatchingARegex.md
@@ -11,16 +11,16 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [PatternpropertiesValidatesPropertiesMatchingARegex.PatternpropertiesValidatesPropertiesMatchingARegex1Boxed](#patternpropertiesvalidatespropertiesmatchingaregex1boxed)<br> sealed interface for validated payloads |
-| record | [PatternpropertiesValidatesPropertiesMatchingARegex.PatternpropertiesValidatesPropertiesMatchingARegex1BoxedVoid](#patternpropertiesvalidatespropertiesmatchingaregex1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [PatternpropertiesValidatesPropertiesMatchingARegex.PatternpropertiesValidatesPropertiesMatchingARegex1BoxedBoolean](#patternpropertiesvalidatespropertiesmatchingaregex1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [PatternpropertiesValidatesPropertiesMatchingARegex.PatternpropertiesValidatesPropertiesMatchingARegex1BoxedNumber](#patternpropertiesvalidatespropertiesmatchingaregex1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [PatternpropertiesValidatesPropertiesMatchingARegex.PatternpropertiesValidatesPropertiesMatchingARegex1BoxedString](#patternpropertiesvalidatespropertiesmatchingaregex1boxedstring)<br> boxed class to store validated String payloads |
-| record | [PatternpropertiesValidatesPropertiesMatchingARegex.PatternpropertiesValidatesPropertiesMatchingARegex1BoxedList](#patternpropertiesvalidatespropertiesmatchingaregex1boxedlist)<br> boxed class to store validated List payloads |
-| record | [PatternpropertiesValidatesPropertiesMatchingARegex.PatternpropertiesValidatesPropertiesMatchingARegex1BoxedMap](#patternpropertiesvalidatespropertiesmatchingaregex1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [PatternpropertiesValidatesPropertiesMatchingARegex.PatternpropertiesValidatesPropertiesMatchingARegex1](#patternpropertiesvalidatespropertiesmatchingaregex1)<br> schema class |
+| data class | [PatternpropertiesValidatesPropertiesMatchingARegex.PatternpropertiesValidatesPropertiesMatchingARegex1BoxedVoid](#patternpropertiesvalidatespropertiesmatchingaregex1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [PatternpropertiesValidatesPropertiesMatchingARegex.PatternpropertiesValidatesPropertiesMatchingARegex1BoxedBoolean](#patternpropertiesvalidatespropertiesmatchingaregex1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [PatternpropertiesValidatesPropertiesMatchingARegex.PatternpropertiesValidatesPropertiesMatchingARegex1BoxedNumber](#patternpropertiesvalidatespropertiesmatchingaregex1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [PatternpropertiesValidatesPropertiesMatchingARegex.PatternpropertiesValidatesPropertiesMatchingARegex1BoxedString](#patternpropertiesvalidatespropertiesmatchingaregex1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [PatternpropertiesValidatesPropertiesMatchingARegex.PatternpropertiesValidatesPropertiesMatchingARegex1BoxedList](#patternpropertiesvalidatespropertiesmatchingaregex1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [PatternpropertiesValidatesPropertiesMatchingARegex.PatternpropertiesValidatesPropertiesMatchingARegex1BoxedMap](#patternpropertiesvalidatespropertiesmatchingaregex1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [PatternpropertiesValidatesPropertiesMatchingARegex.PatternpropertiesValidatesPropertiesMatchingARegex1](#patternpropertiesvalidatespropertiesmatchingaregex1)<br> schema class |
 | sealed interface | [PatternpropertiesValidatesPropertiesMatchingARegex.FoBoxed](#foboxed)<br> sealed interface for validated payloads |
-| record | [PatternpropertiesValidatesPropertiesMatchingARegex.FoBoxedNumber](#foboxednumber)<br> boxed class to store validated Number payloads |
-| static class | [PatternpropertiesValidatesPropertiesMatchingARegex.Fo](#fo)<br> schema class |
+| data class | [PatternpropertiesValidatesPropertiesMatchingARegex.FoBoxedNumber](#foboxednumber)<br> boxed class to store validated Number payloads |
+| class | [PatternpropertiesValidatesPropertiesMatchingARegex.Fo](#fo)<br> schema class |
 
 ## PatternpropertiesValidatesPropertiesMatchingARegex1Boxed
 sealed interface PatternpropertiesValidatesPropertiesMatchingARegex1Boxed<br>
@@ -55,7 +55,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class PatternpropertiesValidatesPropertiesMatchingARegex1BoxedBoolean<br>
 implements [PatternpropertiesValidatesPropertiesMatchingARegex1Boxed](#patternpropertiesvalidatespropertiesmatchingaregex1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PatternpropertiesValidatesPropertiesMatchingARegex.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PatternpropertiesValidatesPropertiesMatchingARegex.md
@@ -152,19 +152,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [PatternpropertiesValidatesPropertiesMatchingARegex1BoxedString](#patternpropertiesvalidatespropertiesmatchingaregex1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [PatternpropertiesValidatesPropertiesMatchingARegex1BoxedVoid](#patternpropertiesvalidatespropertiesmatchingaregex1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [PatternpropertiesValidatesPropertiesMatchingARegex1BoxedNumber](#patternpropertiesvalidatespropertiesmatchingaregex1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [PatternpropertiesValidatesPropertiesMatchingARegex1BoxedBoolean](#patternpropertiesvalidatespropertiesmatchingaregex1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [PatternpropertiesValidatesPropertiesMatchingARegex1BoxedMap](#patternpropertiesvalidatespropertiesmatchingaregex1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [PatternpropertiesValidatesPropertiesMatchingARegex1BoxedBoolean](#patternpropertiesvalidatespropertiesmatchingaregex1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [PatternpropertiesValidatesPropertiesMatchingARegex1BoxedMap](#patternpropertiesvalidatespropertiesmatchingaregex1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [PatternpropertiesValidatesPropertiesMatchingARegex1BoxedList](#patternpropertiesvalidatespropertiesmatchingaregex1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [PatternpropertiesValidatesPropertiesMatchingARegex1Boxed](#patternpropertiesvalidatespropertiesmatchingaregex1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PatternpropertiesWithNullValuedInstanceProperties.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PatternpropertiesWithNullValuedInstanceProperties.md
@@ -152,19 +152,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [PatternpropertiesWithNullValuedInstanceProperties1BoxedString](#patternpropertieswithnullvaluedinstanceproperties1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [PatternpropertiesWithNullValuedInstanceProperties1BoxedVoid](#patternpropertieswithnullvaluedinstanceproperties1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [PatternpropertiesWithNullValuedInstanceProperties1BoxedNumber](#patternpropertieswithnullvaluedinstanceproperties1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [PatternpropertiesWithNullValuedInstanceProperties1BoxedBoolean](#patternpropertieswithnullvaluedinstanceproperties1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [PatternpropertiesWithNullValuedInstanceProperties1BoxedMap](#patternpropertieswithnullvaluedinstanceproperties1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [PatternpropertiesWithNullValuedInstanceProperties1BoxedBoolean](#patternpropertieswithnullvaluedinstanceproperties1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [PatternpropertiesWithNullValuedInstanceProperties1BoxedMap](#patternpropertieswithnullvaluedinstanceproperties1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [PatternpropertiesWithNullValuedInstanceProperties1BoxedList](#patternpropertieswithnullvaluedinstanceproperties1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [PatternpropertiesWithNullValuedInstanceProperties1Boxed](#patternpropertieswithnullvaluedinstanceproperties1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PatternpropertiesWithNullValuedInstanceProperties.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PatternpropertiesWithNullValuedInstanceProperties.md
@@ -11,16 +11,16 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [PatternpropertiesWithNullValuedInstanceProperties.PatternpropertiesWithNullValuedInstanceProperties1Boxed](#patternpropertieswithnullvaluedinstanceproperties1boxed)<br> sealed interface for validated payloads |
-| record | [PatternpropertiesWithNullValuedInstanceProperties.PatternpropertiesWithNullValuedInstanceProperties1BoxedVoid](#patternpropertieswithnullvaluedinstanceproperties1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [PatternpropertiesWithNullValuedInstanceProperties.PatternpropertiesWithNullValuedInstanceProperties1BoxedBoolean](#patternpropertieswithnullvaluedinstanceproperties1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [PatternpropertiesWithNullValuedInstanceProperties.PatternpropertiesWithNullValuedInstanceProperties1BoxedNumber](#patternpropertieswithnullvaluedinstanceproperties1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [PatternpropertiesWithNullValuedInstanceProperties.PatternpropertiesWithNullValuedInstanceProperties1BoxedString](#patternpropertieswithnullvaluedinstanceproperties1boxedstring)<br> boxed class to store validated String payloads |
-| record | [PatternpropertiesWithNullValuedInstanceProperties.PatternpropertiesWithNullValuedInstanceProperties1BoxedList](#patternpropertieswithnullvaluedinstanceproperties1boxedlist)<br> boxed class to store validated List payloads |
-| record | [PatternpropertiesWithNullValuedInstanceProperties.PatternpropertiesWithNullValuedInstanceProperties1BoxedMap](#patternpropertieswithnullvaluedinstanceproperties1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [PatternpropertiesWithNullValuedInstanceProperties.PatternpropertiesWithNullValuedInstanceProperties1](#patternpropertieswithnullvaluedinstanceproperties1)<br> schema class |
+| data class | [PatternpropertiesWithNullValuedInstanceProperties.PatternpropertiesWithNullValuedInstanceProperties1BoxedVoid](#patternpropertieswithnullvaluedinstanceproperties1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [PatternpropertiesWithNullValuedInstanceProperties.PatternpropertiesWithNullValuedInstanceProperties1BoxedBoolean](#patternpropertieswithnullvaluedinstanceproperties1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [PatternpropertiesWithNullValuedInstanceProperties.PatternpropertiesWithNullValuedInstanceProperties1BoxedNumber](#patternpropertieswithnullvaluedinstanceproperties1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [PatternpropertiesWithNullValuedInstanceProperties.PatternpropertiesWithNullValuedInstanceProperties1BoxedString](#patternpropertieswithnullvaluedinstanceproperties1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [PatternpropertiesWithNullValuedInstanceProperties.PatternpropertiesWithNullValuedInstanceProperties1BoxedList](#patternpropertieswithnullvaluedinstanceproperties1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [PatternpropertiesWithNullValuedInstanceProperties.PatternpropertiesWithNullValuedInstanceProperties1BoxedMap](#patternpropertieswithnullvaluedinstanceproperties1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [PatternpropertiesWithNullValuedInstanceProperties.PatternpropertiesWithNullValuedInstanceProperties1](#patternpropertieswithnullvaluedinstanceproperties1)<br> schema class |
 | sealed interface | [PatternpropertiesWithNullValuedInstanceProperties.BarBoxed](#barboxed)<br> sealed interface for validated payloads |
-| record | [PatternpropertiesWithNullValuedInstanceProperties.BarBoxedVoid](#barboxedvoid)<br> boxed class to store validated null payloads |
-| static class | [PatternpropertiesWithNullValuedInstanceProperties.Bar](#bar)<br> schema class |
+| data class | [PatternpropertiesWithNullValuedInstanceProperties.BarBoxedVoid](#barboxedvoid)<br> boxed class to store validated null payloads |
+| class | [PatternpropertiesWithNullValuedInstanceProperties.Bar](#bar)<br> schema class |
 
 ## PatternpropertiesWithNullValuedInstanceProperties1Boxed
 sealed interface PatternpropertiesWithNullValuedInstanceProperties1Boxed<br>
@@ -55,7 +55,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class PatternpropertiesWithNullValuedInstanceProperties1BoxedBoolean<br>
 implements [PatternpropertiesWithNullValuedInstanceProperties1Boxed](#patternpropertieswithnullvaluedinstanceproperties1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PrefixitemsValidationAdjustsTheStartingIndexForItems.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PrefixitemsValidationAdjustsTheStartingIndexForItems.md
@@ -56,29 +56,25 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.PrefixitemsValidationAdjustsTheStartingIndexForItems;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.PrefixitemsValidationAdjustsTheStartingIndexForItems
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // List validation
-PrefixitemsValidationAdjustsTheStartingIndexForItems.PrefixitemsValidationAdjustsTheStartingIndexForItemsList validatedPayload =
+val validatedPayload: PrefixitemsValidationAdjustsTheStartingIndexForItems.PrefixitemsValidationAdjustsTheStartingIndexForItemsList =
     PrefixitemsValidationAdjustsTheStartingIndexForItems.PrefixitemsValidationAdjustsTheStartingIndexForItems1.validate(
-    new PrefixitemsValidationAdjustsTheStartingIndexForItems.PrefixitemsValidationAdjustsTheStartingIndexForItemsListBuilder()
+    PrefixitemsValidationAdjustsTheStartingIndexForItems.PrefixitemsValidationAdjustsTheStartingIndexForItemsListBuilder()
         .add(1)
 
     .build(),
     configuration
-);
+)
 ```
 
 ### Field Summary

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PrefixitemsValidationAdjustsTheStartingIndexForItems.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PrefixitemsValidationAdjustsTheStartingIndexForItems.md
@@ -13,16 +13,16 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [PrefixitemsValidationAdjustsTheStartingIndexForItems.PrefixitemsValidationAdjustsTheStartingIndexForItems1Boxed](#prefixitemsvalidationadjuststhestartingindexforitems1boxed)<br> sealed interface for validated payloads |
-| record | [PrefixitemsValidationAdjustsTheStartingIndexForItems.PrefixitemsValidationAdjustsTheStartingIndexForItems1BoxedList](#prefixitemsvalidationadjuststhestartingindexforitems1boxedlist)<br> boxed class to store validated List payloads |
-| static class | [PrefixitemsValidationAdjustsTheStartingIndexForItems.PrefixitemsValidationAdjustsTheStartingIndexForItems1](#prefixitemsvalidationadjuststhestartingindexforitems1)<br> schema class |
+| data class | [PrefixitemsValidationAdjustsTheStartingIndexForItems.PrefixitemsValidationAdjustsTheStartingIndexForItems1BoxedList](#prefixitemsvalidationadjuststhestartingindexforitems1boxedlist)<br> boxed class to store validated List payloads |
+| class | [PrefixitemsValidationAdjustsTheStartingIndexForItems.PrefixitemsValidationAdjustsTheStartingIndexForItems1](#prefixitemsvalidationadjuststhestartingindexforitems1)<br> schema class |
 | sealed interface | [PrefixitemsValidationAdjustsTheStartingIndexForItems.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [PrefixitemsValidationAdjustsTheStartingIndexForItems.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| static class | [PrefixitemsValidationAdjustsTheStartingIndexForItems.Schema0](#schema0)<br> schema class |
-| static class | [PrefixitemsValidationAdjustsTheStartingIndexForItems.PrefixitemsValidationAdjustsTheStartingIndexForItemsListBuilder](#prefixitemsvalidationadjuststhestartingindexforitemslistbuilder)<br> builder for List payloads |
-| static class | [PrefixitemsValidationAdjustsTheStartingIndexForItems.PrefixitemsValidationAdjustsTheStartingIndexForItemsList](#prefixitemsvalidationadjuststhestartingindexforitemslist)<br> output class for List payloads |
+| data class | [PrefixitemsValidationAdjustsTheStartingIndexForItems.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| class | [PrefixitemsValidationAdjustsTheStartingIndexForItems.Schema0](#schema0)<br> schema class |
+| class | [PrefixitemsValidationAdjustsTheStartingIndexForItems.PrefixitemsValidationAdjustsTheStartingIndexForItemsListBuilder](#prefixitemsvalidationadjuststhestartingindexforitemslistbuilder)<br> builder for List payloads |
+| class | [PrefixitemsValidationAdjustsTheStartingIndexForItems.PrefixitemsValidationAdjustsTheStartingIndexForItemsList](#prefixitemsvalidationadjuststhestartingindexforitemslist)<br> output class for List payloads |
 | sealed interface | [PrefixitemsValidationAdjustsTheStartingIndexForItems.ItemsBoxed](#itemsboxed)<br> sealed interface for validated payloads |
-| record | [PrefixitemsValidationAdjustsTheStartingIndexForItems.ItemsBoxedNumber](#itemsboxednumber)<br> boxed class to store validated Number payloads |
-| static class | [PrefixitemsValidationAdjustsTheStartingIndexForItems.Items](#items)<br> schema class |
+| data class | [PrefixitemsValidationAdjustsTheStartingIndexForItems.ItemsBoxedNumber](#itemsboxednumber)<br> boxed class to store validated Number payloads |
+| class | [PrefixitemsValidationAdjustsTheStartingIndexForItems.Items](#items)<br> schema class |
 
 ## PrefixitemsValidationAdjustsTheStartingIndexForItems1Boxed
 sealed interface PrefixitemsValidationAdjustsTheStartingIndexForItems1Boxed<br>

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PrefixitemsWithNullInstanceElements.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PrefixitemsWithNullInstanceElements.md
@@ -13,18 +13,18 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [PrefixitemsWithNullInstanceElements.PrefixitemsWithNullInstanceElements1Boxed](#prefixitemswithnullinstanceelements1boxed)<br> sealed interface for validated payloads |
-| record | [PrefixitemsWithNullInstanceElements.PrefixitemsWithNullInstanceElements1BoxedVoid](#prefixitemswithnullinstanceelements1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [PrefixitemsWithNullInstanceElements.PrefixitemsWithNullInstanceElements1BoxedBoolean](#prefixitemswithnullinstanceelements1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [PrefixitemsWithNullInstanceElements.PrefixitemsWithNullInstanceElements1BoxedNumber](#prefixitemswithnullinstanceelements1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [PrefixitemsWithNullInstanceElements.PrefixitemsWithNullInstanceElements1BoxedString](#prefixitemswithnullinstanceelements1boxedstring)<br> boxed class to store validated String payloads |
-| record | [PrefixitemsWithNullInstanceElements.PrefixitemsWithNullInstanceElements1BoxedList](#prefixitemswithnullinstanceelements1boxedlist)<br> boxed class to store validated List payloads |
-| record | [PrefixitemsWithNullInstanceElements.PrefixitemsWithNullInstanceElements1BoxedMap](#prefixitemswithnullinstanceelements1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [PrefixitemsWithNullInstanceElements.PrefixitemsWithNullInstanceElements1](#prefixitemswithnullinstanceelements1)<br> schema class |
+| data class | [PrefixitemsWithNullInstanceElements.PrefixitemsWithNullInstanceElements1BoxedVoid](#prefixitemswithnullinstanceelements1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [PrefixitemsWithNullInstanceElements.PrefixitemsWithNullInstanceElements1BoxedBoolean](#prefixitemswithnullinstanceelements1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [PrefixitemsWithNullInstanceElements.PrefixitemsWithNullInstanceElements1BoxedNumber](#prefixitemswithnullinstanceelements1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [PrefixitemsWithNullInstanceElements.PrefixitemsWithNullInstanceElements1BoxedString](#prefixitemswithnullinstanceelements1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [PrefixitemsWithNullInstanceElements.PrefixitemsWithNullInstanceElements1BoxedList](#prefixitemswithnullinstanceelements1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [PrefixitemsWithNullInstanceElements.PrefixitemsWithNullInstanceElements1BoxedMap](#prefixitemswithnullinstanceelements1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [PrefixitemsWithNullInstanceElements.PrefixitemsWithNullInstanceElements1](#prefixitemswithnullinstanceelements1)<br> schema class |
 | sealed interface | [PrefixitemsWithNullInstanceElements.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [PrefixitemsWithNullInstanceElements.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| static class | [PrefixitemsWithNullInstanceElements.Schema0](#schema0)<br> schema class |
-| static class | [PrefixitemsWithNullInstanceElements.PrefixitemsWithNullInstanceElementsListBuilder](#prefixitemswithnullinstanceelementslistbuilder)<br> builder for List payloads |
-| static class | [PrefixitemsWithNullInstanceElements.PrefixitemsWithNullInstanceElementsList](#prefixitemswithnullinstanceelementslist)<br> output class for List payloads |
+| data class | [PrefixitemsWithNullInstanceElements.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| class | [PrefixitemsWithNullInstanceElements.Schema0](#schema0)<br> schema class |
+| class | [PrefixitemsWithNullInstanceElements.PrefixitemsWithNullInstanceElementsListBuilder](#prefixitemswithnullinstanceelementslistbuilder)<br> builder for List payloads |
+| class | [PrefixitemsWithNullInstanceElements.PrefixitemsWithNullInstanceElementsList](#prefixitemswithnullinstanceelementslist)<br> output class for List payloads |
 
 ## PrefixitemsWithNullInstanceElements1Boxed
 sealed interface PrefixitemsWithNullInstanceElements1Boxed<br>
@@ -59,7 +59,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class PrefixitemsWithNullInstanceElements1BoxedBoolean<br>
 implements [PrefixitemsWithNullInstanceElements1Boxed](#prefixitemswithnullinstanceelements1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PrefixitemsWithNullInstanceElements.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PrefixitemsWithNullInstanceElements.md
@@ -156,19 +156,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [PrefixitemsWithNullInstanceElementsList](#prefixitemswithnullinstanceelementslist) | validate(arg: [List<*>](#prefixitemswithnullinstanceelementslistbuilder), configuration: SchemaConfiguration) |
 | [PrefixitemsWithNullInstanceElements1BoxedString](#prefixitemswithnullinstanceelements1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [PrefixitemsWithNullInstanceElements1BoxedVoid](#prefixitemswithnullinstanceelements1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [PrefixitemsWithNullInstanceElements1BoxedNumber](#prefixitemswithnullinstanceelements1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [PrefixitemsWithNullInstanceElements1BoxedBoolean](#prefixitemswithnullinstanceelements1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [PrefixitemsWithNullInstanceElements1BoxedMap](#prefixitemswithnullinstanceelements1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [PrefixitemsWithNullInstanceElements1BoxedBoolean](#prefixitemswithnullinstanceelements1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [PrefixitemsWithNullInstanceElements1BoxedMap](#prefixitemswithnullinstanceelements1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [PrefixitemsWithNullInstanceElements1BoxedList](#prefixitemswithnullinstanceelements1boxedlist) | validateAndBox([List<*>](#prefixitemswithnullinstanceelementslistbuilder), configuration: SchemaConfiguration) |
 | [PrefixitemsWithNullInstanceElements1Boxed](#prefixitemswithnullinstanceelements1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PropertiesPatternpropertiesAdditionalpropertiesInteraction.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PropertiesPatternpropertiesAdditionalpropertiesInteraction.md
@@ -13,27 +13,27 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.PropertiesPatternpropertiesAdditionalpropertiesInteraction1Boxed](#propertiespatternpropertiesadditionalpropertiesinteraction1boxed)<br> sealed interface for validated payloads |
-| record | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.PropertiesPatternpropertiesAdditionalpropertiesInteraction1BoxedMap](#propertiespatternpropertiesadditionalpropertiesinteraction1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.PropertiesPatternpropertiesAdditionalpropertiesInteraction1](#propertiespatternpropertiesadditionalpropertiesinteraction1)<br> schema class |
-| static class | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.PropertiesPatternpropertiesAdditionalpropertiesInteractionMapBuilder](#propertiespatternpropertiesadditionalpropertiesinteractionmapbuilder)<br> builder for Map payloads |
-| static class | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.PropertiesPatternpropertiesAdditionalpropertiesInteractionMap](#propertiespatternpropertiesadditionalpropertiesinteractionmap)<br> output class for Map payloads |
+| data class | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.PropertiesPatternpropertiesAdditionalpropertiesInteraction1BoxedMap](#propertiespatternpropertiesadditionalpropertiesinteraction1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.PropertiesPatternpropertiesAdditionalpropertiesInteraction1](#propertiespatternpropertiesadditionalpropertiesinteraction1)<br> schema class |
+| class | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.PropertiesPatternpropertiesAdditionalpropertiesInteractionMapBuilder](#propertiespatternpropertiesadditionalpropertiesinteractionmapbuilder)<br> builder for Map payloads |
+| class | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.PropertiesPatternpropertiesAdditionalpropertiesInteractionMap](#propertiespatternpropertiesadditionalpropertiesinteractionmap)<br> output class for Map payloads |
 | sealed interface | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.BarBoxed](#barboxed)<br> sealed interface for validated payloads |
-| record | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.BarBoxedList](#barboxedlist)<br> boxed class to store validated List payloads |
-| static class | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.Bar](#bar)<br> schema class |
+| data class | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.BarBoxedList](#barboxedlist)<br> boxed class to store validated List payloads |
+| class | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.Bar](#bar)<br> schema class |
 | sealed interface | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.FooBoxedList](#fooboxedlist)<br> boxed class to store validated List payloads |
-| static class | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.Foo](#foo)<br> schema class |
+| data class | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.FooBoxedList](#fooboxedlist)<br> boxed class to store validated List payloads |
+| class | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.Foo](#foo)<br> schema class |
 | sealed interface | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.FoBoxed](#foboxed)<br> sealed interface for validated payloads |
-| record | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.FoBoxedVoid](#foboxedvoid)<br> boxed class to store validated null payloads |
-| record | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.FoBoxedBoolean](#foboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.FoBoxedNumber](#foboxednumber)<br> boxed class to store validated Number payloads |
-| record | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.FoBoxedString](#foboxedstring)<br> boxed class to store validated String payloads |
-| record | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.FoBoxedList](#foboxedlist)<br> boxed class to store validated List payloads |
-| record | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.FoBoxedMap](#foboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.Fo](#fo)<br> schema class |
+| data class | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.FoBoxedVoid](#foboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.FoBoxedBoolean](#foboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.FoBoxedNumber](#foboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.FoBoxedString](#foboxedstring)<br> boxed class to store validated String payloads |
+| data class | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.FoBoxedList](#foboxedlist)<br> boxed class to store validated List payloads |
+| data class | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.FoBoxedMap](#foboxedmap)<br> boxed class to store validated Map payloads |
+| class | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.Fo](#fo)<br> schema class |
 | sealed interface | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.AdditionalPropertiesBoxed](#additionalpropertiesboxed)<br> sealed interface for validated payloads |
-| record | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.AdditionalPropertiesBoxedNumber](#additionalpropertiesboxednumber)<br> boxed class to store validated Number payloads |
-| static class | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.AdditionalProperties](#additionalproperties)<br> schema class |
+| data class | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.AdditionalPropertiesBoxedNumber](#additionalpropertiesboxednumber)<br> boxed class to store validated Number payloads |
+| class | [PropertiesPatternpropertiesAdditionalpropertiesInteraction.AdditionalProperties](#additionalproperties)<br> schema class |
 
 ## PropertiesPatternpropertiesAdditionalpropertiesInteraction1Boxed
 sealed interface PropertiesPatternpropertiesAdditionalpropertiesInteraction1Boxed<br>
@@ -252,7 +252,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class FoBoxedBoolean<br>
 implements [FoBoxed](#foboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PropertiesPatternpropertiesAdditionalpropertiesInteraction.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PropertiesPatternpropertiesAdditionalpropertiesInteraction.md
@@ -67,29 +67,25 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.PropertiesPatternpropertiesAdditionalpropertiesInteraction;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.PropertiesPatternpropertiesAdditionalpropertiesInteraction
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // Map validation
-PropertiesPatternpropertiesAdditionalpropertiesInteraction.PropertiesPatternpropertiesAdditionalpropertiesInteractionMap validatedPayload =
+val validatedPayload: PropertiesPatternpropertiesAdditionalpropertiesInteraction.PropertiesPatternpropertiesAdditionalpropertiesInteractionMap =
     PropertiesPatternpropertiesAdditionalpropertiesInteraction.PropertiesPatternpropertiesAdditionalpropertiesInteraction1.validate(
-    new PropertiesPatternpropertiesAdditionalpropertiesInteraction.PropertiesPatternpropertiesAdditionalpropertiesInteractionMapBuilder()
+    PropertiesPatternpropertiesAdditionalpropertiesInteraction.PropertiesPatternpropertiesAdditionalpropertiesInteractionMapBuilder()
         .additionalProperty("someAdditionalProperty", 1)
 
     .build(),
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -103,8 +99,8 @@ PropertiesPatternpropertiesAdditionalpropertiesInteraction.PropertiesPatternprop
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| [PropertiesPatternpropertiesAdditionalpropertiesInteractionMap](#propertiespatternpropertiesadditionalpropertiesinteractionmap) | validate(arg: [Map&lt;?, ?&gt;](#propertiespatternpropertiesadditionalpropertiesinteractionmapbuilder), configuration: SchemaConfiguration) |
-| [PropertiesPatternpropertiesAdditionalpropertiesInteraction1BoxedMap](#propertiespatternpropertiesadditionalpropertiesinteraction1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#propertiespatternpropertiesadditionalpropertiesinteractionmapbuilder), configuration: SchemaConfiguration) |
+| [PropertiesPatternpropertiesAdditionalpropertiesInteractionMap](#propertiespatternpropertiesadditionalpropertiesinteractionmap) | validate(arg: [Map&lt;*, *&gt;](#propertiespatternpropertiesadditionalpropertiesinteractionmapbuilder), configuration: SchemaConfiguration) |
+| [PropertiesPatternpropertiesAdditionalpropertiesInteraction1BoxedMap](#propertiespatternpropertiesadditionalpropertiesinteraction1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#propertiespatternpropertiesadditionalpropertiesinteractionmapbuilder), configuration: SchemaConfiguration) |
 | [PropertiesPatternpropertiesAdditionalpropertiesInteraction1Boxed](#propertiespatternpropertiesadditionalpropertiesinteraction1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
 
@@ -213,7 +209,7 @@ A schema class that validates payloads
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
 | Set<Class<?>> | type = setOf(List::class.java) |
-| Integer | maxItems = 3 |
+| Int | maxItems = 3 |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
@@ -346,26 +342,26 @@ A schema class that validates payloads
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
-| Integer | minItems = 2 |
+| Int | minItems = 2 |
 
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [FoBoxedString](#foboxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [FoBoxedVoid](#foboxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [FoBoxedNumber](#foboxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [FoBoxedBoolean](#foboxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [FoBoxedMap](#foboxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [FoBoxedBoolean](#foboxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [FoBoxedMap](#foboxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [FoBoxedList](#foboxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [FoBoxed](#foboxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PropertiesWhoseNamesAreJavascriptObjectPropertyNames.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PropertiesWhoseNamesAreJavascriptObjectPropertyNames.md
@@ -172,19 +172,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [PropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap](#propertieswhosenamesarejavascriptobjectpropertynamesmap) | validate(arg: [Map&lt;?, ?&gt;](#propertieswhosenamesarejavascriptobjectpropertynamesmapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [PropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap](#propertieswhosenamesarejavascriptobjectpropertynamesmap) | validate(arg: [Map&lt;*, *&gt;](#propertieswhosenamesarejavascriptobjectpropertynamesmapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedString](#propertieswhosenamesarejavascriptobjectpropertynames1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedVoid](#propertieswhosenamesarejavascriptobjectpropertynames1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedNumber](#propertieswhosenamesarejavascriptobjectpropertynames1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [PropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedBoolean](#propertieswhosenamesarejavascriptobjectpropertynames1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [PropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedMap](#propertieswhosenamesarejavascriptobjectpropertynames1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#propertieswhosenamesarejavascriptobjectpropertynamesmapbuilder), configuration: SchemaConfiguration) |
+| [PropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedBoolean](#propertieswhosenamesarejavascriptobjectpropertynames1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [PropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedMap](#propertieswhosenamesarejavascriptobjectpropertynames1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#propertieswhosenamesarejavascriptobjectpropertynamesmapbuilder), configuration: SchemaConfiguration) |
 | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedList](#propertieswhosenamesarejavascriptobjectpropertynames1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames1Boxed](#propertieswhosenamesarejavascriptobjectpropertynames1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -409,19 +409,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [ToStringMap](#tostringmap) | validate(arg: [Map&lt;?, ?&gt;](#tostringmapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [ToStringMap](#tostringmap) | validate(arg: [Map&lt;*, *&gt;](#tostringmapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [ToStringSchemaBoxedString](#tostringschemaboxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [ToStringSchemaBoxedVoid](#tostringschemaboxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [ToStringSchemaBoxedNumber](#tostringschemaboxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [ToStringSchemaBoxedBoolean](#tostringschemaboxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [ToStringSchemaBoxedMap](#tostringschemaboxedmap) | validateAndBox([Map&lt;?, ?&gt;](#tostringmapbuilder), configuration: SchemaConfiguration) |
+| [ToStringSchemaBoxedBoolean](#tostringschemaboxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [ToStringSchemaBoxedMap](#tostringschemaboxedmap) | validateAndBox([Map&lt;*, *&gt;](#tostringmapbuilder), configuration: SchemaConfiguration) |
 | [ToStringSchemaBoxedList](#tostringschemaboxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [ToStringSchemaBoxed](#tostringschemaboxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PropertiesWhoseNamesAreJavascriptObjectPropertyNames.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PropertiesWhoseNamesAreJavascriptObjectPropertyNames.md
@@ -13,34 +13,34 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.PropertiesWhoseNamesAreJavascriptObjectPropertyNames1Boxed](#propertieswhosenamesarejavascriptobjectpropertynames1boxed)<br> sealed interface for validated payloads |
-| record | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.PropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedVoid](#propertieswhosenamesarejavascriptobjectpropertynames1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.PropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedBoolean](#propertieswhosenamesarejavascriptobjectpropertynames1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.PropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedNumber](#propertieswhosenamesarejavascriptobjectpropertynames1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.PropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedString](#propertieswhosenamesarejavascriptobjectpropertynames1boxedstring)<br> boxed class to store validated String payloads |
-| record | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.PropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedList](#propertieswhosenamesarejavascriptobjectpropertynames1boxedlist)<br> boxed class to store validated List payloads |
-| record | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.PropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedMap](#propertieswhosenamesarejavascriptobjectpropertynames1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.PropertiesWhoseNamesAreJavascriptObjectPropertyNames1](#propertieswhosenamesarejavascriptobjectpropertynames1)<br> schema class |
-| static class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.PropertiesWhoseNamesAreJavascriptObjectPropertyNamesMapBuilder](#propertieswhosenamesarejavascriptobjectpropertynamesmapbuilder)<br> builder for Map payloads |
-| static class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.PropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap](#propertieswhosenamesarejavascriptobjectpropertynamesmap)<br> output class for Map payloads |
+| data class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.PropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedVoid](#propertieswhosenamesarejavascriptobjectpropertynames1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.PropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedBoolean](#propertieswhosenamesarejavascriptobjectpropertynames1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.PropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedNumber](#propertieswhosenamesarejavascriptobjectpropertynames1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.PropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedString](#propertieswhosenamesarejavascriptobjectpropertynames1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.PropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedList](#propertieswhosenamesarejavascriptobjectpropertynames1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.PropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedMap](#propertieswhosenamesarejavascriptobjectpropertynames1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.PropertiesWhoseNamesAreJavascriptObjectPropertyNames1](#propertieswhosenamesarejavascriptobjectpropertynames1)<br> schema class |
+| class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.PropertiesWhoseNamesAreJavascriptObjectPropertyNamesMapBuilder](#propertieswhosenamesarejavascriptobjectpropertynamesmapbuilder)<br> builder for Map payloads |
+| class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.PropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap](#propertieswhosenamesarejavascriptobjectpropertynamesmap)<br> output class for Map payloads |
 | sealed interface | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.ConstructorSchemaBoxed](#constructorschemaboxed)<br> sealed interface for validated payloads |
-| record | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.ConstructorSchemaBoxedNumber](#constructorschemaboxednumber)<br> boxed class to store validated Number payloads |
-| static class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.ConstructorSchema](#constructorschema)<br> schema class |
+| data class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.ConstructorSchemaBoxedNumber](#constructorschemaboxednumber)<br> boxed class to store validated Number payloads |
+| class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.ConstructorSchema](#constructorschema)<br> schema class |
 | sealed interface | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.ToStringSchemaBoxed](#tostringschemaboxed)<br> sealed interface for validated payloads |
-| record | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.ToStringSchemaBoxedVoid](#tostringschemaboxedvoid)<br> boxed class to store validated null payloads |
-| record | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.ToStringSchemaBoxedBoolean](#tostringschemaboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.ToStringSchemaBoxedNumber](#tostringschemaboxednumber)<br> boxed class to store validated Number payloads |
-| record | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.ToStringSchemaBoxedString](#tostringschemaboxedstring)<br> boxed class to store validated String payloads |
-| record | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.ToStringSchemaBoxedList](#tostringschemaboxedlist)<br> boxed class to store validated List payloads |
-| record | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.ToStringSchemaBoxedMap](#tostringschemaboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.ToStringSchema](#tostringschema)<br> schema class |
-| static class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.ToStringMapBuilder](#tostringmapbuilder)<br> builder for Map payloads |
-| static class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.ToStringMap](#tostringmap)<br> output class for Map payloads |
+| data class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.ToStringSchemaBoxedVoid](#tostringschemaboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.ToStringSchemaBoxedBoolean](#tostringschemaboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.ToStringSchemaBoxedNumber](#tostringschemaboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.ToStringSchemaBoxedString](#tostringschemaboxedstring)<br> boxed class to store validated String payloads |
+| data class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.ToStringSchemaBoxedList](#tostringschemaboxedlist)<br> boxed class to store validated List payloads |
+| data class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.ToStringSchemaBoxedMap](#tostringschemaboxedmap)<br> boxed class to store validated Map payloads |
+| class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.ToStringSchema](#tostringschema)<br> schema class |
+| class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.ToStringMapBuilder](#tostringmapbuilder)<br> builder for Map payloads |
+| class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.ToStringMap](#tostringmap)<br> output class for Map payloads |
 | sealed interface | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.LengthBoxed](#lengthboxed)<br> sealed interface for validated payloads |
-| record | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.LengthBoxedString](#lengthboxedstring)<br> boxed class to store validated String payloads |
-| static class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.Length](#length)<br> schema class |
+| data class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.LengthBoxedString](#lengthboxedstring)<br> boxed class to store validated String payloads |
+| class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.Length](#length)<br> schema class |
 | sealed interface | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.ProtoBoxed](#protoboxed)<br> sealed interface for validated payloads |
-| record | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.ProtoBoxedNumber](#protoboxednumber)<br> boxed class to store validated Number payloads |
-| static class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.Proto](#proto)<br> schema class |
+| data class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.ProtoBoxedNumber](#protoboxednumber)<br> boxed class to store validated Number payloads |
+| class | [PropertiesWhoseNamesAreJavascriptObjectPropertyNames.Proto](#proto)<br> schema class |
 
 ## PropertiesWhoseNamesAreJavascriptObjectPropertyNames1Boxed
 sealed interface PropertiesWhoseNamesAreJavascriptObjectPropertyNames1Boxed<br>
@@ -75,7 +75,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class PropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedBoolean<br>
 implements [PropertiesWhoseNamesAreJavascriptObjectPropertyNames1Boxed](#propertieswhosenamesarejavascriptobjectpropertynames1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -312,7 +312,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class ToStringSchemaBoxedBoolean<br>
 implements [ToStringSchemaBoxed](#tostringschemaboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PropertiesWithEscapedCharacters.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PropertiesWithEscapedCharacters.md
@@ -13,33 +13,33 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharacters1Boxed](#propertieswithescapedcharacters1boxed)<br> sealed interface for validated payloads |
-| record | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharacters1BoxedVoid](#propertieswithescapedcharacters1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharacters1BoxedBoolean](#propertieswithescapedcharacters1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharacters1BoxedNumber](#propertieswithescapedcharacters1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharacters1BoxedString](#propertieswithescapedcharacters1boxedstring)<br> boxed class to store validated String payloads |
-| record | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharacters1BoxedList](#propertieswithescapedcharacters1boxedlist)<br> boxed class to store validated List payloads |
-| record | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharacters1BoxedMap](#propertieswithescapedcharacters1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharacters1](#propertieswithescapedcharacters1)<br> schema class |
-| static class | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharactersMapBuilder](#propertieswithescapedcharactersmapbuilder)<br> builder for Map payloads |
-| static class | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharactersMap](#propertieswithescapedcharactersmap)<br> output class for Map payloads |
+| data class | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharacters1BoxedVoid](#propertieswithescapedcharacters1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharacters1BoxedBoolean](#propertieswithescapedcharacters1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharacters1BoxedNumber](#propertieswithescapedcharacters1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharacters1BoxedString](#propertieswithescapedcharacters1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharacters1BoxedList](#propertieswithescapedcharacters1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharacters1BoxedMap](#propertieswithescapedcharacters1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharacters1](#propertieswithescapedcharacters1)<br> schema class |
+| class | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharactersMapBuilder](#propertieswithescapedcharactersmapbuilder)<br> builder for Map payloads |
+| class | [PropertiesWithEscapedCharacters.PropertiesWithEscapedCharactersMap](#propertieswithescapedcharactersmap)<br> output class for Map payloads |
 | sealed interface | [PropertiesWithEscapedCharacters.Foou000CbarBoxed](#foou000cbarboxed)<br> sealed interface for validated payloads |
-| record | [PropertiesWithEscapedCharacters.Foou000CbarBoxedNumber](#foou000cbarboxednumber)<br> boxed class to store validated Number payloads |
-| static class | [PropertiesWithEscapedCharacters.Foou000Cbar](#foou000cbar)<br> schema class |
+| data class | [PropertiesWithEscapedCharacters.Foou000CbarBoxedNumber](#foou000cbarboxednumber)<br> boxed class to store validated Number payloads |
+| class | [PropertiesWithEscapedCharacters.Foou000Cbar](#foou000cbar)<br> schema class |
 | sealed interface | [PropertiesWithEscapedCharacters.FootbarBoxed](#footbarboxed)<br> sealed interface for validated payloads |
-| record | [PropertiesWithEscapedCharacters.FootbarBoxedNumber](#footbarboxednumber)<br> boxed class to store validated Number payloads |
-| static class | [PropertiesWithEscapedCharacters.Footbar](#footbar)<br> schema class |
+| data class | [PropertiesWithEscapedCharacters.FootbarBoxedNumber](#footbarboxednumber)<br> boxed class to store validated Number payloads |
+| class | [PropertiesWithEscapedCharacters.Footbar](#footbar)<br> schema class |
 | sealed interface | [PropertiesWithEscapedCharacters.FoorbarBoxed](#foorbarboxed)<br> sealed interface for validated payloads |
-| record | [PropertiesWithEscapedCharacters.FoorbarBoxedNumber](#foorbarboxednumber)<br> boxed class to store validated Number payloads |
-| static class | [PropertiesWithEscapedCharacters.Foorbar](#foorbar)<br> schema class |
+| data class | [PropertiesWithEscapedCharacters.FoorbarBoxedNumber](#foorbarboxednumber)<br> boxed class to store validated Number payloads |
+| class | [PropertiesWithEscapedCharacters.Foorbar](#foorbar)<br> schema class |
 | sealed interface | [PropertiesWithEscapedCharacters.Foobar1Boxed](#foobar1boxed)<br> sealed interface for validated payloads |
-| record | [PropertiesWithEscapedCharacters.Foobar1BoxedNumber](#foobar1boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [PropertiesWithEscapedCharacters.Foobar1](#foobar1)<br> schema class |
+| data class | [PropertiesWithEscapedCharacters.Foobar1BoxedNumber](#foobar1boxednumber)<br> boxed class to store validated Number payloads |
+| class | [PropertiesWithEscapedCharacters.Foobar1](#foobar1)<br> schema class |
 | sealed interface | [PropertiesWithEscapedCharacters.FoobarBoxed](#foobarboxed)<br> sealed interface for validated payloads |
-| record | [PropertiesWithEscapedCharacters.FoobarBoxedNumber](#foobarboxednumber)<br> boxed class to store validated Number payloads |
-| static class | [PropertiesWithEscapedCharacters.Foobar](#foobar)<br> schema class |
+| data class | [PropertiesWithEscapedCharacters.FoobarBoxedNumber](#foobarboxednumber)<br> boxed class to store validated Number payloads |
+| class | [PropertiesWithEscapedCharacters.Foobar](#foobar)<br> schema class |
 | sealed interface | [PropertiesWithEscapedCharacters.FoonbarBoxed](#foonbarboxed)<br> sealed interface for validated payloads |
-| record | [PropertiesWithEscapedCharacters.FoonbarBoxedNumber](#foonbarboxednumber)<br> boxed class to store validated Number payloads |
-| static class | [PropertiesWithEscapedCharacters.Foonbar](#foonbar)<br> schema class |
+| data class | [PropertiesWithEscapedCharacters.FoonbarBoxedNumber](#foonbarboxednumber)<br> boxed class to store validated Number payloads |
+| class | [PropertiesWithEscapedCharacters.Foonbar](#foonbar)<br> schema class |
 
 ## PropertiesWithEscapedCharacters1Boxed
 sealed interface PropertiesWithEscapedCharacters1Boxed<br>
@@ -74,7 +74,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class PropertiesWithEscapedCharacters1BoxedBoolean<br>
 implements [PropertiesWithEscapedCharacters1Boxed](#propertieswithescapedcharacters1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PropertiesWithEscapedCharacters.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PropertiesWithEscapedCharacters.md
@@ -171,19 +171,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [PropertiesWithEscapedCharactersMap](#propertieswithescapedcharactersmap) | validate(arg: [Map&lt;?, ?&gt;](#propertieswithescapedcharactersmapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [PropertiesWithEscapedCharactersMap](#propertieswithescapedcharactersmap) | validate(arg: [Map&lt;*, *&gt;](#propertieswithescapedcharactersmapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [PropertiesWithEscapedCharacters1BoxedString](#propertieswithescapedcharacters1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [PropertiesWithEscapedCharacters1BoxedVoid](#propertieswithescapedcharacters1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [PropertiesWithEscapedCharacters1BoxedNumber](#propertieswithescapedcharacters1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [PropertiesWithEscapedCharacters1BoxedBoolean](#propertieswithescapedcharacters1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [PropertiesWithEscapedCharacters1BoxedMap](#propertieswithescapedcharacters1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#propertieswithescapedcharactersmapbuilder), configuration: SchemaConfiguration) |
+| [PropertiesWithEscapedCharacters1BoxedBoolean](#propertieswithescapedcharacters1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [PropertiesWithEscapedCharacters1BoxedMap](#propertieswithescapedcharacters1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#propertieswithescapedcharactersmapbuilder), configuration: SchemaConfiguration) |
 | [PropertiesWithEscapedCharacters1BoxedList](#propertieswithescapedcharacters1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [PropertiesWithEscapedCharacters1Boxed](#propertieswithescapedcharacters1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PropertiesWithNullValuedInstanceProperties.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PropertiesWithNullValuedInstanceProperties.md
@@ -156,19 +156,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [PropertiesWithNullValuedInstancePropertiesMap](#propertieswithnullvaluedinstancepropertiesmap) | validate(arg: [Map&lt;?, ?&gt;](#propertieswithnullvaluedinstancepropertiesmapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [PropertiesWithNullValuedInstancePropertiesMap](#propertieswithnullvaluedinstancepropertiesmap) | validate(arg: [Map&lt;*, *&gt;](#propertieswithnullvaluedinstancepropertiesmapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [PropertiesWithNullValuedInstanceProperties1BoxedString](#propertieswithnullvaluedinstanceproperties1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [PropertiesWithNullValuedInstanceProperties1BoxedVoid](#propertieswithnullvaluedinstanceproperties1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [PropertiesWithNullValuedInstanceProperties1BoxedNumber](#propertieswithnullvaluedinstanceproperties1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [PropertiesWithNullValuedInstanceProperties1BoxedBoolean](#propertieswithnullvaluedinstanceproperties1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [PropertiesWithNullValuedInstanceProperties1BoxedMap](#propertieswithnullvaluedinstanceproperties1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#propertieswithnullvaluedinstancepropertiesmapbuilder), configuration: SchemaConfiguration) |
+| [PropertiesWithNullValuedInstanceProperties1BoxedBoolean](#propertieswithnullvaluedinstanceproperties1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [PropertiesWithNullValuedInstanceProperties1BoxedMap](#propertieswithnullvaluedinstanceproperties1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#propertieswithnullvaluedinstancepropertiesmapbuilder), configuration: SchemaConfiguration) |
 | [PropertiesWithNullValuedInstanceProperties1BoxedList](#propertieswithnullvaluedinstanceproperties1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [PropertiesWithNullValuedInstanceProperties1Boxed](#propertieswithnullvaluedinstanceproperties1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PropertiesWithNullValuedInstanceProperties.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PropertiesWithNullValuedInstanceProperties.md
@@ -13,18 +13,18 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [PropertiesWithNullValuedInstanceProperties.PropertiesWithNullValuedInstanceProperties1Boxed](#propertieswithnullvaluedinstanceproperties1boxed)<br> sealed interface for validated payloads |
-| record | [PropertiesWithNullValuedInstanceProperties.PropertiesWithNullValuedInstanceProperties1BoxedVoid](#propertieswithnullvaluedinstanceproperties1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [PropertiesWithNullValuedInstanceProperties.PropertiesWithNullValuedInstanceProperties1BoxedBoolean](#propertieswithnullvaluedinstanceproperties1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [PropertiesWithNullValuedInstanceProperties.PropertiesWithNullValuedInstanceProperties1BoxedNumber](#propertieswithnullvaluedinstanceproperties1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [PropertiesWithNullValuedInstanceProperties.PropertiesWithNullValuedInstanceProperties1BoxedString](#propertieswithnullvaluedinstanceproperties1boxedstring)<br> boxed class to store validated String payloads |
-| record | [PropertiesWithNullValuedInstanceProperties.PropertiesWithNullValuedInstanceProperties1BoxedList](#propertieswithnullvaluedinstanceproperties1boxedlist)<br> boxed class to store validated List payloads |
-| record | [PropertiesWithNullValuedInstanceProperties.PropertiesWithNullValuedInstanceProperties1BoxedMap](#propertieswithnullvaluedinstanceproperties1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [PropertiesWithNullValuedInstanceProperties.PropertiesWithNullValuedInstanceProperties1](#propertieswithnullvaluedinstanceproperties1)<br> schema class |
-| static class | [PropertiesWithNullValuedInstanceProperties.PropertiesWithNullValuedInstancePropertiesMapBuilder](#propertieswithnullvaluedinstancepropertiesmapbuilder)<br> builder for Map payloads |
-| static class | [PropertiesWithNullValuedInstanceProperties.PropertiesWithNullValuedInstancePropertiesMap](#propertieswithnullvaluedinstancepropertiesmap)<br> output class for Map payloads |
+| data class | [PropertiesWithNullValuedInstanceProperties.PropertiesWithNullValuedInstanceProperties1BoxedVoid](#propertieswithnullvaluedinstanceproperties1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [PropertiesWithNullValuedInstanceProperties.PropertiesWithNullValuedInstanceProperties1BoxedBoolean](#propertieswithnullvaluedinstanceproperties1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [PropertiesWithNullValuedInstanceProperties.PropertiesWithNullValuedInstanceProperties1BoxedNumber](#propertieswithnullvaluedinstanceproperties1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [PropertiesWithNullValuedInstanceProperties.PropertiesWithNullValuedInstanceProperties1BoxedString](#propertieswithnullvaluedinstanceproperties1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [PropertiesWithNullValuedInstanceProperties.PropertiesWithNullValuedInstanceProperties1BoxedList](#propertieswithnullvaluedinstanceproperties1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [PropertiesWithNullValuedInstanceProperties.PropertiesWithNullValuedInstanceProperties1BoxedMap](#propertieswithnullvaluedinstanceproperties1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [PropertiesWithNullValuedInstanceProperties.PropertiesWithNullValuedInstanceProperties1](#propertieswithnullvaluedinstanceproperties1)<br> schema class |
+| class | [PropertiesWithNullValuedInstanceProperties.PropertiesWithNullValuedInstancePropertiesMapBuilder](#propertieswithnullvaluedinstancepropertiesmapbuilder)<br> builder for Map payloads |
+| class | [PropertiesWithNullValuedInstanceProperties.PropertiesWithNullValuedInstancePropertiesMap](#propertieswithnullvaluedinstancepropertiesmap)<br> output class for Map payloads |
 | sealed interface | [PropertiesWithNullValuedInstanceProperties.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [PropertiesWithNullValuedInstanceProperties.FooBoxedVoid](#fooboxedvoid)<br> boxed class to store validated null payloads |
-| static class | [PropertiesWithNullValuedInstanceProperties.Foo](#foo)<br> schema class |
+| data class | [PropertiesWithNullValuedInstanceProperties.FooBoxedVoid](#fooboxedvoid)<br> boxed class to store validated null payloads |
+| class | [PropertiesWithNullValuedInstanceProperties.Foo](#foo)<br> schema class |
 
 ## PropertiesWithNullValuedInstanceProperties1Boxed
 sealed interface PropertiesWithNullValuedInstanceProperties1Boxed<br>
@@ -59,7 +59,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class PropertiesWithNullValuedInstanceProperties1BoxedBoolean<br>
 implements [PropertiesWithNullValuedInstanceProperties1Boxed](#propertieswithnullvaluedinstanceproperties1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PropertyNamedRefThatIsNotAReference.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PropertyNamedRefThatIsNotAReference.md
@@ -13,18 +13,18 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReference1Boxed](#propertynamedrefthatisnotareference1boxed)<br> sealed interface for validated payloads |
-| record | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReference1BoxedVoid](#propertynamedrefthatisnotareference1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReference1BoxedBoolean](#propertynamedrefthatisnotareference1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReference1BoxedNumber](#propertynamedrefthatisnotareference1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReference1BoxedString](#propertynamedrefthatisnotareference1boxedstring)<br> boxed class to store validated String payloads |
-| record | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReference1BoxedList](#propertynamedrefthatisnotareference1boxedlist)<br> boxed class to store validated List payloads |
-| record | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReference1BoxedMap](#propertynamedrefthatisnotareference1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReference1](#propertynamedrefthatisnotareference1)<br> schema class |
-| static class | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReferenceMapBuilder](#propertynamedrefthatisnotareferencemapbuilder)<br> builder for Map payloads |
-| static class | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReferenceMap](#propertynamedrefthatisnotareferencemap)<br> output class for Map payloads |
+| data class | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReference1BoxedVoid](#propertynamedrefthatisnotareference1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReference1BoxedBoolean](#propertynamedrefthatisnotareference1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReference1BoxedNumber](#propertynamedrefthatisnotareference1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReference1BoxedString](#propertynamedrefthatisnotareference1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReference1BoxedList](#propertynamedrefthatisnotareference1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReference1BoxedMap](#propertynamedrefthatisnotareference1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReference1](#propertynamedrefthatisnotareference1)<br> schema class |
+| class | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReferenceMapBuilder](#propertynamedrefthatisnotareferencemapbuilder)<br> builder for Map payloads |
+| class | [PropertyNamedRefThatIsNotAReference.PropertyNamedRefThatIsNotAReferenceMap](#propertynamedrefthatisnotareferencemap)<br> output class for Map payloads |
 | sealed interface | [PropertyNamedRefThatIsNotAReference.RefBoxed](#refboxed)<br> sealed interface for validated payloads |
-| record | [PropertyNamedRefThatIsNotAReference.RefBoxedString](#refboxedstring)<br> boxed class to store validated String payloads |
-| static class | [PropertyNamedRefThatIsNotAReference.Ref](#ref)<br> schema class |
+| data class | [PropertyNamedRefThatIsNotAReference.RefBoxedString](#refboxedstring)<br> boxed class to store validated String payloads |
+| class | [PropertyNamedRefThatIsNotAReference.Ref](#ref)<br> schema class |
 
 ## PropertyNamedRefThatIsNotAReference1Boxed
 sealed interface PropertyNamedRefThatIsNotAReference1Boxed<br>
@@ -59,7 +59,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class PropertyNamedRefThatIsNotAReference1BoxedBoolean<br>
 implements [PropertyNamedRefThatIsNotAReference1Boxed](#propertynamedrefthatisnotareference1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PropertyNamedRefThatIsNotAReference.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PropertyNamedRefThatIsNotAReference.md
@@ -156,19 +156,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [PropertyNamedRefThatIsNotAReferenceMap](#propertynamedrefthatisnotareferencemap) | validate(arg: [Map&lt;?, ?&gt;](#propertynamedrefthatisnotareferencemapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [PropertyNamedRefThatIsNotAReferenceMap](#propertynamedrefthatisnotareferencemap) | validate(arg: [Map&lt;*, *&gt;](#propertynamedrefthatisnotareferencemapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [PropertyNamedRefThatIsNotAReference1BoxedString](#propertynamedrefthatisnotareference1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [PropertyNamedRefThatIsNotAReference1BoxedVoid](#propertynamedrefthatisnotareference1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [PropertyNamedRefThatIsNotAReference1BoxedNumber](#propertynamedrefthatisnotareference1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [PropertyNamedRefThatIsNotAReference1BoxedBoolean](#propertynamedrefthatisnotareference1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [PropertyNamedRefThatIsNotAReference1BoxedMap](#propertynamedrefthatisnotareference1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#propertynamedrefthatisnotareferencemapbuilder), configuration: SchemaConfiguration) |
+| [PropertyNamedRefThatIsNotAReference1BoxedBoolean](#propertynamedrefthatisnotareference1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [PropertyNamedRefThatIsNotAReference1BoxedMap](#propertynamedrefthatisnotareference1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#propertynamedrefthatisnotareferencemapbuilder), configuration: SchemaConfiguration) |
 | [PropertyNamedRefThatIsNotAReference1BoxedList](#propertynamedrefthatisnotareference1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [PropertyNamedRefThatIsNotAReference1Boxed](#propertynamedrefthatisnotareference1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PropertynamesValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PropertynamesValidation.md
@@ -11,16 +11,16 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [PropertynamesValidation.PropertynamesValidation1Boxed](#propertynamesvalidation1boxed)<br> sealed interface for validated payloads |
-| record | [PropertynamesValidation.PropertynamesValidation1BoxedVoid](#propertynamesvalidation1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [PropertynamesValidation.PropertynamesValidation1BoxedBoolean](#propertynamesvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [PropertynamesValidation.PropertynamesValidation1BoxedNumber](#propertynamesvalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [PropertynamesValidation.PropertynamesValidation1BoxedString](#propertynamesvalidation1boxedstring)<br> boxed class to store validated String payloads |
-| record | [PropertynamesValidation.PropertynamesValidation1BoxedList](#propertynamesvalidation1boxedlist)<br> boxed class to store validated List payloads |
-| record | [PropertynamesValidation.PropertynamesValidation1BoxedMap](#propertynamesvalidation1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [PropertynamesValidation.PropertynamesValidation1](#propertynamesvalidation1)<br> schema class |
+| data class | [PropertynamesValidation.PropertynamesValidation1BoxedVoid](#propertynamesvalidation1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [PropertynamesValidation.PropertynamesValidation1BoxedBoolean](#propertynamesvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [PropertynamesValidation.PropertynamesValidation1BoxedNumber](#propertynamesvalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [PropertynamesValidation.PropertynamesValidation1BoxedString](#propertynamesvalidation1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [PropertynamesValidation.PropertynamesValidation1BoxedList](#propertynamesvalidation1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [PropertynamesValidation.PropertynamesValidation1BoxedMap](#propertynamesvalidation1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [PropertynamesValidation.PropertynamesValidation1](#propertynamesvalidation1)<br> schema class |
 | sealed interface | [PropertynamesValidation.PropertyNamesBoxed](#propertynamesboxed)<br> sealed interface for validated payloads |
-| record | [PropertynamesValidation.PropertyNamesBoxedString](#propertynamesboxedstring)<br> boxed class to store validated String payloads |
-| static class | [PropertynamesValidation.PropertyNames](#propertynames)<br> schema class |
+| data class | [PropertynamesValidation.PropertyNamesBoxedString](#propertynamesboxedstring)<br> boxed class to store validated String payloads |
+| class | [PropertynamesValidation.PropertyNames](#propertynames)<br> schema class |
 
 ## PropertynamesValidation1Boxed
 sealed interface PropertynamesValidation1Boxed<br>
@@ -55,7 +55,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class PropertynamesValidation1BoxedBoolean<br>
 implements [PropertynamesValidation1Boxed](#propertynamesvalidation1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PropertynamesValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/PropertynamesValidation.md
@@ -152,19 +152,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [PropertynamesValidation1BoxedString](#propertynamesvalidation1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [PropertynamesValidation1BoxedVoid](#propertynamesvalidation1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [PropertynamesValidation1BoxedNumber](#propertynamesvalidation1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [PropertynamesValidation1BoxedBoolean](#propertynamesvalidation1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [PropertynamesValidation1BoxedMap](#propertynamesvalidation1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [PropertynamesValidation1BoxedBoolean](#propertynamesvalidation1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [PropertynamesValidation1BoxedMap](#propertynamesvalidation1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [PropertynamesValidation1BoxedList](#propertynamesvalidation1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [PropertynamesValidation1Boxed](#propertynamesvalidation1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -201,32 +201,28 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.PropertynamesValidation;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.PropertynamesValidation
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // String validation
-String validatedPayload = PropertynamesValidation.PropertyNames.validate(
+val validatedPayload: String = PropertynamesValidation.PropertyNames.validate(
     "a",
     configuration
-);
+)
 ```
 
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
 | Set<Class<?>> | type = setOf(<br/>&nbsp;&nbsp;&nbsp;&nbsp;String::class.java<br/>)<br/> |
-| Integer | maxLength = 3 |
+| Int | maxLength = 3 |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/RegexFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/RegexFormat.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [RegexFormat.RegexFormat1Boxed](#regexformat1boxed)<br> sealed interface for validated payloads |
-| record | [RegexFormat.RegexFormat1BoxedVoid](#regexformat1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [RegexFormat.RegexFormat1BoxedBoolean](#regexformat1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [RegexFormat.RegexFormat1BoxedNumber](#regexformat1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [RegexFormat.RegexFormat1BoxedString](#regexformat1boxedstring)<br> boxed class to store validated String payloads |
-| record | [RegexFormat.RegexFormat1BoxedList](#regexformat1boxedlist)<br> boxed class to store validated List payloads |
-| record | [RegexFormat.RegexFormat1BoxedMap](#regexformat1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [RegexFormat.RegexFormat1](#regexformat1)<br> schema class |
+| data class | [RegexFormat.RegexFormat1BoxedVoid](#regexformat1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [RegexFormat.RegexFormat1BoxedBoolean](#regexformat1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [RegexFormat.RegexFormat1BoxedNumber](#regexformat1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [RegexFormat.RegexFormat1BoxedString](#regexformat1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [RegexFormat.RegexFormat1BoxedList](#regexformat1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [RegexFormat.RegexFormat1BoxedMap](#regexformat1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [RegexFormat.RegexFormat1](#regexformat1)<br> schema class |
 
 ## RegexFormat1Boxed
 sealed interface RegexFormat1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class RegexFormat1BoxedBoolean<br>
 implements [RegexFormat1Boxed](#regexformat1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/RegexFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/RegexFormat.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [RegexFormat1BoxedString](#regexformat1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [RegexFormat1BoxedVoid](#regexformat1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [RegexFormat1BoxedNumber](#regexformat1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [RegexFormat1BoxedBoolean](#regexformat1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [RegexFormat1BoxedMap](#regexformat1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [RegexFormat1BoxedBoolean](#regexformat1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [RegexFormat1BoxedMap](#regexformat1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [RegexFormat1BoxedList](#regexformat1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [RegexFormat1Boxed](#regexformat1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/RegexesAreNotAnchoredByDefaultAndAreCaseSensitive.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/RegexesAreNotAnchoredByDefaultAndAreCaseSensitive.md
@@ -11,19 +11,19 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive.RegexesAreNotAnchoredByDefaultAndAreCaseSensitive1Boxed](#regexesarenotanchoredbydefaultandarecasesensitive1boxed)<br> sealed interface for validated payloads |
-| record | [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive.RegexesAreNotAnchoredByDefaultAndAreCaseSensitive1BoxedVoid](#regexesarenotanchoredbydefaultandarecasesensitive1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive.RegexesAreNotAnchoredByDefaultAndAreCaseSensitive1BoxedBoolean](#regexesarenotanchoredbydefaultandarecasesensitive1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive.RegexesAreNotAnchoredByDefaultAndAreCaseSensitive1BoxedNumber](#regexesarenotanchoredbydefaultandarecasesensitive1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive.RegexesAreNotAnchoredByDefaultAndAreCaseSensitive1BoxedString](#regexesarenotanchoredbydefaultandarecasesensitive1boxedstring)<br> boxed class to store validated String payloads |
-| record | [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive.RegexesAreNotAnchoredByDefaultAndAreCaseSensitive1BoxedList](#regexesarenotanchoredbydefaultandarecasesensitive1boxedlist)<br> boxed class to store validated List payloads |
-| record | [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive.RegexesAreNotAnchoredByDefaultAndAreCaseSensitive1BoxedMap](#regexesarenotanchoredbydefaultandarecasesensitive1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive.RegexesAreNotAnchoredByDefaultAndAreCaseSensitive1](#regexesarenotanchoredbydefaultandarecasesensitive1)<br> schema class |
+| data class | [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive.RegexesAreNotAnchoredByDefaultAndAreCaseSensitive1BoxedVoid](#regexesarenotanchoredbydefaultandarecasesensitive1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive.RegexesAreNotAnchoredByDefaultAndAreCaseSensitive1BoxedBoolean](#regexesarenotanchoredbydefaultandarecasesensitive1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive.RegexesAreNotAnchoredByDefaultAndAreCaseSensitive1BoxedNumber](#regexesarenotanchoredbydefaultandarecasesensitive1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive.RegexesAreNotAnchoredByDefaultAndAreCaseSensitive1BoxedString](#regexesarenotanchoredbydefaultandarecasesensitive1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive.RegexesAreNotAnchoredByDefaultAndAreCaseSensitive1BoxedList](#regexesarenotanchoredbydefaultandarecasesensitive1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive.RegexesAreNotAnchoredByDefaultAndAreCaseSensitive1BoxedMap](#regexesarenotanchoredbydefaultandarecasesensitive1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive.RegexesAreNotAnchoredByDefaultAndAreCaseSensitive1](#regexesarenotanchoredbydefaultandarecasesensitive1)<br> schema class |
 | sealed interface | [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive.XBoxed](#xboxed)<br> sealed interface for validated payloads |
-| record | [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive.XBoxedString](#xboxedstring)<br> boxed class to store validated String payloads |
-| static class | [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive.X](#x)<br> schema class |
+| data class | [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive.XBoxedString](#xboxedstring)<br> boxed class to store validated String payloads |
+| class | [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive.X](#x)<br> schema class |
 | sealed interface | [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive.Schema092Boxed](#schema092boxed)<br> sealed interface for validated payloads |
-| record | [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive.Schema092BoxedBoolean](#schema092boxedboolean)<br> boxed class to store validated boolean payloads |
-| static class | [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive.Schema092](#schema092)<br> schema class |
+| data class | [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive.Schema092BoxedBoolean](#schema092boxedboolean)<br> boxed class to store validated boolean payloads |
+| class | [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive.Schema092](#schema092)<br> schema class |
 
 ## RegexesAreNotAnchoredByDefaultAndAreCaseSensitive1Boxed
 sealed interface RegexesAreNotAnchoredByDefaultAndAreCaseSensitive1Boxed<br>
@@ -58,7 +58,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class RegexesAreNotAnchoredByDefaultAndAreCaseSensitive1BoxedBoolean<br>
 implements [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive1Boxed](#regexesarenotanchoredbydefaultandarecasesensitive1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -218,7 +218,7 @@ sealed interface that stores validated payloads using boxed classes
 data class Schema092BoxedBoolean<br>
 implements [Schema092Boxed](#schema092boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/RegexesAreNotAnchoredByDefaultAndAreCaseSensitive.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/RegexesAreNotAnchoredByDefaultAndAreCaseSensitive.md
@@ -155,19 +155,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive1BoxedString](#regexesarenotanchoredbydefaultandarecasesensitive1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive1BoxedVoid](#regexesarenotanchoredbydefaultandarecasesensitive1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive1BoxedNumber](#regexesarenotanchoredbydefaultandarecasesensitive1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive1BoxedBoolean](#regexesarenotanchoredbydefaultandarecasesensitive1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive1BoxedMap](#regexesarenotanchoredbydefaultandarecasesensitive1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive1BoxedBoolean](#regexesarenotanchoredbydefaultandarecasesensitive1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive1BoxedMap](#regexesarenotanchoredbydefaultandarecasesensitive1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive1BoxedList](#regexesarenotanchoredbydefaultandarecasesensitive1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [RegexesAreNotAnchoredByDefaultAndAreCaseSensitive1Boxed](#regexesarenotanchoredbydefaultandarecasesensitive1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/RelativeJsonPointerFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/RelativeJsonPointerFormat.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [RelativeJsonPointerFormat.RelativeJsonPointerFormat1Boxed](#relativejsonpointerformat1boxed)<br> sealed interface for validated payloads |
-| record | [RelativeJsonPointerFormat.RelativeJsonPointerFormat1BoxedVoid](#relativejsonpointerformat1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [RelativeJsonPointerFormat.RelativeJsonPointerFormat1BoxedBoolean](#relativejsonpointerformat1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [RelativeJsonPointerFormat.RelativeJsonPointerFormat1BoxedNumber](#relativejsonpointerformat1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [RelativeJsonPointerFormat.RelativeJsonPointerFormat1BoxedString](#relativejsonpointerformat1boxedstring)<br> boxed class to store validated String payloads |
-| record | [RelativeJsonPointerFormat.RelativeJsonPointerFormat1BoxedList](#relativejsonpointerformat1boxedlist)<br> boxed class to store validated List payloads |
-| record | [RelativeJsonPointerFormat.RelativeJsonPointerFormat1BoxedMap](#relativejsonpointerformat1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [RelativeJsonPointerFormat.RelativeJsonPointerFormat1](#relativejsonpointerformat1)<br> schema class |
+| data class | [RelativeJsonPointerFormat.RelativeJsonPointerFormat1BoxedVoid](#relativejsonpointerformat1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [RelativeJsonPointerFormat.RelativeJsonPointerFormat1BoxedBoolean](#relativejsonpointerformat1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [RelativeJsonPointerFormat.RelativeJsonPointerFormat1BoxedNumber](#relativejsonpointerformat1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [RelativeJsonPointerFormat.RelativeJsonPointerFormat1BoxedString](#relativejsonpointerformat1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [RelativeJsonPointerFormat.RelativeJsonPointerFormat1BoxedList](#relativejsonpointerformat1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [RelativeJsonPointerFormat.RelativeJsonPointerFormat1BoxedMap](#relativejsonpointerformat1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [RelativeJsonPointerFormat.RelativeJsonPointerFormat1](#relativejsonpointerformat1)<br> schema class |
 
 ## RelativeJsonPointerFormat1Boxed
 sealed interface RelativeJsonPointerFormat1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class RelativeJsonPointerFormat1BoxedBoolean<br>
 implements [RelativeJsonPointerFormat1Boxed](#relativejsonpointerformat1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/RelativeJsonPointerFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/RelativeJsonPointerFormat.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [RelativeJsonPointerFormat1BoxedString](#relativejsonpointerformat1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [RelativeJsonPointerFormat1BoxedVoid](#relativejsonpointerformat1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [RelativeJsonPointerFormat1BoxedNumber](#relativejsonpointerformat1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [RelativeJsonPointerFormat1BoxedBoolean](#relativejsonpointerformat1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [RelativeJsonPointerFormat1BoxedMap](#relativejsonpointerformat1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [RelativeJsonPointerFormat1BoxedBoolean](#relativejsonpointerformat1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [RelativeJsonPointerFormat1BoxedMap](#relativejsonpointerformat1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [RelativeJsonPointerFormat1BoxedList](#relativejsonpointerformat1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [RelativeJsonPointerFormat1Boxed](#relativejsonpointerformat1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/RequiredDefaultValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/RequiredDefaultValidation.md
@@ -13,23 +13,23 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [RequiredDefaultValidation.RequiredDefaultValidation1Boxed](#requireddefaultvalidation1boxed)<br> sealed interface for validated payloads |
-| record | [RequiredDefaultValidation.RequiredDefaultValidation1BoxedVoid](#requireddefaultvalidation1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [RequiredDefaultValidation.RequiredDefaultValidation1BoxedBoolean](#requireddefaultvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [RequiredDefaultValidation.RequiredDefaultValidation1BoxedNumber](#requireddefaultvalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [RequiredDefaultValidation.RequiredDefaultValidation1BoxedString](#requireddefaultvalidation1boxedstring)<br> boxed class to store validated String payloads |
-| record | [RequiredDefaultValidation.RequiredDefaultValidation1BoxedList](#requireddefaultvalidation1boxedlist)<br> boxed class to store validated List payloads |
-| record | [RequiredDefaultValidation.RequiredDefaultValidation1BoxedMap](#requireddefaultvalidation1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [RequiredDefaultValidation.RequiredDefaultValidation1](#requireddefaultvalidation1)<br> schema class |
-| static class | [RequiredDefaultValidation.RequiredDefaultValidationMapBuilder](#requireddefaultvalidationmapbuilder)<br> builder for Map payloads |
-| static class | [RequiredDefaultValidation.RequiredDefaultValidationMap](#requireddefaultvalidationmap)<br> output class for Map payloads |
+| data class | [RequiredDefaultValidation.RequiredDefaultValidation1BoxedVoid](#requireddefaultvalidation1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [RequiredDefaultValidation.RequiredDefaultValidation1BoxedBoolean](#requireddefaultvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [RequiredDefaultValidation.RequiredDefaultValidation1BoxedNumber](#requireddefaultvalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [RequiredDefaultValidation.RequiredDefaultValidation1BoxedString](#requireddefaultvalidation1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [RequiredDefaultValidation.RequiredDefaultValidation1BoxedList](#requireddefaultvalidation1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [RequiredDefaultValidation.RequiredDefaultValidation1BoxedMap](#requireddefaultvalidation1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [RequiredDefaultValidation.RequiredDefaultValidation1](#requireddefaultvalidation1)<br> schema class |
+| class | [RequiredDefaultValidation.RequiredDefaultValidationMapBuilder](#requireddefaultvalidationmapbuilder)<br> builder for Map payloads |
+| class | [RequiredDefaultValidation.RequiredDefaultValidationMap](#requireddefaultvalidationmap)<br> output class for Map payloads |
 | sealed interface | [RequiredDefaultValidation.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [RequiredDefaultValidation.FooBoxedVoid](#fooboxedvoid)<br> boxed class to store validated null payloads |
-| record | [RequiredDefaultValidation.FooBoxedBoolean](#fooboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [RequiredDefaultValidation.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
-| record | [RequiredDefaultValidation.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
-| record | [RequiredDefaultValidation.FooBoxedList](#fooboxedlist)<br> boxed class to store validated List payloads |
-| record | [RequiredDefaultValidation.FooBoxedMap](#fooboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [RequiredDefaultValidation.Foo](#foo)<br> schema class |
+| data class | [RequiredDefaultValidation.FooBoxedVoid](#fooboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [RequiredDefaultValidation.FooBoxedBoolean](#fooboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [RequiredDefaultValidation.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [RequiredDefaultValidation.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
+| data class | [RequiredDefaultValidation.FooBoxedList](#fooboxedlist)<br> boxed class to store validated List payloads |
+| data class | [RequiredDefaultValidation.FooBoxedMap](#fooboxedmap)<br> boxed class to store validated Map payloads |
+| class | [RequiredDefaultValidation.Foo](#foo)<br> schema class |
 
 ## RequiredDefaultValidation1Boxed
 sealed interface RequiredDefaultValidation1Boxed<br>
@@ -64,7 +64,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class RequiredDefaultValidation1BoxedBoolean<br>
 implements [RequiredDefaultValidation1Boxed](#requireddefaultvalidation1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -258,7 +258,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class FooBoxedBoolean<br>
 implements [FooBoxed](#fooboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/RequiredDefaultValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/RequiredDefaultValidation.md
@@ -161,19 +161,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [RequiredDefaultValidationMap](#requireddefaultvalidationmap) | validate(arg: [Map&lt;?, ?&gt;](#requireddefaultvalidationmapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [RequiredDefaultValidationMap](#requireddefaultvalidationmap) | validate(arg: [Map&lt;*, *&gt;](#requireddefaultvalidationmapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [RequiredDefaultValidation1BoxedString](#requireddefaultvalidation1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [RequiredDefaultValidation1BoxedVoid](#requireddefaultvalidation1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [RequiredDefaultValidation1BoxedNumber](#requireddefaultvalidation1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [RequiredDefaultValidation1BoxedBoolean](#requireddefaultvalidation1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [RequiredDefaultValidation1BoxedMap](#requireddefaultvalidation1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#requireddefaultvalidationmapbuilder), configuration: SchemaConfiguration) |
+| [RequiredDefaultValidation1BoxedBoolean](#requireddefaultvalidation1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [RequiredDefaultValidation1BoxedMap](#requireddefaultvalidation1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#requireddefaultvalidationmapbuilder), configuration: SchemaConfiguration) |
 | [RequiredDefaultValidation1BoxedList](#requireddefaultvalidation1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [RequiredDefaultValidation1Boxed](#requireddefaultvalidation1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames.md
@@ -153,19 +153,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap) | validate(arg: [Map&lt;?, ?&gt;](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap) | validate(arg: [Map&lt;*, *&gt;](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedString](#requiredpropertieswhosenamesarejavascriptobjectpropertynames1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedVoid](#requiredpropertieswhosenamesarejavascriptobjectpropertynames1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedNumber](#requiredpropertieswhosenamesarejavascriptobjectpropertynames1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedBoolean](#requiredpropertieswhosenamesarejavascriptobjectpropertynames1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedMap](#requiredpropertieswhosenamesarejavascriptobjectpropertynames1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmapbuilder), configuration: SchemaConfiguration) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedBoolean](#requiredpropertieswhosenamesarejavascriptobjectpropertynames1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedMap](#requiredpropertieswhosenamesarejavascriptobjectpropertynames1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmapbuilder), configuration: SchemaConfiguration) |
 | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedList](#requiredpropertieswhosenamesarejavascriptobjectpropertynames1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames1Boxed](#requiredpropertieswhosenamesarejavascriptobjectpropertynames1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames.md
@@ -13,15 +13,15 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames.RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames1Boxed](#requiredpropertieswhosenamesarejavascriptobjectpropertynames1boxed)<br> sealed interface for validated payloads |
-| record | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames.RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedVoid](#requiredpropertieswhosenamesarejavascriptobjectpropertynames1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames.RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedBoolean](#requiredpropertieswhosenamesarejavascriptobjectpropertynames1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames.RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedNumber](#requiredpropertieswhosenamesarejavascriptobjectpropertynames1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames.RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedString](#requiredpropertieswhosenamesarejavascriptobjectpropertynames1boxedstring)<br> boxed class to store validated String payloads |
-| record | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames.RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedList](#requiredpropertieswhosenamesarejavascriptobjectpropertynames1boxedlist)<br> boxed class to store validated List payloads |
-| record | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames.RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedMap](#requiredpropertieswhosenamesarejavascriptobjectpropertynames1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames.RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames1](#requiredpropertieswhosenamesarejavascriptobjectpropertynames1)<br> schema class |
-| static class | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames.RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMapBuilder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmapbuilder)<br> builder for Map payloads |
-| static class | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames.RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap)<br> output class for Map payloads |
+| data class | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames.RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedVoid](#requiredpropertieswhosenamesarejavascriptobjectpropertynames1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames.RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedBoolean](#requiredpropertieswhosenamesarejavascriptobjectpropertynames1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames.RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedNumber](#requiredpropertieswhosenamesarejavascriptobjectpropertynames1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames.RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedString](#requiredpropertieswhosenamesarejavascriptobjectpropertynames1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames.RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedList](#requiredpropertieswhosenamesarejavascriptobjectpropertynames1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames.RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedMap](#requiredpropertieswhosenamesarejavascriptobjectpropertynames1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames.RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames1](#requiredpropertieswhosenamesarejavascriptobjectpropertynames1)<br> schema class |
+| class | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames.RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMapBuilder](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmapbuilder)<br> builder for Map payloads |
+| class | [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames.RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNamesMap](#requiredpropertieswhosenamesarejavascriptobjectpropertynamesmap)<br> output class for Map payloads |
 
 ## RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames1Boxed
 sealed interface RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames1Boxed<br>
@@ -56,7 +56,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames1BoxedBoolean<br>
 implements [RequiredPropertiesWhoseNamesAreJavascriptObjectPropertyNames1Boxed](#requiredpropertieswhosenamesarejavascriptobjectpropertynames1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/RequiredValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/RequiredValidation.md
@@ -13,31 +13,31 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [RequiredValidation.RequiredValidation1Boxed](#requiredvalidation1boxed)<br> sealed interface for validated payloads |
-| record | [RequiredValidation.RequiredValidation1BoxedVoid](#requiredvalidation1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [RequiredValidation.RequiredValidation1BoxedBoolean](#requiredvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [RequiredValidation.RequiredValidation1BoxedNumber](#requiredvalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [RequiredValidation.RequiredValidation1BoxedString](#requiredvalidation1boxedstring)<br> boxed class to store validated String payloads |
-| record | [RequiredValidation.RequiredValidation1BoxedList](#requiredvalidation1boxedlist)<br> boxed class to store validated List payloads |
-| record | [RequiredValidation.RequiredValidation1BoxedMap](#requiredvalidation1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [RequiredValidation.RequiredValidation1](#requiredvalidation1)<br> schema class |
-| static class | [RequiredValidation.RequiredValidationMapBuilder](#requiredvalidationmapbuilder)<br> builder for Map payloads |
-| static class | [RequiredValidation.RequiredValidationMap](#requiredvalidationmap)<br> output class for Map payloads |
+| data class | [RequiredValidation.RequiredValidation1BoxedVoid](#requiredvalidation1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [RequiredValidation.RequiredValidation1BoxedBoolean](#requiredvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [RequiredValidation.RequiredValidation1BoxedNumber](#requiredvalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [RequiredValidation.RequiredValidation1BoxedString](#requiredvalidation1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [RequiredValidation.RequiredValidation1BoxedList](#requiredvalidation1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [RequiredValidation.RequiredValidation1BoxedMap](#requiredvalidation1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [RequiredValidation.RequiredValidation1](#requiredvalidation1)<br> schema class |
+| class | [RequiredValidation.RequiredValidationMapBuilder](#requiredvalidationmapbuilder)<br> builder for Map payloads |
+| class | [RequiredValidation.RequiredValidationMap](#requiredvalidationmap)<br> output class for Map payloads |
 | sealed interface | [RequiredValidation.BarBoxed](#barboxed)<br> sealed interface for validated payloads |
-| record | [RequiredValidation.BarBoxedVoid](#barboxedvoid)<br> boxed class to store validated null payloads |
-| record | [RequiredValidation.BarBoxedBoolean](#barboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [RequiredValidation.BarBoxedNumber](#barboxednumber)<br> boxed class to store validated Number payloads |
-| record | [RequiredValidation.BarBoxedString](#barboxedstring)<br> boxed class to store validated String payloads |
-| record | [RequiredValidation.BarBoxedList](#barboxedlist)<br> boxed class to store validated List payloads |
-| record | [RequiredValidation.BarBoxedMap](#barboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [RequiredValidation.Bar](#bar)<br> schema class |
+| data class | [RequiredValidation.BarBoxedVoid](#barboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [RequiredValidation.BarBoxedBoolean](#barboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [RequiredValidation.BarBoxedNumber](#barboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [RequiredValidation.BarBoxedString](#barboxedstring)<br> boxed class to store validated String payloads |
+| data class | [RequiredValidation.BarBoxedList](#barboxedlist)<br> boxed class to store validated List payloads |
+| data class | [RequiredValidation.BarBoxedMap](#barboxedmap)<br> boxed class to store validated Map payloads |
+| class | [RequiredValidation.Bar](#bar)<br> schema class |
 | sealed interface | [RequiredValidation.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [RequiredValidation.FooBoxedVoid](#fooboxedvoid)<br> boxed class to store validated null payloads |
-| record | [RequiredValidation.FooBoxedBoolean](#fooboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [RequiredValidation.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
-| record | [RequiredValidation.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
-| record | [RequiredValidation.FooBoxedList](#fooboxedlist)<br> boxed class to store validated List payloads |
-| record | [RequiredValidation.FooBoxedMap](#fooboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [RequiredValidation.Foo](#foo)<br> schema class |
+| data class | [RequiredValidation.FooBoxedVoid](#fooboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [RequiredValidation.FooBoxedBoolean](#fooboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [RequiredValidation.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [RequiredValidation.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
+| data class | [RequiredValidation.FooBoxedList](#fooboxedlist)<br> boxed class to store validated List payloads |
+| data class | [RequiredValidation.FooBoxedMap](#fooboxedmap)<br> boxed class to store validated Map payloads |
+| class | [RequiredValidation.Foo](#foo)<br> schema class |
 
 ## RequiredValidation1Boxed
 sealed interface RequiredValidation1Boxed<br>
@@ -72,7 +72,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class RequiredValidation1BoxedBoolean<br>
 implements [RequiredValidation1Boxed](#requiredvalidation1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -292,7 +292,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class BarBoxedBoolean<br>
 implements [BarBoxed](#barboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -417,7 +417,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class FooBoxedBoolean<br>
 implements [FooBoxed](#fooboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/RequiredValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/RequiredValidation.md
@@ -170,19 +170,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [RequiredValidationMap](#requiredvalidationmap) | validate(arg: [Map&lt;?, ?&gt;](#requiredvalidationmapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [RequiredValidationMap](#requiredvalidationmap) | validate(arg: [Map&lt;*, *&gt;](#requiredvalidationmapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [RequiredValidation1BoxedString](#requiredvalidation1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [RequiredValidation1BoxedVoid](#requiredvalidation1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [RequiredValidation1BoxedNumber](#requiredvalidation1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [RequiredValidation1BoxedBoolean](#requiredvalidation1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [RequiredValidation1BoxedMap](#requiredvalidation1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#requiredvalidationmapbuilder), configuration: SchemaConfiguration) |
+| [RequiredValidation1BoxedBoolean](#requiredvalidation1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [RequiredValidation1BoxedMap](#requiredvalidation1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#requiredvalidationmapbuilder), configuration: SchemaConfiguration) |
 | [RequiredValidation1BoxedList](#requiredvalidation1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [RequiredValidation1Boxed](#requiredvalidation1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/RequiredWithEmptyArray.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/RequiredWithEmptyArray.md
@@ -161,19 +161,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [RequiredWithEmptyArrayMap](#requiredwithemptyarraymap) | validate(arg: [Map&lt;?, ?&gt;](#requiredwithemptyarraymapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [RequiredWithEmptyArrayMap](#requiredwithemptyarraymap) | validate(arg: [Map&lt;*, *&gt;](#requiredwithemptyarraymapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [RequiredWithEmptyArray1BoxedString](#requiredwithemptyarray1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [RequiredWithEmptyArray1BoxedVoid](#requiredwithemptyarray1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [RequiredWithEmptyArray1BoxedNumber](#requiredwithemptyarray1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [RequiredWithEmptyArray1BoxedBoolean](#requiredwithemptyarray1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [RequiredWithEmptyArray1BoxedMap](#requiredwithemptyarray1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#requiredwithemptyarraymapbuilder), configuration: SchemaConfiguration) |
+| [RequiredWithEmptyArray1BoxedBoolean](#requiredwithemptyarray1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [RequiredWithEmptyArray1BoxedMap](#requiredwithemptyarray1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#requiredwithemptyarraymapbuilder), configuration: SchemaConfiguration) |
 | [RequiredWithEmptyArray1BoxedList](#requiredwithemptyarray1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [RequiredWithEmptyArray1Boxed](#requiredwithemptyarray1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/RequiredWithEmptyArray.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/RequiredWithEmptyArray.md
@@ -13,23 +13,23 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [RequiredWithEmptyArray.RequiredWithEmptyArray1Boxed](#requiredwithemptyarray1boxed)<br> sealed interface for validated payloads |
-| record | [RequiredWithEmptyArray.RequiredWithEmptyArray1BoxedVoid](#requiredwithemptyarray1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [RequiredWithEmptyArray.RequiredWithEmptyArray1BoxedBoolean](#requiredwithemptyarray1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [RequiredWithEmptyArray.RequiredWithEmptyArray1BoxedNumber](#requiredwithemptyarray1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [RequiredWithEmptyArray.RequiredWithEmptyArray1BoxedString](#requiredwithemptyarray1boxedstring)<br> boxed class to store validated String payloads |
-| record | [RequiredWithEmptyArray.RequiredWithEmptyArray1BoxedList](#requiredwithemptyarray1boxedlist)<br> boxed class to store validated List payloads |
-| record | [RequiredWithEmptyArray.RequiredWithEmptyArray1BoxedMap](#requiredwithemptyarray1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [RequiredWithEmptyArray.RequiredWithEmptyArray1](#requiredwithemptyarray1)<br> schema class |
-| static class | [RequiredWithEmptyArray.RequiredWithEmptyArrayMapBuilder](#requiredwithemptyarraymapbuilder)<br> builder for Map payloads |
-| static class | [RequiredWithEmptyArray.RequiredWithEmptyArrayMap](#requiredwithemptyarraymap)<br> output class for Map payloads |
+| data class | [RequiredWithEmptyArray.RequiredWithEmptyArray1BoxedVoid](#requiredwithemptyarray1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [RequiredWithEmptyArray.RequiredWithEmptyArray1BoxedBoolean](#requiredwithemptyarray1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [RequiredWithEmptyArray.RequiredWithEmptyArray1BoxedNumber](#requiredwithemptyarray1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [RequiredWithEmptyArray.RequiredWithEmptyArray1BoxedString](#requiredwithemptyarray1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [RequiredWithEmptyArray.RequiredWithEmptyArray1BoxedList](#requiredwithemptyarray1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [RequiredWithEmptyArray.RequiredWithEmptyArray1BoxedMap](#requiredwithemptyarray1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [RequiredWithEmptyArray.RequiredWithEmptyArray1](#requiredwithemptyarray1)<br> schema class |
+| class | [RequiredWithEmptyArray.RequiredWithEmptyArrayMapBuilder](#requiredwithemptyarraymapbuilder)<br> builder for Map payloads |
+| class | [RequiredWithEmptyArray.RequiredWithEmptyArrayMap](#requiredwithemptyarraymap)<br> output class for Map payloads |
 | sealed interface | [RequiredWithEmptyArray.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [RequiredWithEmptyArray.FooBoxedVoid](#fooboxedvoid)<br> boxed class to store validated null payloads |
-| record | [RequiredWithEmptyArray.FooBoxedBoolean](#fooboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [RequiredWithEmptyArray.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
-| record | [RequiredWithEmptyArray.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
-| record | [RequiredWithEmptyArray.FooBoxedList](#fooboxedlist)<br> boxed class to store validated List payloads |
-| record | [RequiredWithEmptyArray.FooBoxedMap](#fooboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [RequiredWithEmptyArray.Foo](#foo)<br> schema class |
+| data class | [RequiredWithEmptyArray.FooBoxedVoid](#fooboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [RequiredWithEmptyArray.FooBoxedBoolean](#fooboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [RequiredWithEmptyArray.FooBoxedNumber](#fooboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [RequiredWithEmptyArray.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
+| data class | [RequiredWithEmptyArray.FooBoxedList](#fooboxedlist)<br> boxed class to store validated List payloads |
+| data class | [RequiredWithEmptyArray.FooBoxedMap](#fooboxedmap)<br> boxed class to store validated Map payloads |
+| class | [RequiredWithEmptyArray.Foo](#foo)<br> schema class |
 
 ## RequiredWithEmptyArray1Boxed
 sealed interface RequiredWithEmptyArray1Boxed<br>
@@ -64,7 +64,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class RequiredWithEmptyArray1BoxedBoolean<br>
 implements [RequiredWithEmptyArray1Boxed](#requiredwithemptyarray1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -258,7 +258,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class FooBoxedBoolean<br>
 implements [FooBoxed](#fooboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/RequiredWithEscapedCharacters.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/RequiredWithEscapedCharacters.md
@@ -13,15 +13,15 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [RequiredWithEscapedCharacters.RequiredWithEscapedCharacters1Boxed](#requiredwithescapedcharacters1boxed)<br> sealed interface for validated payloads |
-| record | [RequiredWithEscapedCharacters.RequiredWithEscapedCharacters1BoxedVoid](#requiredwithescapedcharacters1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [RequiredWithEscapedCharacters.RequiredWithEscapedCharacters1BoxedBoolean](#requiredwithescapedcharacters1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [RequiredWithEscapedCharacters.RequiredWithEscapedCharacters1BoxedNumber](#requiredwithescapedcharacters1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [RequiredWithEscapedCharacters.RequiredWithEscapedCharacters1BoxedString](#requiredwithescapedcharacters1boxedstring)<br> boxed class to store validated String payloads |
-| record | [RequiredWithEscapedCharacters.RequiredWithEscapedCharacters1BoxedList](#requiredwithescapedcharacters1boxedlist)<br> boxed class to store validated List payloads |
-| record | [RequiredWithEscapedCharacters.RequiredWithEscapedCharacters1BoxedMap](#requiredwithescapedcharacters1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [RequiredWithEscapedCharacters.RequiredWithEscapedCharacters1](#requiredwithescapedcharacters1)<br> schema class |
-| static class | [RequiredWithEscapedCharacters.RequiredWithEscapedCharactersMapBuilder](#requiredwithescapedcharactersmapbuilder)<br> builder for Map payloads |
-| static class | [RequiredWithEscapedCharacters.RequiredWithEscapedCharactersMap](#requiredwithescapedcharactersmap)<br> output class for Map payloads |
+| data class | [RequiredWithEscapedCharacters.RequiredWithEscapedCharacters1BoxedVoid](#requiredwithescapedcharacters1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [RequiredWithEscapedCharacters.RequiredWithEscapedCharacters1BoxedBoolean](#requiredwithescapedcharacters1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [RequiredWithEscapedCharacters.RequiredWithEscapedCharacters1BoxedNumber](#requiredwithescapedcharacters1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [RequiredWithEscapedCharacters.RequiredWithEscapedCharacters1BoxedString](#requiredwithescapedcharacters1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [RequiredWithEscapedCharacters.RequiredWithEscapedCharacters1BoxedList](#requiredwithescapedcharacters1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [RequiredWithEscapedCharacters.RequiredWithEscapedCharacters1BoxedMap](#requiredwithescapedcharacters1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [RequiredWithEscapedCharacters.RequiredWithEscapedCharacters1](#requiredwithescapedcharacters1)<br> schema class |
+| class | [RequiredWithEscapedCharacters.RequiredWithEscapedCharactersMapBuilder](#requiredwithescapedcharactersmapbuilder)<br> builder for Map payloads |
+| class | [RequiredWithEscapedCharacters.RequiredWithEscapedCharactersMap](#requiredwithescapedcharactersmap)<br> output class for Map payloads |
 
 ## RequiredWithEscapedCharacters1Boxed
 sealed interface RequiredWithEscapedCharacters1Boxed<br>
@@ -56,7 +56,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class RequiredWithEscapedCharacters1BoxedBoolean<br>
 implements [RequiredWithEscapedCharacters1Boxed](#requiredwithescapedcharacters1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/RequiredWithEscapedCharacters.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/RequiredWithEscapedCharacters.md
@@ -153,19 +153,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| [RequiredWithEscapedCharactersMap](#requiredwithescapedcharactersmap) | validate(arg: [Map&lt;?, ?&gt;](#requiredwithescapedcharactersmapbuilder), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| [RequiredWithEscapedCharactersMap](#requiredwithescapedcharactersmap) | validate(arg: [Map&lt;*, *&gt;](#requiredwithescapedcharactersmapbuilder), configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [RequiredWithEscapedCharacters1BoxedString](#requiredwithescapedcharacters1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [RequiredWithEscapedCharacters1BoxedVoid](#requiredwithescapedcharacters1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [RequiredWithEscapedCharacters1BoxedNumber](#requiredwithescapedcharacters1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [RequiredWithEscapedCharacters1BoxedBoolean](#requiredwithescapedcharacters1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [RequiredWithEscapedCharacters1BoxedMap](#requiredwithescapedcharacters1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#requiredwithescapedcharactersmapbuilder), configuration: SchemaConfiguration) |
+| [RequiredWithEscapedCharacters1BoxedBoolean](#requiredwithescapedcharacters1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [RequiredWithEscapedCharacters1BoxedMap](#requiredwithescapedcharacters1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#requiredwithescapedcharactersmapbuilder), configuration: SchemaConfiguration) |
 | [RequiredWithEscapedCharacters1BoxedList](#requiredwithescapedcharacters1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [RequiredWithEscapedCharacters1Boxed](#requiredwithescapedcharacters1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/SimpleEnumValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/SimpleEnumValidation.md
@@ -51,25 +51,21 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.SimpleEnumValidation;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.SimpleEnumValidation
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // int validation
-int validatedPayload = SimpleEnumValidation.SimpleEnumValidation1.validate(
+val validatedPayload: Int = SimpleEnumValidation.SimpleEnumValidation1.validate(
     1,
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -90,7 +86,7 @@ int validatedPayload = SimpleEnumValidation.SimpleEnumValidation1.validate(
 public enum IntegerSimpleEnumValidationEnums<br>
 extends `Enum<IntegerSimpleEnumValidationEnums>`
 
-A class that stores Integer enum values
+A class that stores Int enum values
 
 ### Enum Constant Summary
 | Enum Constant | Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/SimpleEnumValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/SimpleEnumValidation.md
@@ -12,8 +12,8 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [SimpleEnumValidation.SimpleEnumValidation1Boxed](#simpleenumvalidation1boxed)<br> sealed interface for validated payloads |
-| record | [SimpleEnumValidation.SimpleEnumValidation1BoxedNumber](#simpleenumvalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [SimpleEnumValidation.SimpleEnumValidation1](#simpleenumvalidation1)<br> schema class |
+| data class | [SimpleEnumValidation.SimpleEnumValidation1BoxedNumber](#simpleenumvalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| class | [SimpleEnumValidation.SimpleEnumValidation1](#simpleenumvalidation1)<br> schema class |
 | enum | [SimpleEnumValidation.IntegerSimpleEnumValidationEnums](#integersimpleenumvalidationenums)<br>Integer enum |
 | enum | [SimpleEnumValidation.LongSimpleEnumValidationEnums](#longsimpleenumvalidationenums)<br>Long enum |
 | enum | [SimpleEnumValidation.FloatSimpleEnumValidationEnums](#floatsimpleenumvalidationenums)<br>Float enum |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/SingleDependency.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/SingleDependency.md
@@ -157,19 +157,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [SingleDependency1BoxedString](#singledependency1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [SingleDependency1BoxedVoid](#singledependency1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [SingleDependency1BoxedNumber](#singledependency1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [SingleDependency1BoxedBoolean](#singledependency1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [SingleDependency1BoxedMap](#singledependency1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [SingleDependency1BoxedBoolean](#singledependency1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [SingleDependency1BoxedMap](#singledependency1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [SingleDependency1BoxedList](#singledependency1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [SingleDependency1Boxed](#singledependency1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/SingleDependency.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/SingleDependency.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [SingleDependency.SingleDependency1Boxed](#singledependency1boxed)<br> sealed interface for validated payloads |
-| record | [SingleDependency.SingleDependency1BoxedVoid](#singledependency1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [SingleDependency.SingleDependency1BoxedBoolean](#singledependency1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [SingleDependency.SingleDependency1BoxedNumber](#singledependency1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [SingleDependency.SingleDependency1BoxedString](#singledependency1boxedstring)<br> boxed class to store validated String payloads |
-| record | [SingleDependency.SingleDependency1BoxedList](#singledependency1boxedlist)<br> boxed class to store validated List payloads |
-| record | [SingleDependency.SingleDependency1BoxedMap](#singledependency1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [SingleDependency.SingleDependency1](#singledependency1)<br> schema class |
+| data class | [SingleDependency.SingleDependency1BoxedVoid](#singledependency1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [SingleDependency.SingleDependency1BoxedBoolean](#singledependency1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [SingleDependency.SingleDependency1BoxedNumber](#singledependency1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [SingleDependency.SingleDependency1BoxedString](#singledependency1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [SingleDependency.SingleDependency1BoxedList](#singledependency1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [SingleDependency.SingleDependency1BoxedMap](#singledependency1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [SingleDependency.SingleDependency1](#singledependency1)<br> schema class |
 
 ## SingleDependency1Boxed
 sealed interface SingleDependency1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class SingleDependency1BoxedBoolean<br>
 implements [SingleDependency1Boxed](#singledependency1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/SmallMultipleOfLargeInteger.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/SmallMultipleOfLargeInteger.md
@@ -11,8 +11,8 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [SmallMultipleOfLargeInteger.SmallMultipleOfLargeInteger1Boxed](#smallmultipleoflargeinteger1boxed)<br> sealed interface for validated payloads |
-| record | [SmallMultipleOfLargeInteger.SmallMultipleOfLargeInteger1BoxedNumber](#smallmultipleoflargeinteger1boxednumber)<br> boxed class to store validated Number payloads |
-| static class | [SmallMultipleOfLargeInteger.SmallMultipleOfLargeInteger1](#smallmultipleoflargeinteger1)<br> schema class |
+| data class | [SmallMultipleOfLargeInteger.SmallMultipleOfLargeInteger1BoxedNumber](#smallmultipleoflargeinteger1boxednumber)<br> boxed class to store validated Number payloads |
+| class | [SmallMultipleOfLargeInteger.SmallMultipleOfLargeInteger1](#smallmultipleoflargeinteger1)<br> schema class |
 
 ## SmallMultipleOfLargeInteger1Boxed
 sealed interface SmallMultipleOfLargeInteger1Boxed<br>

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/SmallMultipleOfLargeInteger.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/SmallMultipleOfLargeInteger.md
@@ -46,25 +46,21 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.SmallMultipleOfLargeInteger;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.SmallMultipleOfLargeInteger
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // int validation
-int validatedPayload = SmallMultipleOfLargeInteger.SmallMultipleOfLargeInteger1.validate(
+val validatedPayload: Int = SmallMultipleOfLargeInteger.SmallMultipleOfLargeInteger1.validate(
     1L,
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -77,7 +73,7 @@ int validatedPayload = SmallMultipleOfLargeInteger.SmallMultipleOfLargeInteger1.
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
 | [SmallMultipleOfLargeInteger1BoxedNumber](#smallmultipleoflargeinteger1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
 | [SmallMultipleOfLargeInteger1Boxed](#smallmultipleoflargeinteger1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/StringTypeMatchesStrings.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/StringTypeMatchesStrings.md
@@ -11,8 +11,8 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [StringTypeMatchesStrings.StringTypeMatchesStrings1Boxed](#stringtypematchesstrings1boxed)<br> sealed interface for validated payloads |
-| record | [StringTypeMatchesStrings.StringTypeMatchesStrings1BoxedString](#stringtypematchesstrings1boxedstring)<br> boxed class to store validated String payloads |
-| static class | [StringTypeMatchesStrings.StringTypeMatchesStrings1](#stringtypematchesstrings1)<br> schema class |
+| data class | [StringTypeMatchesStrings.StringTypeMatchesStrings1BoxedString](#stringtypematchesstrings1boxedstring)<br> boxed class to store validated String payloads |
+| class | [StringTypeMatchesStrings.StringTypeMatchesStrings1](#stringtypematchesstrings1)<br> schema class |
 
 ## StringTypeMatchesStrings1Boxed
 sealed interface StringTypeMatchesStrings1Boxed<br>

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/TimeFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/TimeFormat.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [TimeFormat1BoxedString](#timeformat1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [TimeFormat1BoxedVoid](#timeformat1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [TimeFormat1BoxedNumber](#timeformat1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [TimeFormat1BoxedBoolean](#timeformat1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [TimeFormat1BoxedMap](#timeformat1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [TimeFormat1BoxedBoolean](#timeformat1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [TimeFormat1BoxedMap](#timeformat1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [TimeFormat1BoxedList](#timeformat1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [TimeFormat1Boxed](#timeformat1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/TimeFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/TimeFormat.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [TimeFormat.TimeFormat1Boxed](#timeformat1boxed)<br> sealed interface for validated payloads |
-| record | [TimeFormat.TimeFormat1BoxedVoid](#timeformat1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [TimeFormat.TimeFormat1BoxedBoolean](#timeformat1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [TimeFormat.TimeFormat1BoxedNumber](#timeformat1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [TimeFormat.TimeFormat1BoxedString](#timeformat1boxedstring)<br> boxed class to store validated String payloads |
-| record | [TimeFormat.TimeFormat1BoxedList](#timeformat1boxedlist)<br> boxed class to store validated List payloads |
-| record | [TimeFormat.TimeFormat1BoxedMap](#timeformat1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [TimeFormat.TimeFormat1](#timeformat1)<br> schema class |
+| data class | [TimeFormat.TimeFormat1BoxedVoid](#timeformat1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [TimeFormat.TimeFormat1BoxedBoolean](#timeformat1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [TimeFormat.TimeFormat1BoxedNumber](#timeformat1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [TimeFormat.TimeFormat1BoxedString](#timeformat1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [TimeFormat.TimeFormat1BoxedList](#timeformat1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [TimeFormat.TimeFormat1BoxedMap](#timeformat1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [TimeFormat.TimeFormat1](#timeformat1)<br> schema class |
 
 ## TimeFormat1Boxed
 sealed interface TimeFormat1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class TimeFormat1BoxedBoolean<br>
 implements [TimeFormat1Boxed](#timeformat1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/TypeArrayObjectOrNull.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/TypeArrayObjectOrNull.md
@@ -11,10 +11,10 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [TypeArrayObjectOrNull.TypeArrayObjectOrNull1Boxed](#typearrayobjectornull1boxed)<br> sealed interface for validated payloads |
-| record | [TypeArrayObjectOrNull.TypeArrayObjectOrNull1BoxedList](#typearrayobjectornull1boxedlist)<br> boxed class to store validated List payloads |
-| record | [TypeArrayObjectOrNull.TypeArrayObjectOrNull1BoxedMap](#typearrayobjectornull1boxedmap)<br> boxed class to store validated Map payloads |
-| record | [TypeArrayObjectOrNull.TypeArrayObjectOrNull1BoxedVoid](#typearrayobjectornull1boxedvoid)<br> boxed class to store validated null payloads |
-| static class | [TypeArrayObjectOrNull.TypeArrayObjectOrNull1](#typearrayobjectornull1)<br> schema class |
+| data class | [TypeArrayObjectOrNull.TypeArrayObjectOrNull1BoxedList](#typearrayobjectornull1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [TypeArrayObjectOrNull.TypeArrayObjectOrNull1BoxedMap](#typearrayobjectornull1boxedmap)<br> boxed class to store validated Map payloads |
+| data class | [TypeArrayObjectOrNull.TypeArrayObjectOrNull1BoxedVoid](#typearrayobjectornull1boxedvoid)<br> boxed class to store validated null payloads |
+| class | [TypeArrayObjectOrNull.TypeArrayObjectOrNull1](#typearrayobjectornull1)<br> schema class |
 
 ## TypeArrayObjectOrNull1Boxed
 sealed interface TypeArrayObjectOrNull1Boxed<br>

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/TypeArrayObjectOrNull.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/TypeArrayObjectOrNull.md
@@ -84,25 +84,21 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.TypeArrayObjectOrNull;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.TypeArrayObjectOrNull
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // null validation
-Nothing? validatedPayload = TypeArrayObjectOrNull.TypeArrayObjectOrNull1.validate(
+val validatedPayload: Nothing? = TypeArrayObjectOrNull.TypeArrayObjectOrNull1.validate(
     null,
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -115,8 +111,8 @@ Nothing? validatedPayload = TypeArrayObjectOrNull.TypeArrayObjectOrNull1.validat
 | ----------------- | ---------------------- |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [TypeArrayObjectOrNull1BoxedList](#typearrayobjectornull1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
-| FrozenMap<String, Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
-| [TypeArrayObjectOrNull1BoxedMap](#typearrayobjectornull1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| FrozenMap<String, Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
+| [TypeArrayObjectOrNull1BoxedMap](#typearrayobjectornull1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
 | [TypeArrayObjectOrNull1BoxedVoid](#typearrayobjectornull1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [TypeArrayObjectOrNull1Boxed](#typearrayobjectornull1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/TypeArrayOrObject.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/TypeArrayOrObject.md
@@ -73,8 +73,8 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [TypeArrayOrObject1BoxedList](#typearrayorobject1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
-| FrozenMap<String, Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
-| [TypeArrayOrObject1BoxedMap](#typearrayorobject1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| FrozenMap<String, Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
+| [TypeArrayOrObject1BoxedMap](#typearrayorobject1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [TypeArrayOrObject1Boxed](#typearrayorobject1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
 

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/TypeArrayOrObject.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/TypeArrayOrObject.md
@@ -11,9 +11,9 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [TypeArrayOrObject.TypeArrayOrObject1Boxed](#typearrayorobject1boxed)<br> sealed interface for validated payloads |
-| record | [TypeArrayOrObject.TypeArrayOrObject1BoxedList](#typearrayorobject1boxedlist)<br> boxed class to store validated List payloads |
-| record | [TypeArrayOrObject.TypeArrayOrObject1BoxedMap](#typearrayorobject1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [TypeArrayOrObject.TypeArrayOrObject1](#typearrayorobject1)<br> schema class |
+| data class | [TypeArrayOrObject.TypeArrayOrObject1BoxedList](#typearrayorobject1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [TypeArrayOrObject.TypeArrayOrObject1BoxedMap](#typearrayorobject1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [TypeArrayOrObject.TypeArrayOrObject1](#typearrayorobject1)<br> schema class |
 
 ## TypeArrayOrObject1Boxed
 sealed interface TypeArrayOrObject1Boxed<br>

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/TypeAsArrayWithOneItem.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/TypeAsArrayWithOneItem.md
@@ -11,8 +11,8 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [TypeAsArrayWithOneItem.TypeAsArrayWithOneItem1Boxed](#typeasarraywithoneitem1boxed)<br> sealed interface for validated payloads |
-| record | [TypeAsArrayWithOneItem.TypeAsArrayWithOneItem1BoxedString](#typeasarraywithoneitem1boxedstring)<br> boxed class to store validated String payloads |
-| static class | [TypeAsArrayWithOneItem.TypeAsArrayWithOneItem1](#typeasarraywithoneitem1)<br> schema class |
+| data class | [TypeAsArrayWithOneItem.TypeAsArrayWithOneItem1BoxedString](#typeasarraywithoneitem1boxedstring)<br> boxed class to store validated String payloads |
+| class | [TypeAsArrayWithOneItem.TypeAsArrayWithOneItem1](#typeasarraywithoneitem1)<br> schema class |
 
 ## TypeAsArrayWithOneItem1Boxed
 sealed interface TypeAsArrayWithOneItem1Boxed<br>

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UnevaluateditemsAsSchema.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UnevaluateditemsAsSchema.md
@@ -11,16 +11,16 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [UnevaluateditemsAsSchema.UnevaluateditemsAsSchema1Boxed](#unevaluateditemsasschema1boxed)<br> sealed interface for validated payloads |
-| record | [UnevaluateditemsAsSchema.UnevaluateditemsAsSchema1BoxedVoid](#unevaluateditemsasschema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [UnevaluateditemsAsSchema.UnevaluateditemsAsSchema1BoxedBoolean](#unevaluateditemsasschema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [UnevaluateditemsAsSchema.UnevaluateditemsAsSchema1BoxedNumber](#unevaluateditemsasschema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [UnevaluateditemsAsSchema.UnevaluateditemsAsSchema1BoxedString](#unevaluateditemsasschema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [UnevaluateditemsAsSchema.UnevaluateditemsAsSchema1BoxedList](#unevaluateditemsasschema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [UnevaluateditemsAsSchema.UnevaluateditemsAsSchema1BoxedMap](#unevaluateditemsasschema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [UnevaluateditemsAsSchema.UnevaluateditemsAsSchema1](#unevaluateditemsasschema1)<br> schema class |
+| data class | [UnevaluateditemsAsSchema.UnevaluateditemsAsSchema1BoxedVoid](#unevaluateditemsasschema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [UnevaluateditemsAsSchema.UnevaluateditemsAsSchema1BoxedBoolean](#unevaluateditemsasschema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [UnevaluateditemsAsSchema.UnevaluateditemsAsSchema1BoxedNumber](#unevaluateditemsasschema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [UnevaluateditemsAsSchema.UnevaluateditemsAsSchema1BoxedString](#unevaluateditemsasschema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [UnevaluateditemsAsSchema.UnevaluateditemsAsSchema1BoxedList](#unevaluateditemsasschema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [UnevaluateditemsAsSchema.UnevaluateditemsAsSchema1BoxedMap](#unevaluateditemsasschema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [UnevaluateditemsAsSchema.UnevaluateditemsAsSchema1](#unevaluateditemsasschema1)<br> schema class |
 | sealed interface | [UnevaluateditemsAsSchema.UnevaluatedItemsBoxed](#unevaluateditemsboxed)<br> sealed interface for validated payloads |
-| record | [UnevaluateditemsAsSchema.UnevaluatedItemsBoxedString](#unevaluateditemsboxedstring)<br> boxed class to store validated String payloads |
-| static class | [UnevaluateditemsAsSchema.UnevaluatedItems](#unevaluateditems)<br> schema class |
+| data class | [UnevaluateditemsAsSchema.UnevaluatedItemsBoxedString](#unevaluateditemsboxedstring)<br> boxed class to store validated String payloads |
+| class | [UnevaluateditemsAsSchema.UnevaluatedItems](#unevaluateditems)<br> schema class |
 
 ## UnevaluateditemsAsSchema1Boxed
 sealed interface UnevaluateditemsAsSchema1Boxed<br>
@@ -55,7 +55,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class UnevaluateditemsAsSchema1BoxedBoolean<br>
 implements [UnevaluateditemsAsSchema1Boxed](#unevaluateditemsasschema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UnevaluateditemsAsSchema.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UnevaluateditemsAsSchema.md
@@ -152,19 +152,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [UnevaluateditemsAsSchema1BoxedString](#unevaluateditemsasschema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [UnevaluateditemsAsSchema1BoxedVoid](#unevaluateditemsasschema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [UnevaluateditemsAsSchema1BoxedNumber](#unevaluateditemsasschema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [UnevaluateditemsAsSchema1BoxedBoolean](#unevaluateditemsasschema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [UnevaluateditemsAsSchema1BoxedMap](#unevaluateditemsasschema1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [UnevaluateditemsAsSchema1BoxedBoolean](#unevaluateditemsasschema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [UnevaluateditemsAsSchema1BoxedMap](#unevaluateditemsasschema1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [UnevaluateditemsAsSchema1BoxedList](#unevaluateditemsasschema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [UnevaluateditemsAsSchema1Boxed](#unevaluateditemsasschema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UnevaluateditemsDependsOnMultipleNestedContains.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UnevaluateditemsDependsOnMultipleNestedContains.md
@@ -11,53 +11,53 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [UnevaluateditemsDependsOnMultipleNestedContains.UnevaluateditemsDependsOnMultipleNestedContains1Boxed](#unevaluateditemsdependsonmultiplenestedcontains1boxed)<br> sealed interface for validated payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.UnevaluateditemsDependsOnMultipleNestedContains1BoxedVoid](#unevaluateditemsdependsonmultiplenestedcontains1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.UnevaluateditemsDependsOnMultipleNestedContains1BoxedBoolean](#unevaluateditemsdependsonmultiplenestedcontains1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.UnevaluateditemsDependsOnMultipleNestedContains1BoxedNumber](#unevaluateditemsdependsonmultiplenestedcontains1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.UnevaluateditemsDependsOnMultipleNestedContains1BoxedString](#unevaluateditemsdependsonmultiplenestedcontains1boxedstring)<br> boxed class to store validated String payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.UnevaluateditemsDependsOnMultipleNestedContains1BoxedList](#unevaluateditemsdependsonmultiplenestedcontains1boxedlist)<br> boxed class to store validated List payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.UnevaluateditemsDependsOnMultipleNestedContains1BoxedMap](#unevaluateditemsdependsonmultiplenestedcontains1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [UnevaluateditemsDependsOnMultipleNestedContains.UnevaluateditemsDependsOnMultipleNestedContains1](#unevaluateditemsdependsonmultiplenestedcontains1)<br> schema class |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.UnevaluateditemsDependsOnMultipleNestedContains1BoxedVoid](#unevaluateditemsdependsonmultiplenestedcontains1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.UnevaluateditemsDependsOnMultipleNestedContains1BoxedBoolean](#unevaluateditemsdependsonmultiplenestedcontains1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.UnevaluateditemsDependsOnMultipleNestedContains1BoxedNumber](#unevaluateditemsdependsonmultiplenestedcontains1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.UnevaluateditemsDependsOnMultipleNestedContains1BoxedString](#unevaluateditemsdependsonmultiplenestedcontains1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.UnevaluateditemsDependsOnMultipleNestedContains1BoxedList](#unevaluateditemsdependsonmultiplenestedcontains1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.UnevaluateditemsDependsOnMultipleNestedContains1BoxedMap](#unevaluateditemsdependsonmultiplenestedcontains1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [UnevaluateditemsDependsOnMultipleNestedContains.UnevaluateditemsDependsOnMultipleNestedContains1](#unevaluateditemsdependsonmultiplenestedcontains1)<br> schema class |
 | sealed interface | [UnevaluateditemsDependsOnMultipleNestedContains.UnevaluatedItemsBoxed](#unevaluateditemsboxed)<br> sealed interface for validated payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.UnevaluatedItemsBoxedVoid](#unevaluateditemsboxedvoid)<br> boxed class to store validated null payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.UnevaluatedItemsBoxedBoolean](#unevaluateditemsboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.UnevaluatedItemsBoxedNumber](#unevaluateditemsboxednumber)<br> boxed class to store validated Number payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.UnevaluatedItemsBoxedString](#unevaluateditemsboxedstring)<br> boxed class to store validated String payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.UnevaluatedItemsBoxedList](#unevaluateditemsboxedlist)<br> boxed class to store validated List payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.UnevaluatedItemsBoxedMap](#unevaluateditemsboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [UnevaluateditemsDependsOnMultipleNestedContains.UnevaluatedItems](#unevaluateditems)<br> schema class |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.UnevaluatedItemsBoxedVoid](#unevaluateditemsboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.UnevaluatedItemsBoxedBoolean](#unevaluateditemsboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.UnevaluatedItemsBoxedNumber](#unevaluateditemsboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.UnevaluatedItemsBoxedString](#unevaluateditemsboxedstring)<br> boxed class to store validated String payloads |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.UnevaluatedItemsBoxedList](#unevaluateditemsboxedlist)<br> boxed class to store validated List payloads |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.UnevaluatedItemsBoxedMap](#unevaluateditemsboxedmap)<br> boxed class to store validated Map payloads |
+| class | [UnevaluateditemsDependsOnMultipleNestedContains.UnevaluatedItems](#unevaluateditems)<br> schema class |
 | sealed interface | [UnevaluateditemsDependsOnMultipleNestedContains.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [UnevaluateditemsDependsOnMultipleNestedContains.Schema1](#schema1)<br> schema class |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.Schema1BoxedVoid](#schema1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.Schema1BoxedNumber](#schema1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.Schema1BoxedString](#schema1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.Schema1BoxedList](#schema1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.Schema1BoxedMap](#schema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [UnevaluateditemsDependsOnMultipleNestedContains.Schema1](#schema1)<br> schema class |
 | sealed interface | [UnevaluateditemsDependsOnMultipleNestedContains.Contains1Boxed](#contains1boxed)<br> sealed interface for validated payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.Contains1BoxedVoid](#contains1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.Contains1BoxedBoolean](#contains1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.Contains1BoxedNumber](#contains1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.Contains1BoxedString](#contains1boxedstring)<br> boxed class to store validated String payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.Contains1BoxedList](#contains1boxedlist)<br> boxed class to store validated List payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.Contains1BoxedMap](#contains1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [UnevaluateditemsDependsOnMultipleNestedContains.Contains1](#contains1)<br> schema class |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.Contains1BoxedVoid](#contains1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.Contains1BoxedBoolean](#contains1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.Contains1BoxedNumber](#contains1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.Contains1BoxedString](#contains1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.Contains1BoxedList](#contains1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.Contains1BoxedMap](#contains1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [UnevaluateditemsDependsOnMultipleNestedContains.Contains1](#contains1)<br> schema class |
 | sealed interface | [UnevaluateditemsDependsOnMultipleNestedContains.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [UnevaluateditemsDependsOnMultipleNestedContains.Schema0](#schema0)<br> schema class |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.Schema0BoxedVoid](#schema0boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.Schema0BoxedNumber](#schema0boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.Schema0BoxedString](#schema0boxedstring)<br> boxed class to store validated String payloads |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.Schema0BoxedList](#schema0boxedlist)<br> boxed class to store validated List payloads |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.Schema0BoxedMap](#schema0boxedmap)<br> boxed class to store validated Map payloads |
+| class | [UnevaluateditemsDependsOnMultipleNestedContains.Schema0](#schema0)<br> schema class |
 | sealed interface | [UnevaluateditemsDependsOnMultipleNestedContains.ContainsBoxed](#containsboxed)<br> sealed interface for validated payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.ContainsBoxedVoid](#containsboxedvoid)<br> boxed class to store validated null payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.ContainsBoxedBoolean](#containsboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.ContainsBoxedNumber](#containsboxednumber)<br> boxed class to store validated Number payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.ContainsBoxedString](#containsboxedstring)<br> boxed class to store validated String payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.ContainsBoxedList](#containsboxedlist)<br> boxed class to store validated List payloads |
-| record | [UnevaluateditemsDependsOnMultipleNestedContains.ContainsBoxedMap](#containsboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [UnevaluateditemsDependsOnMultipleNestedContains.Contains](#contains)<br> schema class |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.ContainsBoxedVoid](#containsboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.ContainsBoxedBoolean](#containsboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.ContainsBoxedNumber](#containsboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.ContainsBoxedString](#containsboxedstring)<br> boxed class to store validated String payloads |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.ContainsBoxedList](#containsboxedlist)<br> boxed class to store validated List payloads |
+| data class | [UnevaluateditemsDependsOnMultipleNestedContains.ContainsBoxedMap](#containsboxedmap)<br> boxed class to store validated Map payloads |
+| class | [UnevaluateditemsDependsOnMultipleNestedContains.Contains](#contains)<br> schema class |
 
 ## UnevaluateditemsDependsOnMultipleNestedContains1Boxed
 sealed interface UnevaluateditemsDependsOnMultipleNestedContains1Boxed<br>
@@ -92,7 +92,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class UnevaluateditemsDependsOnMultipleNestedContains1BoxedBoolean<br>
 implements [UnevaluateditemsDependsOnMultipleNestedContains1Boxed](#unevaluateditemsdependsonmultiplenestedcontains1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -240,7 +240,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class UnevaluatedItemsBoxedBoolean<br>
 implements [UnevaluatedItemsBoxed](#unevaluateditemsboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -387,7 +387,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema1BoxedBoolean<br>
 implements [Schema1Boxed](#schema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -534,7 +534,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Contains1BoxedBoolean<br>
 implements [Contains1Boxed](#contains1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -681,7 +681,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -828,7 +828,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class ContainsBoxedBoolean<br>
 implements [ContainsBoxed](#containsboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UnevaluateditemsDependsOnMultipleNestedContains.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UnevaluateditemsDependsOnMultipleNestedContains.md
@@ -190,19 +190,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [UnevaluateditemsDependsOnMultipleNestedContains1BoxedString](#unevaluateditemsdependsonmultiplenestedcontains1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [UnevaluateditemsDependsOnMultipleNestedContains1BoxedVoid](#unevaluateditemsdependsonmultiplenestedcontains1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [UnevaluateditemsDependsOnMultipleNestedContains1BoxedNumber](#unevaluateditemsdependsonmultiplenestedcontains1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [UnevaluateditemsDependsOnMultipleNestedContains1BoxedBoolean](#unevaluateditemsdependsonmultiplenestedcontains1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [UnevaluateditemsDependsOnMultipleNestedContains1BoxedMap](#unevaluateditemsdependsonmultiplenestedcontains1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [UnevaluateditemsDependsOnMultipleNestedContains1BoxedBoolean](#unevaluateditemsdependsonmultiplenestedcontains1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [UnevaluateditemsDependsOnMultipleNestedContains1BoxedMap](#unevaluateditemsdependsonmultiplenestedcontains1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [UnevaluateditemsDependsOnMultipleNestedContains1BoxedList](#unevaluateditemsdependsonmultiplenestedcontains1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [UnevaluateditemsDependsOnMultipleNestedContains1Boxed](#unevaluateditemsdependsonmultiplenestedcontains1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -337,19 +337,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [UnevaluatedItemsBoxedString](#unevaluateditemsboxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [UnevaluatedItemsBoxedVoid](#unevaluateditemsboxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [UnevaluatedItemsBoxedNumber](#unevaluateditemsboxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [UnevaluatedItemsBoxedBoolean](#unevaluateditemsboxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [UnevaluatedItemsBoxedMap](#unevaluateditemsboxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [UnevaluatedItemsBoxedBoolean](#unevaluateditemsboxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [UnevaluatedItemsBoxedMap](#unevaluateditemsboxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [UnevaluatedItemsBoxedList](#unevaluateditemsboxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [UnevaluatedItemsBoxed](#unevaluateditemsboxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -484,19 +484,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema1BoxedString](#schema1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema1BoxedVoid](#schema1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema1BoxedNumber](#schema1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema1BoxedBoolean](#schema1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema1BoxedMap](#schema1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema1BoxedList](#schema1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema1Boxed](#schema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -631,19 +631,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Contains1BoxedString](#contains1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Contains1BoxedVoid](#contains1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Contains1BoxedNumber](#contains1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Contains1BoxedBoolean](#contains1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Contains1BoxedMap](#contains1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Contains1BoxedBoolean](#contains1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Contains1BoxedMap](#contains1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Contains1BoxedList](#contains1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Contains1Boxed](#contains1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -778,19 +778,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [Schema0BoxedString](#schema0boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [Schema0BoxedVoid](#schema0boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [Schema0BoxedNumber](#schema0boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [Schema0BoxedBoolean](#schema0boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [Schema0BoxedMap](#schema0boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [Schema0BoxedList](#schema0boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [Schema0Boxed](#schema0boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -925,19 +925,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [ContainsBoxedString](#containsboxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [ContainsBoxedVoid](#containsboxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [ContainsBoxedNumber](#containsboxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [ContainsBoxedBoolean](#containsboxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [ContainsBoxedMap](#containsboxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [ContainsBoxedBoolean](#containsboxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [ContainsBoxedMap](#containsboxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [ContainsBoxedList](#containsboxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [ContainsBoxed](#containsboxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UnevaluateditemsWithItems.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UnevaluateditemsWithItems.md
@@ -56,29 +56,25 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.UnevaluateditemsWithItems;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.UnevaluateditemsWithItems
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // List validation
-UnevaluateditemsWithItems.UnevaluateditemsWithItemsList validatedPayload =
+val validatedPayload: UnevaluateditemsWithItems.UnevaluateditemsWithItemsList =
     UnevaluateditemsWithItems.UnevaluateditemsWithItems1.validate(
-    new UnevaluateditemsWithItems.UnevaluateditemsWithItemsListBuilder()
+    UnevaluateditemsWithItems.UnevaluateditemsWithItemsListBuilder()
         .add(1)
 
     .build(),
     configuration
-);
+)
 ```
 
 ### Field Summary

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UnevaluateditemsWithItems.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UnevaluateditemsWithItems.md
@@ -13,16 +13,16 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [UnevaluateditemsWithItems.UnevaluateditemsWithItems1Boxed](#unevaluateditemswithitems1boxed)<br> sealed interface for validated payloads |
-| record | [UnevaluateditemsWithItems.UnevaluateditemsWithItems1BoxedList](#unevaluateditemswithitems1boxedlist)<br> boxed class to store validated List payloads |
-| static class | [UnevaluateditemsWithItems.UnevaluateditemsWithItems1](#unevaluateditemswithitems1)<br> schema class |
+| data class | [UnevaluateditemsWithItems.UnevaluateditemsWithItems1BoxedList](#unevaluateditemswithitems1boxedlist)<br> boxed class to store validated List payloads |
+| class | [UnevaluateditemsWithItems.UnevaluateditemsWithItems1](#unevaluateditemswithitems1)<br> schema class |
 | sealed interface | [UnevaluateditemsWithItems.UnevaluatedItemsBoxed](#unevaluateditemsboxed)<br> sealed interface for validated payloads |
-| record | [UnevaluateditemsWithItems.UnevaluatedItemsBoxedString](#unevaluateditemsboxedstring)<br> boxed class to store validated String payloads |
-| static class | [UnevaluateditemsWithItems.UnevaluatedItems](#unevaluateditems)<br> schema class |
-| static class | [UnevaluateditemsWithItems.UnevaluateditemsWithItemsListBuilder](#unevaluateditemswithitemslistbuilder)<br> builder for List payloads |
-| static class | [UnevaluateditemsWithItems.UnevaluateditemsWithItemsList](#unevaluateditemswithitemslist)<br> output class for List payloads |
+| data class | [UnevaluateditemsWithItems.UnevaluatedItemsBoxedString](#unevaluateditemsboxedstring)<br> boxed class to store validated String payloads |
+| class | [UnevaluateditemsWithItems.UnevaluatedItems](#unevaluateditems)<br> schema class |
+| class | [UnevaluateditemsWithItems.UnevaluateditemsWithItemsListBuilder](#unevaluateditemswithitemslistbuilder)<br> builder for List payloads |
+| class | [UnevaluateditemsWithItems.UnevaluateditemsWithItemsList](#unevaluateditemswithitemslist)<br> output class for List payloads |
 | sealed interface | [UnevaluateditemsWithItems.ItemsBoxed](#itemsboxed)<br> sealed interface for validated payloads |
-| record | [UnevaluateditemsWithItems.ItemsBoxedNumber](#itemsboxednumber)<br> boxed class to store validated Number payloads |
-| static class | [UnevaluateditemsWithItems.Items](#items)<br> schema class |
+| data class | [UnevaluateditemsWithItems.ItemsBoxedNumber](#itemsboxednumber)<br> boxed class to store validated Number payloads |
+| class | [UnevaluateditemsWithItems.Items](#items)<br> schema class |
 
 ## UnevaluateditemsWithItems1Boxed
 sealed interface UnevaluateditemsWithItems1Boxed<br>

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UnevaluateditemsWithNullInstanceElements.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UnevaluateditemsWithNullInstanceElements.md
@@ -11,16 +11,16 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [UnevaluateditemsWithNullInstanceElements.UnevaluateditemsWithNullInstanceElements1Boxed](#unevaluateditemswithnullinstanceelements1boxed)<br> sealed interface for validated payloads |
-| record | [UnevaluateditemsWithNullInstanceElements.UnevaluateditemsWithNullInstanceElements1BoxedVoid](#unevaluateditemswithnullinstanceelements1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [UnevaluateditemsWithNullInstanceElements.UnevaluateditemsWithNullInstanceElements1BoxedBoolean](#unevaluateditemswithnullinstanceelements1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [UnevaluateditemsWithNullInstanceElements.UnevaluateditemsWithNullInstanceElements1BoxedNumber](#unevaluateditemswithnullinstanceelements1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [UnevaluateditemsWithNullInstanceElements.UnevaluateditemsWithNullInstanceElements1BoxedString](#unevaluateditemswithnullinstanceelements1boxedstring)<br> boxed class to store validated String payloads |
-| record | [UnevaluateditemsWithNullInstanceElements.UnevaluateditemsWithNullInstanceElements1BoxedList](#unevaluateditemswithnullinstanceelements1boxedlist)<br> boxed class to store validated List payloads |
-| record | [UnevaluateditemsWithNullInstanceElements.UnevaluateditemsWithNullInstanceElements1BoxedMap](#unevaluateditemswithnullinstanceelements1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [UnevaluateditemsWithNullInstanceElements.UnevaluateditemsWithNullInstanceElements1](#unevaluateditemswithnullinstanceelements1)<br> schema class |
+| data class | [UnevaluateditemsWithNullInstanceElements.UnevaluateditemsWithNullInstanceElements1BoxedVoid](#unevaluateditemswithnullinstanceelements1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [UnevaluateditemsWithNullInstanceElements.UnevaluateditemsWithNullInstanceElements1BoxedBoolean](#unevaluateditemswithnullinstanceelements1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [UnevaluateditemsWithNullInstanceElements.UnevaluateditemsWithNullInstanceElements1BoxedNumber](#unevaluateditemswithnullinstanceelements1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [UnevaluateditemsWithNullInstanceElements.UnevaluateditemsWithNullInstanceElements1BoxedString](#unevaluateditemswithnullinstanceelements1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [UnevaluateditemsWithNullInstanceElements.UnevaluateditemsWithNullInstanceElements1BoxedList](#unevaluateditemswithnullinstanceelements1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [UnevaluateditemsWithNullInstanceElements.UnevaluateditemsWithNullInstanceElements1BoxedMap](#unevaluateditemswithnullinstanceelements1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [UnevaluateditemsWithNullInstanceElements.UnevaluateditemsWithNullInstanceElements1](#unevaluateditemswithnullinstanceelements1)<br> schema class |
 | sealed interface | [UnevaluateditemsWithNullInstanceElements.UnevaluatedItemsBoxed](#unevaluateditemsboxed)<br> sealed interface for validated payloads |
-| record | [UnevaluateditemsWithNullInstanceElements.UnevaluatedItemsBoxedVoid](#unevaluateditemsboxedvoid)<br> boxed class to store validated null payloads |
-| static class | [UnevaluateditemsWithNullInstanceElements.UnevaluatedItems](#unevaluateditems)<br> schema class |
+| data class | [UnevaluateditemsWithNullInstanceElements.UnevaluatedItemsBoxedVoid](#unevaluateditemsboxedvoid)<br> boxed class to store validated null payloads |
+| class | [UnevaluateditemsWithNullInstanceElements.UnevaluatedItems](#unevaluateditems)<br> schema class |
 
 ## UnevaluateditemsWithNullInstanceElements1Boxed
 sealed interface UnevaluateditemsWithNullInstanceElements1Boxed<br>
@@ -55,7 +55,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class UnevaluateditemsWithNullInstanceElements1BoxedBoolean<br>
 implements [UnevaluateditemsWithNullInstanceElements1Boxed](#unevaluateditemswithnullinstanceelements1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UnevaluateditemsWithNullInstanceElements.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UnevaluateditemsWithNullInstanceElements.md
@@ -152,19 +152,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [UnevaluateditemsWithNullInstanceElements1BoxedString](#unevaluateditemswithnullinstanceelements1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [UnevaluateditemsWithNullInstanceElements1BoxedVoid](#unevaluateditemswithnullinstanceelements1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [UnevaluateditemsWithNullInstanceElements1BoxedNumber](#unevaluateditemswithnullinstanceelements1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [UnevaluateditemsWithNullInstanceElements1BoxedBoolean](#unevaluateditemswithnullinstanceelements1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [UnevaluateditemsWithNullInstanceElements1BoxedMap](#unevaluateditemswithnullinstanceelements1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [UnevaluateditemsWithNullInstanceElements1BoxedBoolean](#unevaluateditemswithnullinstanceelements1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [UnevaluateditemsWithNullInstanceElements1BoxedMap](#unevaluateditemswithnullinstanceelements1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [UnevaluateditemsWithNullInstanceElements1BoxedList](#unevaluateditemswithnullinstanceelements1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [UnevaluateditemsWithNullInstanceElements1Boxed](#unevaluateditemswithnullinstanceelements1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UnevaluatedpropertiesNotAffectedByPropertynames.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UnevaluatedpropertiesNotAffectedByPropertynames.md
@@ -11,19 +11,19 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [UnevaluatedpropertiesNotAffectedByPropertynames.UnevaluatedpropertiesNotAffectedByPropertynames1Boxed](#unevaluatedpropertiesnotaffectedbypropertynames1boxed)<br> sealed interface for validated payloads |
-| record | [UnevaluatedpropertiesNotAffectedByPropertynames.UnevaluatedpropertiesNotAffectedByPropertynames1BoxedVoid](#unevaluatedpropertiesnotaffectedbypropertynames1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [UnevaluatedpropertiesNotAffectedByPropertynames.UnevaluatedpropertiesNotAffectedByPropertynames1BoxedBoolean](#unevaluatedpropertiesnotaffectedbypropertynames1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [UnevaluatedpropertiesNotAffectedByPropertynames.UnevaluatedpropertiesNotAffectedByPropertynames1BoxedNumber](#unevaluatedpropertiesnotaffectedbypropertynames1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [UnevaluatedpropertiesNotAffectedByPropertynames.UnevaluatedpropertiesNotAffectedByPropertynames1BoxedString](#unevaluatedpropertiesnotaffectedbypropertynames1boxedstring)<br> boxed class to store validated String payloads |
-| record | [UnevaluatedpropertiesNotAffectedByPropertynames.UnevaluatedpropertiesNotAffectedByPropertynames1BoxedList](#unevaluatedpropertiesnotaffectedbypropertynames1boxedlist)<br> boxed class to store validated List payloads |
-| record | [UnevaluatedpropertiesNotAffectedByPropertynames.UnevaluatedpropertiesNotAffectedByPropertynames1BoxedMap](#unevaluatedpropertiesnotaffectedbypropertynames1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [UnevaluatedpropertiesNotAffectedByPropertynames.UnevaluatedpropertiesNotAffectedByPropertynames1](#unevaluatedpropertiesnotaffectedbypropertynames1)<br> schema class |
+| data class | [UnevaluatedpropertiesNotAffectedByPropertynames.UnevaluatedpropertiesNotAffectedByPropertynames1BoxedVoid](#unevaluatedpropertiesnotaffectedbypropertynames1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [UnevaluatedpropertiesNotAffectedByPropertynames.UnevaluatedpropertiesNotAffectedByPropertynames1BoxedBoolean](#unevaluatedpropertiesnotaffectedbypropertynames1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [UnevaluatedpropertiesNotAffectedByPropertynames.UnevaluatedpropertiesNotAffectedByPropertynames1BoxedNumber](#unevaluatedpropertiesnotaffectedbypropertynames1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [UnevaluatedpropertiesNotAffectedByPropertynames.UnevaluatedpropertiesNotAffectedByPropertynames1BoxedString](#unevaluatedpropertiesnotaffectedbypropertynames1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [UnevaluatedpropertiesNotAffectedByPropertynames.UnevaluatedpropertiesNotAffectedByPropertynames1BoxedList](#unevaluatedpropertiesnotaffectedbypropertynames1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [UnevaluatedpropertiesNotAffectedByPropertynames.UnevaluatedpropertiesNotAffectedByPropertynames1BoxedMap](#unevaluatedpropertiesnotaffectedbypropertynames1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [UnevaluatedpropertiesNotAffectedByPropertynames.UnevaluatedpropertiesNotAffectedByPropertynames1](#unevaluatedpropertiesnotaffectedbypropertynames1)<br> schema class |
 | sealed interface | [UnevaluatedpropertiesNotAffectedByPropertynames.UnevaluatedPropertiesBoxed](#unevaluatedpropertiesboxed)<br> sealed interface for validated payloads |
-| record | [UnevaluatedpropertiesNotAffectedByPropertynames.UnevaluatedPropertiesBoxedNumber](#unevaluatedpropertiesboxednumber)<br> boxed class to store validated Number payloads |
-| static class | [UnevaluatedpropertiesNotAffectedByPropertynames.UnevaluatedProperties](#unevaluatedproperties)<br> schema class |
+| data class | [UnevaluatedpropertiesNotAffectedByPropertynames.UnevaluatedPropertiesBoxedNumber](#unevaluatedpropertiesboxednumber)<br> boxed class to store validated Number payloads |
+| class | [UnevaluatedpropertiesNotAffectedByPropertynames.UnevaluatedProperties](#unevaluatedproperties)<br> schema class |
 | sealed interface | [UnevaluatedpropertiesNotAffectedByPropertynames.PropertyNamesBoxed](#propertynamesboxed)<br> sealed interface for validated payloads |
-| record | [UnevaluatedpropertiesNotAffectedByPropertynames.PropertyNamesBoxedString](#propertynamesboxedstring)<br> boxed class to store validated String payloads |
-| static class | [UnevaluatedpropertiesNotAffectedByPropertynames.PropertyNames](#propertynames)<br> schema class |
+| data class | [UnevaluatedpropertiesNotAffectedByPropertynames.PropertyNamesBoxedString](#propertynamesboxedstring)<br> boxed class to store validated String payloads |
+| class | [UnevaluatedpropertiesNotAffectedByPropertynames.PropertyNames](#propertynames)<br> schema class |
 
 ## UnevaluatedpropertiesNotAffectedByPropertynames1Boxed
 sealed interface UnevaluatedpropertiesNotAffectedByPropertynames1Boxed<br>
@@ -58,7 +58,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class UnevaluatedpropertiesNotAffectedByPropertynames1BoxedBoolean<br>
 implements [UnevaluatedpropertiesNotAffectedByPropertynames1Boxed](#unevaluatedpropertiesnotaffectedbypropertynames1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UnevaluatedpropertiesNotAffectedByPropertynames.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UnevaluatedpropertiesNotAffectedByPropertynames.md
@@ -156,19 +156,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [UnevaluatedpropertiesNotAffectedByPropertynames1BoxedString](#unevaluatedpropertiesnotaffectedbypropertynames1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [UnevaluatedpropertiesNotAffectedByPropertynames1BoxedVoid](#unevaluatedpropertiesnotaffectedbypropertynames1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [UnevaluatedpropertiesNotAffectedByPropertynames1BoxedNumber](#unevaluatedpropertiesnotaffectedbypropertynames1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [UnevaluatedpropertiesNotAffectedByPropertynames1BoxedBoolean](#unevaluatedpropertiesnotaffectedbypropertynames1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [UnevaluatedpropertiesNotAffectedByPropertynames1BoxedMap](#unevaluatedpropertiesnotaffectedbypropertynames1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [UnevaluatedpropertiesNotAffectedByPropertynames1BoxedBoolean](#unevaluatedpropertiesnotaffectedbypropertynames1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [UnevaluatedpropertiesNotAffectedByPropertynames1BoxedMap](#unevaluatedpropertiesnotaffectedbypropertynames1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [UnevaluatedpropertiesNotAffectedByPropertynames1BoxedList](#unevaluatedpropertiesnotaffectedbypropertynames1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [UnevaluatedpropertiesNotAffectedByPropertynames1Boxed](#unevaluatedpropertiesnotaffectedbypropertynames1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -240,32 +240,28 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.UnevaluatedpropertiesNotAffectedByPropertynames;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.UnevaluatedpropertiesNotAffectedByPropertynames
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // String validation
-String validatedPayload = UnevaluatedpropertiesNotAffectedByPropertynames.PropertyNames.validate(
+val validatedPayload: String = UnevaluatedpropertiesNotAffectedByPropertynames.PropertyNames.validate(
     "a",
     configuration
-);
+)
 ```
 
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
 | Set<Class<?>> | type = setOf(<br/>&nbsp;&nbsp;&nbsp;&nbsp;String::class.java<br/>)<br/> |
-| Integer | maxLength = 1 |
+| Int | maxLength = 1 |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UnevaluatedpropertiesSchema.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UnevaluatedpropertiesSchema.md
@@ -56,8 +56,8 @@ A schema class that validates payloads
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| FrozenMap<String, Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
-| [UnevaluatedpropertiesSchema1BoxedMap](#unevaluatedpropertiesschema1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| FrozenMap<String, Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
+| [UnevaluatedpropertiesSchema1BoxedMap](#unevaluatedpropertiesschema1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [UnevaluatedpropertiesSchema1Boxed](#unevaluatedpropertiesschema1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
 
@@ -93,32 +93,28 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.UnevaluatedpropertiesSchema;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.UnevaluatedpropertiesSchema
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // String validation
-String validatedPayload = UnevaluatedpropertiesSchema.UnevaluatedProperties.validate(
+val validatedPayload: String = UnevaluatedpropertiesSchema.UnevaluatedProperties.validate(
     "a",
     configuration
-);
+)
 ```
 
 ### Field Summary
 | Modifier and Type | Field and Description |
 | ----------------- | ---------------------- |
 | Set<Class<?>> | type = setOf(<br/>&nbsp;&nbsp;&nbsp;&nbsp;String::class.java<br/>)<br/> |
-| Integer | minLength = 3 |
+| Int | minLength = 3 |
 
 ### Method Summary
 | Modifier and Type | Method and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UnevaluatedpropertiesSchema.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UnevaluatedpropertiesSchema.md
@@ -11,11 +11,11 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [UnevaluatedpropertiesSchema.UnevaluatedpropertiesSchema1Boxed](#unevaluatedpropertiesschema1boxed)<br> sealed interface for validated payloads |
-| record | [UnevaluatedpropertiesSchema.UnevaluatedpropertiesSchema1BoxedMap](#unevaluatedpropertiesschema1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [UnevaluatedpropertiesSchema.UnevaluatedpropertiesSchema1](#unevaluatedpropertiesschema1)<br> schema class |
+| data class | [UnevaluatedpropertiesSchema.UnevaluatedpropertiesSchema1BoxedMap](#unevaluatedpropertiesschema1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [UnevaluatedpropertiesSchema.UnevaluatedpropertiesSchema1](#unevaluatedpropertiesschema1)<br> schema class |
 | sealed interface | [UnevaluatedpropertiesSchema.UnevaluatedPropertiesBoxed](#unevaluatedpropertiesboxed)<br> sealed interface for validated payloads |
-| record | [UnevaluatedpropertiesSchema.UnevaluatedPropertiesBoxedString](#unevaluatedpropertiesboxedstring)<br> boxed class to store validated String payloads |
-| static class | [UnevaluatedpropertiesSchema.UnevaluatedProperties](#unevaluatedproperties)<br> schema class |
+| data class | [UnevaluatedpropertiesSchema.UnevaluatedPropertiesBoxedString](#unevaluatedpropertiesboxedstring)<br> boxed class to store validated String payloads |
+| class | [UnevaluatedpropertiesSchema.UnevaluatedProperties](#unevaluatedproperties)<br> schema class |
 
 ## UnevaluatedpropertiesSchema1Boxed
 sealed interface UnevaluatedpropertiesSchema1Boxed<br>

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UnevaluatedpropertiesWithAdjacentAdditionalproperties.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UnevaluatedpropertiesWithAdjacentAdditionalproperties.md
@@ -69,29 +69,25 @@ A schema class that validates payloads
 
 ### Code Sample
 ```
-import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags;
-import org.openapijsonschematools.client.configurations.SchemaConfiguration;
-import org.openapijsonschematools.client.exceptions.ValidationException;
-import org.openapijsonschematools.client.schemas.validation.MapUtils;
-import org.openapijsonschematools.client.schemas.validation.FrozenList;
-import org.openapijsonschematools.client.schemas.validation.FrozenMap;
-import org.openapijsonschematools.client.components.schemas.UnevaluatedpropertiesWithAdjacentAdditionalproperties;
+import org.openapijsonschematools.client.configurations.JsonSchemaKeywordFlags
+import org.openapijsonschematools.client.configurations.SchemaConfiguration
+import org.openapijsonschematools.client.exceptions.ValidationException
+import org.openapijsonschematools.client.schemas.validation.MapUtils
+import org.openapijsonschematools.client.schemas.validation.FrozenList
+import org.openapijsonschematools.client.schemas.validation.FrozenMap
+import org.openapijsonschematools.client.components.schemas.UnevaluatedpropertiesWithAdjacentAdditionalproperties
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 
 // Map validation
-UnevaluatedpropertiesWithAdjacentAdditionalproperties.UnevaluatedpropertiesWithAdjacentAdditionalpropertiesMap validatedPayload =
+val validatedPayload: UnevaluatedpropertiesWithAdjacentAdditionalproperties.UnevaluatedpropertiesWithAdjacentAdditionalpropertiesMap =
     UnevaluatedpropertiesWithAdjacentAdditionalproperties.UnevaluatedpropertiesWithAdjacentAdditionalproperties1.validate(
-    new UnevaluatedpropertiesWithAdjacentAdditionalproperties.UnevaluatedpropertiesWithAdjacentAdditionalpropertiesMapBuilder()
+    UnevaluatedpropertiesWithAdjacentAdditionalproperties.UnevaluatedpropertiesWithAdjacentAdditionalpropertiesMapBuilder()
         .foo("a")
 
     .build(),
     configuration
-);
+)
 ```
 
 ### Field Summary
@@ -105,8 +101,8 @@ UnevaluatedpropertiesWithAdjacentAdditionalproperties.UnevaluatedpropertiesWithA
 ### Method Summary
 | Modifier and Type | Method and Description |
 | ----------------- | ---------------------- |
-| [UnevaluatedpropertiesWithAdjacentAdditionalpropertiesMap](#unevaluatedpropertieswithadjacentadditionalpropertiesmap) | validate(arg: [Map&lt;?, ?&gt;](#unevaluatedpropertieswithadjacentadditionalpropertiesmapbuilder), configuration: SchemaConfiguration) |
-| [UnevaluatedpropertiesWithAdjacentAdditionalproperties1BoxedMap](#unevaluatedpropertieswithadjacentadditionalproperties1boxedmap) | validateAndBox([Map&lt;?, ?&gt;](#unevaluatedpropertieswithadjacentadditionalpropertiesmapbuilder), configuration: SchemaConfiguration) |
+| [UnevaluatedpropertiesWithAdjacentAdditionalpropertiesMap](#unevaluatedpropertieswithadjacentadditionalpropertiesmap) | validate(arg: [Map&lt;*, *&gt;](#unevaluatedpropertieswithadjacentadditionalpropertiesmapbuilder), configuration: SchemaConfiguration) |
+| [UnevaluatedpropertiesWithAdjacentAdditionalproperties1BoxedMap](#unevaluatedpropertieswithadjacentadditionalproperties1boxedmap) | validateAndBox([Map&lt;*, *&gt;](#unevaluatedpropertieswithadjacentadditionalpropertiesmapbuilder), configuration: SchemaConfiguration) |
 | [UnevaluatedpropertiesWithAdjacentAdditionalproperties1Boxed](#unevaluatedpropertieswithadjacentadditionalproperties1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
 

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UnevaluatedpropertiesWithAdjacentAdditionalproperties.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UnevaluatedpropertiesWithAdjacentAdditionalproperties.md
@@ -13,29 +13,29 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.UnevaluatedpropertiesWithAdjacentAdditionalproperties1Boxed](#unevaluatedpropertieswithadjacentadditionalproperties1boxed)<br> sealed interface for validated payloads |
-| record | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.UnevaluatedpropertiesWithAdjacentAdditionalproperties1BoxedMap](#unevaluatedpropertieswithadjacentadditionalproperties1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.UnevaluatedpropertiesWithAdjacentAdditionalproperties1](#unevaluatedpropertieswithadjacentadditionalproperties1)<br> schema class |
+| data class | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.UnevaluatedpropertiesWithAdjacentAdditionalproperties1BoxedMap](#unevaluatedpropertieswithadjacentadditionalproperties1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.UnevaluatedpropertiesWithAdjacentAdditionalproperties1](#unevaluatedpropertieswithadjacentadditionalproperties1)<br> schema class |
 | sealed interface | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.UnevaluatedPropertiesBoxed](#unevaluatedpropertiesboxed)<br> sealed interface for validated payloads |
-| record | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.UnevaluatedPropertiesBoxedVoid](#unevaluatedpropertiesboxedvoid)<br> boxed class to store validated null payloads |
-| record | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.UnevaluatedPropertiesBoxedBoolean](#unevaluatedpropertiesboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.UnevaluatedPropertiesBoxedNumber](#unevaluatedpropertiesboxednumber)<br> boxed class to store validated Number payloads |
-| record | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.UnevaluatedPropertiesBoxedString](#unevaluatedpropertiesboxedstring)<br> boxed class to store validated String payloads |
-| record | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.UnevaluatedPropertiesBoxedList](#unevaluatedpropertiesboxedlist)<br> boxed class to store validated List payloads |
-| record | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.UnevaluatedPropertiesBoxedMap](#unevaluatedpropertiesboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.UnevaluatedProperties](#unevaluatedproperties)<br> schema class |
-| static class | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.UnevaluatedpropertiesWithAdjacentAdditionalpropertiesMapBuilder](#unevaluatedpropertieswithadjacentadditionalpropertiesmapbuilder)<br> builder for Map payloads |
-| static class | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.UnevaluatedpropertiesWithAdjacentAdditionalpropertiesMap](#unevaluatedpropertieswithadjacentadditionalpropertiesmap)<br> output class for Map payloads |
+| data class | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.UnevaluatedPropertiesBoxedVoid](#unevaluatedpropertiesboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.UnevaluatedPropertiesBoxedBoolean](#unevaluatedpropertiesboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.UnevaluatedPropertiesBoxedNumber](#unevaluatedpropertiesboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.UnevaluatedPropertiesBoxedString](#unevaluatedpropertiesboxedstring)<br> boxed class to store validated String payloads |
+| data class | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.UnevaluatedPropertiesBoxedList](#unevaluatedpropertiesboxedlist)<br> boxed class to store validated List payloads |
+| data class | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.UnevaluatedPropertiesBoxedMap](#unevaluatedpropertiesboxedmap)<br> boxed class to store validated Map payloads |
+| class | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.UnevaluatedProperties](#unevaluatedproperties)<br> schema class |
+| class | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.UnevaluatedpropertiesWithAdjacentAdditionalpropertiesMapBuilder](#unevaluatedpropertieswithadjacentadditionalpropertiesmapbuilder)<br> builder for Map payloads |
+| class | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.UnevaluatedpropertiesWithAdjacentAdditionalpropertiesMap](#unevaluatedpropertieswithadjacentadditionalpropertiesmap)<br> output class for Map payloads |
 | sealed interface | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.FooBoxed](#fooboxed)<br> sealed interface for validated payloads |
-| record | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
-| static class | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.Foo](#foo)<br> schema class |
+| data class | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.FooBoxedString](#fooboxedstring)<br> boxed class to store validated String payloads |
+| class | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.Foo](#foo)<br> schema class |
 | sealed interface | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.AdditionalPropertiesBoxed](#additionalpropertiesboxed)<br> sealed interface for validated payloads |
-| record | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.AdditionalPropertiesBoxedVoid](#additionalpropertiesboxedvoid)<br> boxed class to store validated null payloads |
-| record | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.AdditionalPropertiesBoxedBoolean](#additionalpropertiesboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.AdditionalPropertiesBoxedNumber](#additionalpropertiesboxednumber)<br> boxed class to store validated Number payloads |
-| record | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.AdditionalPropertiesBoxedString](#additionalpropertiesboxedstring)<br> boxed class to store validated String payloads |
-| record | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.AdditionalPropertiesBoxedList](#additionalpropertiesboxedlist)<br> boxed class to store validated List payloads |
-| record | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.AdditionalPropertiesBoxedMap](#additionalpropertiesboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.AdditionalProperties](#additionalproperties)<br> schema class |
+| data class | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.AdditionalPropertiesBoxedVoid](#additionalpropertiesboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.AdditionalPropertiesBoxedBoolean](#additionalpropertiesboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.AdditionalPropertiesBoxedNumber](#additionalpropertiesboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.AdditionalPropertiesBoxedString](#additionalpropertiesboxedstring)<br> boxed class to store validated String payloads |
+| data class | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.AdditionalPropertiesBoxedList](#additionalpropertiesboxedlist)<br> boxed class to store validated List payloads |
+| data class | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.AdditionalPropertiesBoxedMap](#additionalpropertiesboxedmap)<br> boxed class to store validated Map payloads |
+| class | [UnevaluatedpropertiesWithAdjacentAdditionalproperties.AdditionalProperties](#additionalproperties)<br> schema class |
 
 ## UnevaluatedpropertiesWithAdjacentAdditionalproperties1Boxed
 sealed interface UnevaluatedpropertiesWithAdjacentAdditionalproperties1Boxed<br>
@@ -139,7 +139,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class UnevaluatedPropertiesBoxedBoolean<br>
 implements [UnevaluatedPropertiesBoxed](#unevaluatedpropertiesboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -338,7 +338,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class AdditionalPropertiesBoxedBoolean<br>
 implements [AdditionalPropertiesBoxed](#additionalpropertiesboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UnevaluatedpropertiesWithNullValuedInstanceProperties.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UnevaluatedpropertiesWithNullValuedInstanceProperties.md
@@ -152,19 +152,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [UnevaluatedpropertiesWithNullValuedInstanceProperties1BoxedString](#unevaluatedpropertieswithnullvaluedinstanceproperties1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [UnevaluatedpropertiesWithNullValuedInstanceProperties1BoxedVoid](#unevaluatedpropertieswithnullvaluedinstanceproperties1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [UnevaluatedpropertiesWithNullValuedInstanceProperties1BoxedNumber](#unevaluatedpropertieswithnullvaluedinstanceproperties1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [UnevaluatedpropertiesWithNullValuedInstanceProperties1BoxedBoolean](#unevaluatedpropertieswithnullvaluedinstanceproperties1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [UnevaluatedpropertiesWithNullValuedInstanceProperties1BoxedMap](#unevaluatedpropertieswithnullvaluedinstanceproperties1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [UnevaluatedpropertiesWithNullValuedInstanceProperties1BoxedBoolean](#unevaluatedpropertieswithnullvaluedinstanceproperties1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [UnevaluatedpropertiesWithNullValuedInstanceProperties1BoxedMap](#unevaluatedpropertieswithnullvaluedinstanceproperties1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [UnevaluatedpropertiesWithNullValuedInstanceProperties1BoxedList](#unevaluatedpropertieswithnullvaluedinstanceproperties1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [UnevaluatedpropertiesWithNullValuedInstanceProperties1Boxed](#unevaluatedpropertieswithnullvaluedinstanceproperties1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UnevaluatedpropertiesWithNullValuedInstanceProperties.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UnevaluatedpropertiesWithNullValuedInstanceProperties.md
@@ -11,16 +11,16 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [UnevaluatedpropertiesWithNullValuedInstanceProperties.UnevaluatedpropertiesWithNullValuedInstanceProperties1Boxed](#unevaluatedpropertieswithnullvaluedinstanceproperties1boxed)<br> sealed interface for validated payloads |
-| record | [UnevaluatedpropertiesWithNullValuedInstanceProperties.UnevaluatedpropertiesWithNullValuedInstanceProperties1BoxedVoid](#unevaluatedpropertieswithnullvaluedinstanceproperties1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [UnevaluatedpropertiesWithNullValuedInstanceProperties.UnevaluatedpropertiesWithNullValuedInstanceProperties1BoxedBoolean](#unevaluatedpropertieswithnullvaluedinstanceproperties1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [UnevaluatedpropertiesWithNullValuedInstanceProperties.UnevaluatedpropertiesWithNullValuedInstanceProperties1BoxedNumber](#unevaluatedpropertieswithnullvaluedinstanceproperties1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [UnevaluatedpropertiesWithNullValuedInstanceProperties.UnevaluatedpropertiesWithNullValuedInstanceProperties1BoxedString](#unevaluatedpropertieswithnullvaluedinstanceproperties1boxedstring)<br> boxed class to store validated String payloads |
-| record | [UnevaluatedpropertiesWithNullValuedInstanceProperties.UnevaluatedpropertiesWithNullValuedInstanceProperties1BoxedList](#unevaluatedpropertieswithnullvaluedinstanceproperties1boxedlist)<br> boxed class to store validated List payloads |
-| record | [UnevaluatedpropertiesWithNullValuedInstanceProperties.UnevaluatedpropertiesWithNullValuedInstanceProperties1BoxedMap](#unevaluatedpropertieswithnullvaluedinstanceproperties1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [UnevaluatedpropertiesWithNullValuedInstanceProperties.UnevaluatedpropertiesWithNullValuedInstanceProperties1](#unevaluatedpropertieswithnullvaluedinstanceproperties1)<br> schema class |
+| data class | [UnevaluatedpropertiesWithNullValuedInstanceProperties.UnevaluatedpropertiesWithNullValuedInstanceProperties1BoxedVoid](#unevaluatedpropertieswithnullvaluedinstanceproperties1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [UnevaluatedpropertiesWithNullValuedInstanceProperties.UnevaluatedpropertiesWithNullValuedInstanceProperties1BoxedBoolean](#unevaluatedpropertieswithnullvaluedinstanceproperties1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [UnevaluatedpropertiesWithNullValuedInstanceProperties.UnevaluatedpropertiesWithNullValuedInstanceProperties1BoxedNumber](#unevaluatedpropertieswithnullvaluedinstanceproperties1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [UnevaluatedpropertiesWithNullValuedInstanceProperties.UnevaluatedpropertiesWithNullValuedInstanceProperties1BoxedString](#unevaluatedpropertieswithnullvaluedinstanceproperties1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [UnevaluatedpropertiesWithNullValuedInstanceProperties.UnevaluatedpropertiesWithNullValuedInstanceProperties1BoxedList](#unevaluatedpropertieswithnullvaluedinstanceproperties1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [UnevaluatedpropertiesWithNullValuedInstanceProperties.UnevaluatedpropertiesWithNullValuedInstanceProperties1BoxedMap](#unevaluatedpropertieswithnullvaluedinstanceproperties1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [UnevaluatedpropertiesWithNullValuedInstanceProperties.UnevaluatedpropertiesWithNullValuedInstanceProperties1](#unevaluatedpropertieswithnullvaluedinstanceproperties1)<br> schema class |
 | sealed interface | [UnevaluatedpropertiesWithNullValuedInstanceProperties.UnevaluatedPropertiesBoxed](#unevaluatedpropertiesboxed)<br> sealed interface for validated payloads |
-| record | [UnevaluatedpropertiesWithNullValuedInstanceProperties.UnevaluatedPropertiesBoxedVoid](#unevaluatedpropertiesboxedvoid)<br> boxed class to store validated null payloads |
-| static class | [UnevaluatedpropertiesWithNullValuedInstanceProperties.UnevaluatedProperties](#unevaluatedproperties)<br> schema class |
+| data class | [UnevaluatedpropertiesWithNullValuedInstanceProperties.UnevaluatedPropertiesBoxedVoid](#unevaluatedpropertiesboxedvoid)<br> boxed class to store validated null payloads |
+| class | [UnevaluatedpropertiesWithNullValuedInstanceProperties.UnevaluatedProperties](#unevaluatedproperties)<br> schema class |
 
 ## UnevaluatedpropertiesWithNullValuedInstanceProperties1Boxed
 sealed interface UnevaluatedpropertiesWithNullValuedInstanceProperties1Boxed<br>
@@ -55,7 +55,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class UnevaluatedpropertiesWithNullValuedInstanceProperties1BoxedBoolean<br>
 implements [UnevaluatedpropertiesWithNullValuedInstanceProperties1Boxed](#unevaluatedpropertieswithnullvaluedinstanceproperties1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UniqueitemsFalseValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UniqueitemsFalseValidation.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [UniqueitemsFalseValidation1BoxedString](#uniqueitemsfalsevalidation1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [UniqueitemsFalseValidation1BoxedVoid](#uniqueitemsfalsevalidation1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [UniqueitemsFalseValidation1BoxedNumber](#uniqueitemsfalsevalidation1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [UniqueitemsFalseValidation1BoxedBoolean](#uniqueitemsfalsevalidation1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [UniqueitemsFalseValidation1BoxedMap](#uniqueitemsfalsevalidation1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [UniqueitemsFalseValidation1BoxedBoolean](#uniqueitemsfalsevalidation1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [UniqueitemsFalseValidation1BoxedMap](#uniqueitemsfalsevalidation1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [UniqueitemsFalseValidation1BoxedList](#uniqueitemsfalsevalidation1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [UniqueitemsFalseValidation1Boxed](#uniqueitemsfalsevalidation1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UniqueitemsFalseValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UniqueitemsFalseValidation.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [UniqueitemsFalseValidation.UniqueitemsFalseValidation1Boxed](#uniqueitemsfalsevalidation1boxed)<br> sealed interface for validated payloads |
-| record | [UniqueitemsFalseValidation.UniqueitemsFalseValidation1BoxedVoid](#uniqueitemsfalsevalidation1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [UniqueitemsFalseValidation.UniqueitemsFalseValidation1BoxedBoolean](#uniqueitemsfalsevalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [UniqueitemsFalseValidation.UniqueitemsFalseValidation1BoxedNumber](#uniqueitemsfalsevalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [UniqueitemsFalseValidation.UniqueitemsFalseValidation1BoxedString](#uniqueitemsfalsevalidation1boxedstring)<br> boxed class to store validated String payloads |
-| record | [UniqueitemsFalseValidation.UniqueitemsFalseValidation1BoxedList](#uniqueitemsfalsevalidation1boxedlist)<br> boxed class to store validated List payloads |
-| record | [UniqueitemsFalseValidation.UniqueitemsFalseValidation1BoxedMap](#uniqueitemsfalsevalidation1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [UniqueitemsFalseValidation.UniqueitemsFalseValidation1](#uniqueitemsfalsevalidation1)<br> schema class |
+| data class | [UniqueitemsFalseValidation.UniqueitemsFalseValidation1BoxedVoid](#uniqueitemsfalsevalidation1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [UniqueitemsFalseValidation.UniqueitemsFalseValidation1BoxedBoolean](#uniqueitemsfalsevalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [UniqueitemsFalseValidation.UniqueitemsFalseValidation1BoxedNumber](#uniqueitemsfalsevalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [UniqueitemsFalseValidation.UniqueitemsFalseValidation1BoxedString](#uniqueitemsfalsevalidation1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [UniqueitemsFalseValidation.UniqueitemsFalseValidation1BoxedList](#uniqueitemsfalsevalidation1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [UniqueitemsFalseValidation.UniqueitemsFalseValidation1BoxedMap](#uniqueitemsfalsevalidation1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [UniqueitemsFalseValidation.UniqueitemsFalseValidation1](#uniqueitemsfalsevalidation1)<br> schema class |
 
 ## UniqueitemsFalseValidation1Boxed
 sealed interface UniqueitemsFalseValidation1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class UniqueitemsFalseValidation1BoxedBoolean<br>
 implements [UniqueitemsFalseValidation1Boxed](#uniqueitemsfalsevalidation1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UniqueitemsFalseWithAnArrayOfItems.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UniqueitemsFalseWithAnArrayOfItems.md
@@ -13,21 +13,21 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [UniqueitemsFalseWithAnArrayOfItems.UniqueitemsFalseWithAnArrayOfItems1Boxed](#uniqueitemsfalsewithanarrayofitems1boxed)<br> sealed interface for validated payloads |
-| record | [UniqueitemsFalseWithAnArrayOfItems.UniqueitemsFalseWithAnArrayOfItems1BoxedVoid](#uniqueitemsfalsewithanarrayofitems1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [UniqueitemsFalseWithAnArrayOfItems.UniqueitemsFalseWithAnArrayOfItems1BoxedBoolean](#uniqueitemsfalsewithanarrayofitems1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [UniqueitemsFalseWithAnArrayOfItems.UniqueitemsFalseWithAnArrayOfItems1BoxedNumber](#uniqueitemsfalsewithanarrayofitems1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [UniqueitemsFalseWithAnArrayOfItems.UniqueitemsFalseWithAnArrayOfItems1BoxedString](#uniqueitemsfalsewithanarrayofitems1boxedstring)<br> boxed class to store validated String payloads |
-| record | [UniqueitemsFalseWithAnArrayOfItems.UniqueitemsFalseWithAnArrayOfItems1BoxedList](#uniqueitemsfalsewithanarrayofitems1boxedlist)<br> boxed class to store validated List payloads |
-| record | [UniqueitemsFalseWithAnArrayOfItems.UniqueitemsFalseWithAnArrayOfItems1BoxedMap](#uniqueitemsfalsewithanarrayofitems1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [UniqueitemsFalseWithAnArrayOfItems.UniqueitemsFalseWithAnArrayOfItems1](#uniqueitemsfalsewithanarrayofitems1)<br> schema class |
+| data class | [UniqueitemsFalseWithAnArrayOfItems.UniqueitemsFalseWithAnArrayOfItems1BoxedVoid](#uniqueitemsfalsewithanarrayofitems1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [UniqueitemsFalseWithAnArrayOfItems.UniqueitemsFalseWithAnArrayOfItems1BoxedBoolean](#uniqueitemsfalsewithanarrayofitems1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [UniqueitemsFalseWithAnArrayOfItems.UniqueitemsFalseWithAnArrayOfItems1BoxedNumber](#uniqueitemsfalsewithanarrayofitems1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [UniqueitemsFalseWithAnArrayOfItems.UniqueitemsFalseWithAnArrayOfItems1BoxedString](#uniqueitemsfalsewithanarrayofitems1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [UniqueitemsFalseWithAnArrayOfItems.UniqueitemsFalseWithAnArrayOfItems1BoxedList](#uniqueitemsfalsewithanarrayofitems1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [UniqueitemsFalseWithAnArrayOfItems.UniqueitemsFalseWithAnArrayOfItems1BoxedMap](#uniqueitemsfalsewithanarrayofitems1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [UniqueitemsFalseWithAnArrayOfItems.UniqueitemsFalseWithAnArrayOfItems1](#uniqueitemsfalsewithanarrayofitems1)<br> schema class |
 | sealed interface | [UniqueitemsFalseWithAnArrayOfItems.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [UniqueitemsFalseWithAnArrayOfItems.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| static class | [UniqueitemsFalseWithAnArrayOfItems.Schema1](#schema1)<br> schema class |
+| data class | [UniqueitemsFalseWithAnArrayOfItems.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| class | [UniqueitemsFalseWithAnArrayOfItems.Schema1](#schema1)<br> schema class |
 | sealed interface | [UniqueitemsFalseWithAnArrayOfItems.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [UniqueitemsFalseWithAnArrayOfItems.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| static class | [UniqueitemsFalseWithAnArrayOfItems.Schema0](#schema0)<br> schema class |
-| static class | [UniqueitemsFalseWithAnArrayOfItems.UniqueitemsFalseWithAnArrayOfItemsListBuilder](#uniqueitemsfalsewithanarrayofitemslistbuilder)<br> builder for List payloads |
-| static class | [UniqueitemsFalseWithAnArrayOfItems.UniqueitemsFalseWithAnArrayOfItemsList](#uniqueitemsfalsewithanarrayofitemslist)<br> output class for List payloads |
+| data class | [UniqueitemsFalseWithAnArrayOfItems.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| class | [UniqueitemsFalseWithAnArrayOfItems.Schema0](#schema0)<br> schema class |
+| class | [UniqueitemsFalseWithAnArrayOfItems.UniqueitemsFalseWithAnArrayOfItemsListBuilder](#uniqueitemsfalsewithanarrayofitemslistbuilder)<br> builder for List payloads |
+| class | [UniqueitemsFalseWithAnArrayOfItems.UniqueitemsFalseWithAnArrayOfItemsList](#uniqueitemsfalsewithanarrayofitemslist)<br> output class for List payloads |
 
 ## UniqueitemsFalseWithAnArrayOfItems1Boxed
 sealed interface UniqueitemsFalseWithAnArrayOfItems1Boxed<br>
@@ -62,7 +62,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class UniqueitemsFalseWithAnArrayOfItems1BoxedBoolean<br>
 implements [UniqueitemsFalseWithAnArrayOfItems1Boxed](#uniqueitemsfalsewithanarrayofitems1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -188,7 +188,7 @@ sealed interface that stores validated payloads using boxed classes
 data class Schema1BoxedBoolean<br>
 implements [Schema1Boxed](#schema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -223,7 +223,7 @@ sealed interface that stores validated payloads using boxed classes
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UniqueitemsFalseWithAnArrayOfItems.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UniqueitemsFalseWithAnArrayOfItems.md
@@ -160,19 +160,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [UniqueitemsFalseWithAnArrayOfItemsList](#uniqueitemsfalsewithanarrayofitemslist) | validate(arg: [List<*>](#uniqueitemsfalsewithanarrayofitemslistbuilder), configuration: SchemaConfiguration) |
 | [UniqueitemsFalseWithAnArrayOfItems1BoxedString](#uniqueitemsfalsewithanarrayofitems1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [UniqueitemsFalseWithAnArrayOfItems1BoxedVoid](#uniqueitemsfalsewithanarrayofitems1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [UniqueitemsFalseWithAnArrayOfItems1BoxedNumber](#uniqueitemsfalsewithanarrayofitems1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [UniqueitemsFalseWithAnArrayOfItems1BoxedBoolean](#uniqueitemsfalsewithanarrayofitems1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [UniqueitemsFalseWithAnArrayOfItems1BoxedMap](#uniqueitemsfalsewithanarrayofitems1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [UniqueitemsFalseWithAnArrayOfItems1BoxedBoolean](#uniqueitemsfalsewithanarrayofitems1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [UniqueitemsFalseWithAnArrayOfItems1BoxedMap](#uniqueitemsfalsewithanarrayofitems1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [UniqueitemsFalseWithAnArrayOfItems1BoxedList](#uniqueitemsfalsewithanarrayofitems1boxedlist) | validateAndBox([List<*>](#uniqueitemsfalsewithanarrayofitemslistbuilder), configuration: SchemaConfiguration) |
 | [UniqueitemsFalseWithAnArrayOfItems1Boxed](#uniqueitemsfalsewithanarrayofitems1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UniqueitemsValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UniqueitemsValidation.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [UniqueitemsValidation.UniqueitemsValidation1Boxed](#uniqueitemsvalidation1boxed)<br> sealed interface for validated payloads |
-| record | [UniqueitemsValidation.UniqueitemsValidation1BoxedVoid](#uniqueitemsvalidation1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [UniqueitemsValidation.UniqueitemsValidation1BoxedBoolean](#uniqueitemsvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [UniqueitemsValidation.UniqueitemsValidation1BoxedNumber](#uniqueitemsvalidation1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [UniqueitemsValidation.UniqueitemsValidation1BoxedString](#uniqueitemsvalidation1boxedstring)<br> boxed class to store validated String payloads |
-| record | [UniqueitemsValidation.UniqueitemsValidation1BoxedList](#uniqueitemsvalidation1boxedlist)<br> boxed class to store validated List payloads |
-| record | [UniqueitemsValidation.UniqueitemsValidation1BoxedMap](#uniqueitemsvalidation1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [UniqueitemsValidation.UniqueitemsValidation1](#uniqueitemsvalidation1)<br> schema class |
+| data class | [UniqueitemsValidation.UniqueitemsValidation1BoxedVoid](#uniqueitemsvalidation1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [UniqueitemsValidation.UniqueitemsValidation1BoxedBoolean](#uniqueitemsvalidation1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [UniqueitemsValidation.UniqueitemsValidation1BoxedNumber](#uniqueitemsvalidation1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [UniqueitemsValidation.UniqueitemsValidation1BoxedString](#uniqueitemsvalidation1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [UniqueitemsValidation.UniqueitemsValidation1BoxedList](#uniqueitemsvalidation1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [UniqueitemsValidation.UniqueitemsValidation1BoxedMap](#uniqueitemsvalidation1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [UniqueitemsValidation.UniqueitemsValidation1](#uniqueitemsvalidation1)<br> schema class |
 
 ## UniqueitemsValidation1Boxed
 sealed interface UniqueitemsValidation1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class UniqueitemsValidation1BoxedBoolean<br>
 implements [UniqueitemsValidation1Boxed](#uniqueitemsvalidation1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UniqueitemsValidation.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UniqueitemsValidation.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [UniqueitemsValidation1BoxedString](#uniqueitemsvalidation1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [UniqueitemsValidation1BoxedVoid](#uniqueitemsvalidation1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [UniqueitemsValidation1BoxedNumber](#uniqueitemsvalidation1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [UniqueitemsValidation1BoxedBoolean](#uniqueitemsvalidation1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [UniqueitemsValidation1BoxedMap](#uniqueitemsvalidation1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [UniqueitemsValidation1BoxedBoolean](#uniqueitemsvalidation1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [UniqueitemsValidation1BoxedMap](#uniqueitemsvalidation1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [UniqueitemsValidation1BoxedList](#uniqueitemsvalidation1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [UniqueitemsValidation1Boxed](#uniqueitemsvalidation1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UniqueitemsWithAnArrayOfItems.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UniqueitemsWithAnArrayOfItems.md
@@ -13,21 +13,21 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [UniqueitemsWithAnArrayOfItems.UniqueitemsWithAnArrayOfItems1Boxed](#uniqueitemswithanarrayofitems1boxed)<br> sealed interface for validated payloads |
-| record | [UniqueitemsWithAnArrayOfItems.UniqueitemsWithAnArrayOfItems1BoxedVoid](#uniqueitemswithanarrayofitems1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [UniqueitemsWithAnArrayOfItems.UniqueitemsWithAnArrayOfItems1BoxedBoolean](#uniqueitemswithanarrayofitems1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [UniqueitemsWithAnArrayOfItems.UniqueitemsWithAnArrayOfItems1BoxedNumber](#uniqueitemswithanarrayofitems1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [UniqueitemsWithAnArrayOfItems.UniqueitemsWithAnArrayOfItems1BoxedString](#uniqueitemswithanarrayofitems1boxedstring)<br> boxed class to store validated String payloads |
-| record | [UniqueitemsWithAnArrayOfItems.UniqueitemsWithAnArrayOfItems1BoxedList](#uniqueitemswithanarrayofitems1boxedlist)<br> boxed class to store validated List payloads |
-| record | [UniqueitemsWithAnArrayOfItems.UniqueitemsWithAnArrayOfItems1BoxedMap](#uniqueitemswithanarrayofitems1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [UniqueitemsWithAnArrayOfItems.UniqueitemsWithAnArrayOfItems1](#uniqueitemswithanarrayofitems1)<br> schema class |
+| data class | [UniqueitemsWithAnArrayOfItems.UniqueitemsWithAnArrayOfItems1BoxedVoid](#uniqueitemswithanarrayofitems1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [UniqueitemsWithAnArrayOfItems.UniqueitemsWithAnArrayOfItems1BoxedBoolean](#uniqueitemswithanarrayofitems1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [UniqueitemsWithAnArrayOfItems.UniqueitemsWithAnArrayOfItems1BoxedNumber](#uniqueitemswithanarrayofitems1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [UniqueitemsWithAnArrayOfItems.UniqueitemsWithAnArrayOfItems1BoxedString](#uniqueitemswithanarrayofitems1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [UniqueitemsWithAnArrayOfItems.UniqueitemsWithAnArrayOfItems1BoxedList](#uniqueitemswithanarrayofitems1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [UniqueitemsWithAnArrayOfItems.UniqueitemsWithAnArrayOfItems1BoxedMap](#uniqueitemswithanarrayofitems1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [UniqueitemsWithAnArrayOfItems.UniqueitemsWithAnArrayOfItems1](#uniqueitemswithanarrayofitems1)<br> schema class |
 | sealed interface | [UniqueitemsWithAnArrayOfItems.Schema1Boxed](#schema1boxed)<br> sealed interface for validated payloads |
-| record | [UniqueitemsWithAnArrayOfItems.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
-| static class | [UniqueitemsWithAnArrayOfItems.Schema1](#schema1)<br> schema class |
+| data class | [UniqueitemsWithAnArrayOfItems.Schema1BoxedBoolean](#schema1boxedboolean)<br> boxed class to store validated boolean payloads |
+| class | [UniqueitemsWithAnArrayOfItems.Schema1](#schema1)<br> schema class |
 | sealed interface | [UniqueitemsWithAnArrayOfItems.Schema0Boxed](#schema0boxed)<br> sealed interface for validated payloads |
-| record | [UniqueitemsWithAnArrayOfItems.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
-| static class | [UniqueitemsWithAnArrayOfItems.Schema0](#schema0)<br> schema class |
-| static class | [UniqueitemsWithAnArrayOfItems.UniqueitemsWithAnArrayOfItemsListBuilder](#uniqueitemswithanarrayofitemslistbuilder)<br> builder for List payloads |
-| static class | [UniqueitemsWithAnArrayOfItems.UniqueitemsWithAnArrayOfItemsList](#uniqueitemswithanarrayofitemslist)<br> output class for List payloads |
+| data class | [UniqueitemsWithAnArrayOfItems.Schema0BoxedBoolean](#schema0boxedboolean)<br> boxed class to store validated boolean payloads |
+| class | [UniqueitemsWithAnArrayOfItems.Schema0](#schema0)<br> schema class |
+| class | [UniqueitemsWithAnArrayOfItems.UniqueitemsWithAnArrayOfItemsListBuilder](#uniqueitemswithanarrayofitemslistbuilder)<br> builder for List payloads |
+| class | [UniqueitemsWithAnArrayOfItems.UniqueitemsWithAnArrayOfItemsList](#uniqueitemswithanarrayofitemslist)<br> output class for List payloads |
 
 ## UniqueitemsWithAnArrayOfItems1Boxed
 sealed interface UniqueitemsWithAnArrayOfItems1Boxed<br>
@@ -62,7 +62,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class UniqueitemsWithAnArrayOfItems1BoxedBoolean<br>
 implements [UniqueitemsWithAnArrayOfItems1Boxed](#uniqueitemswithanarrayofitems1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -188,7 +188,7 @@ sealed interface that stores validated payloads using boxed classes
 data class Schema1BoxedBoolean<br>
 implements [Schema1Boxed](#schema1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -223,7 +223,7 @@ sealed interface that stores validated payloads using boxed classes
 data class Schema0BoxedBoolean<br>
 implements [Schema0Boxed](#schema0boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UniqueitemsWithAnArrayOfItems.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UniqueitemsWithAnArrayOfItems.md
@@ -160,19 +160,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [UniqueitemsWithAnArrayOfItemsList](#uniqueitemswithanarrayofitemslist) | validate(arg: [List<*>](#uniqueitemswithanarrayofitemslistbuilder), configuration: SchemaConfiguration) |
 | [UniqueitemsWithAnArrayOfItems1BoxedString](#uniqueitemswithanarrayofitems1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [UniqueitemsWithAnArrayOfItems1BoxedVoid](#uniqueitemswithanarrayofitems1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [UniqueitemsWithAnArrayOfItems1BoxedNumber](#uniqueitemswithanarrayofitems1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [UniqueitemsWithAnArrayOfItems1BoxedBoolean](#uniqueitemswithanarrayofitems1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [UniqueitemsWithAnArrayOfItems1BoxedMap](#uniqueitemswithanarrayofitems1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [UniqueitemsWithAnArrayOfItems1BoxedBoolean](#uniqueitemswithanarrayofitems1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [UniqueitemsWithAnArrayOfItems1BoxedMap](#uniqueitemswithanarrayofitems1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [UniqueitemsWithAnArrayOfItems1BoxedList](#uniqueitemswithanarrayofitems1boxedlist) | validateAndBox([List<*>](#uniqueitemswithanarrayofitemslistbuilder), configuration: SchemaConfiguration) |
 | [UniqueitemsWithAnArrayOfItems1Boxed](#uniqueitemswithanarrayofitems1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UriFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UriFormat.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [UriFormat.UriFormat1Boxed](#uriformat1boxed)<br> sealed interface for validated payloads |
-| record | [UriFormat.UriFormat1BoxedVoid](#uriformat1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [UriFormat.UriFormat1BoxedBoolean](#uriformat1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [UriFormat.UriFormat1BoxedNumber](#uriformat1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [UriFormat.UriFormat1BoxedString](#uriformat1boxedstring)<br> boxed class to store validated String payloads |
-| record | [UriFormat.UriFormat1BoxedList](#uriformat1boxedlist)<br> boxed class to store validated List payloads |
-| record | [UriFormat.UriFormat1BoxedMap](#uriformat1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [UriFormat.UriFormat1](#uriformat1)<br> schema class |
+| data class | [UriFormat.UriFormat1BoxedVoid](#uriformat1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [UriFormat.UriFormat1BoxedBoolean](#uriformat1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [UriFormat.UriFormat1BoxedNumber](#uriformat1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [UriFormat.UriFormat1BoxedString](#uriformat1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [UriFormat.UriFormat1BoxedList](#uriformat1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [UriFormat.UriFormat1BoxedMap](#uriformat1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [UriFormat.UriFormat1](#uriformat1)<br> schema class |
 
 ## UriFormat1Boxed
 sealed interface UriFormat1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class UriFormat1BoxedBoolean<br>
 implements [UriFormat1Boxed](#uriformat1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UriFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UriFormat.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [UriFormat1BoxedString](#uriformat1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [UriFormat1BoxedVoid](#uriformat1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [UriFormat1BoxedNumber](#uriformat1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [UriFormat1BoxedBoolean](#uriformat1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [UriFormat1BoxedMap](#uriformat1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [UriFormat1BoxedBoolean](#uriformat1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [UriFormat1BoxedMap](#uriformat1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [UriFormat1BoxedList](#uriformat1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [UriFormat1Boxed](#uriformat1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UriReferenceFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UriReferenceFormat.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [UriReferenceFormat1BoxedString](#urireferenceformat1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [UriReferenceFormat1BoxedVoid](#urireferenceformat1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [UriReferenceFormat1BoxedNumber](#urireferenceformat1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [UriReferenceFormat1BoxedBoolean](#urireferenceformat1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [UriReferenceFormat1BoxedMap](#urireferenceformat1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [UriReferenceFormat1BoxedBoolean](#urireferenceformat1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [UriReferenceFormat1BoxedMap](#urireferenceformat1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [UriReferenceFormat1BoxedList](#urireferenceformat1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [UriReferenceFormat1Boxed](#urireferenceformat1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UriReferenceFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UriReferenceFormat.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [UriReferenceFormat.UriReferenceFormat1Boxed](#urireferenceformat1boxed)<br> sealed interface for validated payloads |
-| record | [UriReferenceFormat.UriReferenceFormat1BoxedVoid](#urireferenceformat1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [UriReferenceFormat.UriReferenceFormat1BoxedBoolean](#urireferenceformat1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [UriReferenceFormat.UriReferenceFormat1BoxedNumber](#urireferenceformat1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [UriReferenceFormat.UriReferenceFormat1BoxedString](#urireferenceformat1boxedstring)<br> boxed class to store validated String payloads |
-| record | [UriReferenceFormat.UriReferenceFormat1BoxedList](#urireferenceformat1boxedlist)<br> boxed class to store validated List payloads |
-| record | [UriReferenceFormat.UriReferenceFormat1BoxedMap](#urireferenceformat1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [UriReferenceFormat.UriReferenceFormat1](#urireferenceformat1)<br> schema class |
+| data class | [UriReferenceFormat.UriReferenceFormat1BoxedVoid](#urireferenceformat1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [UriReferenceFormat.UriReferenceFormat1BoxedBoolean](#urireferenceformat1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [UriReferenceFormat.UriReferenceFormat1BoxedNumber](#urireferenceformat1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [UriReferenceFormat.UriReferenceFormat1BoxedString](#urireferenceformat1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [UriReferenceFormat.UriReferenceFormat1BoxedList](#urireferenceformat1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [UriReferenceFormat.UriReferenceFormat1BoxedMap](#urireferenceformat1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [UriReferenceFormat.UriReferenceFormat1](#urireferenceformat1)<br> schema class |
 
 ## UriReferenceFormat1Boxed
 sealed interface UriReferenceFormat1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class UriReferenceFormat1BoxedBoolean<br>
 implements [UriReferenceFormat1Boxed](#urireferenceformat1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UriTemplateFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UriTemplateFormat.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [UriTemplateFormat1BoxedString](#uritemplateformat1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [UriTemplateFormat1BoxedVoid](#uritemplateformat1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [UriTemplateFormat1BoxedNumber](#uritemplateformat1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [UriTemplateFormat1BoxedBoolean](#uritemplateformat1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [UriTemplateFormat1BoxedMap](#uritemplateformat1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [UriTemplateFormat1BoxedBoolean](#uritemplateformat1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [UriTemplateFormat1BoxedMap](#uritemplateformat1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [UriTemplateFormat1BoxedList](#uritemplateformat1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [UriTemplateFormat1Boxed](#uritemplateformat1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UriTemplateFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UriTemplateFormat.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [UriTemplateFormat.UriTemplateFormat1Boxed](#uritemplateformat1boxed)<br> sealed interface for validated payloads |
-| record | [UriTemplateFormat.UriTemplateFormat1BoxedVoid](#uritemplateformat1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [UriTemplateFormat.UriTemplateFormat1BoxedBoolean](#uritemplateformat1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [UriTemplateFormat.UriTemplateFormat1BoxedNumber](#uritemplateformat1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [UriTemplateFormat.UriTemplateFormat1BoxedString](#uritemplateformat1boxedstring)<br> boxed class to store validated String payloads |
-| record | [UriTemplateFormat.UriTemplateFormat1BoxedList](#uritemplateformat1boxedlist)<br> boxed class to store validated List payloads |
-| record | [UriTemplateFormat.UriTemplateFormat1BoxedMap](#uritemplateformat1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [UriTemplateFormat.UriTemplateFormat1](#uritemplateformat1)<br> schema class |
+| data class | [UriTemplateFormat.UriTemplateFormat1BoxedVoid](#uritemplateformat1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [UriTemplateFormat.UriTemplateFormat1BoxedBoolean](#uritemplateformat1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [UriTemplateFormat.UriTemplateFormat1BoxedNumber](#uritemplateformat1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [UriTemplateFormat.UriTemplateFormat1BoxedString](#uritemplateformat1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [UriTemplateFormat.UriTemplateFormat1BoxedList](#uritemplateformat1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [UriTemplateFormat.UriTemplateFormat1BoxedMap](#uritemplateformat1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [UriTemplateFormat.UriTemplateFormat1](#uritemplateformat1)<br> schema class |
 
 ## UriTemplateFormat1Boxed
 sealed interface UriTemplateFormat1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class UriTemplateFormat1BoxedBoolean<br>
 implements [UriTemplateFormat1Boxed](#uritemplateformat1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UuidFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UuidFormat.md
@@ -11,13 +11,13 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [UuidFormat.UuidFormat1Boxed](#uuidformat1boxed)<br> sealed interface for validated payloads |
-| record | [UuidFormat.UuidFormat1BoxedVoid](#uuidformat1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [UuidFormat.UuidFormat1BoxedBoolean](#uuidformat1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [UuidFormat.UuidFormat1BoxedNumber](#uuidformat1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [UuidFormat.UuidFormat1BoxedString](#uuidformat1boxedstring)<br> boxed class to store validated String payloads |
-| record | [UuidFormat.UuidFormat1BoxedList](#uuidformat1boxedlist)<br> boxed class to store validated List payloads |
-| record | [UuidFormat.UuidFormat1BoxedMap](#uuidformat1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [UuidFormat.UuidFormat1](#uuidformat1)<br> schema class |
+| data class | [UuidFormat.UuidFormat1BoxedVoid](#uuidformat1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [UuidFormat.UuidFormat1BoxedBoolean](#uuidformat1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [UuidFormat.UuidFormat1BoxedNumber](#uuidformat1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [UuidFormat.UuidFormat1BoxedString](#uuidformat1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [UuidFormat.UuidFormat1BoxedList](#uuidformat1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [UuidFormat.UuidFormat1BoxedMap](#uuidformat1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [UuidFormat.UuidFormat1](#uuidformat1)<br> schema class |
 
 ## UuidFormat1Boxed
 sealed interface UuidFormat1Boxed<br>
@@ -52,7 +52,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class UuidFormat1BoxedBoolean<br>
 implements [UuidFormat1Boxed](#uuidformat1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UuidFormat.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/UuidFormat.md
@@ -149,19 +149,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [UuidFormat1BoxedString](#uuidformat1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [UuidFormat1BoxedVoid](#uuidformat1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [UuidFormat1BoxedNumber](#uuidformat1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [UuidFormat1BoxedBoolean](#uuidformat1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [UuidFormat1BoxedMap](#uuidformat1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [UuidFormat1BoxedBoolean](#uuidformat1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [UuidFormat1BoxedMap](#uuidformat1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [UuidFormat1BoxedList](#uuidformat1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [UuidFormat1Boxed](#uuidformat1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ValidateAgainstCorrectBranchThenVsElse.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ValidateAgainstCorrectBranchThenVsElse.md
@@ -11,37 +11,37 @@ A class that contains necessary nested
 | Modifier and Type | Class and Description |
 | ----------------- | ---------------------- |
 | sealed interface | [ValidateAgainstCorrectBranchThenVsElse.ValidateAgainstCorrectBranchThenVsElse1Boxed](#validateagainstcorrectbranchthenvselse1boxed)<br> sealed interface for validated payloads |
-| record | [ValidateAgainstCorrectBranchThenVsElse.ValidateAgainstCorrectBranchThenVsElse1BoxedVoid](#validateagainstcorrectbranchthenvselse1boxedvoid)<br> boxed class to store validated null payloads |
-| record | [ValidateAgainstCorrectBranchThenVsElse.ValidateAgainstCorrectBranchThenVsElse1BoxedBoolean](#validateagainstcorrectbranchthenvselse1boxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [ValidateAgainstCorrectBranchThenVsElse.ValidateAgainstCorrectBranchThenVsElse1BoxedNumber](#validateagainstcorrectbranchthenvselse1boxednumber)<br> boxed class to store validated Number payloads |
-| record | [ValidateAgainstCorrectBranchThenVsElse.ValidateAgainstCorrectBranchThenVsElse1BoxedString](#validateagainstcorrectbranchthenvselse1boxedstring)<br> boxed class to store validated String payloads |
-| record | [ValidateAgainstCorrectBranchThenVsElse.ValidateAgainstCorrectBranchThenVsElse1BoxedList](#validateagainstcorrectbranchthenvselse1boxedlist)<br> boxed class to store validated List payloads |
-| record | [ValidateAgainstCorrectBranchThenVsElse.ValidateAgainstCorrectBranchThenVsElse1BoxedMap](#validateagainstcorrectbranchthenvselse1boxedmap)<br> boxed class to store validated Map payloads |
-| static class | [ValidateAgainstCorrectBranchThenVsElse.ValidateAgainstCorrectBranchThenVsElse1](#validateagainstcorrectbranchthenvselse1)<br> schema class |
+| data class | [ValidateAgainstCorrectBranchThenVsElse.ValidateAgainstCorrectBranchThenVsElse1BoxedVoid](#validateagainstcorrectbranchthenvselse1boxedvoid)<br> boxed class to store validated null payloads |
+| data class | [ValidateAgainstCorrectBranchThenVsElse.ValidateAgainstCorrectBranchThenVsElse1BoxedBoolean](#validateagainstcorrectbranchthenvselse1boxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [ValidateAgainstCorrectBranchThenVsElse.ValidateAgainstCorrectBranchThenVsElse1BoxedNumber](#validateagainstcorrectbranchthenvselse1boxednumber)<br> boxed class to store validated Number payloads |
+| data class | [ValidateAgainstCorrectBranchThenVsElse.ValidateAgainstCorrectBranchThenVsElse1BoxedString](#validateagainstcorrectbranchthenvselse1boxedstring)<br> boxed class to store validated String payloads |
+| data class | [ValidateAgainstCorrectBranchThenVsElse.ValidateAgainstCorrectBranchThenVsElse1BoxedList](#validateagainstcorrectbranchthenvselse1boxedlist)<br> boxed class to store validated List payloads |
+| data class | [ValidateAgainstCorrectBranchThenVsElse.ValidateAgainstCorrectBranchThenVsElse1BoxedMap](#validateagainstcorrectbranchthenvselse1boxedmap)<br> boxed class to store validated Map payloads |
+| class | [ValidateAgainstCorrectBranchThenVsElse.ValidateAgainstCorrectBranchThenVsElse1](#validateagainstcorrectbranchthenvselse1)<br> schema class |
 | sealed interface | [ValidateAgainstCorrectBranchThenVsElse.ThenBoxed](#thenboxed)<br> sealed interface for validated payloads |
-| record | [ValidateAgainstCorrectBranchThenVsElse.ThenBoxedVoid](#thenboxedvoid)<br> boxed class to store validated null payloads |
-| record | [ValidateAgainstCorrectBranchThenVsElse.ThenBoxedBoolean](#thenboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [ValidateAgainstCorrectBranchThenVsElse.ThenBoxedNumber](#thenboxednumber)<br> boxed class to store validated Number payloads |
-| record | [ValidateAgainstCorrectBranchThenVsElse.ThenBoxedString](#thenboxedstring)<br> boxed class to store validated String payloads |
-| record | [ValidateAgainstCorrectBranchThenVsElse.ThenBoxedList](#thenboxedlist)<br> boxed class to store validated List payloads |
-| record | [ValidateAgainstCorrectBranchThenVsElse.ThenBoxedMap](#thenboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [ValidateAgainstCorrectBranchThenVsElse.Then](#then)<br> schema class |
+| data class | [ValidateAgainstCorrectBranchThenVsElse.ThenBoxedVoid](#thenboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [ValidateAgainstCorrectBranchThenVsElse.ThenBoxedBoolean](#thenboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [ValidateAgainstCorrectBranchThenVsElse.ThenBoxedNumber](#thenboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [ValidateAgainstCorrectBranchThenVsElse.ThenBoxedString](#thenboxedstring)<br> boxed class to store validated String payloads |
+| data class | [ValidateAgainstCorrectBranchThenVsElse.ThenBoxedList](#thenboxedlist)<br> boxed class to store validated List payloads |
+| data class | [ValidateAgainstCorrectBranchThenVsElse.ThenBoxedMap](#thenboxedmap)<br> boxed class to store validated Map payloads |
+| class | [ValidateAgainstCorrectBranchThenVsElse.Then](#then)<br> schema class |
 | sealed interface | [ValidateAgainstCorrectBranchThenVsElse.IfSchemaBoxed](#ifschemaboxed)<br> sealed interface for validated payloads |
-| record | [ValidateAgainstCorrectBranchThenVsElse.IfSchemaBoxedVoid](#ifschemaboxedvoid)<br> boxed class to store validated null payloads |
-| record | [ValidateAgainstCorrectBranchThenVsElse.IfSchemaBoxedBoolean](#ifschemaboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [ValidateAgainstCorrectBranchThenVsElse.IfSchemaBoxedNumber](#ifschemaboxednumber)<br> boxed class to store validated Number payloads |
-| record | [ValidateAgainstCorrectBranchThenVsElse.IfSchemaBoxedString](#ifschemaboxedstring)<br> boxed class to store validated String payloads |
-| record | [ValidateAgainstCorrectBranchThenVsElse.IfSchemaBoxedList](#ifschemaboxedlist)<br> boxed class to store validated List payloads |
-| record | [ValidateAgainstCorrectBranchThenVsElse.IfSchemaBoxedMap](#ifschemaboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [ValidateAgainstCorrectBranchThenVsElse.IfSchema](#ifschema)<br> schema class |
+| data class | [ValidateAgainstCorrectBranchThenVsElse.IfSchemaBoxedVoid](#ifschemaboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [ValidateAgainstCorrectBranchThenVsElse.IfSchemaBoxedBoolean](#ifschemaboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [ValidateAgainstCorrectBranchThenVsElse.IfSchemaBoxedNumber](#ifschemaboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [ValidateAgainstCorrectBranchThenVsElse.IfSchemaBoxedString](#ifschemaboxedstring)<br> boxed class to store validated String payloads |
+| data class | [ValidateAgainstCorrectBranchThenVsElse.IfSchemaBoxedList](#ifschemaboxedlist)<br> boxed class to store validated List payloads |
+| data class | [ValidateAgainstCorrectBranchThenVsElse.IfSchemaBoxedMap](#ifschemaboxedmap)<br> boxed class to store validated Map payloads |
+| class | [ValidateAgainstCorrectBranchThenVsElse.IfSchema](#ifschema)<br> schema class |
 | sealed interface | [ValidateAgainstCorrectBranchThenVsElse.ElseSchemaBoxed](#elseschemaboxed)<br> sealed interface for validated payloads |
-| record | [ValidateAgainstCorrectBranchThenVsElse.ElseSchemaBoxedVoid](#elseschemaboxedvoid)<br> boxed class to store validated null payloads |
-| record | [ValidateAgainstCorrectBranchThenVsElse.ElseSchemaBoxedBoolean](#elseschemaboxedboolean)<br> boxed class to store validated boolean payloads |
-| record | [ValidateAgainstCorrectBranchThenVsElse.ElseSchemaBoxedNumber](#elseschemaboxednumber)<br> boxed class to store validated Number payloads |
-| record | [ValidateAgainstCorrectBranchThenVsElse.ElseSchemaBoxedString](#elseschemaboxedstring)<br> boxed class to store validated String payloads |
-| record | [ValidateAgainstCorrectBranchThenVsElse.ElseSchemaBoxedList](#elseschemaboxedlist)<br> boxed class to store validated List payloads |
-| record | [ValidateAgainstCorrectBranchThenVsElse.ElseSchemaBoxedMap](#elseschemaboxedmap)<br> boxed class to store validated Map payloads |
-| static class | [ValidateAgainstCorrectBranchThenVsElse.ElseSchema](#elseschema)<br> schema class |
+| data class | [ValidateAgainstCorrectBranchThenVsElse.ElseSchemaBoxedVoid](#elseschemaboxedvoid)<br> boxed class to store validated null payloads |
+| data class | [ValidateAgainstCorrectBranchThenVsElse.ElseSchemaBoxedBoolean](#elseschemaboxedboolean)<br> boxed class to store validated boolean payloads |
+| data class | [ValidateAgainstCorrectBranchThenVsElse.ElseSchemaBoxedNumber](#elseschemaboxednumber)<br> boxed class to store validated Number payloads |
+| data class | [ValidateAgainstCorrectBranchThenVsElse.ElseSchemaBoxedString](#elseschemaboxedstring)<br> boxed class to store validated String payloads |
+| data class | [ValidateAgainstCorrectBranchThenVsElse.ElseSchemaBoxedList](#elseschemaboxedlist)<br> boxed class to store validated List payloads |
+| data class | [ValidateAgainstCorrectBranchThenVsElse.ElseSchemaBoxedMap](#elseschemaboxedmap)<br> boxed class to store validated Map payloads |
+| class | [ValidateAgainstCorrectBranchThenVsElse.ElseSchema](#elseschema)<br> schema class |
 
 ## ValidateAgainstCorrectBranchThenVsElse1Boxed
 sealed interface ValidateAgainstCorrectBranchThenVsElse1Boxed<br>
@@ -76,7 +76,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class ValidateAgainstCorrectBranchThenVsElse1BoxedBoolean<br>
 implements [ValidateAgainstCorrectBranchThenVsElse1Boxed](#validateagainstcorrectbranchthenvselse1boxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -225,7 +225,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class ThenBoxedBoolean<br>
 implements [ThenBoxed](#thenboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -372,7 +372,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class IfSchemaBoxedBoolean<br>
 implements [IfSchemaBoxed](#ifschemaboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |
@@ -519,7 +519,7 @@ data class that stores validated null payloads, sealed permits implementation
 data class ElseSchemaBoxedBoolean<br>
 implements [ElseSchemaBoxed](#elseschemaboxed)
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 ### Constructor Summary
 | Constructor and Description |

--- a/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ValidateAgainstCorrectBranchThenVsElse.md
+++ b/samples/client/3_1_0_unit_test/kotlin/docs/components/schemas/ValidateAgainstCorrectBranchThenVsElse.md
@@ -175,19 +175,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [ValidateAgainstCorrectBranchThenVsElse1BoxedString](#validateagainstcorrectbranchthenvselse1boxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [ValidateAgainstCorrectBranchThenVsElse1BoxedVoid](#validateagainstcorrectbranchthenvselse1boxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [ValidateAgainstCorrectBranchThenVsElse1BoxedNumber](#validateagainstcorrectbranchthenvselse1boxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [ValidateAgainstCorrectBranchThenVsElse1BoxedBoolean](#validateagainstcorrectbranchthenvselse1boxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [ValidateAgainstCorrectBranchThenVsElse1BoxedMap](#validateagainstcorrectbranchthenvselse1boxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [ValidateAgainstCorrectBranchThenVsElse1BoxedBoolean](#validateagainstcorrectbranchthenvselse1boxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [ValidateAgainstCorrectBranchThenVsElse1BoxedMap](#validateagainstcorrectbranchthenvselse1boxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [ValidateAgainstCorrectBranchThenVsElse1BoxedList](#validateagainstcorrectbranchthenvselse1boxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [ValidateAgainstCorrectBranchThenVsElse1Boxed](#validateagainstcorrectbranchthenvselse1boxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -322,19 +322,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [ThenBoxedString](#thenboxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [ThenBoxedVoid](#thenboxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [ThenBoxedNumber](#thenboxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [ThenBoxedBoolean](#thenboxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [ThenBoxedMap](#thenboxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [ThenBoxedBoolean](#thenboxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [ThenBoxedMap](#thenboxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [ThenBoxedList](#thenboxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [ThenBoxed](#thenboxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -469,19 +469,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [IfSchemaBoxedString](#ifschemaboxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [IfSchemaBoxedVoid](#ifschemaboxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [IfSchemaBoxedNumber](#ifschemaboxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [IfSchemaBoxedBoolean](#ifschemaboxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [IfSchemaBoxedMap](#ifschemaboxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [IfSchemaBoxedBoolean](#ifschemaboxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [IfSchemaBoxedMap](#ifschemaboxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [IfSchemaBoxedList](#ifschemaboxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [IfSchemaBoxed](#ifschemaboxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |
@@ -616,19 +616,19 @@ A schema class that validates payloads
 | ----------------- | ---------------------- |
 | String | validate(arg: String, configuration: SchemaConfiguration) |
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | FrozenList<Any?> | validate(arg: List<*>, configuration: SchemaConfiguration) |
 | [ElseSchemaBoxedString](#elseschemaboxedstring) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [ElseSchemaBoxedVoid](#elseschemaboxedvoid) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [ElseSchemaBoxedNumber](#elseschemaboxednumber) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [ElseSchemaBoxedBoolean](#elseschemaboxedboolean) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [ElseSchemaBoxedMap](#elseschemaboxedmap) | validateAndBox(Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| [ElseSchemaBoxedBoolean](#elseschemaboxedboolean) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [ElseSchemaBoxedMap](#elseschemaboxedmap) | validateAndBox(Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
 | [ElseSchemaBoxedList](#elseschemaboxedlist) | validateAndBox(List<*>, configuration: SchemaConfiguration) |
 | [ElseSchemaBoxed](#elseschemaboxed) | validateAndBox(Any?, configuration: SchemaConfiguration) |
 | Any? | validate(arg: Any?, configuration: SchemaConfiguration) |

--- a/src/main/resources/kotlin/build.gradle.hbs
+++ b/src/main/resources/kotlin/build.gradle.hbs
@@ -21,10 +21,8 @@ group = "{{groupId}}"
 version = "{{artifactVersion}}"
 description = "{{artifactDescription}}"
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
-    }
+kotlin {
+    jvmToolchain(17)
 }
 
 tasks.wrapper {

--- a/src/main/resources/kotlin/src/main/kotlin/packagename/components/schemas/SchemaClass/_boxedBoolean.hbs
+++ b/src/main/resources/kotlin/src/main/kotlin/packagename/components/schemas/SchemaClass/_boxedBoolean.hbs
@@ -3,7 +3,7 @@
 data class {{jsonPathPiece.pascalCase}}BoxedBoolean<br>
 implements [{{jsonPathPiece.pascalCase}}Boxed](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxed" "")) }})
 
-record that stores validated boolean payloads, sealed permits implementation
+data class that stores validated boolean payloads, sealed permits implementation
 
 {{headerSize}}## Constructor Summary
 | Constructor and Description |

--- a/src/main/resources/kotlin/src/main/kotlin/packagename/components/schemas/Schema_doc.hbs
+++ b/src/main/resources/kotlin/src/main/kotlin/packagename/components/schemas/Schema_doc.hbs
@@ -252,7 +252,7 @@ A class that stores String enum values
 public enum Integer{{../jsonPathPiece.pascalCase}}<br>
 extends `Enum<Integer{{../jsonPathPiece.pascalCase}}>`
 
-A class that stores Integer enum values
+A class that stores Int enum values
                                                 {{else}}
                                                     {{#eq @key "Long"}}
 {{> src/main/kotlin/packagename/components/_helper_header_from_identifier_pieces headerSize=(join headerSize "#" "") identifierPieces=(append identifierPieces (join "Long" ../jsonPathPiece.pascalCase "") ) }}

--- a/src/main/resources/kotlin/src/main/kotlin/packagename/components/schemas/Schema_doc.hbs
+++ b/src/main/resources/kotlin/src/main/kotlin/packagename/components/schemas/Schema_doc.hbs
@@ -37,44 +37,44 @@ A class that contains necessary nested
 | sealed interface | [{{../containerJsonPathPiece.pascalCase}}.{{jsonPathPiece.pascalCase}}Boxed](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxed" "")) }})<br> sealed interface for validated payloads |
             {{#each types}}
                 {{#eq this "null"}}
-| record | [{{../../containerJsonPathPiece.pascalCase}}.{{jsonPathPiece.pascalCase}}BoxedVoid](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxedvoid" ""))}})<br> boxed class to store validated null payloads |
+| data class | [{{../../containerJsonPathPiece.pascalCase}}.{{jsonPathPiece.pascalCase}}BoxedVoid](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxedvoid" ""))}})<br> boxed class to store validated null payloads |
                 {{/eq}}
                 {{#eq this "boolean"}}
-| record | [{{../../containerJsonPathPiece.pascalCase}}.{{jsonPathPiece.pascalCase}}BoxedBoolean](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxedboolean" ""))}})<br> boxed class to store validated boolean payloads |
+| data class | [{{../../containerJsonPathPiece.pascalCase}}.{{jsonPathPiece.pascalCase}}BoxedBoolean](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxedboolean" ""))}})<br> boxed class to store validated boolean payloads |
                 {{/eq}}
                 {{#or (eq this "number") (eq this "integer")}}
-| record | [{{../../containerJsonPathPiece.pascalCase}}.{{jsonPathPiece.pascalCase}}BoxedNumber](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxednumber" ""))}})<br> boxed class to store validated Number payloads |
+| data class | [{{../../containerJsonPathPiece.pascalCase}}.{{jsonPathPiece.pascalCase}}BoxedNumber](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxednumber" ""))}})<br> boxed class to store validated Number payloads |
                 {{/or}}
                 {{#and (eq this "string") (neq ../format "binary") }}
-| record | [{{../../containerJsonPathPiece.pascalCase}}.{{jsonPathPiece.pascalCase}}BoxedString](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxedstring" ""))}})<br> boxed class to store validated String payloads |
+| data class | [{{../../containerJsonPathPiece.pascalCase}}.{{jsonPathPiece.pascalCase}}BoxedString](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxedstring" ""))}})<br> boxed class to store validated String payloads |
                 {{/and}}
                 {{#eq this "array"}}
-| record | [{{../../containerJsonPathPiece.pascalCase}}.{{jsonPathPiece.pascalCase}}BoxedList](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxedlist" ""))}})<br> boxed class to store validated List payloads |
+| data class | [{{../../containerJsonPathPiece.pascalCase}}.{{jsonPathPiece.pascalCase}}BoxedList](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxedlist" ""))}})<br> boxed class to store validated List payloads |
                 {{/eq}}{{#eq this "object"}}
-| record | [{{../../containerJsonPathPiece.pascalCase}}.{{jsonPathPiece.pascalCase}}BoxedMap](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxedmap" ""))}})<br> boxed class to store validated Map payloads |
+| data class | [{{../../containerJsonPathPiece.pascalCase}}.{{jsonPathPiece.pascalCase}}BoxedMap](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxedmap" ""))}})<br> boxed class to store validated Map payloads |
                 {{/eq}}
             {{else}}
-| record | [{{../containerJsonPathPiece.pascalCase}}.{{jsonPathPiece.pascalCase}}BoxedVoid](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxedvoid" ""))}})<br> boxed class to store validated null payloads |
-| record | [{{../containerJsonPathPiece.pascalCase}}.{{jsonPathPiece.pascalCase}}BoxedBoolean](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxedboolean" ""))}})<br> boxed class to store validated boolean payloads |
-| record | [{{../containerJsonPathPiece.pascalCase}}.{{jsonPathPiece.pascalCase}}BoxedNumber](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxednumber" ""))}})<br> boxed class to store validated Number payloads |
-| record | [{{../containerJsonPathPiece.pascalCase}}.{{jsonPathPiece.pascalCase}}BoxedString](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxedstring" ""))}})<br> boxed class to store validated String payloads |
-| record | [{{../containerJsonPathPiece.pascalCase}}.{{jsonPathPiece.pascalCase}}BoxedList](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxedlist" ""))}})<br> boxed class to store validated List payloads |
-| record | [{{../containerJsonPathPiece.pascalCase}}.{{jsonPathPiece.pascalCase}}BoxedMap](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxedmap" ""))}})<br> boxed class to store validated Map payloads |
+| data class | [{{../containerJsonPathPiece.pascalCase}}.{{jsonPathPiece.pascalCase}}BoxedVoid](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxedvoid" ""))}})<br> boxed class to store validated null payloads |
+| data class | [{{../containerJsonPathPiece.pascalCase}}.{{jsonPathPiece.pascalCase}}BoxedBoolean](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxedboolean" ""))}})<br> boxed class to store validated boolean payloads |
+| data class | [{{../containerJsonPathPiece.pascalCase}}.{{jsonPathPiece.pascalCase}}BoxedNumber](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxednumber" ""))}})<br> boxed class to store validated Number payloads |
+| data class | [{{../containerJsonPathPiece.pascalCase}}.{{jsonPathPiece.pascalCase}}BoxedString](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxedstring" ""))}})<br> boxed class to store validated String payloads |
+| data class | [{{../containerJsonPathPiece.pascalCase}}.{{jsonPathPiece.pascalCase}}BoxedList](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxedlist" ""))}})<br> boxed class to store validated List payloads |
+| data class | [{{../containerJsonPathPiece.pascalCase}}.{{jsonPathPiece.pascalCase}}BoxedMap](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxedmap" ""))}})<br> boxed class to store validated Map payloads |
             {{/each}}
         {{/eq}}
-| static class | [{{../containerJsonPathPiece.pascalCase}}.{{jsonPathPiece.pascalCase}}](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces jsonPathPiece) }})<br> schema class |
+| class | [{{../containerJsonPathPiece.pascalCase}}.{{jsonPathPiece.pascalCase}}](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces jsonPathPiece) }})<br> schema class |
     {{else}}
         {{#eq instanceType "propertiesOutputType"}}
-| static class | [{{../containerJsonPathPiece.pascalCase}}.{{mapOutputJsonPathPiece.pascalCase}}](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces mapOutputJsonPathPiece) }})<br> output class for Map payloads |
+| class | [{{../containerJsonPathPiece.pascalCase}}.{{mapOutputJsonPathPiece.pascalCase}}](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces mapOutputJsonPathPiece) }})<br> output class for Map payloads |
         {{else}}
             {{#eq instanceType "arrayOutputType"}}
-| static class | [{{../containerJsonPathPiece.pascalCase}}.{{arrayOutputJsonPathPiece.pascalCase}}](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces arrayOutputJsonPathPiece) }})<br> output class for List payloads |
+| class | [{{../containerJsonPathPiece.pascalCase}}.{{arrayOutputJsonPathPiece.pascalCase}}](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces arrayOutputJsonPathPiece) }})<br> output class for List payloads |
             {{else}}
                 {{#eq instanceType "arrayInputType"}}
-| static class | [{{../containerJsonPathPiece.pascalCase}}.{{arrayInputJsonPathPiece.pascalCase}}](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces arrayInputJsonPathPiece) }})<br> builder for List payloads |
+| class | [{{../containerJsonPathPiece.pascalCase}}.{{arrayInputJsonPathPiece.pascalCase}}](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces arrayInputJsonPathPiece) }})<br> builder for List payloads |
                 {{else}}
                     {{#or (eq instanceType "propertiesInputType") (eq instanceType "requiredPropertiesInputType") (eq instanceType "optionalPropertiesInputType") }}
-| static class | [{{../containerJsonPathPiece.pascalCase}}.{{mapInputJsonPathPiece.pascalCase}}](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces mapInputJsonPathPiece) }})<br> builder for Map payloads |
+| class | [{{../containerJsonPathPiece.pascalCase}}.{{mapInputJsonPathPiece.pascalCase}}](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces mapInputJsonPathPiece) }})<br> builder for Map payloads |
                     {{else}}
                         {{#eq instanceType "enumClass"}}
                             {{#with enumInfo}}

--- a/src/main/resources/kotlin/src/main/kotlin/packagename/components/schemas/Schema_doc.hbs
+++ b/src/main/resources/kotlin/src/main/kotlin/packagename/components/schemas/Schema_doc.hbs
@@ -136,19 +136,15 @@ A schema class that validates payloads
 
 {{headerSize}}## Code Sample
 ```
-import {{{packageName}}}.configurations.JsonSchemaKeywordFlags;
-import {{{packageName}}}.configurations.SchemaConfiguration;
-import {{{packageName}}}.exceptions.ValidationException;
-import {{{packageName}}}.schemas.validation.MapUtils;
-import {{{packageName}}}.schemas.validation.FrozenList;
-import {{{packageName}}}.schemas.validation.FrozenMap;
-import {{{packageName}}}.{{../subpackage}}.{{../containerJsonPathPiece.pascalCase}};
+import {{{packageName}}}.configurations.JsonSchemaKeywordFlags
+import {{{packageName}}}.configurations.SchemaConfiguration
+import {{{packageName}}}.exceptions.ValidationException
+import {{{packageName}}}.schemas.validation.MapUtils
+import {{{packageName}}}.schemas.validation.FrozenList
+import {{{packageName}}}.schemas.validation.FrozenMap
+import {{{packageName}}}.{{../subpackage}}.{{../containerJsonPathPiece.pascalCase}}
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.AbstractMap;
-
-static final SchemaConfiguration configuration = new SchemaConfiguration(new JsonSchemaKeywordFlags.Builder().build());
+val configuration = SchemaConfiguration(JsonSchemaKeywordFlags.Builder().build())
 {{> src/main/kotlin/packagename/components/schemas/validateSchemaCodeSample payloadVarName="validatedPayload" configVarName="configuration" }}
 ```
             {{/if}}

--- a/src/main/resources/kotlin/src/main/kotlin/packagename/components/schemas/docschema_fields_field.hbs
+++ b/src/main/resources/kotlin/src/main/kotlin/packagename/components/schemas/docschema_fields_field.hbs
@@ -29,22 +29,22 @@
 | BigDecimal | {{> src/main/kotlin/packagename/components/schemas/SchemaClass/_multipleOf }} |
 {{/neq}}
 {{#neq maxItems null}}
-| Integer | {{> src/main/kotlin/packagename/components/schemas/SchemaClass/_maxItems }} |
+| Int | {{> src/main/kotlin/packagename/components/schemas/SchemaClass/_maxItems }} |
 {{/neq}}
 {{#neq minItems null}}
-| Integer | {{> src/main/kotlin/packagename/components/schemas/SchemaClass/_minItems }} |
+| Int | {{> src/main/kotlin/packagename/components/schemas/SchemaClass/_minItems }} |
 {{/neq}}
 {{#neq maxLength null }}
-| Integer | {{> src/main/kotlin/packagename/components/schemas/SchemaClass/_maxLength }} |
+| Int | {{> src/main/kotlin/packagename/components/schemas/SchemaClass/_maxLength }} |
 {{/neq}}
 {{#neq minLength null }}
-| Integer | {{> src/main/kotlin/packagename/components/schemas/SchemaClass/_minLength }} |
+| Int | {{> src/main/kotlin/packagename/components/schemas/SchemaClass/_minLength }} |
 {{/neq}}
 {{#neq maxProperties null}}
-| Integer | {{> src/main/kotlin/packagename/components/schemas/SchemaClass/_maxProperties }} |
+| Int | {{> src/main/kotlin/packagename/components/schemas/SchemaClass/_maxProperties }} |
 {{/neq}}
 {{#neq minProperties null}}
-| Integer | {{> src/main/kotlin/packagename/components/schemas/SchemaClass/_minProperties }} |
+| Int | {{> src/main/kotlin/packagename/components/schemas/SchemaClass/_minProperties }} |
 {{/neq}}
 {{#if additionalProperties}}
 | Class<? extends JsonSchema> | {{> src/main/kotlin/packagename/components/schemas/SchemaClass/_additionalProperties }} |
@@ -77,10 +77,10 @@
 | Class<? extends JsonSchema> | {{> src/main/kotlin/packagename/components/schemas/SchemaClass/_contains }} |
 {{/if}}
 {{#neq maxContains null}}
-| Integer | {{> src/main/kotlin/packagename/components/schemas/SchemaClass/_maxContains }} |
+| Int | {{> src/main/kotlin/packagename/components/schemas/SchemaClass/_maxContains }} |
 {{/neq}}
 {{#neq minContains null}}
-| Integer | {{> src/main/kotlin/packagename/components/schemas/SchemaClass/_minContains }} |
+| Int | {{> src/main/kotlin/packagename/components/schemas/SchemaClass/_minContains }} |
 {{/neq}}
 {{#if propertyNames}}
 | Class<? extends JsonSchema> | {{> src/main/kotlin/packagename/components/schemas/SchemaClass/_propertyNames }} |

--- a/src/main/resources/kotlin/src/main/kotlin/packagename/components/schemas/docschema_io_types.hbs
+++ b/src/main/resources/kotlin/src/main/kotlin/packagename/components/schemas/docschema_io_types.hbs
@@ -7,19 +7,19 @@
     {{#and enumInfo enumInfo.typeToValues.null}}
 | Nothing? | validate(arg: [Null{{enumInfo.jsonPathPiece.pascalCase}}](#null{{enumInfo.jsonPathPiece.kebabCase}}), configuration: SchemaConfiguration) |
     {{/and}}
-| int | validate(arg: int, configuration: SchemaConfiguration) |
-| long | validate(arg: long, configuration: SchemaConfiguration) |
-| float | validate(arg: float, configuration: SchemaConfiguration) |
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
     {{#and enumInfo enumInfo.typeToValues.boolean}}
-| boolean | validate(arg: [Boolean{{enumInfo.jsonPathPiece.pascalCase}}](#boolean{{enumInfo.jsonPathPiece.kebabCase}}), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: [Boolean{{enumInfo.jsonPathPiece.pascalCase}}](#boolean{{enumInfo.jsonPathPiece.kebabCase}}), configuration: SchemaConfiguration) |
     {{/and}}
     {{#if mapOutputJsonPathPiece }}
-| [{{mapOutputJsonPathPiece.pascalCase}}](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces mapOutputJsonPathPiece) }}) | validate(arg: [Map&lt;?, ?&gt;](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces mapInputJsonPathPiece) }}), configuration: SchemaConfiguration) |
+| [{{mapOutputJsonPathPiece.pascalCase}}](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces mapOutputJsonPathPiece) }}) | validate(arg: [Map&lt;*, *&gt;](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces mapInputJsonPathPiece) }}), configuration: SchemaConfiguration) |
     {{else}}
-| FrozenMap<Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| FrozenMap<Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
     {{/if}}
     {{#if arrayOutputJsonPathPiece}}
 | [{{arrayOutputJsonPathPiece.pascalCase}}](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces arrayOutputJsonPathPiece) }}) | validate(arg: [List<*>](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces arrayInputJsonPathPiece) }}), configuration: SchemaConfiguration) |
@@ -29,17 +29,17 @@
 | [{{jsonPathPiece.pascalCase}}BoxedString](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxedstring" ""))}}) | validateAndBox(String, configuration: SchemaConfiguration) |
 | [{{jsonPathPiece.pascalCase}}BoxedVoid](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxedvoid" ""))}}) | validateAndBox(Nothing?, configuration: SchemaConfiguration) |
 | [{{jsonPathPiece.pascalCase}}BoxedNumber](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxednumber" ""))}}) | validateAndBox(Number, configuration: SchemaConfiguration) |
-| [{{jsonPathPiece.pascalCase}}BoxedBoolean](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxedboolean" ""))}}) | validateAndBox(boolean, configuration: SchemaConfiguration) |
-| [{{jsonPathPiece.pascalCase}}BoxedMap](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxedmap" ""))}}) | validateAndBox({{#if mapInputJsonPathPiece}}[Map&lt;?, ?&gt;](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces mapInputJsonPathPiece) }}){{else}}Map&lt;?, ?&gt;{{/if}}, configuration: SchemaConfiguration) |
+| [{{jsonPathPiece.pascalCase}}BoxedBoolean](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxedboolean" ""))}}) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
+| [{{jsonPathPiece.pascalCase}}BoxedMap](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxedmap" ""))}}) | validateAndBox({{#if mapInputJsonPathPiece}}[Map&lt;*, *&gt;](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces mapInputJsonPathPiece) }}){{else}}Map&lt;*, *&gt;{{/if}}, configuration: SchemaConfiguration) |
 | [{{jsonPathPiece.pascalCase}}BoxedList](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxedlist" ""))}}) | validateAndBox({{#if arrayInputJsonPathPiece}}[List<*>](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces arrayInputJsonPathPiece) }}){{else}}List<*>{{/if}}, configuration: SchemaConfiguration) |
 {{else}}
     {{#each types}}
         {{#eq this "boolean"}}
-| boolean | validate(arg: boolean, configuration: SchemaConfiguration) |
+| Boolean | validate(arg: Boolean, configuration: SchemaConfiguration) |
             {{#and ../enumInfo enumInfo.typeToValues.boolean}}
-| boolean | validate(arg: [Boolean{{../enumInfo.jsonPathPiece.pascalCase}}](#boolean{{../enumInfo.jsonPathPiece.kebabCase}}), configuration: SchemaConfiguration) |
+| Boolean | validate(arg: [Boolean{{../enumInfo.jsonPathPiece.pascalCase}}](#boolean{{../enumInfo.jsonPathPiece.kebabCase}}), configuration: SchemaConfiguration) |
             {{/and}}
-| [{{jsonPathPiece.pascalCase}}BoxedBoolean](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxedboolean" ""))}}) | validateAndBox(boolean, configuration: SchemaConfiguration) |
+| [{{jsonPathPiece.pascalCase}}BoxedBoolean](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxedboolean" ""))}}) | validateAndBox(Boolean, configuration: SchemaConfiguration) |
         {{else}}
             {{#eq this "null"}}
 | Nothing? | validate(arg: Nothing?, configuration: SchemaConfiguration) |
@@ -65,16 +65,16 @@
 | Number | validate(arg: Number, configuration: SchemaConfiguration) |
                         {{else}}
                             {{#eq ../format "float"}}
-| float | validate(arg: float, configuration: SchemaConfiguration) |
+| Float | validate(arg: Float, configuration: SchemaConfiguration) |
                             {{else}}
                                 {{#eq ../format "double"}}
-| double | validate(arg: double, configuration: SchemaConfiguration) |
+| Double | validate(arg: Double, configuration: SchemaConfiguration) |
                                 {{else}}
                                     {{#eq ../format "int32"}}
-| int | validate(arg: int, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
                                     {{else}}
                                         {{#eq ../format "int64"}}
-| long | validate(arg: long, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
                                         {{/eq}}
                                     {{/eq}}
                                 {{/eq}}
@@ -84,12 +84,12 @@
                     {{else}}
                         {{#eq this "integer"}}
                             {{#eq ../format null}}
-| long | validate(arg: long, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
                             {{else}}
                                 {{#eq ../format "int32"}}
-| int | validate(arg: int, configuration: SchemaConfiguration) |
+| Int | validate(arg: Int, configuration: SchemaConfiguration) |
                                 {{else}}
-| long | validate(arg: long, configuration: SchemaConfiguration) |
+| Long | validate(arg: Long, configuration: SchemaConfiguration) |
                                 {{/eq}}
                             {{/eq}}
 | [{{jsonPathPiece.pascalCase}}BoxedNumber](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxednumber" ""))}}) | validateAndBox(Number, configuration: SchemaConfiguration) |
@@ -104,11 +104,11 @@
                             {{else}}
                                 {{#eq this "object"}}
                                     {{#if ../mapOutputJsonPathPiece}}
-| [{{../mapOutputJsonPathPiece.pascalCase}}](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces ../mapOutputJsonPathPiece) }}) | validate(arg: [Map&lt;?, ?&gt;](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces ../mapInputJsonPathPiece) }}), configuration: SchemaConfiguration) |
+| [{{../mapOutputJsonPathPiece.pascalCase}}](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces ../mapOutputJsonPathPiece) }}) | validate(arg: [Map&lt;*, *&gt;](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces ../mapInputJsonPathPiece) }}), configuration: SchemaConfiguration) |
                                     {{else}}
-| FrozenMap<String, Any?> | validate(arg: Map&lt;?, ?&gt;, configuration: SchemaConfiguration) |
+| FrozenMap<String, Any?> | validate(arg: Map&lt;*, *&gt;, configuration: SchemaConfiguration) |
                                     {{/if}}
-| [{{jsonPathPiece.pascalCase}}BoxedMap](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxedmap" ""))}}) | validateAndBox({{#if mapInputJsonPathPiece}}[Map&lt;?, ?&gt;](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces mapInputJsonPathPiece) }}){{else}}Map&lt;?, ?&gt;{{/if}}, configuration: SchemaConfiguration) |
+| [{{jsonPathPiece.pascalCase}}BoxedMap](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces (join jsonPathPiece.kebabCase "boxedmap" ""))}}) | validateAndBox({{#if mapInputJsonPathPiece}}[Map&lt;*, *&gt;](#{{> src/main/kotlin/packagename/components/_helper_anchor_id identifierPieces=(append identifierPieces mapInputJsonPathPiece) }}){{else}}Map&lt;*, *&gt;{{/if}}, configuration: SchemaConfiguration) |
                                 {{/eq}}
                             {{/eq}}
                         {{/eq}}

--- a/src/main/resources/kotlin/src/main/kotlin/packagename/components/schemas/helpers/payload_renderer.hbs
+++ b/src/main/resources/kotlin/src/main/kotlin/packagename/components/schemas/helpers/payload_renderer.hbs
@@ -77,7 +77,7 @@ listOf{{#eq value.size 0}}<Any?>{{/eq}}(
             {{#eq javaType "Double"}}
 {{value}}{{endChar}}
             {{else}}
-{{value}}{{endChar}}{{! Integer }}
+{{value}}{{endChar}}{{! Int }}
             {{/eq}}
         {{/eq}}
     {{/eq}}

--- a/src/main/resources/kotlin/src/main/kotlin/packagename/components/schemas/validateSchemaCodeSample.hbs
+++ b/src/main/resources/kotlin/src/main/kotlin/packagename/components/schemas/validateSchemaCodeSample.hbs
@@ -2,63 +2,63 @@
 
 {{#eq @key "null"}}
 // null validation
-Nothing? {{../payloadVarName}} = {{../../../containerJsonPathPiece.pascalCase}}.{{../jsonPathPiece.pascalCase}}.validate(
+val {{../payloadVarName}}: Nothing? = {{../../../containerJsonPathPiece.pascalCase}}.{{../jsonPathPiece.pascalCase}}.validate(
 {{else}}
     {{#eq @key "object"}}
         {{#if ../mapOutputJsonPathPiece}}
 // Map validation
-{{../../../containerJsonPathPiece.pascalCase}}.{{../mapOutputJsonPathPiece.pascalCase}} {{../payloadVarName}} =
+val {{../payloadVarName}}: {{../../../containerJsonPathPiece.pascalCase}}.{{../mapOutputJsonPathPiece.pascalCase}} =
     {{../../../containerJsonPathPiece.pascalCase}}.{{../jsonPathPiece.pascalCase}}.validate(
         {{else}}
 // Map validation
-FrozenMap<String, Any> {{../payloadVarName}} = {{../../../containerJsonPathPiece.pascalCase}}.{{../jsonPathPiece.pascalCase}}.validate(
+val {{../payloadVarName}}: FrozenMap<String, Any?> = {{../../../containerJsonPathPiece.pascalCase}}.{{../jsonPathPiece.pascalCase}}.validate(
         {{/if}}
     {{else}}
         {{#eq @key "array"}}
             {{#if ../arrayOutputJsonPathPiece}}
 // List validation
-{{../../../containerJsonPathPiece.pascalCase}}.{{../arrayOutputJsonPathPiece.pascalCase}} {{../payloadVarName}} =
+val {{../payloadVarName}}: {{../../../containerJsonPathPiece.pascalCase}}.{{../arrayOutputJsonPathPiece.pascalCase}} =
     {{../../../containerJsonPathPiece.pascalCase}}.{{../jsonPathPiece.pascalCase}}.validate(
             {{else}}
 // List validation
-FrozenList<Any> {{../payloadVarName}} = {{../../../containerJsonPathPiece.pascalCase}}.{{../jsonPathPiece.pascalCase}}.validate(
+val {{../payloadVarName}}: FrozenList<Any?> = {{../../../containerJsonPathPiece.pascalCase}}.{{../jsonPathPiece.pascalCase}}.validate(
             {{/if}}
         {{else}}
             {{#eq @key "string" }}
 // String validation
-String {{../payloadVarName}} = {{../../../containerJsonPathPiece.pascalCase}}.{{../jsonPathPiece.pascalCase}}.validate(
+val {{../payloadVarName}}: String = {{../../../containerJsonPathPiece.pascalCase}}.{{../jsonPathPiece.pascalCase}}.validate(
             {{else}}
                 {{#eq @key "integer"}}
                     {{#or (eq ../format null) (eq ../format "int64") }}
 // long validation
-long {{../payloadVarName}} = {{../../../containerJsonPathPiece.pascalCase}}.{{../jsonPathPiece.pascalCase}}.validate(
+val {{../payloadVarName}}: Long = {{../../../containerJsonPathPiece.pascalCase}}.{{../jsonPathPiece.pascalCase}}.validate(
                     {{else}}
 // int validation
-int {{../payloadVarName}} = {{../../../containerJsonPathPiece.pascalCase}}.{{../jsonPathPiece.pascalCase}}.validate(
+val {{../payloadVarName}}: Int = {{../../../containerJsonPathPiece.pascalCase}}.{{../jsonPathPiece.pascalCase}}.validate(
                     {{/or}}
                 {{else}}
                     {{#eq @key "number"}}
                         {{#eq ../format "int64"}}
 // long validation
-long {{../payloadVarName}} = {{../../../containerJsonPathPiece.pascalCase}}.{{../jsonPathPiece.pascalCase}}.validate(
+val {{../payloadVarName}}: Long = {{../../../containerJsonPathPiece.pascalCase}}.{{../jsonPathPiece.pascalCase}}.validate(
                         {{else}}
                             {{#eq ../format "float"}}
 // float validation
-float {{../payloadVarName}} = {{../../../containerJsonPathPiece.pascalCase}}.{{../jsonPathPiece.pascalCase}}.validate(
+val {{../payloadVarName}}: Float = {{../../../containerJsonPathPiece.pascalCase}}.{{../jsonPathPiece.pascalCase}}.validate(
                             {{else}}
                                 {{#eq ../format "double"}}
 // double validation
-double {{../payloadVarName}} = {{../../../containerJsonPathPiece.pascalCase}}.{{../jsonPathPiece.pascalCase}}.validate(
+val {{../payloadVarName}}: Double = {{../../../containerJsonPathPiece.pascalCase}}.{{../jsonPathPiece.pascalCase}}.validate(
                                 {{else}}
 // int validation
-int {{../payloadVarName}} = {{../../../containerJsonPathPiece.pascalCase}}.{{../jsonPathPiece.pascalCase}}.validate(
+val {{../payloadVarName}}: Int = {{../../../containerJsonPathPiece.pascalCase}}.{{../jsonPathPiece.pascalCase}}.validate(
                                 {{/eq}}
                             {{/eq}}
                         {{/eq}}
                     {{else}}
                         {{#eq @key "boolean"}}
 // boolean validation
-boolean {{../payloadVarName}} = {{../../../containerJsonPathPiece.pascalCase}}.{{../jsonPathPiece.pascalCase}}.validate(
+val {{../payloadVarName}}: Boolean = {{../../../containerJsonPathPiece.pascalCase}}.{{../jsonPathPiece.pascalCase}}.validate(
                         {{/eq}}
                     {{/eq}}
                 {{/eq}}
@@ -68,12 +68,12 @@ boolean {{../payloadVarName}} = {{../../../containerJsonPathPiece.pascalCase}}.{
 {{/eq}}
             {{#with this}}
                 {{#and (eq type "array") ../arrayInputJsonPathPiece.pascalCase }}
-    new {{../../../containerJsonPathPiece.pascalCase}}.{{../arrayInputJsonPathPiece.pascalCase}}()
+    {{../../../containerJsonPathPiece.pascalCase}}.{{../arrayInputJsonPathPiece.pascalCase}}()
         {{> src/main/kotlin/packagename/components/schemas/helpers/payload_renderer endChar="" constructor=true }}
     .build(),
                 {{else}}
                     {{#and (eq type "object") ../mapInputJsonPathPiece.pascalCase }}
-    new {{../../../containerJsonPathPiece.pascalCase}}.{{../mapInputJsonPathPiece.pascalCase}}()
+    {{../../../containerJsonPathPiece.pascalCase}}.{{../mapInputJsonPathPiece.pascalCase}}()
         {{> src/main/kotlin/packagename/components/schemas/helpers/payload_renderer endChar="" constructor=true optionalProperties=../optionalProperties requiredProperties=../requiredProperties }}
     .build(),
                     {{else}}
@@ -82,5 +82,5 @@ boolean {{../payloadVarName}} = {{../../../containerJsonPathPiece.pascalCase}}.{
                 {{/and}}
             {{/with}}
     {{../configVarName}}
-);
+)
         {{/each}}


### PR DESCRIPTION
Kotlin: docs improvements
- int -> Int, long -> Long, float -> Float, double -> Double, boolean -> Boolean in validate documentation signatures
- semicolons removed from schema code samples

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/generate_samples_configs/python*`
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
