### PR TITLE
Fixes Issue 422, const in python

### DIFF
--- a/src/main/resources/python/components/schemas/schema_cls/validate/validate.hbs
+++ b/src/main/resources/python/components/schemas/schema_cls/validate/validate.hbs
@@ -134,7 +134,7 @@ def validate(
                             {{#if ../constInfo}}
 ) -> typing.Literal[
                                     {{#each ../constInfo.typeToValues.string}}
-    "{{{value}}}",
+    "{{{@key.value}}}",
                                     {{/each}}
 ]:
                             {{else}}
@@ -156,7 +156,7 @@ def validate(
                                     {{#if ../constInfo}}
 ) -> typing.Literal[
                                             {{#each ../constInfo.typeToValues.integer}}
-    {{{value}}},
+    {{{@key.value}}},
                                             {{/each}}
 ]:
                                     {{else}}
@@ -198,7 +198,7 @@ def validate(
                 {{#eq this "string"}}
     return typing.cast(typing.Literal[
                     {{#each ../constInfo.typeToValues.string}}
-            "{{{value}}}",
+            "{{{@key.value}}}",
                     {{/each}}
         ],
         validated_arg


### PR DESCRIPTION
Fixes Issue 422, const in python

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/blob/master/docs/contributing.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-json-schema-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/generate_samples_configs/python*`
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
